### PR TITLE
Add Jenkins job for activating distribution image

### DIFF
--- a/jenkinsfiles/activate_distribution.Jenkinsfile
+++ b/jenkinsfiles/activate_distribution.Jenkinsfile
@@ -3,8 +3,7 @@
 // - image_tag
 
 pipeline {
-    // TODO Run on master node (needs 'jq' and 'awscli' to be installed).
-    agent any
+    agent { label 'jenkins-master' }
 
     environment {
         // TODO Extract shared function for domain stuff.
@@ -30,9 +29,9 @@ pipeline {
                     }
                     EOF
                     invalidation_result="$(aws cloudfront create-invalidation --distribution-id "${CF_DISTRIBUTION_ID}" --paths "/${S3_VERSION_PATH}")"
-                    # Wait for invalidation to complete. Depends on 'jq' which is currently not available on the workers.
-                    #invalidation_id="$(jq -r '.Invalidation.Id' <<< "${invalidation_result}")"
-                    #aws cloudfront invalidation-completed --distribution-id "${CF_DISTRIBUTION_ID}" --id "${invalidation_id}"
+                    # Wait for invalidation to complete. Depends on 'jq' which is currently available on the master but not the workers.
+                    invalidation_id="$(jq -r '.Invalidation.Id' <<< "${invalidation_result}")"
+                    aws cloudfront invalidation-completed --distribution-id "${CF_DISTRIBUTION_ID}" --id "${invalidation_id}"
                 '''.stripIndent()
             }
         }

--- a/jenkinsfiles/activate_distribution.Jenkinsfile
+++ b/jenkinsfiles/activate_distribution.Jenkinsfile
@@ -3,7 +3,7 @@
 // - image_tag
 
 pipeline {
-    agent { label 'jenkins-master' }
+    agent { label 'master-node' }
 
     environment {
         // TODO Extract shared function for domain stuff.

--- a/jenkinsfiles/activate_distribution.Jenkinsfile
+++ b/jenkinsfiles/activate_distribution.Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
                     invalidation_result="$(aws cloudfront create-invalidation --distribution-id "${CF_DISTRIBUTION_ID}" --paths "/${S3_VERSION_PATH}")"
                     # Wait for invalidation to complete. Depends on 'jq' which is currently available on the master but not the workers.
                     invalidation_id="$(echo "${invalidation_result}" | jq -r '.Invalidation.Id')"
-                    aws cloudfront invalidation-completed --distribution-id "${CF_DISTRIBUTION_ID}" --id "${invalidation_id}"
+                    aws cloudfront wait invalidation-completed --distribution-id "${CF_DISTRIBUTION_ID}" --id "${invalidation_id}"
                 '''.stripIndent()
             }
         }

--- a/jenkinsfiles/activate_distribution.Jenkinsfile
+++ b/jenkinsfiles/activate_distribution.Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
                     EOF
                     invalidation_result="$(aws cloudfront create-invalidation --distribution-id "${CF_DISTRIBUTION_ID}" --paths "/${S3_VERSION_PATH}")"
                     # Wait for invalidation to complete. Depends on 'jq' which is currently available on the master but not the workers.
-                    invalidation_id="$(jq -r '.Invalidation.Id' <<< "${invalidation_result}")"
+                    invalidation_id="$(echo "${invalidation_result}" | jq -r '.Invalidation.Id')"
                     aws cloudfront invalidation-completed --distribution-id "${CF_DISTRIBUTION_ID}" --id "${invalidation_id}"
                 '''.stripIndent()
             }


### PR DESCRIPTION
The act of activating the distribution images is currently manual and cumbersome. This change adds a Jenkins job that given an environment and image tag will:
- check that the activated image exists
- update the version file and push it to S3
- invalidate the cloudfront cache