### PR TITLE
Added a rustup toolchain file in order to pin the Rust version.

### DIFF
--- a/concordium-node/rust-toolchain
+++ b/concordium-node/rust-toolchain
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.45.2"


### PR DESCRIPTION
## Purpose

The concordium-node uses a pinned version of Rust.
The version can be pinned in a `rustup-toolchain` file to make it easier for developers i.e., developers no longer manually has to set the toolchain version for the repository. 

## Changeso

Added a rustup-toolchain file which pins the Rust version (Currently v1.45.2).

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
