### PR TITLE
Do not accept transactions that are never (or not very likely) going to make it into a block.

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/Parameters.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Parameters.hs
@@ -101,7 +101,9 @@ data RuntimeParameters = RuntimeParameters {
   -- transaction table if a purge is executed.
   rpTransactionsKeepAliveTime :: !TransactionTime,
   -- |Number of seconds between automatic transaction table purging  runs.
-  rpTransactionsPurgingDelay :: !Int
+  rpTransactionsPurgingDelay :: !Int,
+  -- |The maximum allowed time difference between slot time and a transaction's expiry time.
+  rpMaxTimeToExpiry :: !TransactionTime
   }
 
 -- |Default runtime parameters, block size = 10MB.
@@ -115,7 +117,8 @@ defaultRuntimeParameters = RuntimeParameters {
   rpMaxBakingDelay = 10000, -- 10 seconds
   rpInsertionsBeforeTransactionPurge = 1000,
   rpTransactionsKeepAliveTime = 5 * 60, -- 5 min
-  rpTransactionsPurgingDelay = 3 * 60 -- 3 min
+  rpTransactionsPurgingDelay = 3 * 60, -- 3 min
+  rpMaxTimeToExpiry = 60 * 60 * 2 -- 2 hours
   }
 
 instance FromJSON RuntimeParameters where
@@ -129,6 +132,7 @@ instance FromJSON RuntimeParameters where
     rpInsertionsBeforeTransactionPurge <- v .: "insertionsBeforeTransactionPurge"
     rpTransactionsKeepAliveTime <- (fromIntegral :: Int -> TransactionTime) <$> v .: "transactionsKeepAliveTime"
     rpTransactionsPurgingDelay <- v .: "transactionsPurgingDelay"
+    rpMaxTimeToExpiry <- v .: "maxTimeToExpiry"
     when (rpBlockSize <= 0) $
       fail "Block size must be a positive integer."
     when (rpEarlyBlockThreshold <= 0) $

--- a/concordium-consensus/src/Concordium/Skov/Monad.hs
+++ b/concordium-consensus/src/Concordium/Skov/Monad.hs
@@ -56,6 +56,18 @@ data UpdateResult
     -- ^The message duplicates a previously received message
     | ResultStale
     -- ^The message may have been valid in the past, but is no longer relevant
+    | ResultDuplicateNonce
+    -- ^The sequence number for that account or update type was already used in another transaction
+    | ResultNonceTooLarge
+    -- ^The sequence number for that account or update type is larger than the next sequence number
+    | ResultNonexistingSenderAccount
+    -- ^An account corresponding to the transaction's sender does not exist in the focus block
+    | ResultVerificationFailed
+    -- ^Verifying the transaction's signature failed
+    | ResultExpiryTooLate
+    -- ^The transaction expiry time is too far in the future
+    | ResultTooLowEnergy
+    -- ^The stated transaction energy is too low
     | ResultIncorrectFinalizationSession
     -- ^The message refers to a different/unknown finalization session
     | ResultUnverifiable

--- a/concordium-node/src/configuration.rs
+++ b/concordium-node/src/configuration.rs
@@ -45,6 +45,9 @@ pub(crate) fn is_compatible_wire_version(
 /// The maximum size of objects accepted from the network.
 pub const PROTOCOL_MAX_MESSAGE_SIZE: u32 = 20_971_520; // 20 MIB
 
+/// Upper bound on the transaction object size, in bytes.
+pub const PROTOCOL_MAX_TRANSACTION_SIZE: usize = 100 * 1024; // 100 kB.
+
 const APP_PREFERENCES_MAIN: &str = "main.config";
 const APP_PREFERENCES_KEY_VERSION: &str = "VERSION";
 /// Used for a persistent node id setup.
@@ -225,6 +228,13 @@ pub struct BakerConfig {
         long = "import-blocks-from",
         help = "Path to a file exported by the database exporter"
     )]
+    #[structopt(
+        long = "max-expiry-duration",
+        help = "Maximum allowed time difference between now and a transaction's expiry time in \
+                seconds",
+        default_value = "7200"
+    )]
+    pub max_time_to_expiry: u64,
     pub import_path: Option<String>,
     #[structopt(long = "baker-credentials-file", help = "Path to the baker credentials file")]
     pub baker_credentials_file: Option<PathBuf>,

