### PR TITLE
Fix mac node issues regarding special chars in node names

### DIFF
--- a/scripts/distribution/macOS-package/NodeConfigurationInstallerPlugin/NodeConfigurationInstallerPlugin/MyInstallerPane.m
+++ b/scripts/distribution/macOS-package/NodeConfigurationInstallerPlugin/NodeConfigurationInstallerPlugin/MyInstallerPane.m
@@ -40,7 +40,7 @@
                 // Initialize the dialog.
                 [warning addButtonWithTitle:@"OK"];
                 [warning setMessageText:@"Invalid node names"];
-                [warning setInformativeText:@"Node names must be between 1 and 100 characters in length and can only contain a-z, A-Z, 0-9, '-', or '_'."];
+                [warning setInformativeText:@"Node names must be between 1 and 100 characters in length and can only contain a-z, A-Z, 0-9, spaces, '-', or '_'."];
                 [warning setAlertStyle:NSAlertStyleInformational];
                 
                 // Display the warning dialog.
@@ -102,12 +102,12 @@
 
 // Checks that both the mainnet and testnet node names:
 // - have length > 0 and <= 100
-// - only contain characters in [a-zA-Z0-9-_]
+// - only contain characters in [a-zA-Z0-9-_ ]
 - (BOOL) nodeNamesAreValid
 {
     // NB: This character set must be accepted by the service file XML parser.
     // This naturally excludes '<', '>', etc., but the service won't start with a sequence of ',.' in the node name either.
-    NSCharacterSet *allowedChars = [[NSCharacterSet characterSetWithCharactersInString:@"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890-_"] invertedSet];
+    NSCharacterSet *allowedChars = [[NSCharacterSet characterSetWithCharactersInString:@"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890-_ "] invertedSet];
 
     // Default maximum node name length that the collector-backend will accept. Measured in UTF-8 encoded bytes.
     int maxLen = 100;

--- a/scripts/distribution/macOS-package/NodeConfigurationInstallerPlugin/NodeConfigurationInstallerPlugin/MyInstallerPane.m
+++ b/scripts/distribution/macOS-package/NodeConfigurationInstallerPlugin/NodeConfigurationInstallerPlugin/MyInstallerPane.m
@@ -40,7 +40,7 @@
                 // Initialize the dialog.
                 [warning addButtonWithTitle:@"OK"];
                 [warning setMessageText:@"Invalid node names"];
-                [warning setInformativeText:@"Node names must be between 1 and 100 characters in length and can only contain a-z, A-Z, 0-9, spaces, '-', or '_'."];
+                [warning setInformativeText:@"Node names must be between 1 and 100 characters in length and can only contain a-z, A-Z, 0-9, spaces, '-', or '_'. Additionally, names cannot start or end with spaces."];
                 [warning setAlertStyle:NSAlertStyleInformational];
                 
                 // Display the warning dialog.
@@ -103,6 +103,7 @@
 // Checks that both the mainnet and testnet node names:
 // - have length > 0 and <= 100
 // - only contain characters in [a-zA-Z0-9-_ ]
+// - cannot start or end with spaces
 - (BOOL) nodeNamesAreValid
 {
     // NB: This character set must be accepted by the service file XML parser.
@@ -123,6 +124,8 @@
             &&  mainnetNameLen <= maxLen
             &&  testnetNameLen > 0
             &&  testnetNameLen <= maxLen
+            &&  ![mainnetName hasPrefix:@" "]
+            &&  ![mainnetName hasSuffix:@" "]
             && !([mainnetName rangeOfCharacterFromSet:allowedChars].location != NSNotFound)
             && !([testnetName rangeOfCharacterFromSet:allowedChars].location != NSNotFound);
 }

--- a/scripts/distribution/macOS-package/NodeConfigurationInstallerPlugin/NodeConfigurationInstallerPlugin/MyInstallerPane.m
+++ b/scripts/distribution/macOS-package/NodeConfigurationInstallerPlugin/NodeConfigurationInstallerPlugin/MyInstallerPane.m
@@ -40,7 +40,7 @@
                 // Initialize the dialog.
                 [warning addButtonWithTitle:@"OK"];
                 [warning setMessageText:@"Invalid node names"];
-                [warning setInformativeText:@"Node names cannot be empty or contain '\"'."];
+                [warning setInformativeText:@"Node names must be between 1 and 100 characters in length and can only contain a-z, A-Z, 0-9, '-', or '_'."];
                 [warning setAlertStyle:NSAlertStyleInformational];
                 
                 // Display the warning dialog.
@@ -101,17 +101,30 @@
 }
 
 // Checks that both the mainnet and testnet node names:
