### PR TITLE
Accept multiple connections per event.

### DIFF
--- a/concordium-node/src/configuration.rs
+++ b/concordium-node/src/configuration.rs
@@ -344,6 +344,13 @@ pub struct ConnectionConfig {
     )]
     pub hard_connection_limit: u16,
     #[structopt(
+        long = "connection-requests-batch-limit",
+        help = "Maximum number of incoming connection requests to attempt to process per \
+                iteration.",
+        default_value = "9"
+    )]
+    pub conn_requests_batch_limit: u16,
+    #[structopt(
         long = "catch-up-batch-limit",
         help = "The maximum batch size for a catch-up round.",
         default_value = "50"

--- a/concordium-node/src/p2p/connectivity.rs
+++ b/concordium-node/src/p2p/connectivity.rs
@@ -328,21 +328,70 @@ impl P2PNode {
     }
 }
 
+#[derive(Debug)]
+pub enum AcceptFailureReason {
+    TooManyConnections,
+    AlreadyConnectedToIP {
+        ip: IpAddr,
+    },
+    DuplicateConnection {
+        addr: SocketAddr,
+    },
+    Banned,
+    SoftBanned,
+    Other {
+        err: failure::Error,
+    },
+}
+
+impl std::fmt::Display for AcceptFailureReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AcceptFailureReason::TooManyConnections => {
+                f.write_str("Too many existing connections. Not accepting an additional one.")
+            }
+            AcceptFailureReason::AlreadyConnectedToIP {
+                ip,
+            } => write!(f, "Already connected to IP {}.", ip),
+            AcceptFailureReason::DuplicateConnection {
+                addr,
+            } => write!(f, "Duplicate connection attempt from {}", addr),
+            AcceptFailureReason::Banned => f.write_str("Connection attempt from a banned address."),
+            AcceptFailureReason::SoftBanned => {
+                f.write_str("Connection attempt from a soft-banned address.")
+            }
+            AcceptFailureReason::Other {
+                err,
+            } => err.fmt(f),
+        }
+    }
+}
+
+impl From<failure::Error> for AcceptFailureReason {
+    fn from(err: failure::Error) -> Self {
+        Self::Other {
+            err,
+        }
+    }
+}
+
 /// Attempt to accept an incoming network connection.
-/// - If the connection is from a banned peer return Ok(None).
 /// - If an error occurs, e.g., fail to accept the socket connection, or fail to
 ///   register with the poll registry return Err
 /// - Else return the new connection token that can be used to poll for incoming
 ///   data.
-pub fn accept(node: &Arc<P2PNode>) -> Fallible<Option<Token>> {
-    let (socket, addr) = node.connection_handler.socket_server.accept()?;
+pub fn accept(
+    node: &Arc<P2PNode>,
+    socket: TcpStream,
+    addr: SocketAddr,
+) -> Result<Token, AcceptFailureReason> {
     node.stats.conn_received_inc();
 
     // if we fail to read the database we allow the connection.
     // This is fine as long as we assume that nobody can corrupt our ban database.
     if node.is_banned(PersistedBanId::Ip(addr.ip())).unwrap_or(false) {
         warn!("Connection attempt from a banned IP {}.", addr.ip());
-        return Ok(None);
+        return Err(AcceptFailureReason::Banned);
     }
 
     // Lock the candidate list for added safety against duplicate connections
@@ -362,24 +411,28 @@ pub fn accept(node: &Arc<P2PNode>) -> Fallible<Option<Token>> {
             && candidates_lock.len() + conn_read_lock.len()
                 >= node.config.hard_connection_limit as usize
         {
-            bail!("Too many connections, rejecting attempt from {}", addr);
+            return Err(AcceptFailureReason::TooManyConnections);
         }
 
         for conn in candidates_lock.values().chain(conn_read_lock.values()) {
             if conn.remote_addr().ip() == addr.ip() {
                 if node.config.disallow_multiple_peers_on_ip {
-                    bail!("Already connected to IP {}", addr.ip());
+                    return Err(AcceptFailureReason::AlreadyConnectedToIP {
+                        ip: addr.ip(),
+                    });
                 } else if conn.remote_addr().port() == addr.port()
                     || conn.remote_peer.external_port == addr.port()
                 {
-                    bail!("Duplicate connection attempt from {}; rejecting", addr);
+                    return Err(AcceptFailureReason::DuplicateConnection {
+                        addr,
+                    });
                 }
             }
         }
 
         if node.connection_handler.is_soft_banned(addr) {
             warn!("Connection attempt from a soft-banned IP ({}); rejecting", addr.ip());
-            return Ok(None);
+            return Err(AcceptFailureReason::SoftBanned);
         }
     }
 
@@ -398,7 +451,7 @@ pub fn accept(node: &Arc<P2PNode>) -> Fallible<Option<Token>> {
     let conn = Connection::new(node, socket, token, remote_peer, false)?;
     candidates_lock.insert(conn.token(), conn);
 
-    Ok(Some(token))
+    Ok(token)
 }
 
 /// Connect to another node with the specified address and optionally peer id,


### PR DESCRIPTION
## Purpose

Process all incoming connections that are available for any readiness event that is triggered.
In the previous handing some incoming connections could be dropped, depending on the setup and timing.
This could lead to the node no longer accepting any new connections since no events were triggered.

## Changes

Iterate attempting to accept connections for as long as there are any available.
We stop after a fixed amount of time to prevent abuse, and we also stop if we already have enough connections.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
