### PR TITLE
Fix docker distribution entrypoint.

### DIFF
--- a/scripts/distribution/docker-entrypoint.sh
+++ b/scripts/distribution/docker-entrypoint.sh
@@ -37,12 +37,7 @@ then
         echo "  concordium-client baker set-keys <keys-file>.json --sender bakerAccount --out <concordium-data-dir>/baker-credentials.json"
         exit 1
     fi
-    export BAKER_CREDENTIALS_FILENAME="baker-credentials.json"
-fi
-
-if [ -f /var/lib/concordium/data/blocks_to_import.dat ];
-then
-  export IMPORT_BLOCKS_FROM="/var/lib/concordium/data/blocks_to_import.dat"
+    export CONCORDIUM_NODE_BAKER_CREDENTIALS_FILE="baker-credentials.json"
 fi
 
 /usr/bin/supervisord -c /etc/supervisor/supervisord.conf


### PR DESCRIPTION
 ## Purpose

The environment variable for locating baker credentials is incorrect.

## Changes

- Correct name of the environment variable.
- Remove obsolete environment variable for out of band catchup. This is now set by the client tool.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
