### PR TITLE
Unexpose the GRPC web proxy previously used the node-dashboard

### DIFF
--- a/scripts/distribution/builder.Dockerfile
+++ b/scripts/distribution/builder.Dockerfile
@@ -60,8 +60,6 @@ ARG environment
 EXPOSE 8888
 # Node dashboard
 EXPOSE 8099
-# GRPC-web proxy
-EXPOSE 9999
 # GRPC
 EXPOSE 10000
 ENV RPC_SERVER_ADDR=0.0.0.0


### PR DESCRIPTION
## Purpose/Changes

Unexpose GRPC web proxy port from Dockerfile

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
