### PR TITLE
Jenkins: Fix 'activate-distribution-image' pipeline

### DIFF
--- a/jenkinsfiles/activate-distribution-image.Jenkinsfile
+++ b/jenkinsfiles/activate-distribution-image.Jenkinsfile
@@ -13,7 +13,7 @@ node('master-node') {
         error "No value for 'environment' provided."
     }
     
-    def image_name = ${environment}-node"
+    def image_name = "${environment}-node"
     def file_name = "${image_name}-${image_tag}.tar.gz"
     def s3_bucket = "s3://distribution.${concordiumDomain(environment)}"
     def s3_version_path = 'image/version.json'

--- a/jenkinsfiles/activate-distribution-image.Jenkinsfile
+++ b/jenkinsfiles/activate-distribution-image.Jenkinsfile
@@ -13,9 +13,11 @@ node('master-node') {
         error "No value for 'environment' provided."
     }
     
+    def image_name = ${environment}-node"
+    def file_name = "${image_name}-${image_tag}.tar.gz"
     def s3_bucket = "s3://distribution.${concordiumDomain(environment)}"
     def s3_version_path = 'image/version.json'
-    def s3_image_path = "image/${environment}-node-${image_tag}.tar.gz"
+    def s3_image_path = "image/${file_name}"
     def cf_distribution_id = DISTRIBUTION_IDS[environment]
     if (!cf_distribution_id) {
         error "No value for 'cf_distribution_id' found."
@@ -35,8 +37,8 @@ node('master-node') {
             aws s3 cp - "${s3_bucket}/${s3_version_path}" --grants=read=uri=http://acs.amazonaws.com/groups/global/AllUsers <<EOF
             {
                 "image_tag": "${image_tag}",
-                "file": "testnet-node-${image_tag}.tar.gz",
-                "image_name": "testnet-node"
+                "file": "${file_name}",
+                "image_name": "${image_name}"
             }
             EOF
         """.stripIndent())


### PR DESCRIPTION
## Purpose

The pipeline wasn't properly parameterized and used "testnet" regardless of the selected environment.

## Changes

The pipeline now uses the environment parameter properly.