### PR TITLE
Backwards compatibillity fix for collector.

### DIFF
--- a/concordium-node/src/bin/collector.rs
+++ b/concordium-node/src/bin/collector.rs
@@ -416,6 +416,7 @@ async fn collect_data<'a>(
         consensusBakerId: baker_id,
         finalizationCommitteeMember: finalization_committee,
         ancestorsSinceBestBlock: ancestors_since_best_block,
+        stagingNetUsername: None,
         last_updated: 0,
         transactionsPerBlockEMA: transactions_per_block_ema,
         transactionsPerBlockEMSD: transactions_per_block_emsd,

--- a/concordium-node/src/common/collector_utils.rs
+++ b/concordium-node/src/common/collector_utils.rs
@@ -38,6 +38,9 @@ pub struct NodeInfo {
     pub consensusBakerId: Option<u64>,
     pub finalizationCommitteeMember: bool,
     pub ancestorsSinceBestBlock: Option<Vec<String>>,
+    // stagingNetUsername should not be used.
+    // It exists to ensure backwards compatibillity and should not be removed.
+    pub stagingNetUsername: Option<String>,
     pub transactionsPerBlockEMA: Option<f64>,
     pub transactionsPerBlockEMSD: Option<f64>,
     pub bestBlockTransactionsSize: Option<u64>,


### PR DESCRIPTION
## Purpose

It turns out that the PR https://github.com/Concordium/concordium-node/pull/79/ introduced a non-backwards compatible change to the collector.

## Changes

Introduced the `stagingNetUsername` field for the `NodeInfo` type in order to make the communication between the node-collector and node-collector-backend backwards compatible.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
