### PR TITLE
Reduce logging spam in case of many bad events.

### DIFF
--- a/concordium-consensus/src/Concordium/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler.hs
@@ -1481,6 +1481,9 @@ filterTransactions maxSize timeout groups0 = do
   maxEnergy <- getMaxBlockEnergy
   credLimit <- getAccountCreationLimit
   ftTrans <- runNext maxEnergy 0 credLimit False emptyFilteredTransactions groups0
+  -- For each type of invalid message we only log the first 10 items so as to
+  -- not to spend too much time in the logging phase. This makes it useful for debugging,
+  -- but not a potential problem when a lot of invalid transactions are being sent.
   let (toReportTrans, restTrans) = splitAt 10 (ftFailed ftTrans)
   forM_ toReportTrans $ uncurry logInvalidTransaction
   unless (null restTrans) $ logEvent Scheduler LLWarning "Too many invalid transactions. Suppressing reporting the remaining ones."

--- a/concordium-consensus/src/Concordium/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler.hs
@@ -1481,9 +1481,15 @@ filterTransactions maxSize timeout groups0 = do
   maxEnergy <- getMaxBlockEnergy
   credLimit <- getAccountCreationLimit
   ftTrans <- runNext maxEnergy 0 credLimit False emptyFilteredTransactions groups0
-  forM_ (ftFailed ftTrans) $ uncurry logInvalidTransaction
-  forM_ (ftFailedCredentials ftTrans) $ uncurry logInvalidCredential
-  forM_ (ftFailedUpdates ftTrans) $ uncurry logInvalidChainUpdate
+  let (toReportTrans, restTrans) = splitAt 10 (ftFailed ftTrans)
+  forM_ toReportTrans $ uncurry logInvalidTransaction
+  unless (null restTrans) $ logEvent Scheduler LLWarning "Too many invalid transactions. Suppressing reporting the remaining ones."
+  let (toReportCredentials, restCredentials) = splitAt 10 (ftFailedCredentials ftTrans)
+  forM_ toReportCredentials $ uncurry logInvalidCredential
+  unless (null restCredentials) $ logEvent Scheduler LLWarning "Too many invalid credentials. Suppressing reporting the remaining ones."
+  let (toReportUpdates, restUpdates) = splitAt 10 (ftFailedUpdates ftTrans)
+  forM_ toReportUpdates $ uncurry logInvalidChainUpdate
+  unless (null restUpdates) $ logEvent Scheduler LLWarning "Too many invalid updates. Suppressing reporting the remaining ones."
   return ftTrans
   where
         -- Run next credential deployment or transaction group, depending on arrival time.

--- a/concordium-node/src/p2p/connectivity.rs
+++ b/concordium-node/src/p2p/connectivity.rs
@@ -645,14 +645,13 @@ pub fn connection_housekeeping(node: &Arc<P2PNode>) -> bool {
         }
     }
 
+    // Log all the bad events that happened and reset all their counters.
     for (peer_id, invalid_msgs) in lock_or_die!(node.bad_events.invalid_messages).drain() {
         warn!("Received {} invalid messages from peer {}", invalid_msgs, peer_id);
     }
-
     for (peer_id, dropped) in lock_or_die!(node.bad_events.dropped_high_queue).drain() {
         warn!("Dropped {} high priority messages from peer {}.", dropped, peer_id);
     }
-
     for (peer_id, dropped) in lock_or_die!(node.bad_events.dropped_low_queue).drain() {
         warn!("Dropped {} low priority messages from peer {}.", dropped, peer_id);
     }

--- a/concordium-node/src/p2p/connectivity.rs
+++ b/concordium-node/src/p2p/connectivity.rs
@@ -645,6 +645,18 @@ pub fn connection_housekeeping(node: &Arc<P2PNode>) -> bool {
         }
     }
 
+    for (peer_id, invalid_msgs) in lock_or_die!(node.bad_events.invalid_messages).drain() {
+        warn!("Received {} invalid messages from peer {}", invalid_msgs, peer_id);
+    }
+
+    for (peer_id, dropped) in lock_or_die!(node.bad_events.dropped_high_queue).drain() {
+        warn!("Dropped {} high priority messages from peer {}.", dropped, peer_id);
+    }
+
+    for (peer_id, dropped) in lock_or_die!(node.bad_events.dropped_low_queue).drain() {
+        warn!("Dropped {} low priority messages from peer {}.", dropped, peer_id);
+    }
+
     // Reconnect to bootstrappers after a specified amount of time.
     // It's unclear whether we should always be doing this, even if we have enough
     // peers. But the current logic is to try to bootstrap again, and if we have

--- a/concordium-node/src/plugins/consensus.rs
+++ b/concordium-node/src/plugins/consensus.rs
@@ -313,10 +313,15 @@ fn send_msg_to_consensus(
     if consensus_response.is_acceptable() {
         debug!("Processed a {} from {}", message.variant, source_id);
     } else {
-        lock_or_die!(node.bad_events.invalid_messages)
+        let num_bad_events = *lock_or_die!(node.bad_events.invalid_messages)
             .entry(source_id)
             .and_modify(|x| *x += 1)
             .or_insert(1);
+        // we do log some invalid messages to both ease debugging and see problems in
+        // normal circumstances
+        if num_bad_events < 10 {
+            warn!("Couldn't process a {} due to error code {:?}", message, consensus_response);
+        }
     }
 
     Ok(consensus_response)


### PR DESCRIPTION
## Purpose

In cases where there are a lot of invalid messages or just too many messages we have seen the logs get very large which causes further problems, and the node ends up using a lot of resources to simply emit the logs.

The purpose of this PR is to reduce the amount of logging and instead summarize the logs.

## Changes

- Summarize the bad events that happen on the network layer and emit them only at each housekeeping interval.
- In the scheduler only emit the first few invalid transactions. This makes logging still useful for debugging but also makes it so that blocks are produced in a reasonable amount of time. Before this change for example, it happened regularly that it took 10 or more seconds just to log all the invalid transactions after filterTransactions ran.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
