### PR TITLE
Support supplying genesis path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Support custom path for genesis data via `CONCORDIUM_NODE_CONSENSUS_GENESIS_DATA_FILE`.
+
 ## concordium-node 1.1.2
 
 - Fix regression where expired transactions were not immediately rejected.

--- a/concordium-node/src/bin/bootstrap_checker.rs
+++ b/concordium-node/src/bin/bootstrap_checker.rs
@@ -18,7 +18,7 @@ use std::{env, process::Command, thread, time::Duration};
 
 fn main() -> anyhow::Result<()> {
     let (mut conf, app_prefs) = get_config_and_logging_setup()?;
-    let data_dir_path = app_prefs.get_user_app_dir();
+    let data_dir_path = app_prefs.get_data_dir();
 
     conf.connection.max_allowed_nodes = Some(0);
     conf.connection.thread_pool_size = 1;

--- a/concordium-node/src/bin/bootstrapper.rs
+++ b/concordium-node/src/bin/bootstrapper.rs
@@ -20,7 +20,7 @@ use concordium_node::stats_export_service::start_push_gateway;
 fn main() -> anyhow::Result<()> {
     let (mut conf, app_prefs) = get_config_and_logging_setup()?;
     conf.connection.max_allowed_nodes = Some(conf.bootstrapper.max_nodes);
-    let data_dir_path = app_prefs.get_user_app_dir();
+    let data_dir_path = app_prefs.get_data_dir();
 
     let stats_export_service = instantiate_stats_export_engine(&conf)?;
 

--- a/concordium-node/src/bin/cli.rs
+++ b/concordium-node/src/bin/cli.rs
@@ -135,7 +135,7 @@ async fn main() -> anyhow::Result<()> {
         String::new()
     };
 
-    let data_dir_path = app_prefs.get_user_app_dir();
+    let data_dir_path = app_prefs.get_data_dir();
     let mut database_directory = data_dir_path.to_path_buf();
     database_directory.push(concordium_node::configuration::DATABASE_SUB_DIRECTORY_NAME);
     if !database_directory.exists() {

--- a/concordium-node/src/configuration.rs
+++ b/concordium-node/src/configuration.rs
@@ -283,8 +283,17 @@ pub struct BakerConfig {
     )]
     pub max_time_to_expiry: u64,
     #[structopt(
+        long = "genesis-data-file",
+        help = "Path to the data that constitutes the genesis block. If the path is relative it \
+                is interpreted relative to the supplied data directory.",
+        default_value = "genesis.dat",
+        env = "CONCORDIUM_NODE_CONSENSUS_GENESIS_DATA_FILE"
+    )]
+    pub genesis_data_file: PathBuf,
+    #[structopt(
         long = "baker-credentials-file",
-        help = "Path to the baker credentials file",
+        help = "Path to the baker credentials file. If the path is relative it is interpreted \
+                relative to the node process' working directory.",
         env = "CONCORDIUM_NODE_BAKER_CREDENTIALS_FILE"
     )]
     pub baker_credentials_file: Option<PathBuf>,
@@ -951,8 +960,8 @@ impl AppPreferences {
     }
 
     /// Returns the path to the application directory.
-    pub fn get_user_app_dir(&self) -> &Path { &self.override_data_dir }
+    pub fn get_data_dir(&self) -> &Path { &self.override_data_dir }
 
     /// Returns the path to the config directory.
-    pub fn get_user_config_dir(&self) -> &Path { &self.override_config_dir }
+    pub fn get_config_dir(&self) -> &Path { &self.override_config_dir }
 }

--- a/concordium-node/src/utils.rs
+++ b/concordium-node/src/utils.rs
@@ -121,8 +121,8 @@ pub fn get_config_and_logging_setup() -> anyhow::Result<(config::Config, config:
     }
 
     info!("Starting up {} version {}!", crate::APPNAME, crate::VERSION);
