### PR TITLE
Create SQL tables with a useful index.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
   A legacy database will automatically be migrated by renaming and adding version metadata.
 - Remove unused CONCORDIUM_NODE_CONNECTION_BOOTSTRAP_SERVER option and the
   corresponding `--bootstrap-server` flag.
+- Change the automatically created indices on the transaction logging database.
+  Instead of an index on the `id` column on `ati` and `cti` tables there are now
+  multi-column indices that better support the intended use-cases. This only
+  affects newly created databases.
 
 ## concordium-node 1.0.1
 

--- a/concordium-node/src/bin/database_emitter.rs
+++ b/concordium-node/src/bin/database_emitter.rs
@@ -19,7 +19,7 @@ use concordium_node::{
     stats_export_service::instantiate_stats_export_engine,
     utils,
 };
-use crypto_common::serialize::Serial;
+use crypto_common::Serial;
 use std::{
     fs::File,
     io::prelude::*,

--- a/docs/transaction-logging.md
+++ b/docs/transaction-logging.md
@@ -16,11 +16,9 @@ To enable it the following configuration options must be given. We list environm
 
 As mentioned above the database must exist, otherwise the node will fail to start. If correct tables exist in the database then they will be used, otherwise the following will be executed upon startup
 ```sql
-CREATE TABLE "summaries"("id" SERIAL8  PRIMARY KEY UNIQUE,"block" BYTEA NOT NULL,"timestamp" INT8 NOT NULL,"height" INT8 NOT NULL,"summary" JSONB NOT NULL)
-CREATE TABLE "ati"("id" SERIAL8  PRIMARY KEY UNIQUE,"account" BYTEA NOT NULL,"summary" INT8 NOT NULL)
-CREATE TABLE "cti"("id" SERIAL8  PRIMARY KEY UNIQUE,"index" INT8 NOT NULL,"subindex" INT8 NOT NULL,"summary" INT8 NOT NULL)
-ALTER TABLE "ati" ADD CONSTRAINT "ati_summary_fkey" FOREIGN KEY("summary") REFERENCES "summaries"("id") ON DELETE RESTRICT  ON UPDATE RESTRICT
-ALTER TABLE "cti" ADD CONSTRAINT "cti_summary_fkey" FOREIGN KEY("summary") REFERENCES "summaries"("id") ON DELETE RESTRICT  ON UPDATE RESTRICT
+CREATE TABLE summaries(id SERIAL8 PRIMARY KEY UNIQUE, block BYTEA NOT NULL, timestamp INT8 NOT NULL, height INT8 NOT NULL, summary JSONB NOT NULL);
+CREATE TABLE ati(id SERIAL8, account BYTEA NOT NULL, summary INT8 NOT NULL, CONSTRAINT ati_pkey PRIMARY KEY (account, id), CONSTRAINT ati_summary_fkey FOREIGN KEY(summary) REFERENCES summaries(id) ON DELETE RESTRICT  ON UPDATE RESTRICT);
+CREATE TABLE cti(id SERIAL8, index INT8 NOT NULL,subindex INT8 NOT NULL,summary INT8 NOT NULL, CONSTRAINT cti_pkey PRIMARY KEY (index, subindex, id), CONSTRAINT cti_summary_fkey FOREIGN KEY(summary) REFERENCES summaries(id) ON DELETE RESTRICT  ON UPDATE RESTRICT);
 ```
 
 which creates three tables, `ati`, `cti`, and `summaries`. The `ati` and `cti` stand for **a**ccount, respectively **c**ontract, **t**ransaction **i**ndex. They contain an index so that a transaction affecting a given contract or account can be quickly looked up. The outcome of each transaction is in the `summaries` table.


### PR DESCRIPTION
## Purpose

Every time we query the database we filter by account or contract and possibly narrow down by ID. The new indices reflect this and make many queries substantially faster.

The downside is that they do take up more space than the previous ones, but I believe this is a good tradeoff since they make the wallet-proxy more performant and thus more usable.

## Changes

- Replace the automatically derived migration with a custom database creation script that allows more flexibility.
- Check for existence of databases and correct column types on startup manually.
- Log the state of transaction logging databases on startup.

Related PRs
- https://github.com/Concordium/concordium-base/pull/64

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
