### PR TITLE
Fix key updates so that update queues and update types match.

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/Updates.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/Updates.hs
@@ -414,11 +414,9 @@ lookupNextUpdateSequenceNumber u UpdateMintDistribution = u ^. pendingUpdates . 
 lookupNextUpdateSequenceNumber u UpdateTransactionFeeDistribution = u ^. pendingUpdates . pTransactionFeeDistributionQueue . uqNextSequenceNumber
 lookupNextUpdateSequenceNumber u UpdateGASRewards = u ^. pendingUpdates . pGASRewardsQueue . uqNextSequenceNumber
 lookupNextUpdateSequenceNumber u UpdateBakerStakeThreshold = u ^. pendingUpdates . pBakerStakeThresholdQueue . uqNextSequenceNumber
-lookupNextUpdateSequenceNumber u UpdateRootKeysWithRootKeys = u ^. pendingUpdates . pRootKeysUpdateQueue . uqNextSequenceNumber
-lookupNextUpdateSequenceNumber u UpdateLevel1KeysWithRootKeys = u ^. pendingUpdates . pLevel1KeysUpdateQueue . uqNextSequenceNumber
-lookupNextUpdateSequenceNumber u UpdateLevel2KeysWithRootKeys = u ^. pendingUpdates . pLevel2KeysUpdateQueue . uqNextSequenceNumber
-lookupNextUpdateSequenceNumber u UpdateLevel1KeysWithLevel1Keys = u ^. pendingUpdates . pLevel1KeysUpdateQueue . uqNextSequenceNumber
-lookupNextUpdateSequenceNumber u UpdateLevel2KeysWithLevel1Keys = u ^. pendingUpdates . pLevel2KeysUpdateQueue . uqNextSequenceNumber
+lookupNextUpdateSequenceNumber u UpdateRootKeys = u ^. pendingUpdates . pRootKeysUpdateQueue . uqNextSequenceNumber
+lookupNextUpdateSequenceNumber u UpdateLevel1Keys = u ^. pendingUpdates . pLevel1KeysUpdateQueue . uqNextSequenceNumber
+lookupNextUpdateSequenceNumber u UpdateLevel2Keys = u ^. pendingUpdates . pLevel2KeysUpdateQueue . uqNextSequenceNumber
 
 -- |Enqueue an update in the appropriate queue.
 enqueueUpdate :: TransactionTime -> UpdateValue -> Updates -> Updates

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/Updates.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/Updates.hs
@@ -689,11 +689,9 @@ lookupNextUpdateSequenceNumber uref uty = do
             UpdateTransactionFeeDistribution -> uqNextSequenceNumber <$> refLoad (pTransactionFeeDistributionQueue pendingUpdates)
             UpdateGASRewards -> uqNextSequenceNumber <$> refLoad (pGASRewardsQueue pendingUpdates)
             UpdateBakerStakeThreshold -> uqNextSequenceNumber <$> refLoad (pBakerStakeThresholdQueue pendingUpdates)
-            UpdateRootKeysWithRootKeys -> uqNextSequenceNumber <$> refLoad (pRootKeysUpdateQueue pendingUpdates)
-            UpdateLevel1KeysWithRootKeys -> uqNextSequenceNumber <$> refLoad (pLevel1KeysUpdateQueue pendingUpdates)
-            UpdateLevel2KeysWithRootKeys -> uqNextSequenceNumber <$> refLoad (pLevel2KeysUpdateQueue pendingUpdates)
-            UpdateLevel1KeysWithLevel1Keys -> uqNextSequenceNumber <$> refLoad (pLevel1KeysUpdateQueue pendingUpdates)
-            UpdateLevel2KeysWithLevel1Keys -> uqNextSequenceNumber <$> refLoad (pLevel2KeysUpdateQueue pendingUpdates)
+            UpdateRootKeys -> uqNextSequenceNumber <$> refLoad (pRootKeysUpdateQueue pendingUpdates)
+            UpdateLevel1Keys -> uqNextSequenceNumber <$> refLoad (pLevel1KeysUpdateQueue pendingUpdates)
+            UpdateLevel2Keys -> uqNextSequenceNumber <$> refLoad (pLevel2KeysUpdateQueue pendingUpdates)
 
 -- |Enqueue an update in the appropriate queue.
 enqueueUpdate :: (MonadBlobStore m) => TransactionTime -> UpdateValue -> BufferedRef Updates -> m (BufferedRef Updates)

--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium_node"
-version = "0.5.0" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
+version = "0.6.0" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
 description = "Concordium Node"
 authors = ["Concordium <developers@concordium.com>"]
 exclude = [".gitignore", ".gitlab-ci.yml", "test/**/*","**/**/.gitignore","**/**/.gitlab-ci.yml"]

--- a/concordium-node/src/configuration.rs
+++ b/concordium-node/src/configuration.rs
@@ -28,7 +28,7 @@ pub const APP_INFO: AppInfo = AppInfo {
 /// When we reach version 1 we should stick to major versions being for breaking
 /// changes.
 pub(crate) fn is_compatible_version(other: &semver::Version) -> bool {
-    other.major == 0 && other.minor == 5
+    other.major == 0 && other.minor == 6
 }
 
 /// Check that the other wire version is compatible with ours. See


### PR DESCRIPTION
## Purpose

Make the update type consistent with update queues.
This fixes a bug where a node would crash if, e.g., first sent an update with root keys of level 1 keys, and then an update of level 1 keys with level 1 keys.

## Changes

The main change is in concordium-base. This just propagates the type changes in a straightforward way to the node.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
