### PR TITLE
Revise static libs

### DIFF
--- a/docker-compose/Dockerfile
+++ b/docker-compose/Dockerfile
@@ -42,7 +42,7 @@ RUN --mount=type=ssh ./build-static-libraries.sh
 # And build the node
 FROM concordium/base:0.19 as build
 
-ARG GHC_VERSION=8.10.4
+ARG ghc_version=8.10.4
 ARG consensus_profiling
 ENV CONSENSUS_PROFILING=$consensus_profiling
 
@@ -53,9 +53,9 @@ COPY scripts/build-binaries.sh /build/build-binaries.sh
 # Node
 WORKDIR /build
 # Copy static libraries that were built by the static-builder into the correct place, which is concordium-node/deps/static/linux
-COPY --from=static-builder /build/static-consensus-$GHC_VERSION.tar.gz .
+COPY --from=static-builder /build/static-consensus-${ghc_version}.tar.gz .
 RUN mkdir -p concordium-node/deps/static-libs/linux
-RUN tar -xf static-consensus-$GHC_VERSION.tar.gz && cd target && cp -r * ../concordium-node/deps/static-libs/linux/
+RUN tar -xf static-consensus-${ghc_version}.tar.gz && cd target && cp -r * ../concordium-node/deps/static-libs/linux/
 # And then start the build of the rust parts of the node.
 RUN --mount=type=ssh ./build-binaries.sh "collector"
 RUN chmod +x /build/start.sh

--- a/docker-compose/Dockerfile
+++ b/docker-compose/Dockerfile
@@ -30,8 +30,19 @@ RUN GENESIS_DIR=./out/genesis-5-bakers NUM_BAKERS=5 python3 generate-test-genesi
 RUN GENESIS_DIR=./out/genesis-10-bakers NUM_BAKERS=10 python3 generate-test-genesis.py
 RUN GENESIS_DIR=./out/genesis-25-bakers NUM_BAKERS=25 python3 generate-test-genesis.py
 
+
+# Build static consensus libraries
+FROM 192549843005.dkr.ecr.eu-west-1.amazonaws.com/concordium/static-libraries:0.18 as static-builder
+COPY scripts/static-libraries/build-static-libraries.sh /build-static-libraries.sh
+COPY . /build
+ARG GHC_VERSION=8.10.4
+RUN chmod +x /build-static-libraries.sh
+RUN --mount=type=ssh ./build-static-libraries.sh
+
+# And build the node
 FROM concordium/base:0.19 as build
 
+ARG GHC_VERSION=8.10.4
 ARG consensus_profiling
 ENV CONSENSUS_PROFILING=$consensus_profiling
 
@@ -41,11 +52,15 @@ COPY scripts/build-binaries.sh /build/build-binaries.sh
 
 # Node
 WORKDIR /build
-RUN --mount=type=ssh ./scripts/download-static-libs.sh
+# Copy static libraries that were built by the static-builder into the correct place, which is concordium-node/deps/static/linux
+COPY --from=static-builder /build/static-consensus-$GHC_VERSION.tar.gz .
+RUN mkdir -p concordium-node/deps/static-libs/linux
+RUN tar -xf static-consensus-$GHC_VERSION.tar.gz && cd target && cp -r * ../concordium-node/deps/static-libs/linux/
+# And then start the build of the rust parts of the node.
 RUN --mount=type=ssh ./build-binaries.sh "collector"
 RUN chmod +x /build/start.sh
 
-RUN mkdir -p -m 0600 ~/.ssh && ssh-keyscan github.com ~/.ssh/known_hosts
+RUN mkdir -p -m 0600 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
 
 # Baker id gen
 RUN --mount=type=ssh git clone --recurse-submodules --depth 1 --branch main git@github.com:Concordium/concordium-tools-baker-id-gen.git /baker_id_gen
@@ -57,6 +72,7 @@ RUN --mount=type=ssh git clone --recurse-submodules --depth 1 --branch main git@
 WORKDIR /wallet-proxy
 RUN stack build --copy-bins --ghc-options -j4 --local-bin-path target
 
+# Construct the final image. This contains only the necessary binaries without all the build artifacts to make it reasonably small.
 FROM ubuntu:20.04
 
 EXPOSE 8950
@@ -77,7 +93,7 @@ COPY --from=build /build/concordium-node/target/debug/node-collector /node-colle
 COPY --from=build /build/concordium-node/target/debug/node-collector-backend /node-collector-backend 
 COPY --from=build /build/start.sh /start.sh
 
-# Baker ID file.
+# Baker ID generator.
 COPY --from=build /baker_id_gen/target/release/baker_id_gen /baker_id_generator
 
 # Wallet proxy.

--- a/docker-compose/Dockerfile
+++ b/docker-compose/Dockerfile
@@ -32,7 +32,7 @@ RUN GENESIS_DIR=./out/genesis-25-bakers NUM_BAKERS=25 python3 generate-test-gene
 
 
 # Build static consensus libraries
-FROM 192549843005.dkr.ecr.eu-west-1.amazonaws.com/concordium/static-libraries:0.18 as static-builder
+FROM concordium/static-libraries:0.19 as static-builder
 COPY scripts/static-libraries/build-static-libraries.sh /build-static-libraries.sh
 COPY . /build
 ARG GHC_VERSION=8.10.4

