### PR TITLE
Make the scheduler test utils parametric over the protocol version.

### DIFF
--- a/concordium-consensus/tests/scheduler/SchedulerTests/AccountTransactionSpecs.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/AccountTransactionSpecs.hs
@@ -29,7 +29,7 @@ shouldReturnP action f = action >>= (`shouldSatisfy` f)
 initialAmount :: Types.Amount
 initialAmount = 0
 
-initialBlockState :: BlockState PV
+initialBlockState :: BlockState PV1
 initialBlockState = blockStateWithAlesAccount initialAmount Acc.emptyAccounts
 
 -- cdi7, but with lowest possible expiry
@@ -55,8 +55,8 @@ testAccountCreation ::
     IO
     ([(Types.BlockItem, Types.ValidResult)],
      [(Types.CredentialDeploymentWithMeta, Types.FailureKind)],
-     [Maybe (Account PV)],
-     Account PV,
+     [Maybe (Account PV1)],
+     Account PV1,
      Amount)
 testAccountCreation = do
     let transactions = Types.TGCredentialDeployment <$> transactionsInput
@@ -79,8 +79,8 @@ testAccountCreation = do
 checkAccountCreationResult ::
   ([(Types.BlockItem, Types.ValidResult)],
      [(Types.CredentialDeploymentWithMeta, Types.FailureKind)],
-     [Maybe (Account PV)],
-     Account PV,
+     [Maybe (Account PV1)],
+     Account PV1,
      Amount)
   -> Assertion
 checkAccountCreationResult (suc, fails, stateAccs, stateAles, executionCost) = do

--- a/concordium-consensus/tests/scheduler/SchedulerTests/BakerTransactions.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/BakerTransactions.hs
@@ -48,7 +48,7 @@ keyPair = uncurry SigScheme.KeyPairEd25519 . fst . randomEd25519KeyPair . mkStdG
 account :: Int -> Types.AccountAddress
 account = accountAddressFrom
 
-initialBlockState :: BlockState PV
+initialBlockState :: BlockState PV1
 initialBlockState = createBlockState $ foldr putAccountWithRegIds Acc.emptyAccounts
   [mkAccount (SigScheme.correspondingVerifyKey (keyPair i)) (account i) 400_000_000_000 | i <- reverse [0..3]]
 
@@ -229,7 +229,7 @@ transactionsInput =
 type TestResult = ([([(Types.BlockItem, Types.ValidResult)],
                      [(Types.Transaction, Types.FailureKind)],
                      BasicBirkParameters)],
-                    BlockState PV,
+                    BlockState PV1,
                     Types.Amount)
 
 runWithIntermediateStates :: IO TestResult

--- a/concordium-consensus/tests/scheduler/SchedulerTests/BlockEnergyLimitSpec.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/BlockEnergyLimitSpec.hs
@@ -28,7 +28,7 @@ import SchedulerTests.Helpers
 shouldReturnP :: Show a => IO a -> (a -> Bool) -> IO ()
 shouldReturnP action f = action >>= (`shouldSatisfy` f)
 
-initialBlockState :: BlockState PV
+initialBlockState :: BlockState PV1
 initialBlockState = blockStateWithAlesAccount 200000 Acc.emptyAccounts
 
 -- We will use simple transfer transactions.

--- a/concordium-consensus/tests/scheduler/SchedulerTests/ChainMetatest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/ChainMetatest.hs
@@ -25,7 +25,7 @@ import Concordium.Crypto.DummyData
 
 import SchedulerTests.Helpers
 
-initialBlockState :: BlockState PV
+initialBlockState :: BlockState PV1
 initialBlockState = blockStateWithAlesAccount 1000000000 Acc.emptyAccounts
 
 chainMeta :: Types.ChainMetadata

--- a/concordium-consensus/tests/scheduler/SchedulerTests/EncryptedTransfersTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/EncryptedTransfersTest.hs
@@ -69,7 +69,7 @@ import Test.Hspec
 --- |                                  | incomingAmounts |        [] |            [] |
 --- |----------------------------------+-----------------+-----------+---------------|
 
