### PR TITLE
Improve handling of funny characters and spaces in node names.

### DIFF
--- a/scripts/distribution/ubuntu-packages/template/debian/postinst
+++ b/scripts/distribution/ubuntu-packages/template/debian/postinst
@@ -14,7 +14,7 @@ then
     mkdir -p /etc/systemd/system/concordium-node-collector.service.d/
     cat > /etc/systemd/system/concordium-node-collector.service.d/override.conf <<EOF
 [Service]
-Environment="COLLECTOR_NODE_NAME=$NODE_NAME"
+Environment='COLLECTOR_NODE_NAME=`systemd-escape "$NODE_NAME"`'
 EOF
 else
     echo "Node collector override file '/etc/systemd/system/node-collector.d/override.conf' already exists."

--- a/scripts/distribution/ubuntu-packages/template/scripts/concordium-node-wrapper
+++ b/scripts/distribution/ubuntu-packages/template/scripts/concordium-node-wrapper
@@ -157,15 +157,6 @@ then
     ARGS="$ARGS --collector-url $COLLECTOR_URL"
 fi
 
-if [ -n "$COLLECTOR_NODE_NAME" ];
-then
-    ARGS="$ARGS --node-name $COLLECTOR_NODE_NAME"
-elif [ "$MODE" == "collector" ];
-then
-    echo "Node name must be given for the collector."
-    exit 1
-fi
-
 if [ -n "$COLLECTOR_GRPC_HOST" ];
 then
     ARGS="$ARGS --grpc-host $COLLECTOR_GRPC_HOST"
@@ -194,7 +185,16 @@ if [ "$MODE" == "basic" ]; then
 elif [ "$MODE" == "bootstrapper" ]; then
     /usr/bin/p2p_bootstrapper-cli $ARGS
 elif [ "$MODE" == "collector" ]; then
-    /usr/bin/node-collector $ARGS
+    if [ -n "COLLECTOR_NODE_NAME" ];
+    then
+        # this slightly awkward handling of the node name is needed so that
+        # we support node names with spaces. Otherwise when we construct the ARGS string above,
+        # when we splice it here the different words in the name get passed as separate arguments.
+        /usr/bin/node-collector $ARGS --node-name "$COLLECTOR_NODE_NAME"
+    else
+        echo "Node name must be given for the collector."
+        exit 1
+    fi
 else
     echo "No matching MODE was found. Please check!"
 fi

--- a/scripts/distribution/ubuntu-packages/template/scripts/concordium-node-wrapper
+++ b/scripts/distribution/ubuntu-packages/template/scripts/concordium-node-wrapper
@@ -188,8 +188,8 @@ elif [ "$MODE" == "collector" ]; then
     if [ -n "COLLECTOR_NODE_NAME" ];
     then
         # this slightly awkward handling of the node name is needed so that
-        # we support node names with spaces. Otherwise when we construct the ARGS string above,
-        # when we splice it here the different words in the name get passed as separate arguments.
+        # we support node names with whitespace. Otherwise the ARGS string might have spaces,
+        # and items separated with spaces are passed as separate arguments here.
         /usr/bin/node-collector $ARGS --node-name "$COLLECTOR_NODE_NAME"
     else
         echo "Node name must be given for the collector."


### PR DESCRIPTION
## Purpose

The node collector that is part of the debian package would fail to start if the node name would contain spaces, or other funny characters.
This attempts to improve upon that.

## Changes

Escape and properly quote the node name.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.