### PR TITLE
Bugfixes.

### DIFF
--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium_node"
-version = "0.7.0" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
+version = "0.7.1" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
 description = "Concordium Node"
 authors = ["Concordium <developers@concordium.com>"]
 exclude = [".gitignore", ".gitlab-ci.yml", "test/**/*","**/**/.gitignore","**/**/.gitlab-ci.yml"]

--- a/concordium-node/src/configuration.rs
+++ b/concordium-node/src/configuration.rs
@@ -228,6 +228,7 @@ pub struct BakerConfig {
         long = "import-blocks-from",
         help = "Path to a file exported by the database exporter"
     )]
+    pub import_path: Option<String>,
     #[structopt(
         long = "max-expiry-duration",
         help = "Maximum allowed time difference between now and a transaction's expiry time in \
@@ -235,7 +236,6 @@ pub struct BakerConfig {
         default_value = "7200"
     )]
     pub max_time_to_expiry: u64,
-    pub import_path: Option<String>,
     #[structopt(long = "baker-credentials-file", help = "Path to the baker credentials file")]
     pub baker_credentials_file: Option<PathBuf>,
     #[structopt(

--- a/concordium-node/src/consensus_ffi/helpers.rs
+++ b/concordium-node/src/consensus_ffi/helpers.rs
@@ -214,7 +214,17 @@ impl ConsensusFfiResponse {
         use ConsensusFfiResponse::*;
 
         match self {
-            BakerNotFound | DeserializationError | InvalidResult | Unverifiable | BlockTooEarly
+            BakerNotFound
+            | DeserializationError
+            | InvalidResult
+            | Unverifiable
+            | BlockTooEarly
+            | ExpiryTooLate
+            | VerificationFailed
+            | NonexistingSenderAccount
+            | DuplicateNonce
+            | NonceTooLarge
+            | TooLowEnergy
             | ConsensusShutDown => false,
             _ => true,
         }
@@ -231,6 +241,12 @@ impl ConsensusFfiResponse {
             | Stale
             | IncorrectFinalizationSession
             | BlockTooEarly
+            | ExpiryTooLate
+            | VerificationFailed
+            | NonexistingSenderAccount
+            | DuplicateNonce
+            | NonceTooLarge
+            | TooLowEnergy
             | ConsensusShutDown => false,
             _ => true,
         }


### PR DESCRIPTION
## Purpose

Actually do not redistribute transactions if consensus says so.

Fix configuration parsing.

## Changes

- Correctly use responses from consensus.
- Fix configuration flag parsing so that `--import-blocks-from` is available as it  should be.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
