### PR TITLE
Updated flatbuffers to v0.9.0 and flatc to v2.0.0.

### DIFF
--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -60,7 +60,7 @@ crossbeam-channel = "0.4"
 semver = { version = "0.11.0", features = ["serde"] }
 ctrlc = "3.1"
 signal-hook = "0.1"
-flatbuffers = { version = "0.7.0" } # Must be updated when we update Rust version.
+flatbuffers = { version = "0.9.0" } # Must be updated when we update Rust version.
 flatc-rust = { version = "0.2.0" }
 sha2 = "0.9"
 lazy_static = "^1.2"


### PR DESCRIPTION
## Purpose

As [Flatbuffers](https://github.com/google/flatbuffers) [v2.0.0](https://github.com/google/flatbuffers/releases/tag/v2.0.0) has been released, the concordium-node should try to use this newer version at some point in the future with https://github.com/Concordium/concordium-node/issues/43 in mind.

## Changes

- Updated the `flatbuffers` rust dependency: 0.7.0 => 0.9.0.
- Updated the code, such that it is compatible with the code generated via `flatc` v2.0.0.

Note: The code has been tested with Rust v1.52.0, as `flatbuffers` > 0.7.0 requires [const generics](https://blog.rust-lang.org/2021/02/26/const-generics-mvp-beta.html), hence Rust v1.51.0 would probably also suffice. 

- [ ] Confirm that this update is backwards compatible.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
