### PR TITLE
WIP: Blobstore mmap

### DIFF
--- a/concordium-consensus/package.yaml
+++ b/concordium-consensus/package.yaml
@@ -40,6 +40,7 @@ dependencies:
 - transformers >=0.5
 - microlens-platform >=0.3
 - microlens >=0.3
+- mmap >=0.5
 - mtl >=2.2
 - pqueue >= 1.4.1
 - psqueues >= 0.2.7

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
@@ -53,6 +53,7 @@ import qualified Concordium.Types.IdentityProviders as IPS
 import qualified Concordium.Types.AnonymityRevokers as ARS
 import qualified Concordium.GlobalState.Parameters as Parameters
 import Concordium.GlobalState.Basic.BlockState.AccountReleaseSchedule
+import Concordium.GlobalState.Persistent.BlobStore.Flush
 import Concordium.Types
 import Concordium.Types.Updates
 import Concordium.Wasm
@@ -114,7 +115,7 @@ loadBlobStore blobStoreFilePath = do
 -- ensuring all the contents is written out.
 flushBlobStore :: BlobStore -> IO ()
 flushBlobStore BlobStore{..} =
-    withMVar blobStoreFile (hFlush . bhHandle)
+    withMVar blobStoreFile (hFlushOS . bhHandle)
 
 -- |Close all references to the blob store, flushing it
 -- in the process.

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
@@ -43,6 +43,7 @@ import GHC.Stack
 import Data.IORef
 import Concordium.Crypto.EncryptedTransfers
 import Data.Map (Map)
+import System.IO.MMap
 
 import Concordium.GlobalState.Persistent.MonadicRecursive
 
