### PR TITLE
Update static libraries build script.

### DIFF
--- a/scripts/static-libraries/build-and-push-static-libs.sh
+++ b/scripts/static-libraries/build-and-push-static-libs.sh
@@ -5,19 +5,6 @@
 #
 # This will create a docker container that will build the tar archives to the
 # `out` directory and will push the archives to aws s3.
-#
-# It will also modify the `scripts/LATEST_STATIC_LIBRARIES` file with the
-# commit hash of the built libraries. This file is later consumed by
-# `scripts/download-static-libraries.sh` to correctly place all the required
-# libraries for the node to be started with the features `static` or `profiling`.
-#
-# Note this script cannot be used with branches that are push-protected such
-# as `master` or `develop`.
-#
-# This script is consumed by `jenkinsfiles/static-libraries.Jenkinsfile`.
-
-# checkout requested branch for later push
-BRANCH=$(echo $GIT_BRANCH | cut -d'/' -f2-)
 
 set -e
 

--- a/scripts/static-libraries/build-static-libraries.sh
+++ b/scripts/static-libraries/build-static-libraries.sh
@@ -37,8 +37,7 @@ done
 #############################################################################################################################
 ## Copy rust binaries
 
-# TODO: genesis executable might be gone
-cp $(find /build/concordium-base/.stack-work -type f \( -name genesis -or -name generate-update-keys \)) /binaries/bin/
+cp $(stack --stack-yaml /build/concordium-consensus/stack.integer-simple.yaml path --profile --local-install-root)/bin/{generate-update-keys,genesis,database-exporter} /binaries/bin/
 cp /build/concordium-base/rust-src/target/release/*.so /binaries/lib/
 cp /build/concordium-consensus/smart-contracts/wasm-chain-integration/target/release/*.so /binaries/lib/
 cargo build --release --manifest-path /build/concordium-base/rust-bins/Cargo.toml


### PR DESCRIPTION
## Purpose

Cleanup and expose all built binaries.

## Changes

- Remove obsolete comments
- Add the database exporter to the list of exported binaries. This will make it possible to use it in the node deb package, speeding up the build since the entire consensus will not have to be built twice.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG
