### PR TITLE
getenvoy fix

### DIFF
--- a/scripts/distribution/builder.Dockerfile
+++ b/scripts/distribution/builder.Dockerfile
@@ -78,7 +78,7 @@ ENV ENABLE_TERM_HANDLER=true
 
 RUN apt-get update && apt-get install -y unbound curl netbase ca-certificates supervisor nginx libnuma1 libtinfo6 libpq-dev liblmdb-dev jq
 RUN curl -L https://getenvoy.io/cli | bash -s -- -b /usr/local/bin
-RUN getenvoy fetch standard:1.17.0
+RUN getenvoy use 1.18.3
 
 COPY --from=node-dashboard /static /node-dashboard/static
 COPY --from=node-dashboard /envoy.yaml /node-dashboard/envoy.yaml

--- a/scripts/distribution/builder.Dockerfile
+++ b/scripts/distribution/builder.Dockerfile
@@ -77,7 +77,7 @@ ENV DISTRIBUTION_CLIENT=true
 ENV ENABLE_TERM_HANDLER=true
 
 RUN apt-get update && apt-get install -y unbound curl netbase ca-certificates supervisor nginx libnuma1 libtinfo6 libpq-dev liblmdb-dev jq
-RUN curl -L https://getenvoy.io/cli | bash -s -- -b /usr/local/bin
+RUN curl -L https://getenvoy.io/install.sh | bash -s -- -b /usr/local/bin
 RUN getenvoy use 1.18.3
 
 COPY --from=node-dashboard /static /node-dashboard/static

--- a/scripts/distribution/concordium.conf
+++ b/scripts/distribution/concordium.conf
@@ -16,7 +16,7 @@ user=docker
 startretries=50
 
 [program:grpc-web-proxy]
-command=getenvoy run standard:1.17.0 -- --config-path /node-dashboard/envoy.yaml
+command=getenvoy run -c /node-dashboard/envoy.yaml
 autostart=true
 autorestart=true
 startretries=50


### PR DESCRIPTION
## Purpose

Fixing the docker distribution builds. 
It used a no longer supported `getenvoy` version, which resulted in failed builds. 

## Changes

Updated the usages of `getenvoy` such that it accommodates the new API. 

- [x] Confirm that the newly generated docker distribution image actually works. 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

