### PR TITLE
Clarified multiple genesis blocks in network-layer.md

### DIFF
--- a/docs/network-layer.md
+++ b/docs/network-layer.md
@@ -29,7 +29,7 @@ After completing the first part of the handshake, then the two peers will carry 
 
 1. The client versions are compatible
 2. The wire versions are compatible
-3. The peers have *compatible* genesis blocks. *Compatible* in this context means that one peer's list of *genesis blocks* must be a prefix of the other's.
+3. The peers have *compatible* genesis blocks. Initially, where the chain has a single genesis block, this means the peers' genesis blocks must be equal. If there are additional genesis blocks introduced by protocol updates, *compatible* means that one peer's list of *genesis blocks* must be a prefix of the other's. In particular, the initial genesis blocks of both peers must always be equal.
 
 When the *handshake* has been successfully completed then the peers will *promote* each other into their corresponding lists of peers, i.e. the peers are now connected and can communicate with each other, hence the peers can now relay messages between them, carry out *consensus* and *catchup* etc.
 


### PR DESCRIPTION
## Purpose

In the initial description of the network layer, it was unclear where the list genesis blocks comes from.

## Changes

The documentation was extended to explain that protocol updates can introduce additional genesis blocks.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
