### PR TITLE
Update debian packages build setup and instructions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,10 @@
 - The behaviour of GetAccountList, GetInstances, and GetModuleList have changed in the case
   where the block hash is ill-formed. Instead of returning the JSON string "Invalid block hash.",
   these functions will now return the JSON null value.
-- Implement protocol updates, allowing migration to a new protocol. One protocol update is
-  implemented, which does not switch to a new protocol version, but allows for updating a number
-  of genesis parameters that would otherwise be immutable, while retaining the state.
+- Implement protocol updates, allowing migration to a new protocol. Two protocol updates are
+  implemented. One which does not switch to a new protocol version, but allows for updating a number
+  of genesis parameters that would otherwise be immutable, while retaining the
+  state. A second protocol update updates from P1 to P2.
 - Support for a new wire-protocol version (version 1) that adds a genesis index to non-transaction
   messages, a version header to catch-up messages. Version 0 is still supported for communication
   with legacy nodes during migration.

--- a/scripts/distribution/ubuntu-packages/.gitignore
+++ b/scripts/distribution/ubuntu-packages/.gitignore
@@ -1,0 +1,2 @@
+testnet-build/
+mainnet-build/

--- a/scripts/distribution/ubuntu-packages/README.md
+++ b/scripts/distribution/ubuntu-packages/README.md
@@ -71,7 +71,7 @@ The general strategy for building the package is as follows.
 
 1. Obtain genesis-data for the specific network. Copy `genesis.dat` to the
    [template/data](template/data) directory, naming it
-   `$build_env_name_lower-genesis.dat` (e.g., `testnet-genesis.dat`).
+   `${build_env_name_lower}-genesis.dat` (e.g., `testnet-genesis.dat`).
 2. Update [template/debian/changelog](template/debian/changelog) as appropriate.
 3. Update [template/debian/control](template/debian/control) as appropriate.
 4. Possibly update `CONCORDIUM_NODE_COLLECTOR_URL` in
@@ -165,20 +165,20 @@ These files are __not__ removed by the uninstall scripts since they contain
 # Configuration of the node
 
 The node is configured via `systemd` unit files. When installed there is only
-the system unit file in `/lib/systemd/system/concordium-testnet-node.service` which
+the system unit file in `/lib/systemd/system/concordium-${build_env_name_lower}-node.service` which
 contains reasonable defaults for an average system. However there are a number
 of configuration options that could make sense to alter. The intended way to
 modify node settings is to add `systemd` drop-in files. The simplest way to do
 that is to use `systemctl edit`. To edit the node settings
 
 ```console
-sudo systemctl edit concordium-testnet-node.service
+sudo systemctl edit concordium-${build_env_name_lower}-node.service
 ```
 
 this will open an editor which can be used to override the settings in
-`/lib/systemd/system/concordium-testnet-node.service` and add new configuration options.
+`/lib/systemd/system/concordium-${build_env_name_lower}-node.service` and add new configuration options.
 The first time this command is invoked a fresh file will be created at
-`/etc/systemd/system/concordium-testnet-node.service.d/override.conf`. After that the
+`/etc/systemd/system/concordium-${build_env_name_lower}-node.service.d/override.conf`. After that the
 same file will be opened for editing.
 
 The configuration should be done via `Environment` directives in a `[Service]`
