### PR TITLE
Fix issue with bootstrapping when name resolution is slow

### DIFF
--- a/concordium-node/src/p2p/maintenance.rs
+++ b/concordium-node/src/p2p/maintenance.rs
@@ -641,6 +641,8 @@ pub fn spawn(node_ref: &Arc<P2PNode>, mut poll: Poll, consensus: Option<Consensu
         let mut log_time = Instant::now();
         let mut last_buckets_cleaned = Instant::now();
         let mut last_peer_list_update = 0;
+        // The number of polling loop iterations since the last housekeeping.
+        let mut iterations_since_housekeeping = 0;
 
         let num_socket_threads = match node.self_peer.peer_type {
             PeerType::Bootstrapper => 1,
@@ -726,29 +728,36 @@ pub fn spawn(node_ref: &Arc<P2PNode>, mut poll: Poll, consensus: Option<Consensu
             pool.install(|| node.process_network_events(&events));
 
             // Run periodic tasks
-            let now = Instant::now();
-            if now.duration_since(log_time)
-                >= Duration::from_secs(node.config.housekeeping_interval)
-            {
-                let attempted_bootstrap = connection_housekeeping(&node);
-                if node.peer_type() != PeerType::Bootstrapper {
-                    node.measure_connection_latencies();
+            // We prevent housekeeping from occurring too often so that new connections have
+            // a chance to complete the handshake in between invocations of
+            // housekeeping.
+            if iterations_since_housekeeping >= 10 {
+                if Instant::now().duration_since(log_time)
+                    >= Duration::from_secs(node.config.housekeeping_interval)
+                {
+                    let attempted_bootstrap = connection_housekeeping(&node);
+                    if node.peer_type() != PeerType::Bootstrapper {
+                        node.measure_connection_latencies();
+                    }
+
+                    let peer_stat_list = node.get_peer_stats(None);
+                    check_peers(&node, &peer_stat_list, attempted_bootstrap);
+                    node.measure_throughput(&peer_stat_list);
+
+                    log_time = Instant::now();
+                    iterations_since_housekeeping = 0;
                 }
-
-                let peer_stat_list = node.get_peer_stats(None);
-                check_peers(&node, &peer_stat_list, attempted_bootstrap);
-                node.measure_throughput(&peer_stat_list);
-
-                log_time = now;
+            } else {
+                iterations_since_housekeeping += 1;
             }
 
             if node.is_bucket_cleanup_enabled()
-                && now.duration_since(last_buckets_cleaned)
+                && Instant::now().duration_since(last_buckets_cleaned)
                     >= Duration::from_millis(node.config.bucket_cleanup_interval)
             {
                 write_or_die!(node.buckets())
                     .clean_buckets(node.config.timeout_bucket_entry_period);
-                last_buckets_cleaned = now;
+                last_buckets_cleaned = Instant::now();
             }
         }
         info!("Shutting down");

--- a/concordium-node/src/utils.rs
+++ b/concordium-node/src/utils.rs
@@ -126,7 +126,7 @@ pub fn get_resolvers(resolv_conf: &Path, resolvers: &[String]) -> Vec<String> {
 }
 
 #[cfg(target_os = "windows")]
-pub fn get_resolvers(_resolv_conf: &str, resolvers: &[String]) -> Vec<String> {
+pub fn get_resolvers(_resolv_conf: &Path, resolvers: &[String]) -> Vec<String> {
     if !resolvers.is_empty() {
         resolvers.to_owned()
     } else {


### PR DESCRIPTION
## Purpose

This pull request addresses an issue where bootstrapping fails in some circumstances. The failure occurs when name resolution for the bootstrapper nodes takes a long time. Connection housekeeping ends up running on each iteration of the connection polling loop and attempting to bootstrap. As a result, the new connections to the bootstrapper nodes do not get the opportunity to complete the connection handshake before they are considered "old" and are closed.

## Changes

This PR implements two mitigations:

1. Record the time of the last housekeeping after the housekeeping has occurred. This means that the time that is spent in housekeeping (e.g. resolving bootstrapper nodes) is not included in the time measured between housekeeping events. This should prevent slow housekeeping (and in particular, slow name resolution for bootstrappers) from causing housekeeping to happen at an unduly high frequency, and thus prematurely closing handshaking connections.
2. Use a counter to ensure that housekeeping can only occur at most once every 11 iterations. (The number of iterations is fairly arbitrary, but should be enough to complete the handshake, but not so high as to unduly increase the housekeeping interval.) This double check should ensure that bootstrapping connections have sufficient opportunity to complete the handshake even if something other than housekeeping causes (significant) delays in the polling loop.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
