### PR TITLE
Jenkins: Convert job 'activate_distribution' to scripted pipeline

### DIFF
--- a/jenkinsfiles/activate_distribution.Jenkinsfile
+++ b/jenkinsfiles/activate_distribution.Jenkinsfile
@@ -2,38 +2,53 @@
 // - environment
 // - image_tag
 @Library('concordium-pipelines') _
-pipeline {
-    agent { label 'master-node' }
-
-    environment {
-        // TODO Extract shared function for domain stuff.
-        S3_BUCKET = "s3://distribution.${concordiumDomain(environment)}"
-        S3_VERSION_PATH = 'image/version.json'
-        S3_IMAGE_PATH = "image/${environment}-node-${image_tag}.tar.gz"
-        CF_DISTRIBUTION_ID = "${[stagenet: 'E2Z6VZ10YEWPDX', testnet: 'E3OE3P6NHHWU0I', mainnet: 'E1F07594M64NU0'][environment]}"
+node('master-node') {
+    def DISTRIBUTION_IDS = [
+        stagenet: 'E2Z6VZ10YEWPDX',
+        testnet: 'E3OE3P6NHHWU0I',
+        mainnet: 'E1F07594M64NU0',
+    ]
+    
+    if (!environment?.trim()) {
+        error "No value for 'environment' provided."
+    }
+    
+    def s3_bucket = "s3://distribution.${concordiumDomain(environment)}"
+    def s3_version_path = 'image/version.json'
+    def s3_image_path = "image/${environment}-node-${image_tag}.tar.gz"
+    def cf_distribution_id = DISTRIBUTION_IDS[environment]
+    if (!cf_distribution_id) {
+        error "No value for 'cf_distribution_id' found."
     }
 
-    stages {
-        stage('build') {
-            steps {
-                sh '''\
-                    if ! aws s3 ls "${S3_BUCKET}/${S3_IMAGE_PATH}"; then
-                        echo "Image with tag '${image_tag}' does not exist in bucket '${S3_BUCKET}'"
-                        exit 1
-                    fi
-                    aws s3 cp - "${S3_BUCKET}/${S3_VERSION_PATH}" --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers <<EOF
-                    {
-                        "image_tag": "${image_tag}",
-                        "file": "testnet-node-${image_tag}.tar.gz",
-                        "image_name": "testnet-node"
-                    }
-                    EOF
-                    invalidation_result="$(aws cloudfront create-invalidation --distribution-id "${CF_DISTRIBUTION_ID}" --paths "/${S3_VERSION_PATH}")"
-                    # Wait for invalidation to complete. Depends on 'jq' which is currently available on the master but not the workers.
-                    invalidation_id="$(echo "${invalidation_result}" | jq -r '.Invalidation.Id')"
-                    aws cloudfront wait invalidation-completed --distribution-id "${CF_DISTRIBUTION_ID}" --id "${invalidation_id}"
-                '''.stripIndent()
-            }
+    stage('verify') {
+        try {
+            sh (script: """\
+                aws s3 ls "${s3_bucket}/${s3_image_path}"
+            """.stripIndent())
+        } catch (e) {
+            error "Image with tag '${image_tag}' does not exist in bucket '${s3_bucket}' on path '${s3_image_path}'."
         }
+    }
+    stage('update') {
+        sh(script: """\
+            aws s3 cp - "${s3_bucket}/${s3_version_path}" --grants=read=uri=http://acs.amazonaws.com/groups/global/AllUsers <<EOF
+            {
+                "image_tag": "${image_tag}",
+                "file": "testnet-node-${image_tag}.tar.gz",
+                "image_name": "testnet-node"
+            }
+            EOF
+        """.stripIndent())
+    }
+    stage('invalidate') {
+        invalidation_result = sh(script: """\
+            aws cloudfront create-invalidation --distribution-id="${cf_distribution_id}" --paths="/${s3_version_path}"
+        """, returnStdout: true)
+        // Wait for invalidation to complete.
+        invalidation = readJSON(text: invalidation_result)
+        sh(script: """\
+            aws cloudfront wait invalidation-completed --distribution-id="${cf_distribution_id}" --id="${invalidation.Invalidation.Id}"
+        """.stripIndent())
     }
 }


### PR DESCRIPTION
## Purpose

The job was originally created as a declarative pipeline, but is better expressed as a scripted pipeline.

## Changes

Converted the job to [scripted pipeline](https://www.jenkins.io/doc/book/pipeline/syntax/#scripted-pipeline).