### PR TITLE
Bugfixes

### DIFF
--- a/concordium-consensus/src/Concordium/External.hs
+++ b/concordium-consensus/src/Concordium/External.hs
@@ -402,7 +402,7 @@ startConsensusPassive ::
            -> CString -> Int64 -- ^Connection string to access the database. If length is 0 don't do logging.
            -> Ptr (StablePtr ConsensusRunner)
            -> IO Int64
-startConsensusPassive timeout maxTimeToExpiry maxBlock insertionsBeforePurge transactionsPurgingDelay transactionsKeepAlive gdataC gdataLenC cucbk regenesisArcPtr freeRegenesisArc regenesisCB maxLogLevel lcbk appDataC appDataLenC connStringPtr connStringLen runnerPtrPtr = handleStartExceptions logM $ do
+startConsensusPassive maxBlock timeout maxTimeToExpiry insertionsBeforePurge transactionsPurgingDelay transactionsKeepAlive gdataC gdataLenC cucbk regenesisArcPtr freeRegenesisArc regenesisCB maxLogLevel lcbk appDataC appDataLenC connStringPtr connStringLen runnerPtrPtr = handleStartExceptions logM $ do
         gdata <- BS.packCStringLen (gdataC, fromIntegral gdataLenC)
         appData <- peekCStringLen (appDataC, fromIntegral appDataLenC)
         let runtimeParams = RuntimeParameters {

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -1318,7 +1318,8 @@ instance (IsProtocolVersion pv, PersistentState r m) => BlockStateStorage (Persi
 
     dropUpdatableBlockState pbs = liftIO $ writeIORef pbs (error "Block state dropped")
 
-    purgeBlockState pbs = liftIO $ writeIORef (hpbsPointers pbs) (error "Block state purged")
+    purgeBlockState _ = return ()
+    {-# INLINE purgeBlockState #-}
 
     archiveBlockState HashedPersistentBlockState{..} = do
         inner <- liftIO $ readIORef hpbsPointers

--- a/concordium-node/src/connection/message_handlers.rs
+++ b/concordium-node/src/connection/message_handlers.rs
@@ -111,7 +111,10 @@ impl Connection {
             if common_blocks != our_blocks.len() && common_blocks != handshake.genesis_blocks.len()
             {
                 bail!(
-                    "Rejecting handshake: Didn't find a common prefix on the genesis block hashes."
+                    "Rejecting handshake: Didn't find a common prefix on the genesis block \
+                     hashes.\nOur blocks: {:?}\nTheir blocks:{:?}",
+                    our_blocks.clone(),
+                    handshake.genesis_blocks
                 );
             }
         }

--- a/concordium-node/src/network/serialization/fbs.rs
+++ b/concordium-node/src/network/serialization/fbs.rs
@@ -389,7 +389,7 @@ fn serialize_request(
                 .collect::<Vec<flatbuffers::WIPOffset<network::BlockHash>>>();
             builder
                 .start_vector::<flatbuffers::WIPOffset<network::BlockHash>>(genesis_blocks.len());
-            for offset in genesis_blocks.iter() {
+            for offset in genesis_blocks.iter().rev() {
                 builder.push(*offset);
             }
             let genesis_blocks_offset = Some(builder.end_vector(genesis_blocks.len()));

--- a/concordium-node/src/network/serialization/tests.rs
+++ b/concordium-node/src/network/serialization/tests.rs
@@ -45,7 +45,7 @@ test_s11n!(
         remote_port:    1234,
         networks:       [100u16, 1000, 1234, 9999].iter().copied().map(NetworkId::from).collect(),
         node_version:   Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
-        wire_versions:  vec![0],
+        wire_versions:  vec![0, 1, 2],
         genesis_blocks: dummy_regenesis_blocks(),
         proof:          Vec::new(),
     }))

--- a/concordium-node/src/p2p/connectivity.rs
+++ b/concordium-node/src/p2p/connectivity.rs
@@ -115,9 +115,9 @@ impl P2PNode {
     /// exists.
     /// NB: This acquires and releases a read lock on the node's connections.
     pub fn find_conn_to(&self, addr: SocketAddr) -> Option<Token> {
-        read_or_die!(self.connections())
+        lock_or_die!(self.conn_candidates())
             .values()
-            .chain(lock_or_die!(self.conn_candidates()).values())
+            .chain(read_or_die!(self.connections()).values())
             .find_map(|conn| {
                 if conn.remote_addr() == addr {
                     Some(conn.token())

--- a/concordium-node/src/test_utils.rs
+++ b/concordium-node/src/test_utils.rs
@@ -95,7 +95,13 @@ pub fn wait_node_delete_dirs(_: DeletePermission, node: Arc<P2PNode>) {
         .expect("Could not delete node's data directory");
 }
 
-pub fn dummy_regenesis_blocks() -> Vec<BlockHash> { vec![BlockHash::from([0u8; SHA256 as usize])] }
+pub fn dummy_regenesis_blocks() -> Vec<BlockHash> {
+    vec![
+        BlockHash::from([0u8; SHA256 as usize]),
+        BlockHash::from([1u8; SHA256 as usize]),
+        BlockHash::from([2u8; SHA256 as usize]),
+    ]
+}
 
 /// Creates a `P2PNode` for test purposes
 /// This creates a temporary directory for the node's config and data


### PR DESCRIPTION
## Purpose

Bugfixes ported from the #1 branch

## Changes

- ensure consistent locking order when acquiring connection locks
- fix serialization of genesis hashes in network messages
- fix a bug which led to a node crash due to a race condition in some queries

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.