### PR TITLE
Make the database exporter threaded to prevent it from crashing on protocol updates

### DIFF
--- a/concordium-consensus/package.yaml
+++ b/concordium-consensus/package.yaml
@@ -210,6 +210,8 @@ executables:
     - -Wall
     - -Wcompat
     - -fno-ignore-asserts
+    - -threaded
+
     when:
       - condition: os(windows)
         then:


### PR DESCRIPTION
## Purpose

Fix database exporter build.

## Changes

Link with threaded runtime.