@@ -83,7 +84,11 @@ data BlobHandle = BlobHandle{
 -- | The storage context
 data BlobStore = BlobStore {
     blobStoreFile :: !(MVar BlobHandle),
-    blobStoreFilePath :: !FilePath
+    blobStoreFilePath :: !FilePath,
+    -- |The blob store file memory-mapped into a (read-only) 'ByteString'.
+    -- At any given time, this may be smaller than the file, requiring remapping to read later
+    -- parts. It will always map from the start of the file.
+    blobStoreMMap :: !(IORef BS.ByteString)
 }
 
 class HasBlobStore a where
@@ -100,6 +105,7 @@ createBlobStore blobStoreFilePath = do
     when pathEx $ throwIO (userError $ "Blob store path already exists: " ++ blobStoreFilePath)
     bhHandle <- openBinaryFile blobStoreFilePath ReadWriteMode
     blobStoreFile <- newMVar BlobHandle{bhSize=0, bhAtEnd=True,..}
+    blobStoreMMap <- newIORef BS.empty
     return BlobStore{..}
 
 -- |Load an existing blob store from a file.
@@ -109,6 +115,7 @@ loadBlobStore blobStoreFilePath = do
   bhHandle <- openBinaryFile blobStoreFilePath ReadWriteMode
   bhSize <- fromIntegral <$> hFileSize bhHandle
   blobStoreFile <- newMVar BlobHandle{bhAtEnd=bhSize==0,..}
+  blobStoreMMap <- newIORef =<< mmapFileByteString blobStoreFilePath Nothing
   return BlobStore{..}
 
 -- |Flush all buffers associated with the blob store,
@@ -143,13 +150,14 @@ runBlobStoreTemp dir a = bracket openf closef usef
             removeFile tempFP
         usef (fp, h) = do
             mv <- newMVar (BlobHandle h True 0)
-            res <- runReaderT a (BlobStore mv fp)
+            mmap <- newIORef BS.empty
+            res <- runReaderT a (BlobStore mv fp mmap)
             _ <- takeMVar mv
             return res
 
 -- | Read a bytestring from the blob store at the given offset
-readBlobBS :: BlobStore -> BlobRef a -> IO BS.ByteString
-readBlobBS BlobStore{..} (BlobRef offset) = mask $ \restore -> do
+readBlobBSFromHandle :: BlobStore -> BlobRef a -> IO BS.ByteString
+readBlobBSFromHandle BlobStore{..} (BlobRef offset) = mask $ \restore -> do
         bh@BlobHandle{..} <- takeMVar blobStoreFile
         eres <- try $ restore $ do
             hSeek bhHandle AbsoluteSeek (fromIntegral offset)
@@ -161,6 +169,24 @@ readBlobBS BlobStore{..} (BlobRef offset) = mask $ \restore -> do
         case eres :: Either SomeException BS.ByteString of
             Left e -> throwIO e
             Right bs -> return bs
+
+readBlobBS :: BlobStore -> BlobRef a -> IO BS.ByteString
+readBlobBS bs@BlobStore{..} br@(BlobRef offset) = do
+        let ioffset = fromIntegral offset
+        mmap0 <- readIORef blobStoreMMap
+        mmap <- if ioffset >= BS.length mmap0 then do
+                -- Remap the file
+                mmap <- mmapFileByteString blobStoreFilePath Nothing
+                writeIORef blobStoreMMap mmap
+                return mmap
+            else return mmap0
+        if ioffset >= BS.length mmap then readBlobBSFromHandle bs br else do
+            let stringStart = BS.drop ioffset mmap
+            case decode (BS.take 8 stringStart) of
+                Left e -> error e
+                Right (size :: Word64) -> return
+                    $ BS.take (fromIntegral size)
+                    $ BS.drop 8 stringStart
 
 -- | Write a bytestring into the blob store and return the offset
 writeBlobBS :: BlobStore -> BS.ByteString -> IO (BlobRef a)

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
@@ -155,7 +155,7 @@ runBlobStoreTemp dir a = bracket openf closef usef
             _ <- takeMVar mv
             return res
 
--- | Read a bytestring from the blob store at the given offset
+-- | Read a bytestring from the blob store at the given offset using the file handle.
 readBlobBSFromHandle :: BlobStore -> BlobRef a -> IO BS.ByteString
 readBlobBSFromHandle BlobStore{..} (BlobRef offset) = mask $ \restore -> do
         bh@BlobHandle{..} <- takeMVar blobStoreFile
@@ -170,23 +170,34 @@ readBlobBSFromHandle BlobStore{..} (BlobRef offset) = mask $ \restore -> do
             Left e -> throwIO e
             Right bs -> return bs
 
+-- | Read a bytestring from the blob store at the given offset using the memory map.
+-- The file handle is used as a backstop if the data to be read would be outside the memory map
+-- even after re-mapping.
 readBlobBS :: BlobStore -> BlobRef a -> IO BS.ByteString
 readBlobBS bs@BlobStore{..} br@(BlobRef offset) = do
         let ioffset = fromIntegral offset
+        let dataOffset = ioffset + 8
         mmap0 <- readIORef blobStoreMMap
-        mmap <- if ioffset >= BS.length mmap0 then do
+        mmap <- if dataOffset > BS.length mmap0 then do
                 -- Remap the file
                 mmap <- mmapFileByteString blobStoreFilePath Nothing
                 writeIORef blobStoreMMap mmap
                 return mmap
             else return mmap0
-        if ioffset >= BS.length mmap then readBlobBSFromHandle bs br else do
-            let stringStart = BS.drop ioffset mmap
-            case decode (BS.take 8 stringStart) of
+        let mmapLength = BS.length mmap
+        if dataOffset > mmapLength then
+            readBlobBSFromHandle bs br
+        else do
+            let lengthStart = BS.drop ioffset mmap
+            case decode (BS.take 8 lengthStart) of
                 Left e -> error e
-                Right (size :: Word64) -> return
-                    $ BS.take (fromIntegral size)
-                    $ BS.drop 8 stringStart
+                Right (size :: Word64) -> do
+                    if dataOffset + fromIntegral size > mmapLength then
+                        readBlobBSFromHandle bs br
+                    else
+                        return
+                            $ BS.take (fromIntegral size)
+                            $ BS.drop dataOffset mmap
 
 -- | Write a bytestring into the blob store and return the offset
 writeBlobBS :: BlobStore -> BS.ByteString -> IO (BlobRef a)

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore/Flush.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore/Flush.hs
@@ -2,7 +2,7 @@
 
 -- |This module provides functionality for flushing the operating system buffer associated with
 -- a file handle.
-module Concordium.GlobalState.Persistent.BlobStore.Flush(hFlushOS) where
+module Concordium.GlobalState.Persistent.BlobStore.Flush (hFlushOS) where
 
 import Control.Concurrent
 import Control.Monad
@@ -35,11 +35,9 @@ osFlush h = do
         IOError (Just h) IllegalOperation "hFlushOS" "is a socket" Nothing Nothing
     res <- flushFileBuffers (fdFD fd)
     when (res /= 0) $ throwGetLastError "hFlushOS"
-
 #else
     res <- fsync (fdFD fd)
-    when (res /= 0) $ ioError $ errnoToIOError "hFlushOS" res (Just h) Nothing
-
+    when (res /= 0) $ throwErrno "hFlushOS"
 #endif
 
 -- |Flush a file handle, including the operating system buffers.

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore/Flush.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore/Flush.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE CPP #-}
+
+-- |This module provides functionality for flushing the operating system buffer associated with
+-- a file handle.
+module Concordium.GlobalState.Persistent.BlobStore.Flush(hFlushOS) where
+
+import Control.Concurrent
+import Control.Monad
+import Foreign.C
+import GHC.IO.Exception
+import GHC.IO.FD
+import GHC.IO.Handle.FD (handleToFd)
+import System.IO
+
+#if defined(mingw32_HOST_OS)
+import GHC.Windows
+#endif
+
+#if defined(mingw32_HOST_OS)
+
+foreign import ccall safe "FlushFileBuffers" flushFileBuffers :: CInt -> IO CInt
+
+#else
+
+foreign import ccall safe "fsync" fsync :: CInt -> IO CInt
+
+#endif
+
+osFlush :: Handle -> IO ()
+osFlush h = do
+    fd <- handleToFd h
+
+#if defined(mingw32_HOST_OS)
+    when (fdIsSocket_ fd /= 0) $ ioException $
+        IOError (Just h) IllegalOperation "hFlushOS" "is a socket" Nothing Nothing
+    res <- flushFileBuffers (fdFD fd)
+    when (res /= 0) $ throwGetLastError "hFlushOS"
+
+#else
+    res <- fsync (fdFD fd)
+    when (res /= 0) $ ioError $ errnoToIOError "hFlushOS" res (Just h) Nothing
+
+#endif
+
+-- |Flush a file handle, including the operating system buffers.
+hFlushOS :: Handle -> IO ()
+hFlushOS h = runInBoundThread $ do
+    hFlush h
+    osFlush h


### PR DESCRIPTION
## Purpose

It has long been proposed to use a memory-mapped file for the block state.
This PR does this in a fairly simple, but hopefully effective, fashion.
While writes still acquire a lock and append to the file handle, reads use a read-only memory map of the file.
If the read is for some data that is beyond the size of the memory map, the file is re-mapped.
If the data is *still* beyond the end of the file, then reading from the handle is used as a fall-back.

This assumes that generally data is not partially written to the blob store, however, it should be robust even if it is by falling back to using the file handle.
Falling back to the file handle may also be necessary if the data is ever read before it is flushed (which *probably* doesn't happen).

This should also reduce lock contention similar to https://github.com/Concordium/concordium-node/pull/112.

Testing is necessary to ensure that performance doesn't degrade over many queries and remappings, and that behaviour is consistent across platforms.

## Changes

_Describe the changes that were needed.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