-initialBlockState :: BlockState PV
+initialBlockState :: BlockState PV1
 initialBlockState = blockStateWithAlesAccount
     10000000000
     (Acc.putAccountWithRegIds (mkAccount thomasVK thomasAccount 10000000000) Acc.emptyAccounts)
@@ -103,7 +103,7 @@ aggregatedDecryptedAmount1 = makeAggregatedDecryptedAmount encryptedAmount1000 1
 mkEncryptedTransferData1 :: IO EncryptedAmountTransferData
 mkEncryptedTransferData1 = fromJust <$> createEncryptedTransferData thomasEncryptionPublicKey alesEncryptionSecretKey aggregatedDecryptedAmount1 100
 
-mkTestCases :: IO [TestCase]
+mkTestCases :: IO [TestCase PV1]
 mkTestCases = do
   encryptedTransferData1 <- mkEncryptedTransferData1
 

--- a/concordium-consensus/tests/scheduler/SchedulerTests/FibonacciSelfMessageTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/FibonacciSelfMessageTest.hs
@@ -35,7 +35,7 @@ import Concordium.Crypto.DummyData
 import SchedulerTests.TestUtils
 
 
-initialBlockState :: BlockState PV
+initialBlockState :: BlockState PV1
 initialBlockState = blockStateWithAlesAccount
     100000000
     (Acc.putAccountWithRegIds (mkAccount thomasVK thomasAccount 100000000) Acc.emptyAccounts)
@@ -46,7 +46,7 @@ fibParamBytes n = BSS.toShort $ runPut (putWord64le n)
 fibSourceFile :: FilePath
 fibSourceFile = "./testdata/contracts/fib.wasm"
 
