### PR TITLE
Allow supplying multiple Haskell RTS arguments via the environment variable.

### DIFF
--- a/concordium-node/src/configuration.rs
+++ b/concordium-node/src/configuration.rs
@@ -230,7 +230,10 @@ pub struct BakerConfig {
         long = "haskell-rts-flags",
         help = "Haskell RTS flags to pass to consensus.",
         default_value = "",
-        env = "CONCORDIUM_NODE_RUNTIME_HASKELL_RTS_FLAGS"
+        env = "CONCORDIUM_NODE_RUNTIME_HASKELL_RTS_FLAGS",
+        // parse the argument as a comma separated list of values.
+        // Especially useful when supplied via the environment variable.
+        use_delimiter = true
     )]
     pub rts_flags: Vec<String>,
     #[structopt(


### PR DESCRIPTION
## Purpose

Fix an inconsistency and allow supplying multiple arguments as a comma separated list.

As far as I can tell no arguments should have commas, so this change should be backwards compatible.


## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.