### PR TITLE
Reduce lock contention for queries.

### DIFF
--- a/concordium-consensus/package.yaml
+++ b/concordium-consensus/package.yaml
@@ -59,6 +59,14 @@ dependencies:
 - file-embed >= 0.0.11
 - lmdb
 
+when:
+  - condition: os(linux)
+    dependencies:
+      - name: unix
+        mixin:
+          - hiding (System.Posix.IO.ByteString)
+      - unix-bytestring
+
 default-extensions:
 - FlexibleContexts
 - FlexibleInstances


### PR DESCRIPTION
In the current setup there is a global lock on database operations because all the operations are through a single file handle. This is somewhat of a necessity since Haskell mandates that a file can be opened either in read mode by many, or as a single instance in write (or readwrite) mode. However all modern operating systems allow opening files by multiple readers and writers by one or multiple processes.

On linux there is the call [pread](https://man7.org/linux/man-pages/man2/pwrite.2.html) which allows to read from a file descriptor without modifying it. This allows concurrent file access, the synchronization being handled by the operating system. This avoids constant seeks necessary in the current setup.

These changes (see timings below) make the queries now CPU bound. The reason for high CPU usage on the node side is that a lot of values are quite expensive to deserialize. The main culprits are various keys since we check during deserialization that they are valid. This happens always, even if we already know they are valid because we store them in the node's database. Changing this behaviour so that we could have "trusted deserialization" methods which would check less is non-trivial though and might require changing the serialization format to explicitly record length. But it will speed up queries a lot if we do not have to go through the step fully deserializing and promptly JSON encoding the value we retrieve.

Times to query all accounts (there are 418) in block
ebef3627979fc2ec1d5e182265378639988e93d3fb309df41e2e223cc6fd39f0 on the testnet
with the old node running with --haskell-rts-flags=-N4.

The first column indicates how many parallel requests were made. As is clear
from the numbers, most of the time that the client has spent is waiting for a
response (the user time is a small percentage of execution time).
```
1  0.11s user 0.04s system 8% cpu 1.715 total
2  0.05s user 0.06s system 6% cpu 1.703 total
3  0.12s user 0.02s system 5% cpu 2.532 total
4  0.13s user 0.08s system 5% cpu 3.913 total
5  0.13s user 0.08s system 5% cpu 4.162 total
6  0.13s user 0.08s system 5% cpu 3.917 total
7  0.14s user 0.07s system 4% cpu 4.246 total
8  0.15s user 0.05s system 4% cpu 4.128 total
9  0.15s user 0.06s system 4% cpu 4.700 total
10 0.13s user 0.08s system 4% cpu 4.353 total
11 0.14s user 0.09s system 4% cpu 4.909 total
12 0.08s user 0.09s system 4% cpu 3.771 total
13 0.08s user 0.12s system 4% cpu 4.098 total
14 0.13s user 0.09s system 4% cpu 4.980 total
15 0.10s user 0.10s system 4% cpu 4.176 total
16 0.14s user 0.12s system 5% cpu 4.715 total
17 0.11s user 0.14s system 4% cpu 5.365 total
18 0.12s user 0.09s system 4% cpu 4.774 total
19 0.13s user 0.07s system 4% cpu 4.436 total
20 0.14s user 0.10s system 4% cpu 5.199 total
21 0.12s user 0.12s system 4% cpu 5.371 total
22 0.14s user 0.11s system 4% cpu 5.526 total
23 0.14s user 0.09s system 4% cpu 4.974 total
24 0.18s user 0.11s system 4% cpu 6.493 total
25 0.12s user 0.08s system 5% cpu 3.660 total
26 0.13s user 0.08s system 4% cpu 4.943 total
27 0.16s user 0.08s system 4% cpu 4.916 total
28 0.15s user 0.08s system 3% cpu 5.733 total
29 0.16s user 0.09s system 4% cpu 5.189 total
30 0.13s user 0.07s system 5% cpu 3.766 total
31 0.15s user 0.07s system 4% cpu 4.865 total
32 0.19s user 0.07s system 3% cpu 6.600 total
```

Times to query the same accounts with the new node, running with
`--haskell-rts-flags=-N4`
```
1  0.08s user 0.06s system 10% cpu 1.342 total
2  0.07s user 0.04s system 12% cpu 0.887 total
3  0.08s user 0.02s system 16% cpu 0.656 total
4  0.05s user 0.05s system 19% cpu 0.505 total
5  0.06s user 0.04s system 16% cpu 0.597 total
6  0.07s user 0.03s system 18% cpu 0.561 total
7  0.06s user 0.04s system 15% cpu 0.656 total
8  0.06s user 0.04s system 17% cpu 0.566 total
9  0.07s user 0.02s system 17% cpu 0.551 total
10 0.07s user 0.03s system 17% cpu 0.552 total
11 0.08s user 0.02s system 17% cpu 0.545 total
12 0.05s user 0.05s system 16% cpu 0.555 total
13 0.04s user 0.05s system 15% cpu 0.555 total
14 0.04s user 0.04s system 16% cpu 0.527 total
15 0.06s user 0.03s system 17% cpu 0.514 total
16 0.06s user 0.03s system 16% cpu 0.537 total
17 0.07s user 0.02s system 18% cpu 0.504 total
18 0.05s user 0.03s system 16% cpu 0.506 total
19 0.04s user 0.04s system 17% cpu 0.501 total
20 0.06s user 0.02s system 18% cpu 0.487 total
21 0.06s user 0.02s system 17% cpu 0.498 total
22 0.03s user 0.05s system 17% cpu 0.491 total
23 0.06s user 0.03s system 17% cpu 0.488 total
24 0.07s user 0.02s system 18% cpu 0.474 total
25 0.03s user 0.06s system 17% cpu 0.495 total
26 0.05s user 0.04s system 18% cpu 0.485 total
27 0.03s user 0.06s system 17% cpu 0.473 total
28 0.07s user 0.02s system 18% cpu 0.487 total
29 0.06s user 0.03s system 16% cpu 0.527 total
30 0.04s user 0.03s system 16% cpu 0.488 total
31 0.06s user 0.03s system 17% cpu 0.489 total
32 0.05s user 0.03s system 15% cpu 0.548 total
```

And running the new node with `--haskell-rts-flags=-N8`
improves the results a bit further.
```
1  0.04s user 0.11s system 10% cpu 1.367 total
2  0.08s user 0.03s system 12% cpu 0.894 total
3  0.07s user 0.03s system 15% cpu 0.663 total
4  0.04s user 0.06s system 17% cpu 0.575 total
5  0.07s user 0.03s system 21% cpu 0.457 total
6  0.05s user 0.04s system 21% cpu 0.447 total
7  0.05s user 0.04s system 24% cpu 0.398 total
8  0.07s user 0.02s system 23% cpu 0.399 total
9  0.04s user 0.06s system 24% cpu 0.406 total
10 0.02s user 0.06s system 21% cpu 0.401 total
11 0.07s user 0.02s system 21% cpu 0.405 total
12 0.05s user 0.03s system 21% cpu 0.385 total
13 0.07s user 0.02s system 21% cpu 0.406 total
14 0.06s user 0.02s system 22% cpu 0.381 total
15 0.06s user 0.02s system 21% cpu 0.379 total
16 0.05s user 0.03s system 21% cpu 0.377 total
17 0.04s user 0.04s system 20% cpu 0.369 total
18 0.05s user 0.02s system 20% cpu 0.373 total
19 0.04s user 0.04s system 22% cpu 0.352 total
20 0.04s user 0.03s system 21% cpu 0.353 total
21 0.02s user 0.06s system 21% cpu 0.357 total
22 0.05s user 0.02s system 20% cpu 0.359 total
23 0.03s user 0.05s system 21% cpu 0.353 total
24 0.05s user 0.02s system 21% cpu 0.333 total
25 0.05s user 0.02s system 21% cpu 0.337 total
26 0.04s user 0.03s system 21% cpu 0.340 total
27 0.06s user 0.02s system 20% cpu 0.360 total
28 0.05s user 0.02s system 20% cpu 0.339 total
29 0.05s user 0.02s system 20% cpu 0.347 total
30 0.03s user 0.04s system 20% cpu 0.366 total
31 0.05s user 0.03s system 20% cpu 0.357 total
32 0.06s user 0.01s system 20% cpu 0.332 total
```

This is a draft. The following need to be addressed before this can be merged
- [ ] Make the modifications cross-platform. At present this only compiles and runs on linux.
- [ ] Handle error cases and partial reads and writes correctly. It is allowed for pread and write to partially read and write, and it is up to the user to retry.
- [ ] Review the dependencies to make sure they handle error cases for pread and write correctly

## Purpose

TODO
_Describe the purpose of the pull request, link to issue describing the problem, etc.

## Changes

TODO

_Describe the changes that were needed.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
