### PR TITLE
Fix status badges to point to github.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # concordium-node
 
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](https://github.com/Concordium/.github/blob/main/.github/CODE_OF_CONDUCT.md)
+- [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](https://github.com/Concordium/.github/blob/main/.github/CODE_OF_CONDUCT.md)
+
+- ![Format](https://github.com/Concordium/concordium-node/actions/workflows/rustfmt.yaml/badge.svg)
+
+- ![Build and test](https://github.com/Concordium/concordium-node/actions/workflows/build-test.yaml/badge.svg)
 
 This repository contains the implementation of the concordium p2p node with its
 dependencies. It is split into two parts

--- a/concordium-node/README.md
+++ b/concordium-node/README.md
@@ -1,7 +1,5 @@
 # Concordium node implementation
 
-`master` [![master pipeline status](https://gitlab.com/Concordium/concordium-node/badges/master/pipeline.svg)](https://gitlab.com/Concordium/concordium-node/commits/master).
-
 ## General usage information
 This repository relies on git submodules for some internal and external component dependencies.
 Do remember to clone recursively or use `git submodule update --init --recursive` after having cloned it.


### PR DESCRIPTION
## Purpose

Fix obsolete badge links that pointed to gitlab CI.

Closes #25 
