### PR TITLE
Fix windows build script

### DIFF
--- a/scripts/distribution/windows/build-all.ps1
+++ b/scripts/distribution/windows/build-all.ps1
@@ -5,6 +5,8 @@ Write-Output "cargo version: $(cargo --version)"
 Write-Output "flatc version: $(flatc --version)"
 Write-Output "protoc version: $(protoc --version)"
 
+# Set the default rust toolchain so that consensus rust dependencies use it.
+rustup default $rustVersion-x86_64-pc-windows-gnu
 
 Write-Output "Building consensus..."
 stack build

--- a/scripts/distribution/windows/build-all.ps1
+++ b/scripts/distribution/windows/build-all.ps1
@@ -13,7 +13,7 @@ stack build
 if ($LASTEXITCODE -ne 0) { throw "Failed building consensus" }
 
 Write-Output "Building node..."
-stack exec -- cargo +$rustVersion-x86_64-pc-windows-gnu build --manifest-path concordium-node\Cargo.toml --release --features collector
+stack exec -- cargo build --manifest-path concordium-node\Cargo.toml --release --features collector
 if ($LASTEXITCODE -ne 0) { throw "Failed building node" }
 
 Write-Output "Building node runner service..."


### PR DESCRIPTION
## Purpose

The windows build script should set the default rust version to ensure that the rust dependencies are built with the correct version.

## Changes

Set default rust version in windows build script.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