--- a/concordium-node/src/consensus_ffi/consensus.rs
+++ b/concordium-node/src/consensus_ffi/consensus.rs
@@ -210,6 +210,7 @@ impl std::fmt::Display for ConsensusType {
 pub struct ConsensusContainer {
     pub max_block_size:             u64,
     pub block_construction_timeout: u64,
+    pub max_time_to_expiry:         u64,
     pub insertions_before_purging:  u64,
     pub transaction_keep_alive:     u64,
     pub is_baking:                  Arc<AtomicBool>,
@@ -225,6 +226,7 @@ impl ConsensusContainer {
     pub fn new(
         max_block_size: u64,
         block_construction_timeout: u64,
+        max_time_to_expiry: u64,
         insertions_before_purging: u64,
         transaction_keep_alive: u64,
         transactions_purging_delay: u64,
@@ -246,6 +248,7 @@ impl ConsensusContainer {
         match get_consensus_ptr(
             max_block_size,
             block_construction_timeout,
+            max_time_to_expiry,
             insertions_before_purging,
             transaction_keep_alive,
             transactions_purging_delay,
@@ -259,6 +262,7 @@ impl ConsensusContainer {
             Ok(consensus_ptr) => Ok(Self {
                 max_block_size,
                 block_construction_timeout,
+                max_time_to_expiry,
                 insertions_before_purging,
                 transaction_keep_alive,
                 is_baking: Arc::new(AtomicBool::new(false)),

--- a/concordium-node/src/consensus_ffi/ffi.rs
+++ b/concordium-node/src/consensus_ffi/ffi.rs
@@ -255,6 +255,7 @@ extern "C" {
     pub fn startConsensus(
         max_block_size: u64,
         block_construction_timeout: u64,
+        max_time_to_expiry: u64,
         insertions_before_purging: u64,
         transaction_keep_alive: u64,
         transactions_purging_delay: u64,
@@ -278,6 +279,7 @@ extern "C" {
     pub fn startConsensusPassive(
         max_block_size: u64,
         block_construction_timeout: u64,
+        max_time_to_expiry: u64,
         insertions_before_purging: u64,
         transaction_keep_alive: u64,
         transactions_purging_delay: u64,
@@ -416,6 +418,7 @@ extern "C" {
 pub fn get_consensus_ptr(
     max_block_size: u64,
     block_construction_timeout: u64,
+    max_time_to_expiry: u64,
     insertions_before_purging: u64,
     transaction_keep_alive: u64,
     transactions_purging_delay: u64,
@@ -442,6 +445,7 @@ pub fn get_consensus_ptr(
                 startConsensus(
                     max_block_size,
                     block_construction_timeout,
+                    max_time_to_expiry,
                     insertions_before_purging,
                     transaction_keep_alive,
                     transactions_purging_delay,
@@ -471,6 +475,7 @@ pub fn get_consensus_ptr(
                     startConsensusPassive(
                         max_block_size,
                         block_construction_timeout,
+                        max_time_to_expiry,
                         insertions_before_purging,
                         transaction_keep_alive,
                         transactions_purging_delay,

--- a/concordium-node/src/consensus_ffi/helpers.rs
+++ b/concordium-node/src/consensus_ffi/helpers.rs
@@ -183,6 +183,12 @@ pub enum ConsensusFfiResponse {
     BlockTooEarly,
     MissingImportFile,
     ConsensusShutDown,
+    ExpiryTooLate,
+    VerificationFailed,
+    NonexistingSenderAccount,
+    DuplicateNonce,
+    NonceTooLarge,
+    TooLowEnergy,
 }
 
 impl ConsensusFfiResponse {
@@ -254,6 +260,12 @@ impl TryFrom<i64> for ConsensusFfiResponse {
             11 => Ok(BlockTooEarly),
             12 => Ok(MissingImportFile),
             13 => Ok(ConsensusShutDown),
+            14 => Ok(ExpiryTooLate),
+            15 => Ok(VerificationFailed),
+            16 => Ok(NonexistingSenderAccount),
+            17 => Ok(DuplicateNonce),
+            18 => Ok(NonceTooLarge),
+            19 => Ok(TooLowEnergy),
             _ => Err(format_err!("Unsupported FFI return code ({})", value)),
         }
     }

--- a/concordium-node/src/rpc.rs
+++ b/concordium-node/src/rpc.rs
@@ -209,13 +209,21 @@ impl P2p for RpcServerImpl {
         &self,
         req: Request<SendTransactionRequest>,
     ) -> Result<Response<BoolResponse>, Status> {
+        use ConsensusFfiResponse::*;
+
         authenticate!(req, self.access_token);
         if let Some(ref consensus) = self.consensus {
             let req = req.get_ref();
             let transaction = &req.payload;
+            if transaction.len() > configuration::PROTOCOL_MAX_TRANSACTION_SIZE {
+                warn!("Received a transaction that exceeds maximum transaction size.");
+                return Err(Status::invalid_argument(
+                    "Transaction size exceeds maximum allowed size.",
+                ));
+            }
             let consensus_result = consensus.send_transaction(transaction);
 
-            let result = if consensus_result == ConsensusFfiResponse::Success {
+            let result = if consensus_result == Success {
                 let mut payload = Vec::with_capacity(1 + transaction.len());
                 payload.write_u8(PacketType::Transaction as u8)?;
                 payload.write_all(&transaction)?;
@@ -230,25 +238,23 @@ impl P2p for RpcServerImpl {
             } else {
                 Ok(())
             };
+            // make the successful response. If the transaction was added
+            // and retransmitted then the response is true, otherwise
+            // we respond with false
+            let mk_response = |value| {
+                Response::new(BoolResponse {
+                    value,
+                })
+            };
             match (result, consensus_result) {
-                (Ok(_), ConsensusFfiResponse::Success) => Ok(Response::new(BoolResponse {
-                    value: true,
-                })),
-                (Ok(_), ConsensusFfiResponse::DuplicateEntry) => Ok(Response::new(BoolResponse {
-                    value: false,
-                })),
-                (Ok(_), ConsensusFfiResponse::DeserializationError) => {
-                    Ok(Response::new(BoolResponse {
-                        value: false,
-                    }))
-                }
-                (Ok(_), ConsensusFfiResponse::Stale) => Ok(Response::new(BoolResponse {
-                    value: false,
-                })),
-                (Ok(_), ConsensusFfiResponse::InvalidResult) => Ok(Response::new(BoolResponse {
-                    value: false,
-                })),
-                (Err(e), ConsensusFfiResponse::Success) => {
+                (Ok(_), Success) => Ok(mk_response(true)),
+                (Ok(_), DuplicateEntry) => Ok(mk_response(false)),
+                (Ok(_), DeserializationError) => Ok(mk_response(false)),
+                (Ok(_), Stale) => Ok(mk_response(false)),
+                (Ok(_), InvalidResult) => Ok(mk_response(false)),
+                (Ok(_), TooLowEnergy) => Ok(mk_response(false)),
+                (Ok(_), ExpiryTooLate) => Ok(mk_response(false)),
+                (Err(e), Success) => {
                     warn!("Couldn't put a transaction in the outbound queue due to {:?}", e);
                     Err(Status::new(
                         Code::Internal,

--- a/concordium-node/src/rpc.rs
+++ b/concordium-node/src/rpc.rs
@@ -254,6 +254,7 @@ impl P2p for RpcServerImpl {
                 (Ok(_), InvalidResult) => Ok(mk_response(false)),
                 (Ok(_), TooLowEnergy) => Ok(mk_response(false)),
                 (Ok(_), ExpiryTooLate) => Ok(mk_response(false)),
+                (Ok(_), NonexistingSenderAccount) => Ok(mk_response(false)),
                 (Err(e), Success) => {
                     warn!("Couldn't put a transaction in the outbound queue due to {:?}", e);
                     Err(Status::new(

--- a/scripts/genesis/generate-test-genesis.py
+++ b/scripts/genesis/generate-test-genesis.py
@@ -13,7 +13,9 @@ class DockerRunner:
     # pip3 install docker
 
     def __init__(self):
-        self.image = os.environ.get("GENESIS_TOOLS_DOCKER_IMAGE", default = "concordium/genesis-tools:0.5")
+        self.image = os.environ.get("USE_DOCKER")
+        if self.image == "": # default to latest image
+            self.image = "concordium/genesis-tools:latest"
         import docker
         self.client = docker.from_env()
         self.root = os.getcwd()
@@ -106,6 +108,8 @@ INITIAL_STAKE = os.environ.get("INITIAL_STAKE", default = "3000000.0")
 
 # The number of bakers that will be created.
 NUM_BAKERS = os.environ.get("NUM_BAKERS", default = "5")
+# The number of account keys on each of the generated accounts
+NUM_KEYS = os.environ.get("NUM_KEYS", default = "1")
 
 MAX_BLOCK_ENERGY = os.environ.get("MAX_BLOCK_ENERGY", default = "3000000")
 
@@ -147,6 +151,7 @@ def create_bakers():
                           "--ip-info", os.path.join(GENESIS_DIR, "identity_provider-0.pub.json"),
                           "--global", GLOBAL_FILE,
                           "--num", NUM_BAKERS,
+                          "--num-keys", NUM_KEYS,
                           "--stake", INITIAL_STAKE,
                           "--balance", INITIAL_BALANCE,
                           "--template", "baker-account",


### PR DESCRIPTION
## Purpose

Limit what kinds of transactions are accepted by the node before they are added to the input pool.

## Changes

Check the following when accepting transactions
- transaction's energy is too low to ever be included in a block
- transaction's expiry time is too far in the future. The amount is set as a runtime parameter.
- transactions's size is too large
- introduce a new constant PROTOCOL_MAX_TRANSACTION_SIZE. This is checked at the earliest feasible point so that we do not store large objects in memory
- account does not exist in the last finalized block

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
