### PR TITLE
WIP: Blockstate flushing

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
@@ -53,6 +53,7 @@ import qualified Concordium.Types.IdentityProviders as IPS
 import qualified Concordium.Types.AnonymityRevokers as ARS
 import qualified Concordium.GlobalState.Parameters as Parameters
 import Concordium.GlobalState.Basic.BlockState.AccountReleaseSchedule
+import Concordium.GlobalState.Persistent.BlobStore.Flush
 import Concordium.Types
 import Concordium.Types.Updates
 import Concordium.Wasm
@@ -114,7 +115,7 @@ loadBlobStore blobStoreFilePath = do
 -- ensuring all the contents is written out.
 flushBlobStore :: BlobStore -> IO ()
 flushBlobStore BlobStore{..} =
-    withMVar blobStoreFile (hFlush . bhHandle)
+    withMVar blobStoreFile (hFlushOS . bhHandle)
 
 -- |Close all references to the blob store, flushing it
 -- in the process.

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore/Flush.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore/Flush.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE CPP #-}
+
+-- |This module provides functionality for flushing the operating system buffer associated with
+-- a file handle.
+module Concordium.GlobalState.Persistent.BlobStore.Flush(hFlushOS) where
+
+import Control.Concurrent
+import Control.Monad
+import Foreign.C
+import GHC.IO.Exception
+import GHC.IO.FD
+import GHC.IO.Handle.FD (handleToFd)
+import System.IO
+
+#if defined(mingw32_HOST_OS)
+import GHC.Windows
+#endif
+
+#if defined(mingw32_HOST_OS)
+
+foreign import ccall safe "FlushFileBuffers" flushFileBuffers :: CInt -> IO CInt
+
+#else
+
+foreign import ccall safe "fsync" fsync :: CInt -> IO CInt
+
+#endif
+
+osFlush :: Handle -> IO ()
+osFlush h = do
+    fd <- handleToFd h
+
+#if defined(mingw32_HOST_OS)
+    when (fdIsSocket_ fd /= 0) $ ioException $
+        IOError (Just h) IllegalOperation "hFlushOS" "is a socket" Nothing Nothing
+    res <- flushFileBuffers (fdFD fd)
+    when (res /= 0) $ throwGetLastError "hFlushOS"
+
+#else
+    res <- fsync (fdFD fd)
+    when (res /= 0) $ ioError $ errnoToIOError "hFlushOS" res (Just h) Nothing
+
+#endif
+
+-- |Flush a file handle, including the operating system buffers.
+hFlushOS :: Handle -> IO ()
+hFlushOS h = runInBoundThread $ do
+    hFlush h
+    osFlush h


### PR DESCRIPTION
## Purpose

Ensure that the operating system buffers are flushed when the block state is written.
Previously, the file handle was flushed with `hFlush`, but this only ensures the data is sent to the operating system; it does not ensure that the operating system has written it to disk.
This meant that the blockstate was not guaranteed to be written before the tree state that references it, leading to database corruption if the node is terminated unexpectedly.

## Changes

Introduce `hFlushOS`, which calls `FlushFileBuffers` (on Windows) or `fsync` (on Unix) to enforce flushing of the file to disk.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