-// - have length > 0
-// - contain no double quotes
+// - have length > 0 and <= 100
+// - only contain characters in [a-zA-Z0-9-_]
 - (BOOL) nodeNamesAreValid
 {
+    // NB: This character set must be accepted by the service file XML parser.
+    // This naturally excludes '<', '>', etc., but the service won't start with a sequence of ',.' in the node name either.
+    NSCharacterSet *allowedChars = [[NSCharacterSet characterSetWithCharactersInString:@"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890-_"] invertedSet];
+
+    // Default maximum node name length that the collector-backend will accept. Measured in UTF-8 encoded bytes.
+    int maxLen = 100;
+
     NSString *mainnetName = [_oMainnetNodeName stringValue];
     NSString *testnetName = [_oTestnetNodeName stringValue];
-    
-    return      [mainnetName length] > 0
-            &&  [testnetName length] > 0
-            && ![mainnetName containsString:@"\""]
-            && ![testnetName containsString:@"\""];
+
+    // NB: Get the actual length in bytes if allowedChars is changed to contain non-ascii characters.
+    NSUInteger mainnetNameLen = [mainnetName length];
+    NSUInteger testnetNameLen = [mainnetName length];
+
+    return      mainnetNameLen > 0
+            &&  mainnetNameLen <= maxLen
+            &&  testnetNameLen > 0
+            &&  testnetNameLen <= maxLen
+            && !([mainnetName rangeOfCharacterFromSet:allowedChars].location != NSNotFound)
+            && !([testnetName rangeOfCharacterFromSet:allowedChars].location != NSNotFound);
 }
 
 @end

--- a/scripts/distribution/macOS-package/template/payload/Library/Concordium Node/LaunchDaemons/software.concordium.mainnet.node-collector.plist
+++ b/scripts/distribution/macOS-package/template/payload/Library/Concordium Node/LaunchDaemons/software.concordium.mainnet.node-collector.plist
@@ -13,7 +13,17 @@
     <key>EnvironmentVariables</key>
     <dict>
 
-        <!-- Public node name showed on network dashboard. -->
+        <!-- Public node name showed on network dashboard.
+
+             Please note the following:
+                - Must have length 1 - 100 (in bytes)
+                - Replace (escape) characters with special meaning in XML, e.g.: '<'
+                with '&lt;' and '>' with '&gt;'.
+                - Prefixes and suffixes of spaces will be ignored
+                - When using commas it will be interpreted as a list of node names
+                    - In which case you must also provide a comma-separated list
+                    of GRPC hosts of the same length.
+        -->
         <key>CONCORDIUM_NODE_COLLECTOR_NODE_NAME</key>
         <string>__NODE_NAME__</string>
 

--- a/scripts/distribution/macOS-package/template/payload/Library/Concordium Node/LaunchDaemons/software.concordium.testnet.node-collector.plist
+++ b/scripts/distribution/macOS-package/template/payload/Library/Concordium Node/LaunchDaemons/software.concordium.testnet.node-collector.plist
@@ -13,7 +13,17 @@
     <key>EnvironmentVariables</key>
     <dict>
 
-        <!-- Public node name showed on network dashboard. -->
+        <!-- Public node name showed on network dashboard.
+
+             Please note the following:
+                - Must have length 1 - 100 (in bytes)
+                - Replace (escape) characters with special meaning in XML, e.g.: '<'
+                with '&lt;' and '>' with '&gt;'.
+                - Prefixes and suffixes of spaces will be ignored
+                - When using commas it will be interpreted as a list of node names
+                    - In which case you must also provide a comma-separated list
+                    of GRPC hosts of the same length.
+        -->
         <key>CONCORDIUM_NODE_COLLECTOR_NODE_NAME</key>
         <string>__NODE_NAME__</string>
 


### PR DESCRIPTION
## Purpose

Fixes two related issues regarding special character handling in the mac node installer.
Previously:
- If a node name contained XML, the installation would succeed, but the node wouldn't run, as it would (likely) get a parse error on the service file.
- If a node name contained special characters such as `/`, which has a special meaning for `sed`, the installation could fail.

Also adds a limit to the node names, as the collector-backend, by default, won't accept names longer than 100 bytes.

## Changes

- Restrict the allowed characters to a-z, A-Z, -, _, and spaces (not allowed as pre/suffixes).
- Restrict the length of node name to 100.
- Update error message accordingly.
- Explain limitations for names in the service file to aid advanced users

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.