### PR TITLE
Fix underflow error when calculating average throughput

### DIFF
--- a/concordium-node/src/p2p/peers.rs
+++ b/concordium-node/src/p2p/peers.rs
@@ -173,7 +173,7 @@ fn calculate_average_throughput(
 
     ensure!(
         bytes_sent >= prev_bytes_sent,
-        "Sent bytes was lost. Refusing to calculate average throughput."
+        "Sent bytes were lost. Refusing to calculate average throughput."
     );
     let avg_bps_out = (milliseconds_to_second * (bytes_sent - prev_bytes_sent)) / delta;
 

--- a/concordium-node/src/p2p/peers.rs
+++ b/concordium-node/src/p2p/peers.rs
@@ -211,7 +211,7 @@ mod tests {
 
         assert!(
             calculate_average_throughput(1, 1001, 1001, 1002, 1001, 1000).is_err(),
-            "Sent bytes was lost. Refusing to calculate average throughput."
+            "Sent bytes were lost. Refusing to calculate average throughput."
         );
     }
 }

--- a/concordium-node/src/p2p/peers.rs
+++ b/concordium-node/src/p2p/peers.rs
@@ -206,7 +206,7 @@ mod tests {
 
         assert!(
             calculate_average_throughput(1, 1001, 1002, 1001, 1001, 1002).is_err(),
-            "Received bytes was lost. Refusing to calculate average throughput."
+            "Received bytes were lost. Refusing to calculate average throughput."
         );
 
         assert!(

--- a/concordium-node/src/p2p/peers.rs
+++ b/concordium-node/src/p2p/peers.rs
@@ -164,9 +164,10 @@ fn calculate_average_throughput(
         "Time went backwards or did not change. Refusing to calculate average throughput."
     );
     let delta: u64 = (now_millis - before_millis) as u64; // as is safe since we checked the difference is positive.
-
-    let avg_bps_in = (milliseconds_to_second * (bytes_recv - prev_bytes_recv)) / delta;
-    let avg_bps_out = (milliseconds_to_second * (bytes_sent - prev_bytes_sent)) / delta;
+    let recv_diff = if bytes_recv > prev_bytes_recv { bytes_recv - prev_bytes_recv } else {0};
+    let sent_diff = if bytes_sent > prev_bytes_sent { bytes_sent - prev_bytes_sent } else {0};
+    let avg_bps_in = (milliseconds_to_second * recv_diff) / delta;
+    let avg_bps_out = (milliseconds_to_second * sent_diff) / delta;
 
     Ok((avg_bps_in, avg_bps_out))
 }

--- a/concordium-node/src/p2p/peers.rs
+++ b/concordium-node/src/p2p/peers.rs
@@ -167,7 +167,7 @@ fn calculate_average_throughput(
 
     ensure!(
         bytes_recv >= prev_bytes_recv,
-        "Received bytes was lost. Refusing to calculate average throughput."
+        "Received bytes were lost. Refusing to calculate average throughput."
     );
     let avg_bps_in = (milliseconds_to_second * (bytes_recv - prev_bytes_recv)) / delta;
 


### PR DESCRIPTION
## Purpose

The purpose of the PR is to fix the throughput calculation.
Two errors occurred during sync up of the node:

```
2021-07-05T19:02:35.325119000Z: INFO: Skov: Block 7ef3d93c7fa85315832e244ec1ebca9a1671faf897345c3d42e399952a98f18f (7) arrived
2021-07-05T19:02:35.325196000Z: INFO: Skov: Arrive statistics: blocksVerifiedCount=33550 blockLastArrive=1.625511755325089e9 blockArriveLatencyEMA=1954089.2030786565 blockArriveLatencyEMSD=126.40072964454215 blockArrivePeriodEMA=Just 6.001992925280544e-3 blockArrivePeriodEMSD=Just 4.337716518563018e-3 transactionsPerBlockEMA=8.300923972273165e-21 transactionsPerBlockEMSD=9.110940660696488e-11
2021-07-05T19:02:47.116869000Z: WARN: Received 13 invalid messages from peer 0000000000000005
2021-07-05T19:02:47.116900000Z: WARN: Received 5 invalid messages from peer 000000000000000b
2021-07-05T19:02:47.116910000Z: WARN: Received 2 invalid messages from peer 0000000000000007
2021-07-05T19:02:47.116919000Z: WARN: Received 16 invalid messages from peer 0000000000000009
2021-07-05T19:02:47.116929000Z: WARN: Received 2 invalid messages from peer 000000000000000e
2021-07-05T19:02:47.116939000Z: WARN: Received 12 invalid messages from peer 0000000000000003
2021-07-05T19:02:47.116948000Z: WARN: Received 8 invalid messages from peer 0000000000000008
2021-07-05T19:02:47.116958000Z: WARN: Received 7 invalid messages from peer 0000000000000006
2021-07-05T19:02:47.116967000Z: WARN: Received 10 invalid messages from peer 0000000000000010
2021-07-05T19:02:47.116976000Z: WARN: Received 7 invalid messages from peer 000000000000000c
thread 'poll loop' panicked at 'attempt to subtract with overflow', src/p2p/peers.rs:168:48
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
2021-07-05T19:02:47.121339000Z: ERROR: Can't join a node thread: Any
[.....]
2021-07-05T19:17:02.133756000Z: INFO: Skov: Receive statistics: blocksReceivedCount=31257 blockLastReceived=1.625512622132366e9 blockReceiveLatencyEMA=1762308.3119779525 blockReceiveLatencyEMSD=397816.2106821693 blockReceivePeriodEMA=Just 1.4094761584776846e-2 blockReceivePeriodEMSD=Just 2.581884588708582e-2
2021-07-05T19:17:02.135069000Z: INFO: Skov: Receive statistics: blocksReceivedCount=31258 blockLastReceived=1.625512622134128e9 blockReceiveLatencyEMA=1645463.7941929572 blockReceiveLatencyEMSD=515078.37826979376 blockReceivePeriodEMA=Just 1.2861485426299162e-2 blockReceivePeriodEMSD=Just 2.4771763227404806e-2
2021-07-05T19:17:02.139215000Z: WARN: Received 9 invalid messages from peer 0000000000000010
2021-07-05T19:17:02.139294000Z: WARN: Received 7 invalid messages from peer 000000000000000d
2021-07-05T19:17:02.139320000Z: WARN: Received 24 invalid messages from peer 0000000000000006
2021-07-05T19:17:02.139342000Z: WARN: Received 18 invalid messages from peer 0000000000000003
2021-07-05T19:17:02.139365000Z: WARN: Received 40 invalid messages from peer 0000000000000007
2021-07-05T19:17:02.139387000Z: WARN: Received 8 invalid messages from peer 0000000000000004
2021-07-05T19:17:02.139410000Z: WARN: Received 13 invalid messages from peer 0000000000000005
2021-07-05T19:17:02.139432000Z: WARN: Received 44 invalid messages from peer 000000000000000e
2021-07-05T19:17:02.139465000Z: INFO: Skov: Receive statistics: blocksReceivedCount=31259 blockLastReceived=1.625512622137967e9 blockReceiveLatencyEMA=1540302.8785703615 blockReceiveLatencyEMSD=581639.5152980762 blockReceivePeriodEMA=Just 1.1959236883669245e-2 blockReceivePeriodEMSD=Just 2.3655923147263662e-2
thread 'poll loop' panicked at 'attempt to subtract with overflow', src/p2p/peers.rs:170:55
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
2021-07-05T19:17:02.140212000Z: ERROR: Can't join a node thread: Any
```

## Changes

The throughput calculation is fixed by making sure that the difference in sent and receive is bigger/equal to zero.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
