### PR TITLE
Do not allow rebroadcasting of catch-up status messages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased changes
 
 - Check that baker keys are consistent (private key matches the public one) on startup.
+- Prevent rebroadcast of catch-up status messages.
 
 ## concordium-node 1.0.0
 

--- a/concordium-node/src/consensus_ffi/ffi.rs
+++ b/concordium-node/src/consensus_ffi/ffi.rs
@@ -866,6 +866,10 @@ pub extern "C" fn direct_callback(
 
 pub extern "C" fn catchup_status_callback(msg: *const u8, msg_length: i64) {
     trace!("Catch-up status callback hit - queueing message");
+    // Note: this sends a catch-up status message as a broadcast. This is not ideal:
+    // a catch-up status message should always be sent as a direct message, even
+    // when it is sent to every peer.  However, we will rely on peers not to
+    // rebroadcast catch-up status messages.
     sending_callback!(
         None,
         CallbackType::CatchUpStatus,

--- a/concordium-node/src/consensus_ffi/helpers.rs
+++ b/concordium-node/src/consensus_ffi/helpers.rs
@@ -170,7 +170,7 @@ impl PacketType {
     /// Determine whether a packet type can be relayed.
     /// Those that are must be subject to appropriate de-duplication
     /// checks to ensure they are not relayed endlessly.
-    fn is_rebroadcastable(&self) -> bool {
+    pub fn is_rebroadcastable(&self) -> bool {
         match self {
             PacketType::Block => true,
             PacketType::Transaction => true,

--- a/concordium-node/src/consensus_ffi/helpers.rs
+++ b/concordium-node/src/consensus_ffi/helpers.rs
@@ -166,6 +166,21 @@ impl fmt::Display for PacketType {
     }
 }
 
+impl PacketType {
+    /// Determine whether a packet type can be relayed.
+    /// Those that are must be subject to appropriate de-duplication
+    /// checks to ensure they are not relayed endlessly.
+    fn is_rebroadcastable(&self) -> bool {
+        match self {
+            PacketType::Block => true,
+            PacketType::Transaction => true,
+            PacketType::FinalizationRecord => true,
+            PacketType::FinalizationMessage => true,
+            PacketType::CatchUpStatus => false,
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum ConsensusFfiResponse {
     BakerNotFound = -1,

--- a/concordium-node/src/plugins/consensus.rs
+++ b/concordium-node/src/plugins/consensus.rs
@@ -250,7 +250,10 @@ pub fn handle_consensus_inbound_msg(
     let source = request.source_peer();
 
     if node.config.no_rebroadcast_consensus_validation {
-        if !drop_message && request.distribution_mode() == DistributionMode::Broadcast {
+        if !drop_message
+            && request.distribution_mode() == DistributionMode::Broadcast
+            && request.variant.is_rebroadcastable()
+        {
             send_consensus_msg_to_net(
                 &node,
                 request.dont_relay_to(),
@@ -280,6 +283,7 @@ pub fn handle_consensus_inbound_msg(
         // rebroadcast incoming broadcasts if applicable
         if !drop_message
             && request.distribution_mode() == DistributionMode::Broadcast
+            && request.variant.is_rebroadcastable()
             && consensus_result.is_rebroadcastable()
         {
             send_consensus_msg_to_net(


### PR DESCRIPTION
## Purpose

Prevent a node from relaying a catch-up status message to its peers even if it is sent as a broadcast message.

## Changes

When deciding whether a message can be rebroadcast, check that its type supports it.
Define `is_rebroadcastable` for `PacketType`, disallowing rebroadcasts for catch-up status messages.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.