### PR TITLE
Docker compose: Rename and cleanup jenkinsfile

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -50,7 +50,7 @@ container is running, or via `docker run` and mapping /genesis-data to a host di
 
 ## Build
 
-See [dev-master.Jenkinsfile](https://gitlab.com/Concordium/concordium-node/-/blob/master/jenkinsfiles/dev-master.Jenkinsfile).
+See [`dev-node.Jenkinsfile`](https://gitlab.com/Concordium/concordium-node/-/blob/master/jenkinsfiles/dev-node.Jenkinsfile).
 
 # OLD
 

--- a/jenkinsfiles/dev-node.Jenkinsfile
+++ b/jenkinsfiles/dev-node.Jenkinsfile
@@ -7,17 +7,14 @@ pipeline {
     }
     
     stages {
-        stage('ecr-login') {
-            steps {
-                sh '$(aws --region eu-west-1 ecr get-login | sed -e \'s/-e none//g\')'
-            }
-        }
         stage('dockerhub-login') {
             environment {
+                // Defines 'CRED_USR' and 'CRED_PSW'
+                // (see 'https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#handling-credentials').
                 CRED = credentials('jenkins-dockerhub')
             }
             steps {
-                sh 'echo $CRED_PSW | docker login --username $CRED_USR --password-stdin'
+                sh 'echo "${CRED_PSW}" | docker login --username "${CRED_USR}" --password-stdin'
             }
         }
         stage('build') {


### PR DESCRIPTION
Rename `dev-master.Jenkinsfile` to `dev-node.Jenkinsfile` to match the name of the resulting image.

Additionally, the ECR login step is no longer needed and was removed.