--- a/docker-compose/bakers+wallet-proxy.yaml
+++ b/docker-compose/bakers+wallet-proxy.yaml
@@ -9,7 +9,10 @@ services:
     - RUST_BACKTRACE=1
     - RUST_LOG=info
     - MODE=local_bootstrapper
+    - NUM_BAKERS=${NUM_BAKERS}
     - EXTRA_ARGS=${EXTRA_ARGS}
+    - DATA_DIR=/var/lib/concordium/data
+    - CONFIG_DIR=/var/lib/concordium/config
     entrypoint:
     - /start.sh
   collector_backend:
@@ -45,6 +48,7 @@ services:
     - NUM_BAKERS=${NUM_BAKERS}
     - MODE=local_basic
     - DATA_DIR=/var/lib/concordium/data
+    - CONFIG_DIR=/var/lib/concordium/config
     - RPC_SERVER_ADDR=0.0.0.0
     - EXTRA_ARGS=${EXTRA_ARGS}
     - TRANSACTION_OUTCOME_LOGGING=1

--- a/scripts/static-libraries/README.md
+++ b/scripts/static-libraries/README.md
@@ -4,7 +4,8 @@ Static libraries are built using an fPIC GHC created with [these](https://gitlab
 
 These scripts are consumed by the job created with `jenkinsfiles/static-libraries.Jenkinsfile` [here](http://jenkins.internal.concordium.com/job/static-libraries) (internal).
 
-The main script is `build-and-push-static-libs.sh` which creates a docker container in which it builds the static libraries and then pushes them to S3 and adds a commit to the origin branch specifying the latest static libraries built in `LATEST_STATIC_LIBRARIES`.
+The main script is `build-and-push-static-libs.sh` which creates a docker container in which it builds the static libraries and then pushes them to S3 named after the commit of the repository from which the job was run.
+The file `LATEST_STATIC_LIBRARIES` should be updated with this hash after the build is done.
 
 This file is later consumed by `download-static-libs.sh` to correctly place the static libraries, enabling compilation of the node with `static` or `profiling` features.
 

--- a/scripts/static-libraries/build-and-push-static-libs.sh
+++ b/scripts/static-libraries/build-and-push-static-libs.sh
@@ -35,12 +35,6 @@ mv out/static-consensus-binaries-$GHC_VERSION.tar.gz out/static-consensus-binari
 aws s3 cp out/static-consensus-$VERSION_TAG.tar.gz s3://static-libraries.concordium.com/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
 aws s3 cp out/static-consensus-binaries-$VERSION_TAG.tar.gz s3://static-libraries.concordium.com/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
 
-# Commit and push changes
-# rm -rf out
-# echo "Going to push to branch $GIT_BRANCH"
-# echo $VERSION_TAG > scripts/static-libraries/LATEST_STATIC_LIBRARIES
-# git add scripts/static-libraries/LATEST_STATIC_LIBRARIES
-# CI is skipped by default for these commits as the CI doesn't use the
-# static libraries so the outcome would be the same as in the previous commit.
-# git commit -m "Jenkins: push $VERSION_TAG static libraries. [skip ci]"
-# git push origin HEAD:$BRANCH
+echo "The static libraries are pushed to S3/static-libraries bucket with version $VERSION_TAG."
+echo "To record this in the concordium-node repository run"
+echo "echo $VERSION_TAG > scripts/static-libraries/LATEST_STATIC_LIBRARIES"

--- a/scripts/static-libraries/build-and-push-static-libs.sh
+++ b/scripts/static-libraries/build-and-push-static-libs.sh
@@ -36,11 +36,11 @@ aws s3 cp out/static-consensus-$VERSION_TAG.tar.gz s3://static-libraries.concord
 aws s3 cp out/static-consensus-binaries-$VERSION_TAG.tar.gz s3://static-libraries.concordium.com/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
 
 # Commit and push changes
-rm -rf out
-echo "Going to push to branch $GIT_BRANCH"
-echo $VERSION_TAG > scripts/static-libraries/LATEST_STATIC_LIBRARIES
-git add scripts/static-libraries/LATEST_STATIC_LIBRARIES
+# rm -rf out
+# echo "Going to push to branch $GIT_BRANCH"
+# echo $VERSION_TAG > scripts/static-libraries/LATEST_STATIC_LIBRARIES
+# git add scripts/static-libraries/LATEST_STATIC_LIBRARIES
 # CI is skipped by default for these commits as the CI doesn't use the
 # static libraries so the outcome would be the same as in the previous commit.
-git commit -m "Jenkins: push $VERSION_TAG static libraries. [skip ci]"
-git push origin HEAD:$BRANCH
+# git commit -m "Jenkins: push $VERSION_TAG static libraries. [skip ci]"
+# git push origin HEAD:$BRANCH


### PR DESCRIPTION
## Purpose

Avoid downloading static libraries from a potentially stale version.

## Changes

The docker compose images build their own static libraries instead of downloading potentially stale ones.
This does increase the build times, but makes it more robust to changes.