-    info!("Application data directory: {}", app_prefs.get_user_app_dir().to_string_lossy());
-    info!("Application config directory: {}", app_prefs.get_user_config_dir().to_string_lossy());
+    info!("Application data directory: {}", app_prefs.get_data_dir().display());
+    info!("Application config directory: {}", app_prefs.get_config_dir().display());
     info!(
         "Network: {}",
         if conf.cli.no_network {

--- a/docker-compose/bakers.yaml
+++ b/docker-compose/bakers.yaml
@@ -31,7 +31,7 @@ services:
     environment:
     - RUST_BACKTRACE=1
     - RUST_LOG=info
-    - GENESIS_DATA_PATH=/genesis-data/genesis-${NUM_BAKERS}-bakers
+    - GENESIS_DATA_PATH=/genesis-data/genesis-${NUM_BAKERS}-bakers # should be an absolute path
     - BAKER_ID_URL=http://baker_id_gen:8000
     - CONCORDIUM_NODE_CONNECTION_DESIRED_NODES=${DESIRED_PEERS}
     - CONCORDIUM_NODE_CONNECTION_BOOTSTRAP_NODES=bootstrapper:8888

--- a/docker-compose/node-entrypoint.sh
+++ b/docker-compose/node-entrypoint.sh
@@ -4,24 +4,20 @@ set -euxo pipefail
 
 # Extract input values.
 genesis_data_path="${GENESIS_DATA_PATH-}"
-concordium_node_data_dir="${CONCORDIUM_NODE_DATA_DIR}"
-if [ -n "${genesis_data_path}" ]; then
-	baker_id_url="${BAKER_ID_URL}"
-fi
-
 # The correct 'genesis.dat' and baker credentials files for the network are stored in
 # '/genesis-data/genesis-${NUM_BAKERS}-bakers'.
-# The node expects to find 'genesis.dat' in the data dir '/var/lib/concordium/data'.
-# The Compose file sets 'GENESIS_DATA_PATH' to the former path such that we can copy it here
-# and also point at the correct credentials.
+# The Compose file sets 'GENESIS_DATA_PATH' to this path and the rest of this script assumes
+# that the baker credentials as well as genesis.dat is contained in that folder.
 # If the variable isn't set, the assumption is that the files/environment has been set up by some other means.
 # The node will fail on startup if this is not done correctly.
+
 if [ -n "${genesis_data_path}" ]; then
-	# Copy 'genesis.dat' - better solution: support flag in concordium-node to set location.
-	cp "${genesis_data_path}/genesis.dat" "${concordium_node_data_dir}"
-	# Select unique baker credentials file.
+    # Get the baker id by querying a simple service and select the baker credentials file based on this.
+	baker_id_url="${BAKER_ID_URL}"
 	id="$(curl -sS "${baker_id_url}")"
 	export CONCORDIUM_NODE_BAKER_CREDENTIALS_FILE="${genesis_data_path}/bakers/baker-${id}-credentials.json"
+    # Set the correct genesis for the network.
+    export CONCORDIUM_NODE_CONSENSUS_GENESIS_DATA_FILE="${genesis_data_path}/genesis.dat"
 fi
 
 # Run binary - inherits env vars and args.

--- a/docker-compose/node-entrypoint.sh
+++ b/docker-compose/node-entrypoint.sh
@@ -13,9 +13,9 @@ genesis_data_path="${GENESIS_DATA_PATH-}"
 
 if [ -n "${genesis_data_path}" ]; then
     # Get the baker id by querying a simple service and select the baker credentials file based on this.
-	baker_id_url="${BAKER_ID_URL}"
-	id="$(curl -sS "${baker_id_url}")"
-	export CONCORDIUM_NODE_BAKER_CREDENTIALS_FILE="${genesis_data_path}/bakers/baker-${id}-credentials.json"
+    baker_id_url="${BAKER_ID_URL}"
+    id="$(curl -sS "${baker_id_url}")"
+    export CONCORDIUM_NODE_BAKER_CREDENTIALS_FILE="${genesis_data_path}/bakers/baker-${id}-credentials.json"
     # Set the correct genesis for the network.
     export CONCORDIUM_NODE_CONSENSUS_GENESIS_DATA_FILE="${genesis_data_path}/genesis.dat"
 fi

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -25,7 +25,8 @@ fi
 
 if [ -n "$DISTRIBUTION_CLIENT" ];
 then
-    cp /genesis.dat $CONCORDIUM_NODE_DATA_DIR
+    # Tell the node where to find the genesis file.
+    export CONCORDIUM_NODE_CONSENSUS_GENESIS_DATA_FILE=/genesis.dat
 fi
 
 


### PR DESCRIPTION
## Purpose

In a number of places we need to copy genesis.dat file to a fixed location because it is expected at a hardcoded path.
This PR makes the genesis path a parameter to avoid copying.

This improves usability for local testing as well as for some docker images.

## Changes

- Make the location of genesis data a parameter.
- Rename the confusingly (and obsoletely) named get_*user*_* functions since they don't have anything to do with user directories. They just retrieve the nodes' config and data directories.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
