### PR TITLE
Expose account threshold in getAccountInfo.

### DIFF
--- a/concordium-consensus/src/Concordium/Getters.hs
+++ b/concordium-consensus/src/Concordium/Getters.hs
@@ -15,7 +15,7 @@ import qualified Data.HashMap.Strict as HM
 import Control.Monad.State.Class
 
 import Concordium.Common.Version
-import Concordium.ID.Types (CredentialRegistrationID)
+import Concordium.ID.Types (CredentialRegistrationID, aiThreshold)
 import qualified Concordium.Scheduler.Types as AT
 import Concordium.GlobalState.Types
 import qualified Concordium.GlobalState.TreeState as TS
@@ -226,6 +226,7 @@ getAccountInfo hash sfsRef pointer = runStateQuery sfsRef $
               Nonce nonce <- BS.getAccountNonce acc
               amount <- BS.getAccountAmount acc
               creds <- BS.getAccountCredentials acc
+              accountThreshold <- aiThreshold <$> BS.getAccountVerificationKeys acc
               baker <- BS.getAccountBaker acc
               encrypted <- BS.getAccountEncryptedAmount acc
               encryptionKey <- BS.getAccountEncryptionKey acc
@@ -234,6 +235,7 @@ getAccountInfo hash sfsRef pointer = runStateQuery sfsRef $
                               ,"accountAmount" .= amount
                               , "accountReleaseSchedule" .= releaseSchedule
                               ,"accountCredentials" .= fmap (Versioned 0) creds
+                              ,"accountThreshold" .= accountThreshold
                               ,"accountEncryptedAmount" .= encrypted
                               ,"accountEncryptionKey" .= encryptionKey
                               ] <> renderBaker baker


### PR DESCRIPTION
## Purpose

Expose the number of credentials that need to sign transactions from the account.
This is needed by the desktop wallet.

## Changes

Add an additional field to the `getAccountInfo` response.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
