### PR TITLE
Distribution: Stagenet: Fix distribution image build

### DIFF
--- a/scripts/distribution/build-and-push-stagenet.sh
+++ b/scripts/distribution/build-and-push-stagenet.sh
@@ -15,7 +15,7 @@ image_name="stagenet-node"
 # Using '--no-cache' because we're cloning genesis data
 # and BuildKit (and '--ssh default') because the repo is on GitLab.
 DOCKER_BUILDKIT=1 docker build \
-  --build-arg environment="eu.staging.concordium.com"\
+  --build-arg environment="stagenet.concordium.com"\
   --build-arg base_image_tag="${base_image_tag}" \
   --build-arg static_libraries_image_tag="${static_libraries_image_tag}" \
   --build-arg ghc_version="${ghc_version}" \

--- a/scripts/distribution/builder.Dockerfile
+++ b/scripts/distribution/builder.Dockerfile
@@ -52,7 +52,7 @@ FROM ubuntu:20.04
 
 # Which environment we are building the image for.
 # This affects URLs. Currently it should be either
-#   - eu.staging.concordium.com
+#   - staging.concordium.com
 #   - testnet.concordium.com
 #   - mainnet.concordium.software
 ARG environment

--- a/scripts/distribution/builder.Dockerfile
+++ b/scripts/distribution/builder.Dockerfile
@@ -75,9 +75,14 @@ ENV DISTRIBUTION_CLIENT=true
 ENV CONCORDIUM_NODE_COLLECTOR_URL=https://dashboard.${environment}/nodes/post
 ENV CONCORDIUM_NODE_COLLECTOR_GRPC_HOST=http://localhost:10000
 
-RUN apt-get update && apt-get install -y curl netbase ca-certificates supervisor nginx libnuma1 libtinfo6 libpq-dev liblmdb-dev jq
-RUN curl -L https://getenvoy.io/install.sh | bash -s -- -b /usr/local/bin
-RUN getenvoy use 1.18.3
+RUN apt-get update && \
+    apt-get install -y curl netbase ca-certificates supervisor nginx libnuma1 libtinfo6 libpq-dev liblmdb-dev jq apt-transport-https gnupg2 curl lsb-release && \
+    rm -rf /var/lib/apt/lists/*
+RUN curl -sL 'https://deb.dl.getenvoy.io/public/gpg.8115BA8E629CC074.key' | gpg --dearmor -o /usr/share/keyrings/getenvoy-keyring.gpg && \
+    echo a077cb587a1b622e03aa4bf2f3689de14658a9497a9af2c427bba5f4cc3c4723 /usr/share/keyrings/getenvoy-keyring.gpg | sha256sum --check && \
+    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/getenvoy-keyring.gpg] https://deb.dl.getenvoy.io/public/deb/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/getenvoy.list && \
+    apt-get update && \
+    apt-get install -y getenvoy-envoy=1.18.2.p0.gd362e79-1p75.g76c310e
 
 COPY --from=node-dashboard /static /node-dashboard/static
 COPY --from=node-dashboard /envoy.yaml /node-dashboard/envoy.yaml

--- a/scripts/distribution/builder.Dockerfile
+++ b/scripts/distribution/builder.Dockerfile
@@ -78,11 +78,15 @@ ENV CONCORDIUM_NODE_COLLECTOR_GRPC_HOST=http://localhost:10000
 RUN apt-get update && \
     apt-get install -y curl netbase ca-certificates supervisor nginx libnuma1 libtinfo6 libpq-dev liblmdb-dev jq apt-transport-https gnupg2 curl lsb-release && \
     rm -rf /var/lib/apt/lists/*
+# Install Envoy Proxy according to official instructions
+# (see 'https://www.envoyproxy.io/docs/envoy/latest/start/install#install-envoy-on-ubuntu-linux')
+# except that the version is pinned (to the newest one).
 RUN curl -sL 'https://deb.dl.getenvoy.io/public/gpg.8115BA8E629CC074.key' | gpg --dearmor -o /usr/share/keyrings/getenvoy-keyring.gpg && \
     echo a077cb587a1b622e03aa4bf2f3689de14658a9497a9af2c427bba5f4cc3c4723 /usr/share/keyrings/getenvoy-keyring.gpg | sha256sum --check && \
     echo "deb [arch=amd64 signed-by=/usr/share/keyrings/getenvoy-keyring.gpg] https://deb.dl.getenvoy.io/public/deb/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/getenvoy.list && \
     apt-get update && \
-    apt-get install -y getenvoy-envoy=1.18.2.p0.gd362e79-1p75.g76c310e
+    apt-get install -y getenvoy-envoy=1.18.2.p0.gd362e79-1p75.g76c310e && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY --from=node-dashboard /static /node-dashboard/static
 COPY --from=node-dashboard /envoy.yaml /node-dashboard/envoy.yaml

--- a/scripts/distribution/builder.Dockerfile
+++ b/scripts/distribution/builder.Dockerfile
@@ -52,7 +52,7 @@ FROM ubuntu:20.04
 
 # Which environment we are building the image for.
 # This affects URLs. Currently it should be either
-#   - staging.concordium.com
+#   - stagenet.concordium.com
 #   - testnet.concordium.com
 #   - mainnet.concordium.software
 ARG environment

--- a/scripts/distribution/concordium.conf
+++ b/scripts/distribution/concordium.conf
@@ -16,7 +16,7 @@ user=docker
 startretries=50
 
 [program:grpc-web-proxy]
-command=getenvoy run -c /node-dashboard/envoy.yaml
+command=envoy -c /node-dashboard/envoy.yaml
 autostart=true
 autorestart=true
 startretries=50


### PR DESCRIPTION
## Purpose

The [install link](https://getenvoy.io/install.sh) for Envoy is no longer active and is now redirecting to the documentation for how to install the software using distro-specific packages instead.

## Changes

Replacing the old method of installing and running Envoy with the official instructions for installing a Debian package (on Ubuntu). The installed version of the package is pinned, but results in a downgrade from v. `1.18.3` to `1.18.2` as that is the newest available version in the repo.

Also updated the "environment" string used to construct the bootstrapping URL.