### PR TITLE
Clarification on unencrypted credentials.

### DIFF
--- a/scripts/distribution/docker-entrypoint.sh
+++ b/scripts/distribution/docker-entrypoint.sh
@@ -27,7 +27,14 @@ if [ -f /var/lib/concordium/data/baker-credentials.json ];
 then
     if grep -q cipherText /var/lib/concordium/data/baker-credentials.json; then
         echo "This distribution does not support encrypted baker credentials."
-        echo "Please decrypt the baker credentials file before starting the baker."
+        echo "Please replace baker-credentials.json with unencrypted credentials"
+        echo "and restart the baker."
+        echo ""
+        echo "Unencrypted credentails can be generated with"
+        echo "  concordium-client baker generate-keys <keys-file>.json"
+        echo "supplying no password at the prompt."
+        echo "To replace the baker keys on your account with these, use"
+        echo "  concordium-client baker set-keys <keys-file>.json --sender bakerAccount --out <concordium-data-dir>/baker-credentials.json"
         exit 1
     fi
     export BAKER_CREDENTIALS_FILENAME="baker-credentials.json"


### PR DESCRIPTION
## Purpose

Change the message when a docker node is started with encrypted credentials to explain how to generate unencrypted credentials instead.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