@@ -236,7 +236,7 @@ The node supports the following environment variables.
 
 - `CONCORDIUM_NODE_RPC_SERVER_PORT` is the port of the grpc server (default 10000) (NB: If this
   is changed then the variable `COLLECTOR_GRPC_PORT` must be changed as well for
-  the `concordium-testnet-node-collector` service)
+  the `concordium-${build_env_name_lower}-node-collector` service)
 
 - `CONCORDIUM_NODE_EXTERNAL_PORT` is related to the listen-port. If the external port of the
   server is not the same as the port the node is listening on (i.e., it is
@@ -248,13 +248,13 @@ to keep connection to and never drop. The peers must be in the format `addr:port
   address and port of a "trusted node".
 
 - The complete list of configuration options can be obtained by running
-  `concordium-testnet-node --help`.
+  `concordium-${build_env_name_lower}-node --help`.
 
 After editing the configuration file the node must be restarted. This can be
 done via
 
 ```console
-sudo systemctl restart concordium-testnet-node.service
+sudo systemctl restart concordium-${build_env_name_lower}-node.service
 ```
 
 ## Caveat
@@ -271,7 +271,7 @@ sudo systemctl daemon-reload
 To see whether the node is running correctly you may use `systemctl` commands.
 
 ```console
-sudo systemctl status concordium-testnet-node.service
+sudo systemctl status concordium-${build_env_name_lower}-node.service
 ```
 
 will show whether the node is up and what configuration files it is using.
@@ -279,19 +279,19 @@ will show whether the node is up and what configuration files it is using.
 To see the contents of the configuration files you can use
 
 ```console
-sudo systemctl cat concordium-testnet-node.service
+sudo systemctl cat concordium-${build_env_name_lower}-node.service
 ```
 
 The node logs data using `journald`. The logs can be obtained via `journalctl`,
 e.g.,
 
 ```console
-sudo journalctl -u concordium-testnet-node.service
+sudo journalctl -u concordium-${build_env_name_lower}-node.service
 ```
 or only the most recent (e.g., last 10min)
 
 ```console
-sudo journalctl -u concordium-testnet-node.service --since '10min ago'
+sudo journalctl -u concordium-${build_env_name_lower}-node.service --since '10min ago'
 ```
 
 ### Troubleshooting
@@ -303,23 +303,23 @@ If this is the case then the log of the concordium-node will contain errors alon
 ```
 error, called at src/Concordium/GlobalState/Persistent/BlobStore.hs
 ...
-concordium-testnet-node: warning: too many hs_exit()s
-concordium-testnet-node.service: Main process exited, code=exited, status=1/FAILURE
-concordium-testnet-node.service: Failed with result 'exit-code'.
+concordium-${build_env_name_lower}-node: warning: too many hs_exit()s
+concordium-${build_env_name_lower}-node.service: Main process exited, code=exited, status=1/FAILURE
+concordium-${build_env_name_lower}-node.service: Failed with result 'exit-code'.
 ```
 
 In order to `recover` from such a situation, one should take the following steps.
 
-- Stop the concordium-testnet-node service by running the command `sudo systemctl stop concordium-testnet-node.service`
+- Stop the concordium-${build_env_name_lower}-node service by running the command `sudo systemctl stop concordium-${build_env_name_lower}-node.service`
 
 - Delete the contents (**except** the genesis.dat file) of the `data` folder.
 The default path for the `data` folder is `/var/lib/concordium/$GENESIS_HASH/data/`.
 Where $GENESIS_HASH is a hash derived from the configured genesis data.
 
-- Start the concordium-testnet-node service again by running `sudo systemctl start concordium-testnet-node-collector.service`.
+- Start the concordium-${build_env_name_lower}-node service again by running `sudo systemctl start concordium-${build_env_name_lower}-node-collector.service`.
 
 The concordium-node should now be up and running again.
-Verify with the command: `sudo systemctl status concordium-testnet-node`.
+Verify with the command: `sudo systemctl status concordium-${build_env_name_lower}-node`.
 
 ## Configuration of the collector
 
@@ -327,6 +327,6 @@ The main configuration option for the collector is the node name that appears on
 the network dashboard. Use
 
 ```console
-sudo systemctl edit concordium-testnet-node-collector.service
+sudo systemctl edit concordium-${build_env_name_lower}-node-collector.service
 ```
 to edit. The environment variable name is `CONCORDIUM_NODE_COLLECTOR_NODE_NAME`.

--- a/scripts/distribution/ubuntu-packages/README.md
+++ b/scripts/distribution/ubuntu-packages/README.md
@@ -9,8 +9,8 @@ In particular the packages will include
 - the start script for both services
 - configuration files
 
-The start scripts query for some information during setup, in particular they
-query for the node name.
+The installation scripts query for some information during setup, in particular
+they query for the node name.
 
 The template for building the packages is in the [template](./template)
 directory. The following files are relevant
@@ -49,33 +49,38 @@ directory. The following files are relevant
   with minor modifications to install two systemd services as opposed to a
   single, which would be the default.
 
-The strategy for building the package is as follows.
+These files contain a number of placeholders that can be instantiated when
+building a package for different environments. These are meant to be
+instantiated during build time with a tool such as `envsubst`. The variables are
+
+- `build_version` (e.g., 1.1.0, should match the concordium-node version)
+- `build_env_name` (e.g., Testnet)
+- `build_env_name_lower` (e.g., testnet)
+- `build_genesis_hash` (hash of the genesis block (NB: Not this is not the same
+  as the hash of the genesis.dat file.))
+- `build_collector_backend_url` (e.g. https://dashboard.testnet.concordium.com/nodes/post)
+- `build_rpc_server_port` (e.g., 10001)
+- `build_listen_port` (e.g., 8889)
+- `build_bootstrap` (e.g., bootstrap.testnet.concordium.com:8888)
+
+There is a script [./template/instantiate.sh](./template/instantiate.sh) to
+instantiate the template to obtain a concrete package. See the script
+documentation for the steps needed to instantiate the template.
+
+The general strategy for building the package is as follows.
 
 1. Obtain genesis-data for the specific network. Copy `genesis.dat` to the
-   [template/data](template/data) directory (creating the directory as well).
+   [template/data](template/data) directory, naming it
+   `$build_env_name_lower-genesis.dat` (e.g., `testnet-genesis.dat`).
 2. Update [template/debian/changelog](template/debian/changelog) as appropriate.
 3. Update [template/debian/control](template/debian/control) as appropriate.
-4. Update the
-   [template/debian/concordium-node.install](template/debian/concordium-node.install) and [template/debian/concordium-node.dirs](template/debian/concordium-node.dirs) files
-   with the genesis hash (NB: This is __not__ the hash of genesis.dat file,
-   it is the hash of the genesis block, which is defined differently. It is
-   emitted by the genesis tool into a file `genesis_hash`)
-5. Update
-   [template/debian/concordium-node.service](template/debian/concordium-node.service)
-   to match `StateDirectory` and WorkingDirectory values to match the genesis hash.
-6. Possibly update  `CONCORDIUM_NODE_CONNECTION_BOOTSTRAP_NODES` if it does not point to the correct
-   network.
-7. Possibly update `CONCORDIUM_NODE_COLLECTOR_URL` in
+4. Possibly update `CONCORDIUM_NODE_COLLECTOR_URL` in
    [template/debian/concordium-node-collector.service](template/debian/concordium-node-collector.service)
    to point to the correct backend for the network.
-6. Obtain the `concordium-node` and `node-collector` binaries built for the
+5. Obtain the `concordium-node` and `node-collector` binaries built for the
    specific ubuntu platform.
 
-   The [template/debian/rules](template/debian/rules)
-   script assumes that the `static-node-binaries` docker image is available (see
-   [../static-binaries/README.md](../static-binaries/README.md) for details on
-   how to obtain it). Make sure to use the `collector` feature to build them,
-   e.g.,
+   For example use the [../../static-binaries/build-static-binaries.sh](../../static-binaries/build-static-binaries.sh).
    ```console
    $ UBUNTU_VERSION=20.04 STATIC_LIBRARIES_IMAGE_TAG=0.21 GHC_VERSION=8.10.4 EXTRA_FEATURES=collector ./scripts/static-binaries/build-static-binaries.sh
    ```
@@ -83,10 +88,25 @@ The strategy for building the package is as follows.
    If not then just comment out the relevant lines and manually copy the
    binaries into the [template/binaries](template/binaries) (creating the
    directory if needed).
-6. Run `dpkg-buildpackage -us -uc --build=binary` from **inside the template directory**.
+6. Run [template/instantiate.sh](./template/instantiate.sh) script from **inside the template directory**.
    This produces a .deb file in this directory. The file is named in line with
    the debian naming convention, including the version number.
 
+
+# Mainnet and testnet builds
+
+Since mainnet and testnet builds are common the repository includes two scripts
+that will build packages for those two environments with minimal input. These
+scripts are [./build-mainnet-deb.sh](./build-mainnet-deb.sh) and
+[./build-testnet-deb.sh](./build-testnet-deb.sh). They should be run from the
+directory they are in as follows.
+
+```console
+UBUNTU_VERSION=20.04 ./build-testnet-deb.sh
+```
+
+The script uses docker to build the binaries and the debian package. The output
+of the script will be in the directory `testnet-build` (or `mainnet-build`).
 
 # Installing the package
 
@@ -101,40 +121,40 @@ This will take care to install dependencies first.
 
 # Installed package configuration
 
-The layout of the files in the package is as follows (for an example genesis).
+The layout of the files in the package is as follows (for an example genesis)
+and the `testnet` environment.
 
 ```
 .
 ├── lib
 │   └── systemd
 │       └── system
-│           ├── concordium-node-collector.service
-│           └── concordium-node.service
+│           ├── concordium-testnet-node-collector.service
+│           └── concordium-testnet-node.service
 ├── usr
 │   ├── bin
-│   │   ├── concordium-node
-│   │   └── node-collector
+│   │   ├── concordium-testnet-node-1.1.0
+│   │   └── concordium-testnet-node-collector-1.1.0
 │   └── share
 │       └── doc
-│           └── concordium-node
+│           └── concordium-testnet-node
 │               └── changelog.Debian.gz
 └── var
     └── lib
-        └── concordium
-            └── b6078154d6717e909ce0da4a45a25151b592824f31624b755900a74429e3073d
-                └── data
-                    └── genesis.dat
+        └── concordium-b6078154d6717e909ce0da4a45a25151b592824f31624b755900a74429e3073d
+            └── data
+                └── genesis.dat
 ```
 
 The packaging achieves the following
-- upon install the `concordium-node` and `concordium-node-collector` services will be started.
+- upon install the `concordium-testnet-node` and `concordium-testnet-node-collector` services will be started.
 - removing the package will stop the services and delete all of the mentioned
   files.
 
 In addition to the files above the following files are created by the
 installation scripts
 
-- `/etc/systemd/system/concordium-node-collector.service.d/override.conf`
+- `/etc/systemd/system/concordium-testnet-node-collector.service.d/override.conf`
   which is the configuration file with user-specific values for some environment
   variables. This currently contains only the node name that was chosen during
   installation.
@@ -145,20 +165,20 @@ These files are __not__ removed by the uninstall scripts since they contain
 # Configuration of the node
 
 The node is configured via `systemd` unit files. When installed there is only
-the system unit file in `/lib/systemd/system/concordium-node.service` which
+the system unit file in `/lib/systemd/system/concordium-testnet-node.service` which
 contains reasonable defaults for an average system. However there are a number
 of configuration options that could make sense to alter. The intended way to
 modify node settings is to add `systemd` drop-in files. The simplest way to do
 that is to use `systemctl edit`. To edit the node settings
 
 ```console
-sudo systemctl edit concordium-node.service
+sudo systemctl edit concordium-testnet-node.service
 ```
 
 this will open an editor which can be used to override the settings in
-`/lib/systemd/system/concordium-node.service` and add new configuration options.
+`/lib/systemd/system/concordium-testnet-node.service` and add new configuration options.
 The first time this command is invoked a fresh file will be created at
-`/etc/systemd/system/concordium-node.service.d/override.conf`. After that the
+`/etc/systemd/system/concordium-testnet-node.service.d/override.conf`. After that the
 same file will be opened for editing.
 
 The configuration should be done via `Environment` directives in a `[Service]`
@@ -216,7 +236,7 @@ The node supports the following environment variables.
 
 - `CONCORDIUM_NODE_RPC_SERVER_PORT` is the port of the grpc server (default 10000) (NB: If this
   is changed then the variable `COLLECTOR_GRPC_PORT` must be changed as well for
-  the `concordium-node-collector` service)
+  the `concordium-testnet-node-collector` service)
 
 - `CONCORDIUM_NODE_EXTERNAL_PORT` is related to the listen-port. If the external port of the
   server is not the same as the port the node is listening on (i.e., it is
@@ -228,13 +248,13 @@ to keep connection to and never drop. The peers must be in the format `addr:port
   address and port of a "trusted node".
 
 - The complete list of configuration options can be obtained by running
-  `concordium-node --help`.
+  `concordium-testnet-node --help`.
 
 After editing the configuration file the node must be restarted. This can be
 done via
 
 ```console
-sudo systemctl restart concordium-node.service
+sudo systemctl restart concordium-testnet-node.service
 ```
 
 ## Caveat
@@ -251,7 +271,7 @@ sudo systemctl daemon-reload
 To see whether the node is running correctly you may use `systemctl` commands.
 
 ```console
-sudo systemctl status concordium-node.service
+sudo systemctl status concordium-testnet-node.service
 ```
 
 will show whether the node is up and what configuration files it is using.
@@ -259,19 +279,19 @@ will show whether the node is up and what configuration files it is using.
 To see the contents of the configuration files you can use
 
 ```console
-sudo systemctl cat concordium-node.service
+sudo systemctl cat concordium-testnet-node.service
 ```
 
 The node logs data using `journald`. The logs can be obtained via `journalctl`,
 e.g.,
 
 ```console
-sudo journalctl -u concordium-node.service
+sudo journalctl -u concordium-testnet-node.service
 ```
 or only the most recent (e.g., last 10min)
 
 ```console
-sudo journalctl -u concordium-node.service --since '10min ago'
+sudo journalctl -u concordium-testnet-node.service --since '10min ago'
 ```
 
 ### Troubleshooting
@@ -283,23 +303,23 @@ If this is the case then the log of the concordium-node will contain errors alon
 ```
 error, called at src/Concordium/GlobalState/Persistent/BlobStore.hs
 ...
-concordium-node: warning: too many hs_exit()s
-concordium-node.service: Main process exited, code=exited, status=1/FAILURE
-concordium-node.service: Failed with result 'exit-code'.
+concordium-testnet-node: warning: too many hs_exit()s
+concordium-testnet-node.service: Main process exited, code=exited, status=1/FAILURE
+concordium-testnet-node.service: Failed with result 'exit-code'.
 ```
 
 In order to `recover` from such a situation, one should take the following steps.
 
-- Stop the concordium-node service by running the command `sudo systemctl stop concordium-node.service`
+- Stop the concordium-testnet-node service by running the command `sudo systemctl stop concordium-testnet-node.service`
 
 - Delete the contents (**except** the genesis.dat file) of the `data` folder.
 The default path for the `data` folder is `/var/lib/concordium/$GENESIS_HASH/data/`.
 Where $GENESIS_HASH is a hash derived from the configured genesis data.
 
-- Start the concordium-node service again by running `sudo systemctl start concordium-node-collector.service`.
+- Start the concordium-testnet-node service again by running `sudo systemctl start concordium-testnet-node-collector.service`.
 
 The concordium-node should now be up and running again.
-Verify with the command: `sudo systemctl status concordium-node`.
+Verify with the command: `sudo systemctl status concordium-testnet-node`.
 
 ## Configuration of the collector
 
@@ -307,6 +327,6 @@ The main configuration option for the collector is the node name that appears on
 the network dashboard. Use
 
 ```console
-sudo systemctl edit concordium-node-collector.service
+sudo systemctl edit concordium-testnet-node-collector.service
 ```
 to edit. The environment variable name is `CONCORDIUM_NODE_COLLECTOR_NODE_NAME`.

--- a/scripts/distribution/ubuntu-packages/build-mainnet-deb.sh
+++ b/scripts/distribution/ubuntu-packages/build-mainnet-deb.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# Used environment variables.
+# - UBUNTU_VERSION (mandatory)
+# - STATIC_LIBRARIES_IMAGE_TAG (defaults to 'latest' if not given)
+# - GHC_VERSION (defaults to '8.10.4' if not given)
+
+if ! docker inspect --type=image static-node-binaries > /dev/null 2> /dev/null ; then
+    # build static binaries
+    export STATIC_LIBRARIES_IMAGE_TAG="${STATIC_LIBRARIES_IMAGE_TAG:-latest}"
+    export GHC_VERSION="${GHC_VERSION:-8.10.4}"
+    export EXTRA_FEATURES="collector"
+    (cd ../../../; ./scripts/static-binaries/build-static-binaries.sh)
+fi
+
+docker build\
+       --build-arg ubuntu_version=$UBUNTU_VERSION\
+       --build-arg build_env_name=Mainnet\
+       --build-arg build_env_name_lower=mainnet\
+       --build-arg build_genesis_hash=9dd9ca4d19e9393877d2c44b70f89acbfc0883c2243e5eeaecc0d1cd0503f478\
+       --build-arg build_collector_backend_url=https://dashboard.mainnet.concordium.software/nodes/post\
+       --build-arg build_rpc_server_port=10000\
+       --build-arg build_listen_port=8888\
+       --build-arg build_bootstrap=bootstrap.mainnet.concordium.software:8888\
+       -f deb.Dockerfile -t mainnet-deb . --no-cache
+
+# Copy out the build artifacts. We create a temporary container and use docker
+# cp. This makes the output artifacts have correct file permissions (they are
+# owned by the user who ran the script).
+id=$(docker create mainnet-deb)
+docker cp $id:/out mainnet-build
+docker rm $id

--- a/scripts/distribution/ubuntu-packages/build-testnet-deb.sh
+++ b/scripts/distribution/ubuntu-packages/build-testnet-deb.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# Used environment variables.
+# - UBUNTU_VERSION (mandatory)
+# - STATIC_LIBRARIES_IMAGE_TAG (defaults to 'latest' if not given)
+# - GHC_VERSION (defaults to '8.10.4' if not given)
+
+# If the static-node-binaries image exists we use the binaries therein.
+# Otherwise we build it first.
+if ! docker inspect --type=image static-node-binaries > /dev/null 2> /dev/null ; then
+    # build static binaries
+    export STATIC_LIBRARIES_IMAGE_TAG="${STATIC_LIBRARIES_IMAGE_TAG:-latest}"
+    export GHC_VERSION="${GHC_VERSION:-8.10.4}"
+    export EXTRA_FEATURES="collector"
+    (cd ../../../; ./scripts/static-binaries/build-static-binaries.sh)
+fi
+
+docker build\
+       --build-arg ubuntu_version=$UBUNTU_VERSION\
+       --build-arg build_env_name=Testnet\
+       --build-arg build_env_name_lower=testnet\
+       --build-arg build_genesis_hash=b6078154d6717e909ce0da4a45a25151b592824f31624b755900a74429e3073d\
+       --build-arg build_collector_backend_url=https://dashboard.testnet.concordium.com/nodes/post\
+       --build-arg build_rpc_server_port=10001\
+       --build-arg build_listen_port=8889\
+       --build-arg build_bootstrap=bootstrap.testnet.concordium.com:8888\
+       -f deb.Dockerfile -t testnet-deb . --no-cache
+
+# Copy out the build artifacts. We create a temporary container and use docker
+# cp. This makes the output artifacts have correct file permissions (they are
+# owned by the user who ran the script).
+id=$(docker create testnet-deb)
+docker cp $id:/out testnet-build
+docker rm $id
+
+

--- a/scripts/distribution/ubuntu-packages/build-testnet-deb.sh
+++ b/scripts/distribution/ubuntu-packages/build-testnet-deb.sh
@@ -34,5 +34,3 @@ docker build\
 id=$(docker create testnet-deb)
 docker cp $id:/out testnet-build
 docker rm $id
-
-

--- a/scripts/distribution/ubuntu-packages/template/debian/changelog
+++ b/scripts/distribution/ubuntu-packages/template/debian/changelog
@@ -1,7 +1,5 @@
 concordium-${build_env_name_lower}-node ($build_version) unstable; urgency=medium
 
-   * No changes from upstream. See changelog
-	https://github.com/Concordium/concordium-node/blob/main/CHANGELOG.md
-	for upstream changes.
+   * See changelog https://github.com/Concordium/concordium-node/blob/main/CHANGELOG.md for upstream changes.
  
  -- Concordium developers <developers@concordium.com>  Mon, 6 Sep 2021 08:15:00 +2000

--- a/scripts/distribution/ubuntu-packages/template/debian/changelog
+++ b/scripts/distribution/ubuntu-packages/template/debian/changelog
@@ -1,5 +1,7 @@
-concordium-node (1.0.1-testnet) unstable; urgency=medium
+concordium-${build_env_name_lower}-node ($build_version) unstable; urgency=medium
 
-   * Initial release of the testnet version.
+   * No changes from upstream. See changelog
+	https://github.com/Concordium/concordium-node/blob/main/CHANGELOG.md
+	for upstream changes.
  
- -- Concordium developers <developers@concordium.com>  Thu, 13 May 2021 11:48:16 +2000
+ -- Concordium developers <developers@concordium.com>  Mon, 6 Sep 2021 08:15:00 +2000

--- a/scripts/distribution/ubuntu-packages/template/debian/concordium-node-collector.service
+++ b/scripts/distribution/ubuntu-packages/template/debian/concordium-node-collector.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Concordium Node Collector
+Description=Concordium ${build_env_name} Node Collector
 After=syslog.target network.target concordium-node.service
 # The node should be started before this service.
 # Requires will automatically start the node service if this
@@ -7,11 +7,11 @@ After=syslog.target network.target concordium-node.service
 # will be stopped as well.
 # The 'After' clause above means that the node service will be up
 # before this one is started.
-Requires=concordium-node.service
+Requires=concordium-${build_env_name_lower}-node.service
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/node-collector
+ExecStart=/usr/bin/concordium-${build_env_name_lower}-node-collector-${build_version}
 Restart=always
 RestartSec=20
 
@@ -35,8 +35,8 @@ RestrictRealtime=yes
 MemoryDenyWriteExecute=yes
 
 Environment=CONCORDIUM_NODE_COLLECTOR_COLLECT_INTERVAL=5000
-Environment=CONCORDIUM_NODE_COLLECTOR_URL=https://dashboard.testnet.concordium.com/nodes/post
-Environment=CONCORDIUM_NODE_COLLECTOR_GRPC_HOST=http://localhost:10000
+Environment=CONCORDIUM_NODE_COLLECTOR_URL=${build_collector_backend_url}
+Environment=CONCORDIUM_NODE_COLLECTOR_GRPC_HOST=http://localhost:${build_rpc_server_port}
 
 [Install]
 # start the service when reaching multi-user target

--- a/scripts/distribution/ubuntu-packages/template/debian/concordium-node.config
+++ b/scripts/distribution/ubuntu-packages/template/debian/concordium-node.config
@@ -3,9 +3,20 @@ set -e
 . /usr/share/debconf/confmodule
 set -u
 
-if [[ ! -f /etc/systemd/system/concordium-node-collector.service.d/override.conf ]]
+# The systemd dropin file with user configuration.
+DROP_IN="/etc/systemd/system/concordium-${build_env_name_lower}-node-collector.service.d/override.conf"
+
+if [[ ! -f "${DROP_IN}" ]]
 then
-    db_input high node-collector/node-name || true
+    db_input high concordium-${build_env_name_lower}-node-collector/node-name || true
     db_go # show interface
+    # check that the response was not an empty string.
+    db_get concordium-${build_env_name_lower}-node-collector/node-name
+
+    while [ -z "$RET" ]; do
+        db_input high concordium-${build_env_name_lower}-node-collector/node-name || true
+        db_go
+        db_get concordium-${build_env_name_lower}-node-collector/node-name
+    done
 fi
 

--- a/scripts/distribution/ubuntu-packages/template/debian/concordium-node.dirs
+++ b/scripts/distribution/ubuntu-packages/template/debian/concordium-node.dirs
@@ -1,1 +1,1 @@
-/var/lib/concordium/b6078154d6717e909ce0da4a45a25151b592824f31624b755900a74429e3073d/config
+/var/lib/concordium-${build_genesis_hash}/config

--- a/scripts/distribution/ubuntu-packages/template/debian/concordium-node.install
+++ b/scripts/distribution/ubuntu-packages/template/debian/concordium-node.install
@@ -1,3 +1,4 @@
-binaries/concordium-node usr/bin
-binaries/node-collector usr/bin
-data/genesis.dat var/lib/concordium/b6078154d6717e909ce0da4a45a25151b592824f31624b755900a74429e3073d/data
+#! /usr/bin/dh-exec
+binaries/concordium-node => /usr/bin/concordium-${build_env_name_lower}-node-${build_version}
+binaries/concordium-node-collector => /usr/bin/concordium-${build_env_name_lower}-node-collector-${build_version}
+data/${build_env_name_lower}-genesis.dat => /var/lib/concordium-${build_genesis_hash}/data/genesis.dat

--- a/scripts/distribution/ubuntu-packages/template/debian/concordium-node.service
+++ b/scripts/distribution/ubuntu-packages/template/debian/concordium-node.service
@@ -1,10 +1,10 @@
 [Unit]
-Description=Concordium Node
+Description=Concordium ${build_env_name} Node
 After=syslog.target network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/concordium-node --config-dir ${STATE_DIRECTORY}/config --data-dir ${STATE_DIRECTORY}/data
+ExecStart=/usr/bin/concordium-${build_env_name_lower}-node-${build_version} --config-dir ${STATE_DIRECTORY}/config --data-dir ${STATE_DIRECTORY}/data
 Restart=always
 RestartSec=20
 
@@ -30,14 +30,14 @@ MemoryDenyWriteExecute=yes
 DynamicUser=yes
 # state directory is relative to /var/lib/, see systemd man pages Sandboxing section.
 # This sets the STATE_DIRECTORY environment variable that is used as part of the ExecStart command.
-StateDirectory=concordium/b6078154d6717e909ce0da4a45a25151b592824f31624b755900a74429e3073d
+StateDirectory=concordium-${build_genesis_hash}
 # relative to the state directory root %S
-WorkingDirectory=%S/concordium/b6078154d6717e909ce0da4a45a25151b592824f31624b755900a74429e3073d
+WorkingDirectory=%S/concordium-${build_genesis_hash}
 
 # port on which the node will listen for incoming connections
-Environment=CONCORDIUM_NODE_LISTEN_PORT=8888
+Environment=CONCORDIUM_NODE_LISTEN_PORT=${build_listen_port}
 # where to bootstrap from
-Environment=CONCORDIUM_NODE_CONNECTION_BOOTSTRAP_NODES=bootstrap.testnet.concordium.com:8888
+Environment=CONCORDIUM_NODE_CONNECTION_BOOTSTRAP_NODES=${build_bootstrap}
 # desired number of nodes to be connected to.
 Environment=CONCORDIUM_NODE_CONNECTION_DESIRED_NODES=5
 # maximum number of __nodes__ the node will be connected to.
@@ -45,7 +45,7 @@ Environment=CONCORDIUM_NODE_CONNECTION_MAX_ALLOWED_NODES=10
 # address of the GRPC server
 Environment=CONCORDIUM_NODE_RPC_SERVER_ADDR=0.0.0.0
 # and its port
-Environment=CONCORDIUM_NODE_RPC_SERVER_PORT=10000
+Environment=CONCORDIUM_NODE_RPC_SERVER_PORT=${build_rpc_server_port}
 # maximum number of __connections__ the node can have. This can temporarily be more than
 # the number of peers when incoming connections are processed. 
 Environment=CONCORDIUM_NODE_CONNECTION_HARD_CONNECTION_LIMIT=20

--- a/scripts/distribution/ubuntu-packages/template/debian/concordium-node.templates
+++ b/scripts/distribution/ubuntu-packages/template/debian/concordium-node.templates
@@ -1,3 +1,3 @@
-Template: node-collector/node-name
+Template: concordium-${build_env_name_lower}-node-collector/node-name
 Type: string
-Description: Name of the node to appear on the network dashboard
+Description: Name of the node to appear on the network dashboard. Must not be empty.

--- a/scripts/distribution/ubuntu-packages/template/debian/control
+++ b/scripts/distribution/ubuntu-packages/template/debian/control
@@ -1,10 +1,10 @@
-Source: concordium-node
-Maintainer: Concordium Foundation <developers@concordium.com>
-Build-Depends: debconf ( >= 1.5.73 ), debhelper ( >= 12 )
+Source: concordium-${build_env_name_lower}-node
+Maintainer: Concordium developers <developers@concordium.com>
+Build-Depends: debconf ( >= 1.5.73 ), debhelper ( >= 12 ), dh-exec
 
-Package: concordium-node
+Package: concordium-${build_env_name_lower}-node
 Section: extra
 Priority: optional
 Architecture: amd64
 Depends: ${shlibs:Depends}, ${misc:Depends}
-Description: Concordium Testnet Node
+Description: Concordium ${build_env_name} Node

--- a/scripts/distribution/ubuntu-packages/template/debian/postinst
+++ b/scripts/distribution/ubuntu-packages/template/debian/postinst
@@ -31,11 +31,15 @@ fi
 # disjoint. This postinst script is responsible for migration from the old to
 # the new directories.
 
-if [ -d "/var/lib/concordium/${build_genesis_hash}" ];
+if [[ -d "/var/lib/concordium/${build_genesis_hash}/data" && -d "/var/lib/concordium/${build_genesis_hash}/config" ]];
 then
     echo "Migrating existing database directory to '/var/lib/concordium-${build_genesis_hash}'."
-    # At this point the target directory exists, so we only move the data and config to the new place.
-    mv "/var/lib/concordium/${build_genesis_hash}/{data,config}" "/var/lib/concordium-${build_genesis_hash}/"
+    # At this point the target data directory contains genesis.dat so we have to move the contents
+    # instead of just the directory to avoid conflicts.
+    mv /var/lib/concordium/${build_genesis_hash}/data/* /var/lib/concordium-${build_genesis_hash}/data/
+    rmdir /var/lib/concordium/${build_genesis_hash}/data
+    # The target config directory should be empty at this point, so it is OK to just move.
+    mv /var/lib/concordium/${build_genesis_hash}/config /var/lib/concordium-${build_genesis_hash}/
 fi
 
 # include automatically generated postinst scripts after we've update the override files.

--- a/scripts/distribution/ubuntu-packages/template/debian/postinst
+++ b/scripts/distribution/ubuntu-packages/template/debian/postinst
@@ -2,23 +2,39 @@
 set -e
 . /usr/share/debconf/confmodule
 set -u
-db_get node-collector/node-name
+db_get concordium-${build_env_name_lower}-node-collector/node-name
 NODE_NAME="$RET"
+
+# The systemd dropin file with user configuration.
+DROP_IN="/etc/systemd/system/concordium-${build_env_name_lower}-node-collector.service.d/override.conf"
 
 # Only update the node name if the override configuration does not already exist.
 # This is not perfect, since we don't know whether the override contains
 # CONCORDIUM_NODE_COLLECTOR_NODE_NAME, but it is good enough for now.
-if [[ ! -f /etc/systemd/system/concordium-node-collector.service.d/override.conf ]]
+if [[ ! -f "${DROP_IN}" ]]
 then 
-    echo "Writing node name to '/etc/systemd/system/node-collector.d/override.conf'."
-    mkdir -p /etc/systemd/system/concordium-node-collector.service.d/
-    cat > /etc/systemd/system/concordium-node-collector.service.d/override.conf <<EOF
+    echo "Writing node name to '${DROP_IN}'."
+    mkdir -p "$(dirname "${DROP_IN}")"
+    cat > "$DROP_IN" <<EOF
 [Service]
-Environment='CONCORDIUM_NODE_COLLECTOR_NODE_NAME=`systemd-escape "$NODE_NAME"`'
+Environment='CONCORDIUM_NODE_COLLECTOR_NODE_NAME=$(systemd-escape "$NODE_NAME")'
 EOF
 else
-    echo "Node collector override file '/etc/systemd/system/node-collector.d/override.conf' already exists."
+    echo "Node collector override file '${DROP_IN}' already exists."
     echo "To update settings edit the file."
+fi
+
+# Migrate previous state directories. The original concordium-node package.
+# stored state directories in /var/lib/concordium/$HASH. This causes some issues
+# with systemd and DynamicUser sandboxing, so in version 1.1.0 and onward we put
+# state directories in /var/lib/concordium-$HASH so that they are completely
+# disjoint. This postinst script is responsible for migration from the old to
+# the new directories.
+
+if [ -d "/var/lib/concordium/${build_genesis_hash}" ];
+then
+    echo "Migrating existing database directory to '/var/lib/concordium-${build_genesis_hash}'."
+    mv "/var/lib/concordium/${build_genesis_hash}" "/var/lib/concordium-${build_genesis_hash}"
 fi
 
 # include automatically generated postinst scripts after we've update the override files.

--- a/scripts/distribution/ubuntu-packages/template/debian/postinst
+++ b/scripts/distribution/ubuntu-packages/template/debian/postinst
@@ -34,7 +34,8 @@ fi
 if [ -d "/var/lib/concordium/${build_genesis_hash}" ];
 then
     echo "Migrating existing database directory to '/var/lib/concordium-${build_genesis_hash}'."
-    mv "/var/lib/concordium/${build_genesis_hash}" "/var/lib/concordium-${build_genesis_hash}"
+    # At this point the target directory exists, so we only move the data and config to the new place.
+    mv "/var/lib/concordium/${build_genesis_hash}/{data,config}" "/var/lib/concordium-${build_genesis_hash}/"
 fi
 
 # include automatically generated postinst scripts after we've update the override files.

--- a/scripts/distribution/ubuntu-packages/template/debian/rules
+++ b/scripts/distribution/ubuntu-packages/template/debian/rules
@@ -5,9 +5,11 @@
 # install two services
 # They will be enabled and started automatically when installed.
 # Enabled means they will be started on boot.
+# To not enable the service on boot add `--no-enable` to `th_installsystemd`.
+# To not start the service automatically upon install add `--no-start`.
 override_dh_installsystemd:
-		dh_installsystemd --name=concordium-${build_env_name_lower}-node # --no-enable --no-start
-		dh_installsystemd --name=concordium-${build_env_name_lower}-node-collector # --no-enable --no-start
+		dh_installsystemd --name=concordium-${build_env_name_lower}-node
+		dh_installsystemd --name=concordium-${build_env_name_lower}-node-collector
 
 override_dh_dwz:
 		# do nothing since we already stripped the binary

--- a/scripts/distribution/ubuntu-packages/template/debian/rules
+++ b/scripts/distribution/ubuntu-packages/template/debian/rules
@@ -2,17 +2,12 @@
 %:
 	dh $@
 
-# override_dh_update_autotools_config:
-# 		mkdir -p binaries
-# 		docker run -v $(shell pwd)/binaries:/out static-node-binaries cp /build/bin/concordium-node /out
-# 		docker run -v $(shell pwd)/binaries:/out static-node-binaries cp /build/bin/node-collector /out
-
 # install two services
 # They will be enabled and started automatically when installed.
 # Enabled means they will be started on boot.
 override_dh_installsystemd:
-		dh_installsystemd --name=concordium-node # --no-enable --no-start
-		dh_installsystemd --name=concordium-node-collector # --no-enable --no-start
+		dh_installsystemd --name=concordium-${build_env_name_lower}-node # --no-enable --no-start
+		dh_installsystemd --name=concordium-${build_env_name_lower}-node-collector # --no-enable --no-start
 
 override_dh_dwz:
 		# do nothing since we already stripped the binary

--- a/scripts/distribution/ubuntu-packages/template/instantiate.sh
+++ b/scripts/distribution/ubuntu-packages/template/instantiate.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# This script is intended to be run from inside a copy of the template
+# directory. It will rename the files and instantiate the template according to
+# the supplied environment variables.
+
+# Expects the following environment variables to be set.
+# - build_env_name (e.g., Testnet)
+# - build_env_name_lower (e.g., testnet)
+# - build_genesis_hash
+# - build_collector_backend_url (e.g. https://dashboard.testnet.concordium.com/nodes/post)
+# - build_rpc_server_port (e.g., 10001)
+# - build_listen_port (e.g., 8889)
+# - build_bootstrap (e.g., bootstrap.testnet.concordium.com:8888)
+
+# Figure out the package version. We run the concordium-node binary and
+# get its self-reported version to ensure consistency.
+
+export build_version=$(./binaries/concordium-node --version | cut -d ' ' -f 2)
+
+if [[ -z "$build_env_name"  || -z "$build_env_name_lower" || -z "$build_version"
+        || -z "$build_genesis_hash" || -z "$build_collector_backend_url"
+        || -z "$build_rpc_server_port" || -z "$build_listen_port" || -z "$build_bootstrap" ]];
+then
+    echo 'All of $build_env_name $build_env_name_lower $build_version $build_genesis_hash $build_collector_backend_url $build_rpc_server_port $build_listen_port $build_bootstrap must be set.'
+    exit 1
+fi
+
+# The package name will be concordium-$build_env_name-node and the systemd
+# services within are analogously named. To achieve this we rename the template
+# files accordingly, and then subsitute the
+for file in debian/*
+do
+    # insert environment name in template files with concordium-node in their name.
+    out_file="${file/concordium-node/concordium-${build_env_name_lower}-node}"
+    echo "$out_file"
+    # Some files do not get renamed. To avoid problems with envsubst below which
+    # overwrites the file we make a temporary copy for input.
+    mv "$file" "$file.tmp"
+    envsubst '$build_env_name
+              $build_env_name_lower
+              $build_version
+              $build_genesis_hash
+              $build_collector_backend_url
+              $build_rpc_server_port
+              $build_listen_port
+              $build_bootstrap' < "$file.tmp" > "$out_file"
+    rm "$file.tmp"
+done
+
+# The install file should be executable since it renames the executables via dh-exec.
+chmod +x debian/concordium-$build_env_name_lower-node.install
+# Build the package.
+dpkg-buildpackage -us -uc --build=binary
+
+# And copy all of the resulting artifacts (three files, the .deb package being
+# the main one, the other two being metadata) to ../out
+mkdir ../out
+mv ../concordium-$build_env_name_lower-node* ../out/


### PR DESCRIPTION
## Purpose

Update the build scripts and descriptions for the deb packages.

## Changes

- Provide simple scripts for building mainnet and testnet versions.
- Change directory location for databases in packages so that they do not conflict.
- Enable testnet and mainnet packages to be installed and run at the same time.
- The default ports are set the same as for the windows service.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