-testCases :: [TestCase]
+testCases :: [TestCase PV1]
 testCases =
   [ -- NOTE: Could also check resulting balances on each affected account or contract, but
     -- the block state invariant at least tests that the total amount is preserved.

--- a/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
@@ -16,4 +16,4 @@ simpleTransferCost :: Energy
 simpleTransferCost = Cost.baseCost (Types.transactionHeaderSize + 41) 1 + Cost.simpleTransferCost
 
 -- |Protocol version
-type PV = 'Types.P1
+type PV1 = 'Types.P1

--- a/concordium-consensus/tests/scheduler/SchedulerTests/InitContextTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/InitContextTest.hs
@@ -26,7 +26,7 @@ import Concordium.Crypto.DummyData
 
 import SchedulerTests.Helpers
 
-initialBlockState :: BlockState PV
+initialBlockState :: BlockState PV1
 initialBlockState = blockStateWithAlesAccount 1000000000 emptyAccounts
 
 chainMeta :: Types.ChainMetadata

--- a/concordium-consensus/tests/scheduler/SchedulerTests/InitialAccountCreationSpec.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/InitialAccountCreationSpec.hs
@@ -28,7 +28,7 @@ shouldReturnP action f = action >>= (`shouldSatisfy` f)
 initialAmount :: Types.Amount
 initialAmount = 0
 
-initialBlockState :: BlockState PV
+initialBlockState :: BlockState PV1
 initialBlockState = blockStateWithAlesAccount initialAmount Acc.emptyAccounts
 
 transactionsInput :: [Types.CredentialDeploymentWithMeta]
@@ -43,7 +43,7 @@ testAccountCreation ::
     IO
     ([(Types.BlockItem, Types.ValidResult)],
      [(Types.CredentialDeploymentWithMeta, Types.FailureKind)],
-     [Maybe (Account PV)],
+     [Maybe (Account PV1)],
      Amount)
 testAccountCreation = do
     let transactions = Types.TGCredentialDeployment <$> transactionsInput
@@ -66,7 +66,7 @@ testAccountCreation = do
 checkAccountCreationResult ::
   ([(Types.BlockItem, Types.ValidResult)],
      [(Types.CredentialDeploymentWithMeta, Types.FailureKind)],
-     [Maybe (Account PV)],
+     [Maybe (Account PV1)],
      Amount)
   -> Assertion
 checkAccountCreationResult (suc, fails, stateAccs, executionCost) = do

--- a/concordium-consensus/tests/scheduler/SchedulerTests/MaxIncomingAmountsTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/MaxIncomingAmountsTest.hs
@@ -48,7 +48,7 @@ iterateLimitM n f = go 0 where
              y <- f x
              (x:) <$> go (m+1) y
 
-initialBlockState :: BlockState PV
+initialBlockState :: BlockState PV1
 initialBlockState = blockStateWithAlesAccount
     10000000000
     (Acc.putAccountWithRegIds (mkAccount thomasVK thomasAccount 10000000000) Acc.emptyAccounts)
@@ -81,7 +81,7 @@ createSecToPubTransferData =
   makeSecToPubAmountTransferData (initialBlockState ^. blockCryptographicParameters . unhashed)
 
 -- Helper for checking the encrypted balance of an account.
-checkEncryptedBalance :: AccountEncryptedAmount -> AccountAddress -> BlockState PV -> SpecWith ()
+checkEncryptedBalance :: AccountEncryptedAmount -> AccountAddress -> BlockState PV1 -> SpecWith ()
 checkEncryptedBalance accEncAmount acc bs =
   specify ("Correct final balance on " ++ show acc) $
     case Acc.getAccount acc (bs ^. blockAccounts) of
@@ -118,13 +118,13 @@ allTxsIO = do
 -- considers that transferred amounts are added to the incoming amounts and
 -- after that it checks that the initial incoming amounts are being
 -- automatically aggregated.
-transactionsIO :: IO ([(Runner.TransactionJSON, (TResultSpec, BlockState PV -> Spec))],
+transactionsIO :: IO ([(Runner.TransactionJSON, (TResultSpec, BlockState PV1 -> Spec))],
                      [(EncryptedAmountTransferData, Amount)])
 transactionsIO = do
   allTxs <- allTxsIO
   let (normal, interesting) = splitAt maxNumIncoming allTxs
    -- A normal transaction is a transfer before maxNumIncoming amounts have been received.
-  let makeNormalTransaction :: EncryptedAmountTransferData -> EncryptedAmountAggIndex -> (Runner.TransactionJSON, (TResultSpec, BlockState PV -> Spec))
+  let makeNormalTransaction :: EncryptedAmountTransferData -> EncryptedAmountAggIndex -> (Runner.TransactionJSON, (TResultSpec, BlockState PV1 -> Spec))
       makeNormalTransaction x idx = makeTransaction x idx $
         \bs -> do
           checkEncryptedBalance initialAccountEncryptedAmount{_selfAmount = eatdRemainingAmount x} alesAccount bs -- Ales amount should be the remaining amount on the transaction
@@ -134,7 +134,7 @@ transactionsIO = do
             } thomasAccount bs
 
       -- An interesting transaction is a transfer after maxNumIncoming amounts have been received.
-      makeInterestingTransaction :: EncryptedAmountTransferData -> EncryptedAmountAggIndex -> (Runner.TransactionJSON, (TResultSpec, BlockState PV -> Spec))
+      makeInterestingTransaction :: EncryptedAmountTransferData -> EncryptedAmountAggIndex -> (Runner.TransactionJSON, (TResultSpec, BlockState PV1 -> Spec))
       makeInterestingTransaction x idx = makeTransaction x idx $
         \bs -> do
           checkEncryptedBalance initialAccountEncryptedAmount{_selfAmount = eatdRemainingAmount x} alesAccount bs -- Ales amount should be the remaining amount on the transaction
@@ -144,7 +144,7 @@ transactionsIO = do
                                                               _incomingEncryptedAmounts =  kept, -- the list of incoming amounts will hold the `rest` of the amounts
                                                               _aggregatedAmount = Just (combinedAmount, fromIntegral (idx - fromIntegral maxNumIncoming + 1)) -- the combined amount goes into the `_aggregatedAmount` field together with the number of aggregated amounts until this point.
                                                              } thomasAccount bs
