### PR TITLE
Make baker credentials path absolute to not rely on working directory.

### DIFF
--- a/scripts/distribution/docker-entrypoint.sh
+++ b/scripts/distribution/docker-entrypoint.sh
@@ -37,7 +37,7 @@ then
         echo "  concordium-client baker set-keys <keys-file>.json --sender bakerAccount --out <concordium-data-dir>/baker-credentials.json"
         exit 1
     fi
-    export CONCORDIUM_NODE_BAKER_CREDENTIALS_FILE="baker-credentials.json"
+    export CONCORDIUM_NODE_BAKER_CREDENTIALS_FILE="/var/lib/concordium/data/baker-credentials.json"
 fi
 
 /usr/bin/supervisord -c /etc/supervisor/supervisord.conf


### PR DESCRIPTION
## Purpose

The working directory is not set by the start script leading to failure with the relative path.

## Changes

Make the credentials path absolute.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.