### PR TITLE
Fix dead block access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased changes
 
+## concordium-node 1.1.3
+
+- Fix a number of bugs that led to node crashes due to failed block lookup in some situations.
 - Support custom path for genesis data via `CONCORDIUM_NODE_CONSENSUS_GENESIS_DATA_FILE`.
 
 ## concordium-node 1.1.2

--- a/concordium-consensus/src/Concordium/Skov/Update.hs
+++ b/concordium-consensus/src/Concordium/Skov/Update.hs
@@ -203,7 +203,7 @@ processFinalization newFinBlock finRec@FinalizationRecord{..} = do
         doArchive =<< bpParent newFinBlock
         -- Prune the branches: mark dead any block that doesn't descend from
         -- the newly-finalized block.
-        -- Instead of marking blocks dead immediately we accummulate them
+        -- Instead of marking blocks dead immediately we accumulate them
         -- and a return a list. The reason for doing this is that we never
         -- have to look up a parent block that is already marked dead.
         let

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_node"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "anyhow",
  "app_dirs2",

--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium_node"
-version = "1.1.2" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
+version = "1.1.3" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
 description = "Concordium Node"
 authors = ["Concordium <developers@concordium.com>"]
 exclude = [".gitignore", ".gitlab-ci.yml", "test/**/*","**/**/.gitignore","**/**/.gitlab-ci.yml"]

--- a/service/windows/installer/Node.wxs
+++ b/service/windows/installer/Node.wxs
@@ -2,9 +2,9 @@
 <!-- When updating the product version, the Product Id should be refreshed, otherwise it will not be
     possible to upgrade an existing installation.
 -->
-<?define VersionNumber="1.1.2" ?>
+<?define VersionNumber="1.1.3" ?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:Util="http://schemas.microsoft.com/wix/UtilExtension">
-    <Product Name="Concordium Node" Manufacturer="Concordium Software" Id="b06fb385-0f3d-4322-800d-d619ac9ff9f9" UpgradeCode="297295b4-c716-4d33-8170-0f6136663bfd" Language="1033" Codepage="1252" Version="$(var.VersionNumber)">
+    <Product Name="Concordium Node" Manufacturer="Concordium Software" Id="8c92955b-383a-4f86-ba06-b39aa117493f" UpgradeCode="297295b4-c716-4d33-8170-0f6136663bfd" Language="1033" Codepage="1252" Version="$(var.VersionNumber)">
         <Package Id="*" Keywords="Concordium Installer" Description="Concordium Node $(var.VersionNumber) Installer" Manufacturer="Concordium Software" InstallerVersion="500" Languages="1033" Compressed="yes" InstallScope="perMachine" />
         <MajorUpgrade Schedule="afterInstallValidate" DowngradeErrorMessage="The currently-installed version of [ProductName] is newer than the version you are trying to install. The installation cannot continue. If you wish to install this version, please remove the newer version first." />
         <Media Id="1" Cabinet="Node.cab" EmbedCab="yes" />


### PR DESCRIPTION
## Purpose

Fix occasional crashes in high-stress situations.

In combination with #180 closes #179 

Partially addresses #135 by writing finalized blocks by increasing height.

1. For the persistent block storage block parent pointers are weak pointers.
2. During finalization blocks are in some cases marked as dead before their descendants. The node sometimes looks up a block parent that is dead.
3. Depending on the scheduling of the garbage collector the parent block is already reclaimed, or at the very least the weak pointer cannot be dereferenced, leading to a node crash.

## Changes

Instead of marking blocks as dead immediately during finalization we accumulate them and mark them as dead at the end after we no longer need to look up their parents.

This relies on #180.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