-      makeTransaction :: EncryptedAmountTransferData -> EncryptedAmountAggIndex -> (BlockState PV -> Spec) -> (Runner.TransactionJSON, (TResultSpec, BlockState PV -> Spec))
+      makeTransaction :: EncryptedAmountTransferData -> EncryptedAmountAggIndex -> (BlockState PV1 -> Spec) -> (Runner.TransactionJSON, (TResultSpec, BlockState PV1 -> Spec))
       makeTransaction x@EncryptedAmountTransferData{..} idx checks =
         ( Runner.TJSON { payload = Runner.EncryptedAmountTransfer thomasAccount x -- create an encrypted transfer to Thomas
                       , metadata = makeDummyHeader alesAccount (fromIntegral idx + 1) 100000 -- from Ales with nonce idx + 1
@@ -175,7 +175,7 @@ mkSecToPubTransferData transactions = fromJust <$> createSecToPubTransferData th
 
 ------------------------------------- Test -------------------------------------
 
-testCases :: [(Runner.TransactionJSON, (TResultSpec, BlockState PV -> Spec))] -> [TestCase]
+testCases :: [(Runner.TransactionJSON, (TResultSpec, BlockState PV1 -> Spec))] -> [TestCase PV1]
 testCases transactions =
   [ TestCase
     { tcName = "Makes an encrypted transfer"

--- a/concordium-consensus/tests/scheduler/SchedulerTests/RandomBakerTransactions.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/RandomBakerTransactions.hs
@@ -54,7 +54,7 @@ staticKeys = ks (mkStdGen 1333)
 numAccounts :: Int
 numAccounts = 10
 
-initialBlockState :: BlockState PV
+initialBlockState :: BlockState PV1
 initialBlockState = createBlockState
     (foldr addAcc Acc.emptyAccounts (take numAccounts staticKeys))
     where

--- a/concordium-consensus/tests/scheduler/SchedulerTests/ReceiveContextTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/ReceiveContextTest.hs
@@ -29,7 +29,7 @@ alesAccount, thomasAccount :: AccountAddress
 alesAccount = AccountAddress $ pack $ take accountAddressSize $ repeat 1
 thomasAccount = AccountAddress $ pack $ take accountAddressSize $ repeat 2
 
-initialBlockState :: BlockState PV
+initialBlockState :: BlockState PV1
 initialBlockState = createBlockState $ putAccountWithRegIds (mkAccount alesVK alesAccount 1000000000)
                                      $ putAccountWithRegIds (mkAccount thomasVK thomasAccount 1000000000) emptyAccounts
 

--- a/concordium-consensus/tests/scheduler/SchedulerTests/RejectReasons.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/RejectReasons.hs
@@ -25,7 +25,7 @@ import Concordium.Crypto.DummyData
 
 import SchedulerTests.Helpers
 
-initialBlockState :: BlockState PV
+initialBlockState :: BlockState PV1
 initialBlockState = blockStateWithAlesAccount 1000000000 Acc.emptyAccounts
 
 chainMeta :: Types.ChainMetadata

--- a/concordium-consensus/tests/scheduler/SchedulerTests/RejectReasonsRustContract.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/RejectReasonsRustContract.hs
@@ -27,7 +27,7 @@ import Concordium.Wasm (ReceiveName(..))
 import SchedulerTests.Helpers
 import Data.Text (Text)
 
-initialBlockState :: BlockState PV
+initialBlockState :: BlockState PV1
 initialBlockState = blockStateWithAlesAccount 1000000000 Acc.emptyAccounts
 
 chainMeta :: Types.ChainMetadata

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SimpleTransferSpec.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SimpleTransferSpec.hs
@@ -21,12 +21,12 @@ import Concordium.Crypto.DummyData
 
 import SchedulerTests.TestUtils
 
-initialBlockState :: BlockState PV
+initialBlockState :: BlockState PV1
 initialBlockState = blockStateWithAlesAccount
     10000000000
     (Acc.putAccountWithRegIds (mkAccount thomasVK thomasAccount 10000000000) Acc.emptyAccounts)
 
-testCases :: [TestCase]
+testCases :: [TestCase PV1]
 testCases =
   [ -- NOTE: Could also check resulting balances on each affected account or contract, but
     -- the block state invariant at least tests that the total amount is preserved.

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SimpleTransfersTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SimpleTransfersTest.hs
@@ -28,7 +28,7 @@ import SchedulerTests.Helpers
 shouldReturnP :: Show a => IO a -> (a -> Bool) -> IO ()
 shouldReturnP action f = action >>= (`shouldSatisfy` f)
 
-initialBlockState :: BlockState PV
+initialBlockState :: BlockState PV1
 initialBlockState = blockStateWithAlesAccount
     1000000
     (Acc.putAccountWithRegIds (mkAccount thomasVK thomasAccount 1000000) Acc.emptyAccounts)

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContractTests.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContractTests.hs
@@ -42,7 +42,7 @@ import Test.Hspec
 -- ** Test runners **
 
 -- | Run a number of init tests from a specific file.
-runInitTestsFromFile :: FilePath -> [(Text, ShortByteString, TResultSpec)] -> [TestCase]
+runInitTestsFromFile :: FilePath -> [(Text, ShortByteString, TResultSpec)] -> [TestCase PV1]
 runInitTestsFromFile testFile = map f
   where
     f (testName, initParam, resSpec) =
@@ -71,7 +71,7 @@ runInitTestsFromFile testFile = map f
 --   Each test is run in isolation, i.e., with a new state.
 --   The file is expected to have an init function named 'init_test'
 --   and a number of receive functions, each prefixed with 'test.'.
-runReceiveTestsFromFile :: FilePath -> [(Text, ShortByteString, TResultSpec)] -> [TestCase]
+runReceiveTestsFromFile :: FilePath -> [(Text, ShortByteString, TResultSpec)] -> [TestCase PV1]
 runReceiveTestsFromFile testFile = map f
   where
     f (testName, rcvParam, resSpec) =
@@ -105,7 +105,7 @@ runReceiveTestsFromFile testFile = map f
 
 -- ** Helper Functions **
 
-initialBlockState :: BlockState PV
+initialBlockState :: BlockState PV1
 initialBlockState =
   blockStateWithAlesAccount
     100000000
@@ -129,7 +129,7 @@ expectGTUTransferred expectedAmnt events = foldr sumTransfers 0 events `shouldBe
 
 -- ** Tests **
 
-logEventTestCases :: [TestCase]
+logEventTestCases :: [TestCase PV1]
 logEventTestCases =
   runReceiveTestsFromFile
     "./testdata/contracts/log-event-tests.wasm"
@@ -142,7 +142,7 @@ logEventTestCases =
       ("length_greater_than_mem__fail", emptyParam, Reject RuntimeFailure)
     ]
 
-getParameterSizeTestCases :: [TestCase]
+getParameterSizeTestCases :: [TestCase PV1]
 getParameterSizeTestCases =
   runReceiveTestsFromFile
     "./testdata/contracts/get-parameter-size-tests.wasm"
@@ -153,7 +153,7 @@ getParameterSizeTestCases =
     -- Value must stay in sync with MAX_PARAMETER_SIZE from 'wasm-chain-integration/src/constants.src'
     maxSizedParam = mkParamOfSize 1024
 
-getParameterSectionTestCases :: [TestCase]
+getParameterSectionTestCases :: [TestCase PV1]
 getParameterSectionTestCases =
   runReceiveTestsFromFile
     "./testdata/contracts/get-parameter-section-tests.wasm"
@@ -176,7 +176,7 @@ getParameterSectionTestCases =
   where
     param100 = mkParamOfSize 100
 
-stateSizeTestCases :: [TestCase]
+stateSizeTestCases :: [TestCase PV1]
 stateSizeTestCases =
   runReceiveTestsFromFile
     "./testdata/contracts/state-size-tests.wasm"
@@ -184,7 +184,7 @@ stateSizeTestCases =
       ("size_is_max__return_max_and_succeed", emptyParam, Success emptyExpect)
     ]
 
-loadStateTestCases :: [TestCase]
+loadStateTestCases :: [TestCase PV1]
 loadStateTestCases =
   runReceiveTestsFromFile
     "./testdata/contracts/load-state-tests.wasm"
@@ -205,7 +205,7 @@ loadStateTestCases =
       ("write_location_greater_than_mem__fail", emptyParam, Reject RuntimeFailure)
     ]
 
-writeStateTestCases :: [TestCase]
+writeStateTestCases :: [TestCase PV1]
 writeStateTestCases =
   runReceiveTestsFromFile
     "./testdata/contracts/write-state-tests.wasm"
@@ -222,7 +222,7 @@ writeStateTestCases =
       ("offset_greater_than_current_state_size__fail", emptyParam, Reject RuntimeFailure)
     ]
 
-resizeStateTestCases :: [TestCase]
+resizeStateTestCases :: [TestCase PV1]
 resizeStateTestCases =
   runReceiveTestsFromFile
     "./testdata/contracts/resize-state-tests.wasm"
@@ -233,7 +233,7 @@ resizeStateTestCases =
       ("new_size_greater_than_max__return_zero_and_succeed", emptyParam, Success emptyExpect)
     ]
 
-onlyInInitTestCases :: [TestCase]
+onlyInInitTestCases :: [TestCase PV1]
 onlyInInitTestCases =
   runInitTestsFromFile
     file
@@ -247,7 +247,7 @@ onlyInInitTestCases =
   where
     file = "./testdata/contracts/only-in-init-tests.wasm"
 
-onlyInReceiveTestCases :: [TestCase]
+onlyInReceiveTestCases :: [TestCase PV1]
 onlyInReceiveTestCases =
   runInitTestsFromFile
     file
@@ -282,7 +282,7 @@ onlyInReceiveTestCases =
   where
     file = "./testdata/contracts/only-in-receive-tests.wasm"
 
-simpleTransferTestCases :: [TestCase]
+simpleTransferTestCases :: [TestCase PV1]
 simpleTransferTestCases =
   runReceiveTestsFromFile
     "./testdata/contracts/simple-transfer-tests.wasm"
@@ -317,7 +317,7 @@ simpleTransferTestCases =
     -- When using pointing to 32 0s in memory, this is the address that is used.
     Right accRef = addressFromText "2wkBET2rRgE8pahuaczxKbmv7ciehqsne57F9gtzf1PVdr2VP3"
 
-sendTestCases :: [TestCase]
+sendTestCases :: [TestCase PV1]
 sendTestCases =
   runReceiveTestsFromFile
     "./testdata/contracts/send-tests.wasm"
@@ -363,7 +363,7 @@ sendTestCases =
   where
     rcvNameParam = BSS.toShort "test.accept"
 
-actionTreeTestCases :: [TestCase]
+actionTreeTestCases :: [TestCase PV1]
 actionTreeTestCases =
   runReceiveTestsFromFile
     "./testdata/contracts/action-tree-tests.wasm"
@@ -387,7 +387,7 @@ actionTreeTestCases =
       ("combine_or__own_action_id__fail", encodedThomasAcc, Reject RuntimeFailure)
     ]
 
-memoryTestCases :: [TestCase]
+memoryTestCases :: [TestCase PV1]
 memoryTestCases =
   runReceiveTestsFromFile
     "./testdata/contracts/memory-tests.wasm"

--- a/concordium-consensus/tests/scheduler/SchedulerTests/StakedAmountLocked.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/StakedAmountLocked.hs
@@ -37,7 +37,7 @@ import Concordium.Types.DummyData
 import Concordium.Crypto.DummyData
 
 -- |Protocol version
-type PV = 'Types.P1
+type PV1 = 'Types.P1
 
 keyPair :: Int -> SigScheme.KeyPair
 keyPair = uncurry SigScheme.KeyPairEd25519 . fst . randomEd25519KeyPair . mkStdGen
@@ -48,7 +48,7 @@ account = accountAddressFrom
 baker0 :: (FullBakerInfo, VRF.SecretKey, BlockSig.SignKey, Bls.SecretKey)
 baker0 = mkFullBaker 0 0
 
-initialBlockState :: BlockState PV
+initialBlockState :: BlockState PV1
 initialBlockState = createBlockState $ foldr putAccountWithRegIds Acc.emptyAccounts [acc, accWithLockup]
   where acc = mkAccount (SigScheme.correspondingVerifyKey (keyPair 0)) (account 0) 10_000_058 & accountBaker ?~ baker
         baker = AccountBaker {

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TransactionExpirySpec.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TransactionExpirySpec.hs
@@ -35,7 +35,7 @@ import SchedulerTests.Helpers
 shouldReturnP :: Show a => IO a -> (a -> Bool) -> IO ()
 shouldReturnP action f = action >>= (`shouldSatisfy` f)
 
-initialBlockState :: BlockState PV
+initialBlockState :: BlockState PV1
 initialBlockState = blockStateWithAlesAccount 310_000_000_000 Acc.emptyAccounts
 
 baker :: (FullBakerInfo, VRF.SecretKey, BlockSig.SignKey, Bls.SecretKey)

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TransactionGroupingSpec2.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TransactionGroupingSpec2.hs
@@ -35,7 +35,7 @@ import SchedulerTests.Helpers
 
 -- * Definition of test cases
 
-initialBlockState :: BlockState PV
+initialBlockState :: BlockState PV1
 initialBlockState = blockStateWithAlesAccount 2000000 Acc.emptyAccounts
 
 maxBlockEnergy :: Types.Energy

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TrySendTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TrySendTest.hs
@@ -26,7 +26,7 @@ import Concordium.Crypto.DummyData
 
 import SchedulerTests.TestUtils
 
-initialBlockState :: BlockState PV
+initialBlockState :: BlockState PV1
 initialBlockState = blockStateWithAlesAccount
     100000000
     (Acc.putAccountWithRegIds (mkAccount thomasVK thomasAccount 100000000) Acc.emptyAccounts)
@@ -34,7 +34,7 @@ initialBlockState = blockStateWithAlesAccount
 toAddr :: BSS.ShortByteString
 toAddr = BSS.toShort (encode alesAccount)
 
-testCases :: [TestCase]
+testCases :: [TestCase PV1]
 testCases =
   [ -- NOTE: Could also check resulting balances on each affected account or contract, but
     -- the block state invariant at least tests that the total amount is preserved.

--- a/concordium-consensus/tests/scheduler/SchedulerTests/UpdateAccountKeys.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/UpdateAccountKeys.hs
@@ -23,12 +23,12 @@ import qualified  Data.Map as Map
 import            SchedulerTests.TestUtils
 
 
-initialBlockState :: BlockState PV
+initialBlockState :: BlockState PV1
 initialBlockState = createBlockState $
                     Acc.putAccountWithRegIds (mkAccountMultipleKeys [vk kp0, vk kp1] 2 alesAccount 10000000000)
                     Acc.emptyAccounts
 
-initialBlockState2 :: BlockState PV
+initialBlockState2 :: BlockState PV1
 initialBlockState2 = createBlockState $
                     Acc.putAccountWithRegIds (mkAccountMultipleKeys [vk kp0, vk kp1, vk kp2, vk kp3, vk kp4] 2 alesAccount 10000000000)
                     Acc.emptyAccounts
@@ -50,7 +50,7 @@ vk = Sig.correspondingVerifyKey
 alesCid :: CredentialRegistrationID
 alesCid = dummyRegId dummyCryptographicParameters alesAccount
 
-testCases :: [TestCase]
+testCases :: [TestCase PV1]
 testCases =
   [ TestCase
     { tcName = "Credential key updates"

--- a/concordium-consensus/tests/scheduler/SchedulerTests/UpdateCredentials.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/UpdateCredentials.hs
@@ -20,7 +20,7 @@ import qualified  Data.Map as Map
 import            SchedulerTests.TestUtils
 import Data.Maybe
 
-initialBlockState :: BlockState PV
+initialBlockState :: BlockState PV1
 initialBlockState = createBlockState $
                     Acc.putAccountWithRegIds ((newAccount dummyCryptographicParameters cdi8address cdi8ac) & accountAmount .~ 10000000000)
                     Acc.emptyAccounts
@@ -74,7 +74,7 @@ cdi11kp0 = keys cdi11keys Map.! 0
 cdi11kp1 :: Sig.KeyPair
 cdi11kp1 = keys cdi11keys Map.! 1
 
-testCases :: [TestCase]
+testCases :: [TestCase PV1]
 testCases =
   [ TestCase
     { tcName = "Account Credential updates"


### PR DESCRIPTION
## Purpose

To enable tests for the upcoming protocol 2 transactions. Since there is lots of noise introduced by this change it is better if it is a trivial separate PR instead of mixing it with the upcoming changes.

## Changes

Internal changes in tests only.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG
