### PR TITLE
Add additional sandboxing for the node process.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
   that flags now need to have an explicit argument.
 - Disable dnssec by default. This replaces the flag `--no-dnssec` with
   `--require-dnssec`, and the environment variable
-  `CONCORIDUM_NODE_CONNECTION_NO_DNSSEC` with `CONCORDIUM_NODE_CONNECTION_REQUIRE_DNSSEC`.
+  `CONCORDIUM_NODE_CONNECTION_NO_DNSSEC` with `CONCORDIUM_NODE_CONNECTION_REQUIRE_DNSSEC`.
 - Global state database now includes version metadata. The treestate directory and blockstate file
   names are suffixed with "-0" to indicate genesis index 0, for compatibility with protocol updates.
   A legacy database will automatically be migrated by renaming and adding version metadata.

--- a/scripts/distribution/ubuntu-packages/README.md
+++ b/scripts/distribution/ubuntu-packages/README.md
@@ -178,7 +178,7 @@ The node supports the following environment variables.
   and some other parts of the system.
   The recommended way to expose the baker keys to the node is to use the
   `BindReadOnlyPaths` option to remap the file from wherever it is on the host
-  system to a locatio which the node can read. For example (this assumes the baker keys are located in `/home/user/baker-credentials.json` on the host system)
+  system to a location which the node can read. For example (this assumes the baker keys are located in `/home/user/baker-credentials.json` on the host system)
   ```
   Environment=CONCORDIUM_NODE_BAKER_CREDENTIALS_FILE=%S/concordium/baker-credentials.json
   BindReadOnlyPaths=/home/user/baker-credentials.json:%S/concordium/baker-credentials.json

--- a/scripts/distribution/ubuntu-packages/README.md
+++ b/scripts/distribution/ubuntu-packages/README.md
@@ -62,7 +62,7 @@ The strategy for building the package is as follows.
    emitted by the genesis tool into a file `genesis_hash`)
 5. Update
    [template/debian/concordium-node.service](template/debian/concordium-node.service)
-   to match `CONCORDIUM_NODE_CONFIG_DIR` and `CONCORDIUM_NODE_DATA_DIR` to the genesis hash.
+   to match `StateDirectory` and WorkingDirectory values to match the genesis hash.
 6. Possibly update  `CONCORDIUM_NODE_CONNECTION_BOOTSTRAP_NODES` if it does not point to the correct
    network.
 7. Possibly update `CONCORDIUM_NODE_COLLECTOR_URL` in
@@ -171,9 +171,19 @@ which will set the environment variable `CONCORDIUM_NODE_LISTEN_PORT` to `8888` 
 
 The node supports the following environment variables.
 
-- `CONCORDIUM_NODE_BAKER_CREDENTIALS_FILE` the file with baker keys. This must be an absolute
-  path. If it is set then the node will start as a baker. Setting this variable
-  is the way for the node to become a baker.
+- `CONCORDIUM_NODE_BAKER_CREDENTIALS_FILE` the file with baker keys.
+  If it is set then the node will start as a baker, or at least attempt to.
+  This must be a path relative to the `WorkingDirectory` or an absolute path.
+  Since the node is sandboxed it does not have access to the `/home` directory
+  and some other parts of the system.
+  The recommended way to expose the baker keys to the node is to use the
+  `BindReadOnlyPaths` option to remap the file from wherever it is on the host
+  system to a locatio which the node can read. For example (this assumes the baker keys are located in `/home/user/baker-credentials.json` on the host system)
+  ```
+  Environment=CONCORDIUM_NODE_BAKER_CREDENTIALS_FILE=%S/concordium/baker-credentials.json
+  BindReadOnlyPaths=/home/user/baker-credentials.json:%S/concordium/baker-credentials.json
+  ```
+
 
 - `CONCORDIUM_NODE_LISTEN_PORT`, the port on which the node is listening for incoming
   connections. This should be opened in any firewall rules so that the node is a
@@ -213,7 +223,7 @@ The node supports the following environment variables.
   remapped) then this should be set to the external port so that other nodes can
   successfully connect.
 
-- `CONCORDIUM_NODE_CONNECTION_CONNECT_TO` is a comma separated list of peers which the node will try 
+- `CONCORDIUM_NODE_CONNECTION_CONNECT_TO` is a comma separated list of peers which the node will try
 to keep connection to and never drop. The peers must be in the format `addr:port` where addr and port are the
   address and port of a "trusted node".
 
@@ -278,7 +288,7 @@ concordium-node.service: Main process exited, code=exited, status=1/FAILURE
 concordium-node.service: Failed with result 'exit-code'.
 ```
 
-In order to `recover` from such a situation, one should take the following steps. 
+In order to `recover` from such a situation, one should take the following steps.
 
 - Stop the concordium-node service by running the command `sudo systemctl stop concordium-node.service`
 
@@ -288,7 +298,7 @@ Where $GENESIS_HASH is a hash derived from the configured genesis data.
 
 - Start the concordium-node service again by running `sudo systemctl start concordium-node-collector.service`.
 
-The concordium-node should now be up and running again. 
+The concordium-node should now be up and running again.
 Verify with the command: `sudo systemctl status concordium-node`.
 
 ## Configuration of the collector

--- a/scripts/distribution/ubuntu-packages/template/debian/concordium-node.service
+++ b/scripts/distribution/ubuntu-packages/template/debian/concordium-node.service
@@ -4,15 +4,15 @@ After=syslog.target network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/concordium-node
+ExecStart=/usr/bin/concordium-node --config-dir ${STATE_DIRECTORY}/config --data-dir ${STATE_DIRECTORY}/data
 Restart=always
 RestartSec=20
 
 # sandboxing
 # do not allow the process to access /home, /root, and /run/user
 ProtectHome=yes
-# mount /usr, /boot, /efi, and /etc as read-only
-ProtectSystem=full
+# mount /usr, /boot, /efi, and /etc as read-only. Implied by dynamic-user as well.
+ProtectSystem=strict
 NoNewPrivileges=yes
 ProtectClock=yes
 PrivateDevices=yes
@@ -25,6 +25,14 @@ ProtectKernelModules=yes
 ProtectKernelTunables=yes
 CapabilityBoundingSet=
 LockPersonality=yes
+RestrictRealtime=yes
+MemoryDenyWriteExecute=yes
+DynamicUser=yes
+# state directory is relative to /var/lib/, see systemd man pages Sandboxing section.
+# This sets the STATE_DIRECTORY environment variable that is used as part of the ExecStart command.
+StateDirectory=concordium/b6078154d6717e909ce0da4a45a25151b592824f31624b755900a74429e3073d
+# relative to the state directory root %S
+WorkingDirectory=%S/concordium/b6078154d6717e909ce0da4a45a25151b592824f31624b755900a74429e3073d
 
 # port on which the node will listen for incoming connections
 Environment=CONCORDIUM_NODE_LISTEN_PORT=8888
@@ -34,9 +42,6 @@ Environment=CONCORDIUM_NODE_CONNECTION_BOOTSTRAP_NODES=bootstrap.testnet.concord
 Environment=CONCORDIUM_NODE_CONNECTION_DESIRED_NODES=5
 # maximum number of __nodes__ the node will be connected to.
 Environment=CONCORDIUM_NODE_CONNECTION_MAX_ALLOWED_NODES=10
-# configuration and data directories.
-Environment=CONCORDIUM_NODE_CONFIG_DIR=/var/lib/concordium/b6078154d6717e909ce0da4a45a25151b592824f31624b755900a74429e3073d/config
-Environment=CONCORDIUM_NODE_DATA_DIR=/var/lib/concordium/b6078154d6717e909ce0da4a45a25151b592824f31624b755900a74429e3073d/data
 # address of the GRPC server
 Environment=CONCORDIUM_NODE_RPC_SERVER_ADDR=0.0.0.0
 # and its port
@@ -53,8 +58,6 @@ Environment=CONCORDIUM_NODE_NO_LOG_TIMESTAMP=true
 Environment=CONCORDIUM_NODE_CONNECTION_BOOTSTRAPPING_INTERVAL=1800
 # Haskell RTS flags to pass to consensus.
 Environment=CONCORDIUM_NODE_BAKER_HASKELL_RTS_FLAGS=-N2
-# Haskell binding needs proper library path to function
-Environment=LD_LIBRARY_PATH=/usr/local/lib
     
 [Install]
 # start the service when reaching multi-user target


### PR DESCRIPTION
The main restriction is to run as a dynamically allocated user and no longer as root.
The effect of this change is that `systemd-analyze security` reports

```
systemd-analyze security concordium-node.service
...
→ Overall exposure level for concordium-node.service: 4.2 OK
```

An upgrade from 5 Medium of before.

Additional sandboxing could be done by limiting system calls, but that is a lot
more tricky, and the benefits are not great for the node.

## Purpose

Closes #74 by improving adding additional limitations to the service. It no longer runs as root.

## Changes

- Add configuration options to restrict the node service further.
- Update documentation.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

