### PR TITLE
Account aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 - Faster state queries by avoiding locking the block state file when reading.
 - Fix a bug by shutting down RPC before the node, which caused the node to crash
   when attempting a graceful shutdown while processing RPC requests.
+- Introduce support for account aliases via protocol P3. Accounts can be queried
+  in `GetAccountInfo`, `GetAccountNonFinalizedTransactions`,
+  `GetNextAccountNonce` by any alias.
+- `GetAccountInfo` object has an additional field `accountAddress` that contains
+  the canonical address of the account.
 
 ## concordium-node 1.1.3
 

--- a/concordium-consensus/src/Concordium/GlobalState/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Account.hs
@@ -26,7 +26,6 @@ import Concordium.Constants
 import Concordium.Types.HashableTo
 import Concordium.GlobalState.Basic.BlockState.AccountReleaseSchedule
 
-
 -- |A list of credential IDs that have been removed from an account.
 data RemovedCredentials
     = EmptyRemovedCredentials
@@ -230,8 +229,10 @@ data EncryptedAmountUpdate =
 
 -- |An update to an account state.
 data AccountUpdate = AccountUpdate {
-  -- |Address of the affected account.
-  _auAddress :: !AccountAddress
+  -- |Index of the affected account.
+  _auIndex :: !AccountIndex
+  -- |Canonical address of the affected account.
+  ,_auAddress :: !AccountAddress
   -- |Optionally a new account nonce.
   ,_auNonce :: !(Maybe Nonce)
   -- |Optionally an update to the account amount.
@@ -243,8 +244,8 @@ data AccountUpdate = AccountUpdate {
 } deriving(Eq)
 makeLenses ''AccountUpdate
 
-emptyAccountUpdate :: AccountAddress -> AccountUpdate
-emptyAccountUpdate addr = AccountUpdate addr Nothing Nothing Nothing Nothing
+emptyAccountUpdate :: AccountIndex -> AccountAddress -> AccountUpdate
+emptyAccountUpdate ai addr = AccountUpdate ai addr Nothing Nothing Nothing Nothing
 
 updateAccountInformation :: AccountThreshold -> Map.Map CredentialIndex AccountCredential -> [CredentialIndex] -> AccountInformation -> AccountInformation
 updateAccountInformation threshold addCreds remove (AccountInformation oldCredKeys _) =

--- a/concordium-consensus/src/Concordium/GlobalState/AccountMap.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/AccountMap.hs
@@ -101,7 +101,7 @@ empty :: AccountMap pv fix
 empty = AccountMap Trie.empty
 
 mkPrefix :: AccountAddress -> [Word8]
-mkPrefix = take 29 . Trie.unpackKey
+mkPrefix = take accountAddressPrefixSize . Trie.unpackKey
 
 -- |Retrieve the account index for the given address if the address exists.
 -- The semantics of this method depends on the protocol version.

--- a/concordium-consensus/src/Concordium/GlobalState/AccountMap.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/AccountMap.hs
@@ -1,0 +1,186 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE DerivingVia #-}
+module Concordium.GlobalState.AccountMap (
+  AccountMap(..),
+  PersistentAccountMap,
+  PureAccountMap,
+
+  -- * Construction
+  toPersistent,
+  empty,
+
+  -- * Queries
+  lookup,
+  addressWouldClash,
+
+  -- * Modifications
+  insert,
+  maybeInsert,
+
+  -- * Traversals
+  toList,
+  toMap,
+  addresses,
+  accountExists,
+
+  -- * Specializations for the pure in-memory implementation.
+  lookupPure,
+  addressWouldClashPure,
+  insertPure,
+  maybeInsertPure,
+  toListPure,
+  toMapPure,
+  addressesPure,
+  accountExistsPure
+  )
+
+where
+
+import Prelude hiding (lookup)
+import Data.Fix
+import qualified Data.Map.Strict as Map
+import Data.Word
+import Data.Functor.Foldable (Base)
+import Data.Bifunctor
+import Data.Maybe
+import Control.Monad.Identity
+
+import Concordium.Types
+import qualified Concordium.GlobalState.Persistent.Trie as Trie
+import Concordium.GlobalState.Persistent.BlobStore
+import Concordium.GlobalState.Persistent.MonadicRecursive
+
+-- |An account map, mapping account addresses to account indices. Account
+-- addresses are used externally to refer to accounts. Depending on the protocol
+-- version, multiple account addresses may refer to the same account.
+--
+-- Currently, in protocol versions 1 and 2 each account has exactly one address.
+-- In protocol version 3 an account may have up to 2^24 addresses.
+newtype AccountMap (pv :: ProtocolVersion) fix = AccountMap {
+  unAccountMap :: Trie.TrieN fix AccountAddress AccountIndex
+  }
+
+-- |The account map to be used in the persistent block state.
+type PersistentAccountMap pv = AccountMap pv (BufferedBlobbed BlobRef)
+
+-- |The account map that is purely in memory and used in the basic block state.
+type PureAccountMap pv = AccountMap pv Fix
+
+-- Necessary state storage instances for the persistent map. The pure one is not
+-- stored so does not need the related instances.
+instance MonadBlobStore m => Cacheable m (PersistentAccountMap pv) where
+  cache (AccountMap am) = AccountMap <$> cache am
+  {-# INLINE cache #-}
+
+instance MonadBlobStore m => BlobStorable m (PersistentAccountMap pv) where
+  store (AccountMap am) = store am
+  {-# INLINE store #-}
+
+  storeUpdate (AccountMap am) = second AccountMap <$> storeUpdate am
+  {-# INLINE storeUpdate #-}
+
+  load = fmap AccountMap <$> load
+  {-# INLINE load #-}
+
+-- |Convert a pure account map to the persistent one.
+toPersistent :: MonadBlobStore m => PureAccountMap pv -> m (PersistentAccountMap pv)
+toPersistent = fmap AccountMap . Trie.fromTrie . unAccountMap
+
+-- Aliases for reducing constraint repetition in methods below.
+type TrieGetContext fix m = (MRecursive m (fix (Trie.TrieF AccountAddress AccountIndex)), Base (fix (Trie.TrieF AccountAddress AccountIndex)) ~ Trie.TrieF AccountAddress AccountIndex)
+type TrieModifyContext fix m = (TrieGetContext fix m, MCorecursive m (fix (Trie.TrieF AccountAddress AccountIndex)))
+
+
+-- |Account map with no entries.
+empty :: AccountMap pv fix
+empty = AccountMap Trie.empty
+
+mkPrefix :: AccountAddress -> [Word8]
+mkPrefix = take 29 . Trie.unpackKey
+
+-- |Retrieve the account index for the given address if the address exists.
+-- The semantics of this method depends on the protocol version.
+lookup :: forall pv fix m . (IsProtocolVersion pv, TrieGetContext fix m) => AccountAddress -> AccountMap pv fix -> m (Maybe AccountIndex)
+lookup addr (AccountMap am) = case protocolVersion @pv of
+  SP1 -> Trie.lookup addr am
+  SP2 -> Trie.lookup addr am
+  SP3 -> Trie.lookupPrefix (mkPrefix addr) am >>= \case
+    [] -> return Nothing
+    [(_, v)] -> return (Just v)
+    fs -> case filter ((== addr) . fst) fs of
+      [(_, v)] -> return (Just v)
+      _ -> return Nothing
+
+-- |Check whether the given address would clash with any of the existing ones in the map.
+-- The meaning of "clash" depends on the protocol version.
+addressWouldClash :: forall pv fix m . (IsProtocolVersion pv, TrieGetContext fix m) => AccountAddress -> AccountMap pv fix -> m Bool
+addressWouldClash addr (AccountMap am) = case protocolVersion @pv of
+  SP1 -> isJust <$> Trie.lookup addr am
+  SP2 -> isJust <$> Trie.lookup addr am
+  SP3 -> not . null <$> Trie.lookupPrefix (mkPrefix addr) am
+
+-- |Insert a new key value pair if it is fresh. If the key already exists in the
+-- map no changes are made and the existing 'AccountIndex' is returned.
+maybeInsert :: forall pv fix m . TrieModifyContext fix m => AccountAddress -> AccountIndex -> AccountMap pv fix -> m (Maybe AccountIndex, AccountMap pv fix)
+maybeInsert addr ai (AccountMap am)= second AccountMap <$> Trie.adjust upd addr am
+  where upd Nothing = pure (Nothing, Trie.Insert ai)
+        upd (Just eai) = pure (Just eai, Trie.NoChange)
+
+-- |Insert a new value for the given key. If a key is already in the map the value is replaced with the new one.
+insert :: forall pv fix m . TrieModifyContext fix m => AccountAddress -> AccountIndex -> AccountMap pv fix -> m (AccountMap pv fix)
+insert addr ai (AccountMap am) = AccountMap <$> Trie.insert addr ai am
+
+-- |Get a list of all key value pairs in the account map. The order
+-- of keys is unspecified.
+toList :: TrieGetContext fix m => AccountMap pv fix -> m [(AccountAddress, AccountIndex)]
+toList = Trie.toList . unAccountMap
+
+-- |Transform the account map into an ordinary Data.Map. This is mainly used for testing.
+toMap :: TrieGetContext fix m => AccountMap pv fix -> m (Map.Map AccountAddress AccountIndex)
+toMap = Trie.toMap . unAccountMap
+
+-- |Get a list of all addresses stored in the account map.
+addresses :: TrieGetContext fix m => AccountMap pv fix -> m [AccountAddress]
+addresses = Trie.keys . unAccountMap
+
+-- |Check whether an account already exists. Note that this is slightly
+-- different than 'addressWouldClash' and it is in principle possible that
+-- 'accountExists' returns 'False', but 'addressWouldClash' returns 'True'. This
+-- is the case for protocol version 3 where the first 29 bytes of the address
+-- match an existing address, there are at least two addresses already with
+-- those same 29 bytes as prefix, but the actual address does not match any of
+-- the existing ones.
+accountExists :: forall pv fix m . (IsProtocolVersion pv, TrieGetContext fix m) => AccountAddress -> AccountMap pv fix -> m Bool
+accountExists addr am = isJust <$> lookup addr am
+
+
+-- * Convenient specializations of the methods for the pure in-memory account map implementation.
+
+addressWouldClashPure :: forall pv . IsProtocolVersion pv => AccountAddress -> PureAccountMap pv -> Bool
+addressWouldClashPure addr = runIdentity . addressWouldClash addr
+
+lookupPure :: IsProtocolVersion pv => AccountAddress -> PureAccountMap pv -> Maybe AccountIndex
+lookupPure addr = runIdentity . lookup addr
+
+insertPure :: AccountAddress -> AccountIndex -> PureAccountMap pv -> PureAccountMap pv
+insertPure addr ai = runIdentity . insert addr ai
+
+maybeInsertPure :: AccountAddress -> AccountIndex -> PureAccountMap pv -> (Maybe AccountIndex, PureAccountMap pv)
+maybeInsertPure addr ai = runIdentity . maybeInsert addr ai
+
+toListPure :: PureAccountMap pv -> [(AccountAddress, AccountIndex)]
+toListPure = runIdentity . toList
+
+toMapPure :: PureAccountMap pv -> Map.Map AccountAddress AccountIndex
+toMapPure = runIdentity . toMap
+
+addressesPure :: PureAccountMap pv -> [AccountAddress]
+addressesPure = runIdentity . addresses
+
+accountExistsPure :: forall pv . IsProtocolVersion pv => AccountAddress -> PureAccountMap pv -> Bool
+accountExistsPure addr = runIdentity . accountExists addr

--- a/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState.hs
@@ -218,13 +218,14 @@ emptyBlockState _blockBirkParameters cryptographicParameters keysCollection chai
 
 hashBlockState :: forall pv. IsProtocolVersion pv => BlockState pv -> HashedBlockState pv
 hashBlockState = case protocolVersion :: SProtocolVersion pv of
-  SP1 -> hashBlockStateP1P2P3
-  SP2 -> hashBlockStateP1P2P3
-  SP3 -> hashBlockStateP1P2P3
-    -- For protocol versions P1 and P2, convert a @BlockState pv@ to a
+  SP1 -> hashBlockStateP1
+  SP2 -> hashBlockStateP1
+  SP3 -> hashBlockStateP1
+    -- For protocol versions P1, P2, and P3, convert a @BlockState pv@ to a
     -- @HashedBlockState pv@ by computing the state hash. The state and hashing
-    -- is the same.
-  where hashBlockStateP1P2P3 bs@BlockState{..} = HashedBlockState {
+    -- is the same. This function was introduced in protocol version 1 which is
+    -- reflected in its name.
+  where hashBlockStateP1 bs@BlockState{..} = HashedBlockState {
           _unhashedBlockState = bs,
           _blockStateHash = h
           }

--- a/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/Account.hs
@@ -45,6 +45,7 @@ showAccountPersisting :: SProtocolVersion pv -> AccountPersisting pv -> String
 showAccountPersisting spv = case spv of
   SP1 -> show
   SP2 -> show
+  SP3 -> show
 
 -- |An (in-memory) account.
 data Account (pv :: ProtocolVersion) = Account {
@@ -161,6 +162,7 @@ instance (IsProtocolVersion pv) => HashableTo Hash.Hash (Account pv) where
   getHash Account{..} = case protocolVersion @pv of 
       SP1 -> makeAccountHashP1 _accountNonce _accountAmount _accountEncryptedAmount (getHash _accountReleaseSchedule) (getHash _accountPersisting) bkrHash
       SP2 -> makeAccountHashP1 _accountNonce _accountAmount _accountEncryptedAmount (getHash _accountReleaseSchedule) (getHash _accountPersisting) bkrHash
+      SP3 -> makeAccountHashP1 _accountNonce _accountAmount _accountEncryptedAmount (getHash _accountReleaseSchedule) (getHash _accountPersisting) bkrHash
     where
       bkrHash = maybe nullAccountBakerHash getHash _accountBaker
 

--- a/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/Invariants.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/Invariants.hs
@@ -16,6 +16,7 @@ import Concordium.GlobalState.Basic.BlockState.Bakers
 import Concordium.GlobalState.Basic.BlockState.Account
 import qualified Concordium.GlobalState.Basic.BlockState.Accounts as Account
 import qualified Concordium.GlobalState.Basic.BlockState.AccountTable as AT
+import qualified Concordium.GlobalState.AccountMap as AccountMap
 import Concordium.GlobalState.Basic.BlockState.Instances as Instances
 import qualified Concordium.GlobalState.Rewards as Rewards
 
@@ -53,7 +54,7 @@ invariantBlockState bs extraBalance = do
                 ") + GAS account (" ++ show gas ++
                 ") + extra balance (" ++ show extraBalance ++ ")")
             "Total GTU"
-        checkBinary (==) amp (bs ^. blockAccounts . to Account.accountMap) "==" "computed account map" "recorded account map"
+        checkBinary (==) amp (AccountMap.toMapPure (bs ^. blockAccounts . to Account.accountMap)) "==" "computed account map" "recorded account map"
     where
         checkAccount (creds, amp, bal, bakerIds, bakerKeys) (i, acct) = do
             let addr = acct ^. accountAddress

--- a/concordium-consensus/src/Concordium/GlobalState/Basic/TreeState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/TreeState.hs
@@ -84,12 +84,12 @@ initialSkovDataDefault = initialSkovData defaultRuntimeParameters
 initialSkovData :: (IsProtocolVersion pv, BS.BlockStateQuery m, bs ~ BlockState m) => RuntimeParameters -> GenesisData pv -> bs -> m (SkovData pv bs)
 initialSkovData rp gd genState = do
     acctAddrs <- BS.getAccountList genState
-    acctNonces <- foldM (\hm addr ->
+    acctNonces <- foldM (\nnces addr ->
         BS.getAccount genState addr >>= \case
             Nothing -> error "Invariant violation: listed account does not exist"
             Just (_, acct) -> do
                 nonce <- BS.getAccountNonce acct
-                return $! HM.insert addr nonce hm) HM.empty acctAddrs
+                return $! (addr,nonce):nnces) [] acctAddrs
     updSeqNums <- foldM (\m uty -> do
         sn <- BS.getNextUpdateSequenceNumber genState uty
         return $! Map.insert uty sn m) Map.empty [minBound..]

--- a/concordium-consensus/src/Concordium/GlobalState/Basic/TreeState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/TreeState.hs
@@ -245,7 +245,7 @@ instance (bs ~ BlockState m, BS.BlockStateStorage m, Monad m, MonadIO m, MonadSt
           Nothing ->
             case wmdData of
               NormalTransaction tr -> do
-                let sender = transactionSender tr
+                let sender = accountAddressEmbed (transactionSender tr)
                     nonce = transactionNonce tr
                 if (tt ^. ttNonFinalizedTransactions . at' sender . non emptyANFT . anftNextNonce) <= nonce then do
                   transactionTablePurgeCounter += 1
@@ -278,7 +278,7 @@ instance (bs ~ BlockState m, BS.BlockStateStorage m, Monad m, MonadIO m, MonadSt
         where
             finTrans WithMetadata{wmdData=NormalTransaction tr,..} = do
                 let nonce = transactionNonce tr
-                    sender = transactionSender tr
+                    sender = accountAddressEmbed (transactionSender tr)
                 anft <- use (transactionTable . ttNonFinalizedTransactions . at' sender . non emptyANFT)
                 assert (anft ^. anftNextNonce == nonce) $ do
                     let nfn = anft ^. anftMap . at' nonce . non Set.empty
@@ -335,7 +335,7 @@ instance (bs ~ BlockState m, BS.BlockStateStorage m, Monad m, MonadIO m, MonadSt
                     case wmdData of
                       NormalTransaction tr -> do
                         let nonce = transactionNonce tr
-                            sender = transactionSender tr
+                            sender = accountAddressEmbed (transactionSender tr)
                         transactionTable
                           . ttNonFinalizedTransactions
                           . at' sender

--- a/concordium-consensus/src/Concordium/GlobalState/Block.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Block.hs
@@ -111,6 +111,7 @@ class (BlockMetadata b, BlockData b, HashableTo BlockHash b, Show b) => BlockPen
 blockVersion :: SProtocolVersion pv -> Version
 blockVersion SP1 = 2
 blockVersion SP2 = 2
+blockVersion SP3 = 2
 {-# INLINE blockVersion #-}
 
 -- |Type class that supports serialization of a block.

--- a/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
@@ -299,6 +299,9 @@ class (BlockStateQuery m) => BlockStateOperations m where
   -- |Get the contract state from the contract table of the state instance.
   bsoGetInstance :: UpdatableBlockState m -> ContractAddress -> m (Maybe Instance)
 
+  -- |Check whether the given account address would clash with any existing address.
+  bsoAddressWouldClash :: UpdatableBlockState m -> ID.AccountAddress -> m Bool
+
   -- |Check whether an the given credential registration ID exists, and return
   -- the account index of the account it is or was associated with.
   bsoRegIdExists :: UpdatableBlockState m -> ID.CredentialRegistrationID -> m (Maybe AccountIndex)
@@ -692,6 +695,7 @@ instance (Monad (t m), MonadTrans t, BlockStateOperations m) => BlockStateOperat
   bsoGetAccount s = lift . bsoGetAccount s
   bsoGetAccountIndex s = lift . bsoGetAccountIndex s
   bsoGetInstance s = lift . bsoGetInstance s
+  bsoAddressWouldClash s = lift . bsoAddressWouldClash s
   bsoRegIdExists s = lift . bsoRegIdExists s
   bsoCreateAccount s gc accAddr cdv = lift $ bsoCreateAccount s gc accAddr cdv
   bsoPutNewInstance s = lift . bsoPutNewInstance s
@@ -737,6 +741,7 @@ instance (Monad (t m), MonadTrans t, BlockStateOperations m) => BlockStateOperat
   {-# INLINE bsoGetAccount #-}
   {-# INLINE bsoGetAccountIndex #-}
   {-# INLINE bsoGetInstance #-}
+  {-# INLINE bsoAddressWouldClash #-}
   {-# INLINE bsoRegIdExists #-}
   {-# INLINE bsoCreateAccount #-}
   {-# INLINE bsoPutNewInstance #-}

--- a/concordium-consensus/src/Concordium/GlobalState/Paired.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Paired.hs
@@ -301,9 +301,9 @@ instance (Monad m, C.HasGlobalStateContext (PairGSContext lc rc) r, BlockStateQu
 instance (Monad m, C.HasGlobalStateContext (PairGSContext lc rc) r, AccountOperations (BSML pv lc r ls s m), AccountOperations (BSMR pv rc r rs s m), HashableTo H.Hash (Account (BSML pv lc r ls s m)), HashableTo H.Hash (Account (BSMR pv rc r rs s m)))
   => AccountOperations (BlockStateM pv (PairGSContext lc rc) r (PairGState ls rs) s m) where
 
-    getAccountAddress (acc1, acc2) = do
-        addr1 <- coerceBSML (getAccountAddress acc1)
-        addr2 <- coerceBSMR (getAccountAddress acc2)
+    getAccountCanonicalAddress (acc1, acc2) = do
+        addr1 <- coerceBSML (getAccountCanonicalAddress acc1)
+        addr2 <- coerceBSMR (getAccountCanonicalAddress acc2)
         assert (addr1 == addr2) $ return addr1
 
     getAccountAmount (acc1, acc2) = do
@@ -361,9 +361,10 @@ instance (MonadLogger m, C.HasGlobalStateContext (PairGSContext lc rc) r, BlockS
         r1 <- coerceBSML $ bsoGetAccount bs1 aref
         r2 <- coerceBSMR $ bsoGetAccount bs2 aref
         case (r1, r2) of
-          (Just r1', Just r2') ->
+          (Just (ai1, r1'), Just (ai2, r2')) ->
             assert ((getHash r1' :: H.Hash) == getHash r2') $
-              return $ Just (r1', r2')
+              assert (ai1 == ai2) $ 
+                return $ Just (ai1, (r1', r2'))
           (Nothing, Nothing) ->
             return Nothing
           (Nothing, _) ->

--- a/concordium-consensus/src/Concordium/GlobalState/Paired.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Paired.hs
@@ -379,6 +379,10 @@ instance (MonadLogger m, C.HasGlobalStateContext (PairGSContext lc rc) r, BlockS
         r1 <- coerceBSML $ bsoGetInstance bs1 iref
         r2 <- coerceBSMR $ bsoGetInstance bs2 iref
         assert (((==) `on` fmap instanceHash) r1 r2) $ return r1
+    bsoAddressWouldClash (bs1, bs2) addr = do
+        r1 <- coerceBSML $ bsoAddressWouldClash bs1 addr
+        r2 <- coerceBSMR $ bsoAddressWouldClash bs2 addr
+        assert (r1 == r2) $ return r1
     bsoRegIdExists (bs1, bs2) regid = do
         r1 <- coerceBSML $ bsoRegIdExists bs1 regid
         r2 <- coerceBSMR $ bsoRegIdExists bs2 regid

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
@@ -356,6 +356,9 @@ makeAccountHash SP1 n a eas ars pd abh = do
 makeAccountHash SP2 n a eas ars pd abh = do
   pdHash <- getHashM pd
   return $ makeAccountHashP1 n a eas ars pdHash abh
+makeAccountHash SP3 n a eas ars pd abh = do
+  pdHash <- getHashM pd
+  return $ makeAccountHashP1 n a eas ars pdHash abh
 
 
 -- |Recompute the hash of an account.

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
@@ -724,7 +724,6 @@ instance MonadBlobStore m => BlobStorable m ()
 instance MonadBlobStore m => BlobStorable m Word8
 instance MonadBlobStore m => BlobStorable m Word32
 instance MonadBlobStore m => BlobStorable m Word64
-instance MonadBlobStore m => BlobStorable m Word
 
 instance MonadBlobStore m => BlobStorable m AccountEncryptedAmount
 instance (MonadBlobStore m, Serialize (PersistingAccountData pv)) => BlobStorable m (PersistingAccountData pv)

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
@@ -713,8 +713,6 @@ instance MonadBlobStore m => BlobStorable m IPS.IdentityProviders
 instance MonadBlobStore m => BlobStorable m ARS.ArInfo
 instance MonadBlobStore m => BlobStorable m ARS.AnonymityRevokers
 instance MonadBlobStore m => BlobStorable m Parameters.CryptographicParameters
--- FIXME: This uses serialization of accounts for storing them.
--- This is potentially quite wasteful when only small changes are made.
 instance MonadBlobStore m => BlobStorable m Amount
 instance MonadBlobStore m => BlobStorable m BakerId
 instance MonadBlobStore m => BlobStorable m BakerInfo
@@ -723,6 +721,10 @@ instance MonadBlobStore m => BlobStorable m BS.ByteString
 instance MonadBlobStore m => BlobStorable m EncryptedAmount
 instance MonadBlobStore m => BlobStorable m TransactionHash
 instance MonadBlobStore m => BlobStorable m ()
+instance MonadBlobStore m => BlobStorable m Word8
+instance MonadBlobStore m => BlobStorable m Word32
+instance MonadBlobStore m => BlobStorable m Word64
+instance MonadBlobStore m => BlobStorable m Word
 
 instance MonadBlobStore m => BlobStorable m AccountEncryptedAmount
 instance (MonadBlobStore m, Serialize (PersistingAccountData pv)) => BlobStorable m (PersistingAccountData pv)

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -892,6 +892,11 @@ doAccountList pbs = do
         bsp <- loadPBS pbs
         Accounts.accountAddresses (bspAccounts bsp)
 
+doAddressWouldClash :: (IsProtocolVersion pv, MonadBlobStore m) => PersistentBlockState pv -> AccountAddress -> m Bool
+doAddressWouldClash pbs addr = do
+        bsp <- loadPBS pbs
+        Accounts.addressWouldClash addr (bspAccounts bsp)
+
 doRegIdExists :: (IsProtocolVersion pv, MonadBlobStore m) => PersistentBlockState pv -> ID.CredentialRegistrationID -> m (Maybe AccountIndex)
 doRegIdExists pbs regid = do
         bsp <- loadPBS pbs
@@ -1286,6 +1291,7 @@ instance (IsProtocolVersion pv, PersistentState r m) => BlockStateOperations (Pe
     bsoGetAccount bs = doGetAccount bs
     bsoGetAccountIndex = doGetAccountIndex
     bsoGetInstance = doGetInstance
+    bsoAddressWouldClash = doAddressWouldClash
     bsoRegIdExists = doRegIdExists
     bsoCreateAccount = doCreateAccount
     bsoPutNewInstance = doPutNewInstance

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
@@ -189,12 +189,12 @@ initialSkovPersistentData rp treeStateDir gd genState genATI atiContext serState
   -- table correctly reflects the account nonces, and similarly for
   -- updates.
   acctAddrs <- getAccountList genState
-  acctNonces <- foldM (\hm addr ->
+  acctNonces <- foldM (\nnces addr ->
       getAccount genState addr >>= \case
           Nothing -> error "Invariant violation: listed account does not exist"
           Just (_, acct) -> do
               nonce <- getAccountNonce acct
-              return $! HM.insert addr nonce hm) HM.empty acctAddrs
+              return $! (addr, nonce):nnces) [] acctAddrs
   updSeqNums <- foldM (\m uty -> do
       sn <- getNextUpdateSequenceNumber genState uty
       return $! Map.insert uty sn m) Map.empty [minBound..]

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Trie.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Trie.hs
@@ -434,6 +434,7 @@ lookup _ EmptyTrieN = return Nothing
 lookup k (TrieN _ t) = lookupF k t
 
 -- |Given a key prefix, look up all the keys and values where the key has the prefix.
+-- In case of multiple return values the order of keys is not specified.
 lookupPrefix :: (MRecursive m (fix (TrieF k v)), Base (fix (TrieF k v)) ~ TrieF k v, FixedTrieKey k) => [Word8] -> TrieN fix k v -> m [(k, v)]
 lookupPrefix _ EmptyTrieN = return []
 lookupPrefix k (TrieN _ t) = lookupPrefixF k t

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Trie.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Trie.hs
@@ -34,6 +34,14 @@ import qualified Concordium.ID.Types as IDTypes
 
 import Concordium.GlobalState.Persistent.MonadicRecursive
 import Concordium.GlobalState.Persistent.BlobStore
+    ( cacheBufferedBlobbed,
+      BlobRef,
+      BlobStorable(..),
+      BufferedBlobbed,
+      Cacheable(..),
+      FixShowable(..),
+      MonadBlobStore,
+      Nullable(..) )
 
 class FixedTrieKey a where
     -- |Unpack a key to a list of bytes.

--- a/concordium-consensus/src/Concordium/GlobalState/PurgeTransactions.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/PurgeTransactions.hs
@@ -103,7 +103,7 @@ purgeTables lastFinSlot oldestArrivalTime currentTime TransactionTable{..} ptabl
             put (mmnonce', tht')
             return mres
         -- Purge the non-finalized transactions for a specific account.
-        purgeAccount :: AccountAddress -> AccountNonFinalizedTransactions -> State (PendingTransactionTable, TransactionHashTable) AccountNonFinalizedTransactions
+        purgeAccount :: AccountAddressEq -> AccountNonFinalizedTransactions -> State (PendingTransactionTable, TransactionHashTable) AccountNonFinalizedTransactions
         purgeAccount addr AccountNonFinalizedTransactions{..} = do
             (ptt0, trs0) <- get
             -- Purge the transactions from the transaction table.

--- a/concordium-consensus/src/Concordium/GlobalState/TransactionTable.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/TransactionTable.hs
@@ -218,10 +218,10 @@ emptyTransactionTable = TransactionTable {
 
 -- |A transaction table with no transactions, but with the initial next sequence numbers
 -- set for the accounts and update types.
-emptyTransactionTableWithSequenceNumbers :: HM.HashMap AccountAddress Nonce -> Map.Map UpdateType UpdateSequenceNumber -> TransactionTable
+emptyTransactionTableWithSequenceNumbers :: [(AccountAddress, Nonce)] -> Map.Map UpdateType UpdateSequenceNumber -> TransactionTable
 emptyTransactionTableWithSequenceNumbers accs upds = TransactionTable {
         _ttHashMap = HM.empty,
-        _ttNonFinalizedTransactions = HM.fromList . map (\(k, n) -> (accountAddressEmbed k, emptyANFTWithNonce n)) . HM.toList . HM.filter (/= minNonce) $ accs,
+        _ttNonFinalizedTransactions = HM.fromList . map (\(k, n) -> (accountAddressEmbed k, emptyANFTWithNonce n)) . filter (\(_, n) -> n /= minNonce) $ accs,
         _ttNonFinalizedChainUpdates = emptyNFCUWithSequenceNumber <$> Map.filter (/= minUpdateSequenceNumber) upds
     }
 

--- a/concordium-consensus/src/Concordium/GlobalState/TransactionTable.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/TransactionTable.hs
@@ -153,6 +153,7 @@ emptyNFCU = emptyNFCUWithSequenceNumber minUpdateSequenceNumber
 emptyNFCUWithSequenceNumber :: UpdateSequenceNumber -> NonFinalizedChainUpdates
 emptyNFCUWithSequenceNumber = NonFinalizedChainUpdates Map.empty
 
+-- * Account address equivalence
 -- $equivalence
 -- The non-finalized transactions in the transaction table and the pending table
 -- maintain indices by account address equivalence classes. The reason for this
@@ -165,9 +166,20 @@ emptyNFCUWithSequenceNumber = NonFinalizedChainUpdates Map.empty
 -- There is a caveat, in protocol versions 1 and 2 addresses are in 1-1
 -- correspondence with accounts. This means that technically AccountAddressEq
 -- could identify too many addresses, leading to inability of some accounts to
--- send transactions in certain circumstances. This is an extremely unlikely
--- scenarion and will only occur in case of a SHA256 collision on the first 29
--- bytes.
+-- send transactions in certain circumstances.
+-- This would happen in particular because when receiving transactions we
+-- compare the transaction nonce against the last finalized nonce so we might
+-- reject a transaction directly when receiving it due to accidental address
+-- identification. Similarly we might reject a valid block since we deem a nonce
+-- to be duplicate due to accidental address identification, and we reject a
+-- block with transactions with obsolete nonces outright. Once transactions are
+-- in the transaction table there are no soundness issues anymore since the
+-- scheduler resolves addresses to accounts and compares nonces of those
+-- accounts, however it might still happen that when baking a transaction would
+-- not be selected since we might skip it if we think it has a duplicate nonce due
+-- to accidental address identification.
+-- This is an extremely unlikely scenario and will only occur in case of a
+-- SHA256 collision on the first 29 bytes (but not all remaining 3 bytes).
 
 
 -- |The transaction table stores transactions and their statuses.

--- a/concordium-consensus/src/Concordium/GlobalState/TreeState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/TreeState.hs
@@ -223,14 +223,14 @@ class (Eq (BlockPointerType m),
     -- with that nonce. Transaction groups are ordered by increasing nonce.
 
     getAccountNonFinalized ::
-      AccountAddress
+      AccountAddressEq
       -> Nonce
       -> m [(Nonce, Set.Set Transaction)]
 
     -- |Get the successor of the largest known account for the given account
     -- The function should return 'True' in the second component if and only if
     -- all (known) transactions from this account are finalized.
-    getNextAccountNonce :: AccountAddress -> m (Nonce, Bool)
+    getNextAccountNonce :: AccountAddressEq -> m (Nonce, Bool)
 
     -- |Get a credential which has not yet been finalized, i.e., it is correct for this function
     -- to return 'Nothing' if the requested credential has already been finalized.

--- a/concordium-consensus/src/Concordium/GlobalState/Types.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Types.hs
@@ -9,6 +9,7 @@ import Control.Monad.Trans.Maybe
 import Control.Monad.Trans.Except
 import Data.Kind
 
+import Concordium.Types
 import Concordium.GlobalState.BlockPointer (BlockPointerData)
 
 -- |The basic types associated with a monad providing an
@@ -17,6 +18,9 @@ class BlockStateTypes (m :: Type -> Type) where
     type BlockState m :: Type
     type UpdatableBlockState m :: Type
     type Account m :: Type
+
+-- |Account together with its index in the account map.
+type IndexedAccount m = (AccountIndex, Account m)
 
 type family BlockStatePointer (bs :: Type) :: Type
 

--- a/concordium-consensus/src/Concordium/ProtocolUpdate/P2.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/P2.hs
@@ -18,7 +18,7 @@ import Concordium.GlobalState.BlockState
 import Concordium.Kontrol
 import qualified Concordium.ProtocolUpdate.P2.ProtocolP3 as ProtocolP3
 
--- |Updates that are supported from protocol version P1.
+-- |Updates that are supported from protocol version P2.
 data Update = ProtocolP3
     deriving (Show)
 

--- a/concordium-consensus/src/Concordium/ProtocolUpdate/P2.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/P2.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE DataKinds #-}
+
+module Concordium.ProtocolUpdate.P2 (
+    Update (..),
+    checkUpdate,
+    updateRegenesis,
+) where
+
+import qualified Data.HashMap.Strict as HM
+import Data.Serialize
+
+import qualified Concordium.Crypto.SHA256 as SHA256
+import Concordium.Genesis.Data
+import Concordium.Types
+import Concordium.Types.Updates
+
+import Concordium.GlobalState.BlockState
+import Concordium.Kontrol
+import qualified Concordium.ProtocolUpdate.P2.ProtocolP3 as ProtocolP3
+
+-- |Updates that are supported from protocol version P1.
+data Update = ProtocolP3
+    deriving (Show)
+
+-- |Hash map for resolving updates from their specification hash.
+updates :: HM.HashMap SHA256.Hash (Get Update)
+updates = HM.fromList [(ProtocolP3.updateHash, return ProtocolP3)]
+
+-- |Determine if a 'ProtocolUpdate' corresponds to a supported update type.
+checkUpdate :: ProtocolUpdate -> Either String Update
+checkUpdate ProtocolUpdate{..} = case HM.lookup puSpecificationHash updates of
+    Nothing -> Left "Specification hash does not correspond to a known protocol update."
+    Just g -> case runGet g puSpecificationAuxiliaryData of
+        Left err -> Left $! "Could not deserialize auxiliary data: " ++ err
+        Right r -> return r
+
+-- |Construct the genesis data for a P2 update.
+-- It is assumed that the last finalized block is the terminal block of the old chain:
+-- i.e. it is the first (and only) explicitly-finalized block with timestamp after the
+-- update takes effect.
+updateRegenesis :: (BlockStateStorage m, SkovQueryMonad 'P2 m) => Update -> m PVGenesisData
+updateRegenesis ProtocolP3 = ProtocolP3.updateRegenesis

--- a/concordium-consensus/src/Concordium/ProtocolUpdate/P2/ProtocolP3.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/P2/ProtocolP3.hs
@@ -19,9 +19,9 @@
 --
 -- * 'genesisFirstGenesis' is either:
 --
---     * the hash of the genesis block of the previous chain, if it is a 'GDP1Initial'; or
+--     * the hash of the genesis block of the previous chain, if it is a 'GDP2Initial'; or
 --     * the 'genesisFirstGenesis' value of the genesis block of the previous chain, if it
---       is a 'GDP1Regenesis'.
+--       is a 'GDP2Regenesis'.
 --
 -- * 'genesisPreviousGenesis' is the hash of the previous genesis block.
 --

--- a/concordium-consensus/src/Concordium/ProtocolUpdate/P2/ProtocolP3.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/P2/ProtocolP3.hs
@@ -1,0 +1,110 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |This module implements the P2.ProtocolP3 protocol update that introduces account aliases.
+-- This protocol update is valid at protocol version P2, and updates
+-- to protocol version P3.
+-- The block state is preserved across the update.
+--
+-- This produces a new 'GenesisDataP3' using the 'GDP3Regenesis' constructor,
+-- as follows:
+--
+-- * 'genesisCore':
+--
+--     * 'genesisTime' is the timestamp of the last finalized block of the previous chain.
+--     * 'genesisSlotDuration' is unchanged.
+--     * 'genesisEpochLength' is unchanged.
+--     * 'genesisMaxBlockEnergy' is unchanged.
+--     * 'genesisFinalizationParameters' is unchanged.
+--
+-- * 'genesisFirstGenesis' is either:
+--
+--     * the hash of the genesis block of the previous chain, if it is a 'GDP1Initial'; or
+--     * the 'genesisFirstGenesis' value of the genesis block of the previous chain, if it
+--       is a 'GDP1Regenesis'.
+--
+-- * 'genesisPreviousGenesis' is the hash of the previous genesis block.
+--
+-- * 'genesisTerminalBlock' is the hash of the last finalized block of the previous chain.
+--
+-- * 'genesisStateHash' and 'genesisNewState' are the hash and (V0) serialized state of the
+--   new genesis block, which are derived from the block state of the last finalized block of
+--   the previous chain by applying the following changes:
+--
+--     * The 'SeedState' is updated with:
+--
+--         * 'epochLength' is unchanged;
+--         * 'epoch' is @0@;
+--         * 'currentLeadershipElectionNonce' is the SHA256 hash of (@"Regenesis" <> encode (updatedNonce oldSeedState)@); and
+--         * 'updatedNonce' is the same as 'currentLeadershipElectionNonce'.
+--
+--     * The 'Updates' are updated with:
+--
+--         * the current protocol update is set to 'Nothing'; and
+--         * the protocol update queue is emptied.
+--
+-- Note that, while the seed state is revised, the initial epoch of the new chain is not considered
+-- a new epoch for the purposes of block rewards and baker/finalization committee determination.
+-- This means that block rewards at the end of this epoch are paid for all blocks baked in this epoch
+-- and in the final epoch of the previous chain.
+-- Furthermore, the bakers from the final epoch of the previous chain are also the bakers for the
+-- initial epoch of the new chain.
+module Concordium.ProtocolUpdate.P2.ProtocolP3 where
+
+import Data.Serialize
+
+import qualified Concordium.Crypto.SHA256 as SHA256
+import Concordium.Genesis.Data
+import qualified Concordium.Genesis.Data as GenesisData
+import qualified Concordium.Genesis.Data.P2 as P2
+import qualified Concordium.Genesis.Data.P3 as P3
+import Concordium.Types
+import Concordium.Types.SeedState
+
+import Concordium.GlobalState.Block
+import Concordium.GlobalState.BlockMonads
+import Concordium.GlobalState.BlockPointer
+import Concordium.GlobalState.BlockState
+import Concordium.Kontrol
+
+-- |The hash that identifies a update from P2 to P3 protocol.
+-- This is the hash of the published specification document.
+-- TODO: Write the document, insert correct hash.
+updateHash :: SHA256.Hash
+updateHash = read "0000000000000000000000000000000000000000000000000000000000000000"
+
+-- |Construct the genesis data for a P2.ProtocolP3 update.
+-- It is assumed that the last finalized block is the terminal block of the old chain:
+-- i.e. it is the first (and only) explicitly-finalized block with timestamp after the
+-- update takes effect.
+updateRegenesis :: (BlockPointerMonad m, BlockStateStorage m, SkovQueryMonad 'P2 m) => m PVGenesisData
+updateRegenesis = do
+    lfb <- lastFinalizedBlock
+    -- Genesis time is the timestamp of the terminal block
+    regenesisTime <- getSlotTimestamp (blockSlot lfb)
+    -- Core parameters are derived from the old genesis, apart from genesis time which is set for
+    -- the time of the last finalized block.
+    gd <- getGenesisData
+    let core = (P2.genesisCore $ unGDP2 gd) { GenesisData.genesisTime = regenesisTime }
+    -- genesisFirstGenesis is the block hash of the previous genesis, if it is initial,
+    -- or the genesisFirstGenesis of the previous genesis otherwise.
+    let genesisFirstGenesis = case gd of
+            GDP2 P2.GDP2Initial{} -> genesisBlockHash gd
+            GDP2 P2.GDP2Regenesis{genesisRegenesis=GenesisData.RegenesisData{genesisFirstGenesis = firstGen}} -> firstGen
+    let genesisPreviousGenesis = genesisBlockHash gd
+    let genesisTerminalBlock = bpHash lfb
+    -- Determine the new state by updating the terminal state.
+    s0 <- thawBlockState =<< blockState lfb
+    -- Update the seed state
+    oldSeedState <- bsoGetSeedState s0
+    s1 <-
+        bsoSetSeedState s0 $
+            initialSeedState
+                (SHA256.hash $ "Regenesis" <> encode (updatedNonce oldSeedState))
+                $ gdEpochLength gd
+    -- Clear the protocol update.
+    s3 <- bsoClearProtocolUpdate s1
+    regenesisState <- freezeBlockState s3
+    genesisStateHash <- getStateHash regenesisState
+    genesisNewState <- serializeBlockState regenesisState
+    return . PVGenesisData . GDP3 $ P3.GDP3Regenesis{genesisRegenesis = GenesisData.RegenesisData{genesisCore=core,..}}

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -402,7 +402,7 @@ getBlockBirkParameters = liftSkovQueryBlock $ \bp -> do
             let bsBakerLotteryPower = fromIntegral _bakerStake / fromIntegral bakerTotalStake
             -- This should never return Nothing
             bacct <- BS.getBakerAccount bs _bakerIdentity
-            bsBakerAccount <- mapM BS.getAccountAddress bacct
+            bsBakerAccount <- mapM BS.getAccountCanonicalAddress bacct
             return BakerSummary{..}
     bbpBakers <- mapM resolveBaker fullBakerInfos
     return BlockBirkParameters{..}

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -478,6 +478,7 @@ getAccountInfo blockHash acct =
                     aiAccountEncryptedAmount <- BS.getAccountEncryptedAmount acc
                     aiAccountEncryptionKey <- BS.getAccountEncryptionKey acc
                     aiBaker <- BS.getAccountBaker acc
+                    aiAccountAddress <- BS.getAccountCanonicalAddress acc
                     return AccountInfo{..}
             )
             blockHash

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -293,7 +293,7 @@ getBlocksAtHeight height baseGI True = MVR $ \mvr -> do
 
 -- |Get a list of non-finalized transaction hashes for a given account.
 getAccountNonFinalizedTransactions :: AccountAddress -> MVR gsconf finconf [TransactionHash]
-getAccountNonFinalizedTransactions acct = liftSkovQueryLatest $ queryNonFinalizedTransactions acct
+getAccountNonFinalizedTransactions acct = liftSkovQueryLatest $ queryNonFinalizedTransactions . accountAddressEmbed $ acct
 
 -- |Return the best guess as to what the next account nonce should be.
 -- If all account transactions are finalized then this information is reliable.
@@ -301,7 +301,7 @@ getAccountNonFinalizedTransactions acct = liftSkovQueryLatest $ queryNonFinalize
 -- committed to blocks and eventually finalized.
 getNextAccountNonce :: AccountAddress -> MVR gsconf finconf NextAccountNonce
 getNextAccountNonce acct = liftSkovQueryLatest $ do
-    (nanNonce, nanAllFinal) <- queryNextAccountNonce acct
+    (nanNonce, nanAllFinal) <- queryNextAccountNonce . accountAddressEmbed $ acct
     return NextAccountNonce{..}
 
 -- * Queries against latest version that produces a result

--- a/concordium-consensus/src/Concordium/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler.hs
@@ -161,11 +161,10 @@ dispatch msg = do
           -- exists on the account with 'checkHeader'.
           payment <- energyToGtu checkHeaderCost
           chargeExecutionCost (transactionHash msg) senderAccount payment
-          addr <- getAccountCanonicalAddress (snd senderAccount)
           return $ Just $ TxValid $ TransactionSummary{
             tsEnergyCost = checkHeaderCost,
             tsCost = payment,
-            tsSender = Just addr,
+            tsSender = Just (thSender meta), -- the sender of the transaction is as specified in the transaction.
             tsResult = TxReject SerializationFailure,
             tsHash = transactionHash msg,
             tsType = TSTAccountTransaction Nothing,

--- a/concordium-consensus/src/Concordium/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler.hs
@@ -730,8 +730,8 @@ handleMessage origin istance sender transferAmount receiveName parameter = do
   let model = instanceModel istance
   -- Check whether the sender of the message has enough on its account/instance for the transfer.
   -- If the amount is not sufficient, the top-level transaction is rejected.
-  -- Note that this returns the canonical address of the account in case the sender is an account.
-  -- This is deliberate so that consistent addresses are exposed to smart contracts.
+  -- Note that this returns the address that was used in the top-level transaction, or the owner address of the contract instance.
+  -- In both cases it is the address that was used by the sender.
   (senderAddr, senderCredentials) <- mkSenderAddrCredentials sender
   senderamount <- getCurrentAvailableAmount sender
   unless (senderamount >= transferAmount) $ rejectTransaction (AmountTooLarge senderAddr transferAmount)

--- a/concordium-consensus/src/Concordium/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler.hs
@@ -843,9 +843,7 @@ mkSenderAddrCredentials sender =
         return (addr, map snd (OrdMap.toAscList credentials))
 
 
--- | Handle the transfer of an amount from an account or contract instance to an account.
--- TODO: Figure out whether we need the origin information in here (i.e.,
--- whether an account can observe it).
+-- | Handle the transfer of an amount from a contract instance to an account.
 handleTransferAccount ::
   TransactionMonad pv m
   => AccountAddress -- ^The target account address.

--- a/concordium-consensus/src/Concordium/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler.hs
@@ -309,7 +309,7 @@ handleTransferWithSchedule wtc twsTo twsSchedule maybeMemo = withDeposit wtc c k
               -- Rejected transactions's rejection reason is part of block
               -- hashes.
               when (demoteProtocolVersion (protocolVersion @pv) >= P3) $
-                when (fst targetAccount == fst senderAccount) $ rejectTransaction . ScheduledSelfTransfer =<< getAccountCanonicalAddress (snd senderAccount)
+                when (fst targetAccount == fst senderAccount) $ rejectTransaction . ScheduledSelfTransfer $ senderAddress
 
               withScheduledAmount senderAccount targetAccount transferAmount twsSchedule txHash $ return ()
 
@@ -467,7 +467,7 @@ handleEncryptedAmountTransfer wtc toAddress transferData@EncryptedAmountTransfer
           -- to check a self transfer we must check with canonical account
           -- identifiers. We use account indices for that.
           when ((demoteProtocolVersion (protocolVersion @pv) >= P3) && fst targetAccount == fst senderAccount)
-              $ rejectTransaction . EncryptedAmountSelfTransfer =<< getAccountCanonicalAddress (snd senderAccount)
+              $ rejectTransaction . EncryptedAmountSelfTransfer $ senderAddress
 
 
           receiverAllowed <- checkAccountIsAllowed (snd targetAccount) AllowedEncryptedTransfers

--- a/concordium-consensus/src/Concordium/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler.hs
@@ -308,8 +308,7 @@ handleTransferWithSchedule wtc twsTo twsSchedule maybeMemo = withDeposit wtc c k
               -- Rejected transactions's rejection reason is part of block
               -- hashes.
               when (demoteProtocolVersion (protocolVersion @pv) >= P3) $
-                when (fst targetAccount == fst senderAccount) $ rejectTransaction (ScheduledSelfTransfer twsTo)
-
+                when (fst targetAccount == fst senderAccount) $ rejectTransaction . ScheduledSelfTransfer =<< getAccountCanonicalAddress (snd senderAccount)
 
               withScheduledAmount senderAccount targetAccount transferAmount twsSchedule txHash $ return ()
 
@@ -465,7 +464,7 @@ handleEncryptedAmountTransfer wtc toAddress transferData@EncryptedAmountTransfer
           -- to check a self transfer we must check with canonical account
           -- identifiers. We use account indices for that.
           when ((demoteProtocolVersion (protocolVersion @pv) >= P3) && fst targetAccount == fst senderAccount)
-              $ rejectTransaction (EncryptedAmountSelfTransfer toAddress)
+              $ rejectTransaction . EncryptedAmountSelfTransfer =<< getAccountCanonicalAddress (snd senderAccount)
 
 
           receiverAllowed <- checkAccountIsAllowed (snd targetAccount) AllowedEncryptedTransfers

--- a/concordium-consensus/src/Concordium/Scheduler/Environment.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/Environment.hs
@@ -335,16 +335,16 @@ class (StaticInformation m, IsProtocolVersion pv) => TransactionMonad pv m | m -
   -- |Transfer an amount from the first given instance or account to the instance in the second
   -- parameter and run the computation in the modified environment.
   {-# INLINE withToContractAmount #-}
-  withToContractAmount :: Either (IndexedAccount m, Instance) (IndexedAccount m) -> Instance -> Amount -> m a -> m a
+  withToContractAmount :: Either (IndexedAccount m, Instance) (AccountAddress, IndexedAccount m) -> Instance -> Amount -> m a -> m a
   withToContractAmount (Left (_, i)) = withContractToContractAmount i
-  withToContractAmount (Right a) = withAccountToContractAmount a
+  withToContractAmount (Right (_, a)) = withAccountToContractAmount a
 
   getCurrentContractInstance :: ContractAddress -> m (Maybe Instance)
 
   {-# INLINE getCurrentAvailableAmount #-}
-  getCurrentAvailableAmount :: Either (IndexedAccount m, Instance) (IndexedAccount m) -> m Amount
+  getCurrentAvailableAmount :: Either (IndexedAccount m, Instance) (AccountAddress, IndexedAccount m) -> m Amount
   getCurrentAvailableAmount (Left (_, i)) = getCurrentContractAmount i
-  getCurrentAvailableAmount (Right a) = getCurrentAccountAvailableAmount a
+  getCurrentAvailableAmount (Right (_, a)) = getCurrentAccountAvailableAmount a
 
   -- |Get an account with its state at the start of the transaction.
   getStateAccount :: AccountAddress -> m (Maybe (IndexedAccount m))

--- a/concordium-consensus/src/Concordium/Scheduler/Environment.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/Environment.hs
@@ -79,6 +79,11 @@ class (Monad m, StaticInformation m, CanRecordFootprint (Footprint (ATIStorage m
   -- |Get the 'AccountIndex' for an account, if it exists.
   getAccountIndex :: AccountAddress -> m (Maybe AccountIndex)
 
+  -- |Check whether the given account address would clash with any existing
+  -- account's address. The behaviour of this will generally depend on the
+  -- protocol version.
+  addressWouldClash :: AccountAddress -> m Bool
+
   -- |Check whether a given registration id exists in the global state.
   accountRegIdExists :: ID.CredentialRegistrationID -> m Bool
 

--- a/concordium-consensus/src/Concordium/Scheduler/Environment.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/Environment.hs
@@ -74,7 +74,7 @@ class (Monad m, StaticInformation m, CanRecordFootprint (Footprint (ATIStorage m
 
   -- |Get the amount of funds at the particular account address.
   -- To get the amount of funds for a contract instance use getInstance and lookup amount there.
-  getAccount :: AccountAddress -> m (Maybe (Account m))
+  getAccount :: AccountAddress -> m (Maybe (IndexedAccount m))
 
   -- |Get the 'AccountIndex' for an account, if it exists.
   getAccountIndex :: AccountAddress -> m (Maybe AccountIndex)
@@ -105,14 +105,14 @@ class (Monad m, StaticInformation m, CanRecordFootprint (Footprint (ATIStorage m
 
   -- |Bump the next available transaction nonce of the account.
   -- Precondition: the account exists in the block state.
-  increaseAccountNonce :: Account m -> m ()
+  increaseAccountNonce :: IndexedAccount m -> m ()
 
   -- FIXME: This method should not be here, but rather in the transaction monad.
   -- |Update account credentials.
   -- Preconditions:
   -- - The account exists in the block state.
   -- - The account threshold is reasonable.
-  updateAccountCredentials :: Account m
+  updateAccountCredentials :: AccountIndex
                         -> [ID.CredentialIndex]
                         -- ^ The indices of credentials to remove from the account.
                         -> Map.Map ID.CredentialIndex ID.AccountCredential
@@ -174,7 +174,7 @@ class (Monad m, StaticInformation m, CanRecordFootprint (Footprint (ATIStorage m
   -- * @BADuplicateAggregationKey@: the aggregation key is already in use.
   --
   -- Note that if two results could apply, the first in this list takes precedence.  
-  addBaker :: AccountAddress -> BakerAdd -> m BakerAddResult
+  addBaker :: AccountIndex -> BakerAdd -> m BakerAddResult
 
   -- |Remove the baker associated with an account.
   -- The removal takes effect after a cooling-off period.
@@ -188,7 +188,7 @@ class (Monad m, StaticInformation m, CanRecordFootprint (Footprint (ATIStorage m
   -- * @BRInvalidBaker@: the account address is not valid, or the account is not a baker.
   --
   -- * @BRChangePending@: the baker is currently in a cooling-off period and so cannot be removed.
-  removeBaker :: AccountAddress -> m BakerRemoveResult
+  removeBaker :: AccountIndex -> m BakerRemoveResult
 
   -- |Update the keys associated with an account.
   -- It is assumed that the keys have already been checked for validity/ownership as
@@ -202,7 +202,7 @@ class (Monad m, StaticInformation m, CanRecordFootprint (Footprint (ATIStorage m
   -- * @BKUInvalidBaker@: the account does not exist or is not currently a baker.
   --
   -- * @BKUDuplicateAggregationKey@: the aggregation key is a duplicate.
-  updateBakerKeys :: AccountAddress -> BakerKeyUpdate -> m BakerKeyUpdateResult
+  updateBakerKeys :: AccountIndex -> BakerKeyUpdate -> m BakerKeyUpdateResult
 
   -- |Update the stake associated with an account.
   -- A reduction in stake will be delayed by the current cool-off period.
@@ -224,7 +224,7 @@ class (Monad m, StaticInformation m, CanRecordFootprint (Footprint (ATIStorage m
   -- * @BSUChangePending@: the change could not be made since the account is already in a cooling-off period.
   --
   -- * @BSUInsufficientBalance@: the account does not have sufficient balance to cover the staked amount.
-  updateBakerStake :: AccountAddress -> Amount -> m BakerStakeUpdateResult
+  updateBakerStake :: AccountIndex -> Amount -> m BakerStakeUpdateResult
 
   -- |Update whether the baker automatically restakes the rewards it earns.
   --
@@ -233,7 +233,7 @@ class (Monad m, StaticInformation m, CanRecordFootprint (Footprint (ATIStorage m
   -- * @BREUUpdated id@: the flag was updated.
   --
   -- * @BREUInvalidBaker@: the account does not exists, or is not currently a baker.
-  updateBakerRestakeEarnings :: AccountAddress -> Bool -> m BakerRestakeEarningsUpdateResult
+  updateBakerRestakeEarnings :: AccountIndex -> Bool -> m BakerRestakeEarningsUpdateResult
 
   -- *Operations on account keys
 
@@ -241,7 +241,7 @@ class (Monad m, StaticInformation m, CanRecordFootprint (Footprint (ATIStorage m
   -- Preconditions:
   -- * The account exists
   -- * The account has keys defined at the specified indices
-  updateCredentialKeys :: AccountAddress -> ID.CredentialIndex -> ID.CredentialPublicKeys -> m ()
+  updateCredentialKeys :: AccountIndex -> ID.CredentialIndex -> ID.CredentialPublicKeys -> m ()
 
   -- *Other metadata.
 
@@ -285,15 +285,15 @@ class (StaticInformation m, IsProtocolVersion pv) => TransactionMonad pv m | m -
 
   -- |Transfer amount from the first address to the second and run the
   -- computation in the modified environment.
-  withAccountToContractAmount :: Account m -> Instance -> Amount -> m a -> m a
+  withAccountToContractAmount :: IndexedAccount m -> Instance -> Amount -> m a -> m a
 
   -- |Transfer an amount from the first account to the second and run the
   -- computation in the modified environment.
-  withAccountToAccountAmount :: Account m -> Account m -> Amount -> m a -> m a
+  withAccountToAccountAmount :: IndexedAccount m -> IndexedAccount m -> Amount -> m a -> m a
 
   -- |Transfer an amount from the given instance to the given account and run the
   -- computation in the modified environment.
-  withContractToAccountAmount :: Instance -> Account m -> Amount -> m a -> m a
+  withContractToAccountAmount :: Instance -> IndexedAccount m -> Amount -> m a -> m a
 
   -- |Transfer an amount from the first instance to the second and run the
   -- computation in the modified environment.
@@ -301,16 +301,16 @@ class (StaticInformation m, IsProtocolVersion pv) => TransactionMonad pv m | m -
 
   -- |Transfer a scheduled amount from the first address to the second and run
   -- the computation in the modified environment.
-  withScheduledAmount :: Account m -> Account m -> Amount -> [(Timestamp, Amount)] -> TransactionHash -> m a -> m a
+  withScheduledAmount :: IndexedAccount m -> IndexedAccount m -> Amount -> [(Timestamp, Amount)] -> TransactionHash -> m a -> m a
 
   -- |Replace encrypted amounts on an account up to (but not including) the
   -- given limit with a new amount.
-  replaceEncryptedAmount :: Account m -> EncryptedAmountAggIndex -> EncryptedAmount -> m ()
+  replaceEncryptedAmount :: IndexedAccount m -> EncryptedAmountAggIndex -> EncryptedAmount -> m ()
 
   -- |Replace encrypted amounts on an account up to (but not including) the
   -- given limit with a new amount, as well as adding the given amount to the
   -- public balance of the account
-  addAmountFromEncrypted :: Account m -> Amount -> EncryptedAmountAggIndex -> EncryptedAmount -> m ()
+  addAmountFromEncrypted :: IndexedAccount m -> Amount -> EncryptedAmountAggIndex -> EncryptedAmount -> m ()
 
   -- |Add a new encrypted amount to an account, and return its index.
   -- This may assume this is the only update to encrypted amounts on the given account
@@ -318,49 +318,42 @@ class (StaticInformation m, IsProtocolVersion pv) => TransactionMonad pv m | m -
   --
   -- This should be used on the receiver's account when an encrypted amount is
   -- sent to it.
-  addEncryptedAmount :: Account m -> EncryptedAmount -> m EncryptedAmountIndex
+  addEncryptedAmount :: IndexedAccount m -> EncryptedAmount -> m EncryptedAmountIndex
 
   -- |Add an encrypted amount to the self-balance of an account.
   -- This may assume this is the only update to encrypted amounts on the given account
   -- in this transaction.
   --
   -- This should be used when transferring from public to encrypted balance.
-  addSelfEncryptedAmount :: Account m -> Amount -> EncryptedAmount -> m ()
+  addSelfEncryptedAmount :: IndexedAccount m -> Amount -> EncryptedAmount -> m ()
 
   -- |Transfer an amount from the first given instance or account to the instance in the second
   -- parameter and run the computation in the modified environment.
   {-# INLINE withToContractAmount #-}
-  withToContractAmount :: Either (Account m, Instance) (Account m) -> Instance -> Amount -> m a -> m a
+  withToContractAmount :: Either (IndexedAccount m, Instance) (IndexedAccount m) -> Instance -> Amount -> m a -> m a
   withToContractAmount (Left (_, i)) = withContractToContractAmount i
   withToContractAmount (Right a) = withAccountToContractAmount a
-
-  -- |Transfer an amount from the first given instance or account to the account in the second
-  -- parameter and run the computation in the modified environment.
-  {-# INLINE withToAccountAmount #-}
-  withToAccountAmount :: Either (Account m, Instance) (Account m) -> Account m -> Amount -> m a -> m a
-  withToAccountAmount (Left (_, i)) = withContractToAccountAmount i
-  withToAccountAmount (Right a) = withAccountToAccountAmount a
 
   getCurrentContractInstance :: ContractAddress -> m (Maybe Instance)
 
   {-# INLINE getCurrentAvailableAmount #-}
-  getCurrentAvailableAmount :: Either (Account m, Instance) (Account m) -> m Amount
+  getCurrentAvailableAmount :: Either (IndexedAccount m, Instance) (IndexedAccount m) -> m Amount
   getCurrentAvailableAmount (Left (_, i)) = getCurrentContractAmount i
   getCurrentAvailableAmount (Right a) = getCurrentAccountAvailableAmount a
 
   -- |Get an account with its state at the start of the transaction.
-  getStateAccount :: AccountAddress -> m (Maybe (Account m))
+  getStateAccount :: AccountAddress -> m (Maybe (IndexedAccount m))
 
   -- |Get the current total public balance of an account.
   -- This accounts for any pending changes in the course of execution of the transaction.
   -- This includes any funds that cannot be spent due to lock-up or baking.
-  getCurrentAccountTotalAmount :: Account m -> m Amount
+  getCurrentAccountTotalAmount :: IndexedAccount m -> m Amount
 
   -- |Get the current available public balance of an account.
   -- This accounts for any pending changes in the course of execution of the transaction.
   -- The available balance excludes funds that are locked due to a lock-up release schedule
   -- or due to being staked for baking, or both.  That is @available = total - max locked staked@.
-  getCurrentAccountAvailableAmount :: Account m -> m Amount
+  getCurrentAccountAvailableAmount :: IndexedAccount m -> m Amount
 
   -- |Same as above, but for contracts.
   getCurrentContractAmount :: Instance -> m Amount
@@ -410,7 +403,7 @@ class (StaticInformation m, IsProtocolVersion pv) => TransactionMonad pv m | m -
 -- |The set of changes to be commited on a successful transaction.
 data ChangeSet = ChangeSet
     {_affectedTx :: !TransactionHash, -- ^Transaction affected by this changeset.
-     _accountUpdates :: !(HMap.HashMap AccountAddress AccountUpdate) -- ^Accounts whose states changed.
+     _accountUpdates :: !(HMap.HashMap AccountIndex AccountUpdate) -- ^Accounts whose states changed.
     ,_instanceUpdates :: !(HMap.HashMap ContractAddress (AmountDelta, Wasm.ContractState)) -- ^Contracts whose states changed.
     ,_instanceInits :: !(HSet.HashSet ContractAddress) -- ^Contracts that were initialized.
     ,_encryptedChange :: !AmountDelta -- ^Change in the encrypted balance of the system as a result of this contract's execution.
@@ -422,31 +415,31 @@ makeLenses ''ChangeSet
 emptyCS :: TransactionHash -> ChangeSet
 emptyCS txHash = ChangeSet txHash HMap.empty HMap.empty HSet.empty 0 Map.empty
 
-csWithAccountDelta :: TransactionHash -> AccountAddress -> AmountDelta -> ChangeSet
-csWithAccountDelta txHash addr !amnt =
-  (emptyCS txHash) & accountUpdates . at addr ?~ (emptyAccountUpdate addr & auAmount ?~ amnt)
+csWithAccountDelta :: TransactionHash -> AccountIndex -> AccountAddress -> AmountDelta -> ChangeSet
+csWithAccountDelta txHash ai addr !amnt = do
+  emptyCS txHash & accountUpdates . at ai ?~ (emptyAccountUpdate ai addr & auAmount ?~ amnt)
 
 -- |Record an addition to the amount of the given account in the changeset.
 {-# INLINE addAmountToCS #-}
-addAmountToCS :: (AccountOperations m) => Account m -> AmountDelta -> ChangeSet -> m ChangeSet
-addAmountToCS acc !amnt !cs = do
-  addr <- getAccountAddress acc
+addAmountToCS :: AccountOperations m => IndexedAccount m -> AmountDelta -> ChangeSet -> m ChangeSet
+addAmountToCS (ai, acc) !amnt !cs = do
+  addr <- getAccountCanonicalAddress acc
   -- Check whether there already is an 'AccountUpdate' for the given account in the changeset.
   -- If so, modify it accordingly, otherwise add a new entry.
-  return $ cs & accountUpdates . at addr %~ (\case Just upd -> Just (upd & auAmount %~ \case
-                                                                       Just x -> Just (x + amnt)
-                                                                       Nothing -> Just amnt
-                                                                    )
-                                                   Nothing -> Just (emptyAccountUpdate addr & auAmount ?~ amnt))
+  return $ cs & accountUpdates . at ai %~ (\case Just upd -> Just (upd & auAmount %~ \case
+                                                                     Just x -> Just (x + amnt)
+                                                                     Nothing -> Just amnt
+                                                                 )
+                                                 Nothing -> Just (emptyAccountUpdate ai addr & auAmount ?~ amnt))
 
 -- |Record a list of scheduled releases that has to be pushed into the global map and into the map of the account.
 {-# INLINE addScheduledAmountToCS #-}
-addScheduledAmountToCS :: AccountOperations m => Account m -> ([(Timestamp, Amount)], TransactionHash) -> ChangeSet -> m ChangeSet
+addScheduledAmountToCS :: AccountOperations m => IndexedAccount m -> ([(Timestamp, Amount)], TransactionHash) -> ChangeSet -> m ChangeSet
 addScheduledAmountToCS _ ([], _) cs = return cs
-addScheduledAmountToCS acc rel@(((fstRel, _):_), _) !cs = do
-  addr <- getAccountAddress acc
-  return $ cs & accountUpdates . at addr %~ (\case Just upd -> Just (upd & auReleaseSchedule %~ Just . maybe [rel] (rel :))
-                                                   Nothing -> Just (emptyAccountUpdate addr & auReleaseSchedule ?~ [rel]))
+addScheduledAmountToCS (ai, acc) rel@(((fstRel, _):_), _) !cs = do
+  addr <- getAccountCanonicalAddress acc
+  return $ cs & accountUpdates . at ai %~ (\case Just upd -> Just (upd & auReleaseSchedule %~ Just . maybe [rel] (rel :))
+                                                 Nothing -> Just (emptyAccountUpdate ai addr & auReleaseSchedule ?~ [rel]))
               & addedReleaseSchedules %~ (Map.alter (\case
                                                         Nothing -> Just fstRel
                                                         Just rel' -> Just $ min fstRel rel') addr)
@@ -455,8 +448,8 @@ addScheduledAmountToCS acc rel@(((fstRel, _):_), _) !cs = do
 -- It is assumed that the account is already in the changeset and that its balance
 -- is already affected (the auAmount field is set).
 {-# INLINE modifyAmountCS #-}
-modifyAmountCS :: AccountAddress -> AmountDelta -> ChangeSet -> ChangeSet
-modifyAmountCS addr !amnt !cs = cs & (accountUpdates . ix addr . auAmount ) %~
+modifyAmountCS :: AccountIndex -> AmountDelta -> ChangeSet -> ChangeSet
+modifyAmountCS ai !amnt !cs = cs & (accountUpdates . ix ai . auAmount ) %~
                                      (\case Just a -> Just (a + amnt)
                                             Nothing -> error "modifyAmountCS precondition violated.")
 
@@ -506,7 +499,7 @@ makeLenses ''LocalState
 
 data TransactionContext = TransactionContext{
   -- |Header of the transaction initiating the transaction.
-  _tcTxSender :: !AccountAddress,
+  _tcTxSender :: !AccountIndex,
   _tcDepositedAmount :: !Amount
   }
 
@@ -532,7 +525,7 @@ runLocalT :: SchedulerMonad pv m
           => LocalT a m a
           -> TransactionHash
           -> Amount
-          -> AccountAddress
+          -> AccountIndex
           -> Energy -- Energy limit by the transaction header.
           -> Energy -- remaining block energy
           -> m (Either (Maybe RejectReason) a, LocalState)
@@ -572,16 +565,16 @@ computeExecutionCharge meta energy =
 -- is the only one affected by the transaction, either because a transaction was
 -- rejected, or because it was a transaction which only affects one account's
 -- balance such as DeployCredential, or DeployModule.
-chargeExecutionCost :: (AccountOperations m) => SchedulerMonad pv m => TransactionHash -> Account m -> Amount -> m ()
-chargeExecutionCost txHash acc amnt = do
+chargeExecutionCost :: (AccountOperations m) => SchedulerMonad pv m => TransactionHash -> IndexedAccount m -> Amount -> m ()
+chargeExecutionCost txHash (ai, acc) amnt = do
     balance <- getAccountAmount acc
-    addr <- getAccountAddress acc
+    addr <- getAccountCanonicalAddress acc
     assert (balance >= amnt) $
-          commitChanges (csWithAccountDelta txHash addr (amountDiff 0 amnt))
+          commitChanges (csWithAccountDelta txHash ai addr (amountDiff 0 amnt))
     notifyExecutionCost amnt
 
 data WithDepositContext m = WithDepositContext{
-  _wtcSenderAccount :: !(Account m),
+  _wtcSenderAccount :: !(IndexedAccount m),
   -- ^Address of the account initiating the transaction.
   _wtcTransactionType :: !TransactionType,
   -- ^Type of the top-level transaction.
@@ -631,7 +624,7 @@ withDeposit wtc comp k = do
   let energy = totalEnergyToUse - wtc ^. wtcTransactionCheckHeaderCost
   -- record how much we have deposited. This cannot be touched during execution.
   depositedAmount <- energyToGtu totalEnergyToUse
-  (res, ls) <- runLocalT comp tsHash depositedAmount (thSender txHeader) energy beLeft
+  (res, ls) <- runLocalT comp tsHash depositedAmount (wtc ^. wtcSenderAccount . _1) energy beLeft
   case res of
     -- Failure: maximum block energy exceeded
     Left Nothing -> return Nothing
@@ -751,9 +744,9 @@ instance SchedulerMonad pv m => TransactionMonad pv (LocalT r m) where
     changeSet .= cs''
     cont
 
-  replaceEncryptedAmount acc aggIndex newAmount = do
-    addr <- getAccountAddress acc
-    changeSet . accountUpdates . at' addr . non (emptyAccountUpdate addr) . auEncrypted ?= ReplaceUpTo{..}
+  replaceEncryptedAmount (ai, acc) aggIndex newAmount = do
+    addr <- getAccountCanonicalAddress acc
+    changeSet . accountUpdates . at' ai . non (emptyAccountUpdate ai addr) . auEncrypted ?= ReplaceUpTo{..}
 
   addAmountFromEncrypted acc amount aggIndex newAmount = do
     replaceEncryptedAmount acc aggIndex newAmount
@@ -762,16 +755,16 @@ instance SchedulerMonad pv m => TransactionMonad pv (LocalT r m) where
     changeSet .= cs'
     changeSet . encryptedChange += amountDiff 0 amount
 
-  addEncryptedAmount acc newAmount = do
-    addr <- getAccountAddress acc
-    changeSet . accountUpdates . at' addr . non (emptyAccountUpdate addr) . auEncrypted ?= Add{..}
+  addEncryptedAmount (ai, acc) newAmount = do
+    addr <- getAccountCanonicalAddress acc
+    changeSet . accountUpdates . at' ai . non (emptyAccountUpdate ai addr) . auEncrypted ?= Add{..}
     getAccountEncryptedAmountNextIndex acc
 
-  addSelfEncryptedAmount acc transferredAmount newAmount = do
-    addr <- getAccountAddress acc
+  addSelfEncryptedAmount iacc@(ai, acc) transferredAmount newAmount = do
+    addr <- getAccountCanonicalAddress acc
     cs <- use changeSet
-    changeSet <~ addAmountToCS acc (amountDiff 0 transferredAmount) cs
-    changeSet . accountUpdates . at' addr . non (emptyAccountUpdate addr) . auEncrypted ?= AddSelf{..}
+    changeSet <~ addAmountToCS iacc (amountDiff 0 transferredAmount) cs
+    changeSet . accountUpdates . at' ai . non (emptyAccountUpdate ai addr) . auEncrypted ?= AddSelf{..}
     changeSet . encryptedChange += amountToDelta transferredAmount
 
   getCurrentContractInstance addr = do
@@ -790,15 +783,14 @@ instance SchedulerMonad pv m => TransactionMonad pv (LocalT r m) where
   {-# INLINE getStateAccount #-}
   getStateAccount = liftLocal . getAccount
 
-  getCurrentAccountTotalAmount acc = do
-    addr <- getAccountAddress acc
+  getCurrentAccountTotalAmount (ai, acc) = do
     oldTotal <- getAccountAmount acc
     !txCtx <- ask
     -- If the account is the sender, subtract the deposit
-    let netDeposit = if txCtx ^. tcTxSender == addr
+    let netDeposit = if txCtx ^. tcTxSender == ai
           then oldTotal - (txCtx ^. tcDepositedAmount)
           else oldTotal
-    macc <- use (changeSet . accountUpdates . at addr)
+    macc <- use (changeSet . accountUpdates . at ai)
     case macc of
       Just upd -> do
         -- Apply any pending delta and add any new scheduled releases
@@ -808,18 +800,17 @@ instance SchedulerMonad pv m => TransactionMonad pv (LocalT r m) where
         return $ applyAmountDelta (upd ^. auAmount . non 0) netDeposit + newReleases
       Nothing -> return netDeposit
 
-  getCurrentAccountAvailableAmount acc = do
-    addr <- getAccountAddress acc
+  getCurrentAccountAvailableAmount (ai, acc) = do
     oldTotal <- getAccountAmount acc
     oldLockedUp <- ARS._totalLockedUpBalance <$> getAccountReleaseSchedule acc
     bkr <- getAccountBaker acc
     let staked = maybe 0 (^. stakedAmount) bkr
     !txCtx <- ask
     -- If the account is the sender, subtract the deposit
-    let netDeposit = if txCtx ^. tcTxSender == addr
+    let netDeposit = if txCtx ^. tcTxSender == ai
           then oldTotal - (txCtx ^. tcDepositedAmount)
           else oldTotal
-    macc <- use (changeSet . accountUpdates . at addr)
+    macc <- use (changeSet . accountUpdates . at ai)
     case macc of
       Just upd -> do
         -- Apply any pending delta and add any new scheduled releases

--- a/concordium-consensus/src/Concordium/Scheduler/EnvironmentImplementation.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/EnvironmentImplementation.hs
@@ -216,7 +216,9 @@ instance (MonadReader ContextState m,
     -- log the initialized instances too
     lift (mapM_ (tell . logContract)
                       (Set.toList (cs ^. instanceInits)))
-    -- Notify account transfers, but also log the affected accounts.
+    -- Notify account transfers, but also log the affected accounts. Since the
+    -- changeset is meant to contain the canonical address of the account we
+    -- always log affected accounts by the canonical address.
     s'' <- lift (foldM (\curState accUpdate -> do
                            tell (logAccount (accUpdate ^. auAddress))
                            bsoModifyAccount curState accUpdate

--- a/concordium-consensus/src/Concordium/Scheduler/EnvironmentImplementation.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/EnvironmentImplementation.hs
@@ -174,6 +174,10 @@ instance (MonadReader ContextState m,
     schedulerBlockState .= s'
     return res
 
+  {-# INLINE addressWouldClash #-}
+  addressWouldClash !addr =
+    lift . flip bsoAddressWouldClash addr =<< use schedulerBlockState
+
   {-# INLINE accountRegIdExists #-}
   accountRegIdExists !regid =
     lift . fmap isJust . flip bsoRegIdExists regid =<< use schedulerBlockState

--- a/concordium-consensus/src/Concordium/Scheduler/EnvironmentImplementation.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/EnvironmentImplementation.hs
@@ -185,18 +185,17 @@ instance (MonadReader ContextState m,
     return res
 
   {-# INLINE increaseAccountNonce #-}
-  increaseAccountNonce acc = do
+  increaseAccountNonce (ai, acc) = do
     s <- use schedulerBlockState
     nonce <- getAccountNonce acc
-    addr <- getAccountAddress acc
-    s' <- lift (bsoModifyAccount s (emptyAccountUpdate addr & auNonce ?~ (nonce + 1)))
+    addr <- getAccountCanonicalAddress acc
+    s' <- lift (bsoModifyAccount s (emptyAccountUpdate ai addr & auNonce ?~ (nonce + 1)))
     schedulerBlockState .= s'
 
   {-# INLINE updateAccountCredentials #-}
-  updateAccountCredentials !acc !idcs !creds !threshold  = do
+  updateAccountCredentials !ai !idcs !creds !threshold  = do
     s <- use schedulerBlockState
-    addr <- getAccountAddress acc
-    s' <- lift (bsoUpdateAccountCredentials s addr idcs creds threshold)
+    s' <- lift (bsoUpdateAccountCredentials s ai idcs creds threshold)
     schedulerBlockState .= s'
 
   {-# INLINE commitChanges #-}
@@ -244,44 +243,44 @@ instance (MonadReader ContextState m,
     schedulerBlockState .= s'
 
   {-# INLINE addBaker #-}
-  addBaker acct badd = do
+  addBaker ai badd = do
     s <- use schedulerBlockState
-    (ret, s') <- lift (bsoAddBaker s acct badd)
+    (ret, s') <- lift (bsoAddBaker s ai badd)
     schedulerBlockState .= s'
     return ret
 
   {-# INLINE removeBaker #-}
-  removeBaker badd = do
+  removeBaker ai = do
     s <- use schedulerBlockState
-    (ret, s') <- lift (bsoRemoveBaker s badd)
+    (ret, s') <- lift (bsoRemoveBaker s ai)
     schedulerBlockState .= s'
     return ret
 
   {-# INLINE updateBakerKeys #-}
-  updateBakerKeys badd keyUpd = do
+  updateBakerKeys ai keyUpd = do
     s <- use schedulerBlockState
-    (r, s') <- lift (bsoUpdateBakerKeys s badd keyUpd)
+    (r, s') <- lift (bsoUpdateBakerKeys s ai keyUpd)
     schedulerBlockState .= s'
     return r
 
   {-# INLINE updateBakerStake #-}
-  updateBakerStake badd bsu = do
+  updateBakerStake bi bsu = do
     s <- use schedulerBlockState
-    (r, s') <- lift (bsoUpdateBakerStake s badd bsu)
+    (r, s') <- lift (bsoUpdateBakerStake s bi bsu)
     schedulerBlockState .= s'
     return r
 
   {-# INLINE updateBakerRestakeEarnings #-}
-  updateBakerRestakeEarnings badd bre = do
+  updateBakerRestakeEarnings bi bre = do
     s <- use schedulerBlockState
-    (r, s') <- lift (bsoUpdateBakerRestakeEarnings s badd bre)
+    (r, s') <- lift (bsoUpdateBakerRestakeEarnings s bi bre)
     schedulerBlockState .= s'
     return r
 
   {-# INLINE updateCredentialKeys #-}
-  updateCredentialKeys accAddr credIndex newKeys = do
+  updateCredentialKeys accIndex credIndex newKeys = do
     s <- use schedulerBlockState
-    s' <- lift (bsoSetAccountCredentialKeys s accAddr credIndex newKeys)
+    s' <- lift (bsoSetAccountCredentialKeys s accIndex credIndex newKeys)
     schedulerBlockState .= s'
 
   {-# INLINE getIPInfo #-}

--- a/concordium-consensus/src/Concordium/Scheduler/TreeStateEnvironment.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/TreeStateEnvironment.hs
@@ -376,7 +376,7 @@ mintAndReward bshandle blockParent slotNumber bid isNewEpoch mfinInfo transFees 
     -- Add the block to the list of blocks baked in this epoch
     >>= flip bsoNotifyBlockBaked bid
   
-  foundationAccount <- getAccountAddress =<< bsoGetFoundationAccount bshandleEpoch
+  foundationAccount <- getAccountCanonicalAddress =<< bsoGetFoundationAccount bshandleEpoch
 
   -- Then mint GTU.
   let mintUpdates = [(slot, md) | (slot, UVMintDistribution md) <- updates]

--- a/concordium-consensus/src/Concordium/Skov/Monad.hs
+++ b/concordium-consensus/src/Concordium/Skov/Monad.hs
@@ -120,10 +120,10 @@ class (Monad m, Eq (BlockPointerType m), HashableTo BlockHash (BlockPointerType 
     -- |Get the outcomes of a transaction.
     queryTransactionStatus :: TransactionHash -> m (Maybe TransactionStatus)
     -- |Get non-finalized transactions for an account, ordered by increasing nonce.
-    queryNonFinalizedTransactions :: AccountAddress -> m [TransactionHash]
+    queryNonFinalizedTransactions :: AccountAddressEq -> m [TransactionHash]
     -- |Get best guess for next account nonce.
     -- The second argument is 'True' if and only if all transactions from this account are finalized.
-    queryNextAccountNonce :: AccountAddress -> m (Nonce, Bool)
+    queryNextAccountNonce :: AccountAddressEq -> m (Nonce, Bool)
     -- |Get the finalization index of a block's last finalized block.
     blockLastFinalizedIndex :: BlockPointerType m -> m FinalizationIndex
     -- |Get a catch-up status message. The flag indicates if the

--- a/concordium-consensus/src/Concordium/Startup.hs
+++ b/concordium-consensus/src/Concordium/Startup.hs
@@ -37,6 +37,7 @@ import Concordium.ID.DummyData
 import qualified Concordium.Genesis.Data as GenesisData
 import qualified Concordium.Genesis.Data.P1 as P1
 import qualified Concordium.Genesis.Data.P2 as P2
+import qualified Concordium.Genesis.Data.P3 as P3
 
 makeBakersByStake :: [Amount] -> [(BakerIdentity, FullBakerInfo, GenesisAccount, SigScheme.KeyPair)]
 makeBakersByStake = mbs 0
@@ -152,6 +153,10 @@ makeGenesisData
               genesisInitialState=GenesisData.GenesisState{genesisAccounts = Vec.fromList genesisAccounts, ..}
               }
             SP2 -> GDP2 P2.GDP2Initial{
+              genesisCore=GenesisData.CoreGenesisParameters{..},
+              genesisInitialState=GenesisData.GenesisState{genesisAccounts = Vec.fromList genesisAccounts, ..}
+              }
+            SP3 -> GDP3 P3.GDP3Initial{
               genesisCore=GenesisData.CoreGenesisParameters{..},
               genesisInitialState=GenesisData.GenesisState{genesisAccounts = Vec.fromList genesisAccounts, ..}
               }

--- a/concordium-consensus/test-runners/execute-chain/Main.hs
+++ b/concordium-consensus/test-runners/execute-chain/Main.hs
@@ -43,12 +43,12 @@ main = do
     createDirectoryIfMissing True dataDir
     let config ::
             MultiVersionConfiguration
-                (PairGSConfig DiskTreeDiskBlockConfig MemoryTreeMemoryBlockConfig)
+                DiskTreeDiskBlockConfig
                 (NoFinalization ThreadTimer)
         config =
             MultiVersionConfiguration
-                { mvcStateConfig = (DiskStateConfig dataDir, ()),
-                  mvcTXLogConfig = ((), ()),
+                { mvcStateConfig = DiskStateConfig dataDir,
+                  mvcTXLogConfig = (),
                   mvcFinalizationConfig = NoFinalization,
                   mvcRuntimeParameters = defaultRuntimeParameters{rpTransactionsPurgingDelay = 0}
                 }

--- a/concordium-consensus/test-runners/execute-chain/Main.hs
+++ b/concordium-consensus/test-runners/execute-chain/Main.hs
@@ -43,12 +43,12 @@ main = do
     createDirectoryIfMissing True dataDir
     let config ::
             MultiVersionConfiguration
-                DiskTreeDiskBlockConfig
+                (PairGSConfig DiskTreeDiskBlockConfig MemoryTreeMemoryBlockConfig)
                 (NoFinalization ThreadTimer)
         config =
             MultiVersionConfiguration
-                { mvcStateConfig = DiskStateConfig dataDir,
-                  mvcTXLogConfig = (),
+                { mvcStateConfig = (DiskStateConfig dataDir, ()),
+                  mvcTXLogConfig = ((), ()),
                   mvcFinalizationConfig = NoFinalization,
                   mvcRuntimeParameters = defaultRuntimeParameters{rpTransactionsPurgingDelay = 0}
                 }

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/AccountReleaseScheduleTest.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/AccountReleaseScheduleTest.hs
@@ -121,14 +121,14 @@ testing = do
       bs1 = _unhashedBlockState $ _bpState (bs ^. pairStateLeft . Concordium.GlobalState.Basic.TreeState.focusBlock)
       bs2 = PBS.hpbsPointers $ _bpState (bs ^. pairStateRight . Concordium.GlobalState.Persistent.TreeState.focusBlock)
 
-  let [(accA, _), (accB, _)] = take 2 $ map (\(_, ac) -> (ac ^. accountAddress, ac ^. accountAmount)) $ AT.toList $ accountTable (bs1 ^. blockAccounts)
+  let [(accA, aiA), (accB, aiB)] = take 2 $ map (\(ai, ac) -> (ac ^. accountAddress, ai)) $ AT.toList $ accountTable (bs1 ^. blockAccounts)
   b' <- bsoAddReleaseSchedule (bs1, bs2) [(accA, head timestampsA), (accB, head timestampsB)]
   checkEqualBlockReleaseSchedule b'
-  bs'' <- foldlM (\b e@(acc, rels) -> do
-                     newB <- bsoModifyAccount b ((emptyAccountUpdate acc) { _auReleaseSchedule = Just [(rels, dummyTransactionHash)] })
+  bs'' <- foldlM (\b e@((acc, ai), rels) -> do
+                     newB <- bsoModifyAccount b ((emptyAccountUpdate ai acc) { _auReleaseSchedule = Just [(rels, dummyTransactionHash)] })
                      checkCorrectAccountReleaseSchedule newB b e
                      return newB
-                 ) b' (map (accA,) txsA ++ map (accB,) txsB)
+                 ) b' (map ((accA, aiA),) txsA ++ map ((accB, aiB),) txsB)
   checkEqualBlockReleaseSchedule bs''
   let taggedAmounts = OrdMap.toAscList $ OrdMap.unionWith (++) (OrdMap.map ((:[]) . (accA,)) amountsA) (OrdMap.map ((:[]) . (accB,)) amountsB)
   _ <- foldlM (\b (ts, accs) -> do
@@ -172,8 +172,8 @@ checkEqualAccountReleaseSchedule (blockStateBasic, blockStatePersistent) acc = d
   assert (Just (getHash (newBasicAccount ^. accountReleaseSchedule)) == newPersistentAccountReleaseScheduleHash) $ return ()
 
 -- | Check that an an account was correctly updated in the two blockstates with the given release schedule
-checkCorrectAccountReleaseSchedule :: (BS.BlockState PV, PBS.PersistentBlockState PV) -> (BS.BlockState PV, PBS.PersistentBlockState PV) -> (AccountAddress, [(Timestamp, Amount)]) -> ThisMonadConcrete ()
-checkCorrectAccountReleaseSchedule (blockStateBasic, blockStatePersistent) (oldBlockStateBasic, _) (acc, rel) = do
+checkCorrectAccountReleaseSchedule :: (BS.BlockState PV, PBS.PersistentBlockState PV) -> (BS.BlockState PV, PBS.PersistentBlockState PV) -> ((AccountAddress, AccountIndex), [(Timestamp, Amount)]) -> ThisMonadConcrete ()
+checkCorrectAccountReleaseSchedule (blockStateBasic, blockStatePersistent) (oldBlockStateBasic, _) ((acc, ai), rel) = do
   let Just newBasicAccount = Concordium.GlobalState.Basic.BlockState.Accounts.getAccount acc (blockStateBasic ^. blockAccounts)
   let Just oldBasicAccount = Concordium.GlobalState.Basic.BlockState.Accounts.getAccount acc (oldBlockStateBasic ^. blockAccounts)
   checkEqualAccountReleaseSchedule (blockStateBasic, blockStatePersistent) acc

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/AccountReleaseScheduleTest.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/AccountReleaseScheduleTest.hs
@@ -173,7 +173,7 @@ checkEqualAccountReleaseSchedule (blockStateBasic, blockStatePersistent) acc = d
 
 -- | Check that an an account was correctly updated in the two blockstates with the given release schedule
 checkCorrectAccountReleaseSchedule :: (BS.BlockState PV, PBS.PersistentBlockState PV) -> (BS.BlockState PV, PBS.PersistentBlockState PV) -> ((AccountAddress, AccountIndex), [(Timestamp, Amount)]) -> ThisMonadConcrete ()
-checkCorrectAccountReleaseSchedule (blockStateBasic, blockStatePersistent) (oldBlockStateBasic, _) ((acc, ai), rel) = do
+checkCorrectAccountReleaseSchedule (blockStateBasic, blockStatePersistent) (oldBlockStateBasic, _) ((acc, _), rel) = do
   let Just newBasicAccount = Concordium.GlobalState.Basic.BlockState.Accounts.getAccount acc (blockStateBasic ^. blockAccounts)
   let Just oldBasicAccount = Concordium.GlobalState.Basic.BlockState.Accounts.getAccount acc (oldBlockStateBasic ^. blockAccounts)
   checkEqualAccountReleaseSchedule (blockStateBasic, blockStatePersistent) acc

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/AccountTrie.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/AccountTrie.hs
@@ -1,0 +1,138 @@
+{-# LANGUAGE TemplateHaskell #-}
+module GlobalStateTests.AccountTrie where
+
+import Concordium.GlobalState.Persistent.BlobStore
+import qualified Concordium.GlobalState.Persistent.AccountTrie as AT
+import Data.Serialize
+import Data.List (foldl', sort)
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.ByteString as BS
+import qualified Data.Map as Map
+import qualified Data.Vector.Unboxed as VU
+import Control.Monad
+import Control.Monad.Trans
+import qualified Control.Monad.State.Strict as State
+import Lens.Micro.Platform
+
+import Test.QuickCheck
+import Test.Hspec
+
+genValidConfig :: Gen (Int, Int, Bool)
+genValidConfig = do
+  pathLen <- choose (0, 100000)
+  childrenLen <- choose (0, 256)
+  hasValue <- arbitrary
+  return (pathLen, childrenLen, hasValue)
+
+genKey :: Gen AT.Key
+genKey = do
+  len <- choose (0, 1000)
+  VU.replicateM len arbitrary
+
+genInputs :: Gen ([(AT.Key, Word)], [AT.Key])
+genInputs = sized $ \n -> do
+  len <- choose (0, min n 10000)
+  inputs <- replicateM len ((,) <$> genKey <*> arbitrary)
+  extraKeysLen <- choose (0, min n 1000)
+  extraKeys <- replicateM extraKeysLen genKey
+  return (inputs, extraKeys)
+
+constructReference :: [(AT.Key, Word)] -> Map.Map AT.Key Word
+constructReference = Map.fromList
+
+constructTrie :: [(AT.Key, Word)] -> AT.PureNode Word
+constructTrie = foldl' (\acc (k, v) -> snd $ AT.insertPure k v acc) AT.empty
+
+nodeValueLenSerializationTest :: Word -> Spec
+nodeValueLenSerializationTest lvl = it "node value serialization" $ withMaxSuccess (100 ^ lvl) $ property $ do
+  forAll genValidConfig $ \cfg@(pathLen, childrenLen, hasValue) -> runGet AT.getNodeValueLen (runPut (AT.putNodeValueLen pathLen childrenLen hasValue)) === Right cfg
+
+insertionTests :: Word -> Spec
+insertionTests lvl = it "insert and lookup" $
+    withMaxSuccess (10000 * fromIntegral lvl) $ property $
+    forAll genInputs $ \(inputs, extraKeys) ->
+                         let referenceMap = constructReference inputs
+                         in let trie = constructTrie inputs
+                            in conjoin (map (\k -> Map.lookup k referenceMap === AT.lookupPure k trie) (map fst inputs ++ extraKeys))
+
+newtype Buffer = Buffer {
+  _buffer :: BSL.ByteString
+  }
+makeLenses ''Buffer
+
+emptyBuffer :: Buffer
+emptyBuffer = Buffer BSL.empty
+
+instance MonadIO m => MonadBlobStore (State.StateT Buffer m) where
+  storeRaw bs = do
+    pos <- BlobRef . fromIntegral <$> use (buffer . to BSL.length)
+    let len = runPutLazy (putWord64be (fromIntegral (BS.length bs)))
+    buffer %= (`BSL.append` (len `BSL.append` BSL.fromStrict bs))
+    return pos
+  loadRaw (BlobRef pos) = do
+    bs <- use buffer
+    case runGetLazy (getByteString . fromIntegral =<< getWord64be) . BSL.drop (fromIntegral pos) $ bs of
+      Left err -> error $ "Error reading: " ++ err
+      Right x -> return x
+
+  flushStore = return ()
+
+updateM :: AT.Key -> Word -> State.StateT (BlobRef (AT.PersistentNode Word)) (State.StateT Buffer IO) ()
+updateM k v = do
+  ref <- State.get
+  newRef <- lift $ do
+    trie <- loadRef ref
+    newTrie <- snd <$> AT.insertPersistent k v trie
+    storeRef newTrie
+  State.put newRef
+
+lookupM :: AT.Key -> State.StateT (BlobRef (AT.PersistentNode Word)) (State.StateT Buffer IO) (Maybe Word)
+lookupM k = do
+  ref <- State.get
+  lift $ do
+    trie <- loadRef ref
+    AT.lookupPersistent k trie
+
+runUpdates :: [(AT.Key, Word)] -> IO [Maybe Word]
+runUpdates inputs = do
+  let comp = do
+        mapM_ (uncurry updateM) inputs
+        mapM (lookupM . fst) inputs
+  (initialBlobRef, initialBuffer) <- State.runStateT (storeRef AT.empty) emptyBuffer
+  State.evalStateT (State.evalStateT comp initialBlobRef) initialBuffer
+
+makeToList :: [(AT.Key, Word)] -> IO [(AT.Key, Word)]
+makeToList inputs = do
+  let comp = do
+        mapM_ (uncurry updateM) inputs
+        ref <- State.get
+        lift $ AT.toListPersistent =<< loadRef ref
+  (initialBlobRef, initialBuffer) <- State.runStateT (storeRef AT.empty) emptyBuffer
+  State.evalStateT (State.evalStateT comp initialBlobRef) initialBuffer
+
+
+persistentInsertionTests :: Word -> Spec
+persistentInsertionTests lvl = it "insert and lookup in the persistent map" $
+    withMaxSuccess (10000 * fromIntegral lvl) $ property $
+    forAll genInputs $ \(inputs, extraKeys) ->
+                         let referenceMap = constructReference inputs
+                         in ioProperty $ do
+                           results <- runUpdates inputs
+                           return $ conjoin (zipWith (\k res -> Map.lookup k referenceMap === res) (map fst inputs ++ extraKeys) results)
+
+
+persistentToListTests :: Word -> Spec
+persistentToListTests lvl = it "to list the persistent map" $
+    withMaxSuccess (10000 * fromIntegral lvl) $ property $
+    forAll genInputs $ \(inputs, _) ->
+                         let referenceMap = constructReference inputs
+                         in ioProperty $ do
+                           results <- makeToList inputs
+                           return $ sort results === Map.toAscList referenceMap
+
+tests :: Word -> Spec
+tests lvl = describe "GlobalStateTests.AccountTrie" $ do
+              nodeValueLenSerializationTest lvl
+              insertionTests lvl
+              persistentInsertionTests lvl
+              persistentToListTests lvl

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/AccountTrie.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/AccountTrie.hs
@@ -1,138 +1,153 @@
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DataKinds, TypeApplications, ScopedTypeVariables #-}
+{-|
+  Tests of the account map related operations.
+-}
 module GlobalStateTests.AccountTrie where
 
-import Concordium.GlobalState.Persistent.BlobStore
-import qualified Concordium.GlobalState.Persistent.AccountTrie as AT
-import Data.Serialize
-import Data.List (foldl', sort)
-import qualified Data.ByteString.Lazy as BSL
-import qualified Data.ByteString as BS
+import Concordium.Types
+import Concordium.ID.Types
+import qualified Concordium.GlobalState.Persistent.Trie as Trie
+import qualified Concordium.GlobalState.AccountMap as AccountMap
+import Data.List (sort, sortOn, nubBy, nub)
 import qualified Data.Map as Map
-import qualified Data.Vector.Unboxed as VU
 import Control.Monad
-import Control.Monad.Trans
-import qualified Control.Monad.State.Strict as State
-import Lens.Micro.Platform
+import Control.Monad.Identity
+import qualified Data.FixedByteString as FBS
+import Data.Word
+import Data.Maybe
+import Data.Fix
+import Data.Function (on)
+import Data.Proxy
 
 import Test.QuickCheck
 import Test.Hspec
 
-genValidConfig :: Gen (Int, Int, Bool)
-genValidConfig = do
-  pathLen <- choose (0, 100000)
-  childrenLen <- choose (0, 256)
-  hasValue <- arbitrary
-  return (pathLen, childrenLen, hasValue)
+genAccountAddress :: Gen AccountAddress
+genAccountAddress = AccountAddress . FBS.pack <$> vector accountAddressSize
 
-genKey :: Gen AT.Key
-genKey = do
-  len <- choose (0, 1000)
-  VU.replicateM len arbitrary
-
-genInputs :: Gen ([(AT.Key, Word)], [AT.Key])
+genInputs :: Gen ([(AccountAddress, AccountIndex)], [AccountAddress])
 genInputs = sized $ \n -> do
   len <- choose (0, min n 10000)
-  inputs <- replicateM len ((,) <$> genKey <*> arbitrary)
+  inputs <- replicateM len ((,) <$> genAccountAddress <*> (AccountIndex <$> arbitrary))
   extraKeysLen <- choose (0, min n 1000)
-  extraKeys <- replicateM extraKeysLen genKey
+  extraKeys <- replicateM extraKeysLen genAccountAddress
   return (inputs, extraKeys)
 
-constructReference :: [(AT.Key, Word)] -> Map.Map AT.Key Word
+type Trie = Trie.TrieN Fix AccountAddress AccountIndex
+
+-- Construct the reference map for comparing lookups.
+constructReference :: [(AccountAddress, AccountIndex)] -> Map.Map AccountAddress AccountIndex
 constructReference = Map.fromList
 
-constructTrie :: [(AT.Key, Word)] -> AT.PureNode Word
-constructTrie = foldl' (\acc (k, v) -> snd $ AT.insertPure k v acc) AT.empty
+constructTrie :: [(AccountAddress, AccountIndex)] -> Trie
+constructTrie = runIdentity . Trie.fromList
 
-nodeValueLenSerializationTest :: Word -> Spec
-nodeValueLenSerializationTest lvl = it "node value serialization" $ withMaxSuccess (100 ^ lvl) $ property $ do
-  forAll genValidConfig $ \cfg@(pathLen, childrenLen, hasValue) -> runGet AT.getNodeValueLen (runPut (AT.putNodeValueLen pathLen childrenLen hasValue)) === Right cfg
+-- Helper to look up in the trie.
+trieLookup :: AccountAddress -> Trie -> Maybe AccountIndex
+trieLookup addr = runIdentity . Trie.lookup addr
 
+-- Look up all the keys that match the given prefix.
+triePrefixLookup :: [Word8] -> Trie -> [(AccountAddress, AccountIndex)]
+triePrefixLookup prefix = runIdentity . Trie.lookupPrefix prefix
+
+-- Insert and then lookup. Compares results to the reference map using Data.Map.
 insertionTests :: Word -> Spec
 insertionTests lvl = it "insert and lookup" $
     withMaxSuccess (10000 * fromIntegral lvl) $ property $
     forAll genInputs $ \(inputs, extraKeys) ->
                          let referenceMap = constructReference inputs
                          in let trie = constructTrie inputs
-                            in conjoin (map (\k -> Map.lookup k referenceMap === AT.lookupPure k trie) (map fst inputs ++ extraKeys))
+                            in conjoin (map (\k -> Map.lookup k referenceMap === trieLookup k trie) (map fst inputs ++ extraKeys))
 
-newtype Buffer = Buffer {
-  _buffer :: BSL.ByteString
-  }
-makeLenses ''Buffer
-
-emptyBuffer :: Buffer
-emptyBuffer = Buffer BSL.empty
-
-instance MonadIO m => MonadBlobStore (State.StateT Buffer m) where
-  storeRaw bs = do
-    pos <- BlobRef . fromIntegral <$> use (buffer . to BSL.length)
-    let len = runPutLazy (putWord64be (fromIntegral (BS.length bs)))
-    buffer %= (`BSL.append` (len `BSL.append` BSL.fromStrict bs))
-    return pos
-  loadRaw (BlobRef pos) = do
-    bs <- use buffer
-    case runGetLazy (getByteString . fromIntegral =<< getWord64be) . BSL.drop (fromIntegral pos) $ bs of
-      Left err -> error $ "Error reading: " ++ err
-      Right x -> return x
-
-  flushStore = return ()
-
-updateM :: AT.Key -> Word -> State.StateT (BlobRef (AT.PersistentNode Word)) (State.StateT Buffer IO) ()
-updateM k v = do
-  ref <- State.get
-  newRef <- lift $ do
-    trie <- loadRef ref
-    newTrie <- snd <$> AT.insertPersistent k v trie
-    storeRef newTrie
-  State.put newRef
-
-lookupM :: AT.Key -> State.StateT (BlobRef (AT.PersistentNode Word)) (State.StateT Buffer IO) (Maybe Word)
-lookupM k = do
-  ref <- State.get
-  lift $ do
-    trie <- loadRef ref
-    AT.lookupPersistent k trie
-
-runUpdates :: [(AT.Key, Word)] -> IO [Maybe Word]
-runUpdates inputs = do
-  let comp = do
-        mapM_ (uncurry updateM) inputs
-        mapM (lookupM . fst) inputs
-  (initialBlobRef, initialBuffer) <- State.runStateT (storeRef AT.empty) emptyBuffer
-  State.evalStateT (State.evalStateT comp initialBlobRef) initialBuffer
-
-makeToList :: [(AT.Key, Word)] -> IO [(AT.Key, Word)]
-makeToList inputs = do
-  let comp = do
-        mapM_ (uncurry updateM) inputs
-        ref <- State.get
-        lift $ AT.toListPersistent =<< loadRef ref
-  (initialBlobRef, initialBuffer) <- State.runStateT (storeRef AT.empty) emptyBuffer
-  State.evalStateT (State.evalStateT comp initialBlobRef) initialBuffer
-
-
-persistentInsertionTests :: Word -> Spec
-persistentInsertionTests lvl = it "insert and lookup in the persistent map" $
-    withMaxSuccess (10000 * fromIntegral lvl) $ property $
-    forAll genInputs $ \(inputs, extraKeys) ->
-                         let referenceMap = constructReference inputs
-                         in ioProperty $ do
-                           results <- runUpdates inputs
-                           return $ conjoin (zipWith (\k res -> Map.lookup k referenceMap === res) (map fst inputs ++ extraKeys) results)
-
-
-persistentToListTests :: Word -> Spec
-persistentToListTests lvl = it "to list the persistent map" $
+-- |Check that using the empty prefix with 'Trie.lookupPrefix' is equivalent to
+-- 'toList' modulo the order.
+emptyPrefixTest :: Word -> Spec
+emptyPrefixTest lvl = it "lookup empty prefix is the same as toList" $
     withMaxSuccess (10000 * fromIntegral lvl) $ property $
     forAll genInputs $ \(inputs, _) ->
                          let referenceMap = constructReference inputs
-                         in ioProperty $ do
-                           results <- makeToList inputs
-                           return $ sort results === Map.toAscList referenceMap
+                         in let trie = constructTrie inputs
+                            in sort (triePrefixLookup [] trie) === Map.toAscList referenceMap
+
+-- |Check that 'Trie.lookupPrefix' reduces to 'Trie.lookup' in case of an exact
+-- match. That this is a property relies on the fact that all keys have the same
+-- length, which is a requirement for this trie implementation.
+exactPrefixTest :: Word -> Spec
+exactPrefixTest lvl = it "lookup exact prefix matches lookup" $
+    withMaxSuccess (10000 * fromIntegral lvl) $ property $
+    forAll genInputs $ \(inputs, extraKeys) ->
+                         let trie = constructTrie inputs
+                         in conjoin (map (\k -> ((k,) <$> (maybeToList (trieLookup k trie))) === triePrefixLookup (Trie.unpackKey k) trie)
+                                    (map fst inputs ++ extraKeys))
+
+-- |Generate all possible prefix sizes, including empty prefix.
+genPrefixSizes :: Gen Int
+genPrefixSizes = choose (0, 32)
+
+-- |Check that 'Trie.lookupPrefix' returns exactly the right keys. This is
+-- compared to the obvious implementation using the reference map.
+allPrefixes :: Word -> Spec
+allPrefixes lvl = it "lookup prefix" $
+    withMaxSuccess (10000 * fromIntegral lvl) $ property $
+    forAll genInputs $ \(inputs, _) -> forAll genPrefixSizes $ \prefixLen -> 
+                         let trie = constructTrie inputs
+                             -- Take the prefix of the key of specified length.
+                             takePrefix = take prefixLen . Trie.unpackKey
+                             -- All the unique addresses in the generated input.
+                             inputAddresses =
+                               nub .
+                               sort .
+                               map fst $ inputs
+                         in conjoin (map (\k -> sort (map fst (triePrefixLookup (takePrefix k) trie)) ===
+                                               filter ((== (takePrefix k)) . takePrefix) inputAddresses
+                                                )
+                                    (map fst inputs))
+
+-- |Generate some aliases for the given account address. All aliases are unique
+-- and the return list will have at least one.
+genAliases :: AccountAddress -> Gen [AccountAddress]
+genAliases (AccountAddress addr) = sized $ \n -> do
+  len <- choose (1, min n 1000)
+  aliases <- replicateM len (AccountAddress . FBS.pack . take 29 . (FBS.unpack addr ++) <$> vector 3)
+  return (nub . sort $ aliases)
+
+constructAccountMap :: forall pv . [(AccountAddress, AccountIndex)] -> AccountMap.PureAccountMap pv
+constructAccountMap = AccountMap.AccountMap . runIdentity . Trie.fromList
+
+-- |Check that for protocol version 3 
+checkClashesP3 :: Word -> Spec
+checkClashesP3 lvl = it "check aliases for P3" $
+    withMaxSuccess (10000 * fromIntegral lvl) $ property $
+    forAll genInputs $ \(inputs, _) -> 
+       let am = constructAccountMap @'P3 inputs
+       in conjoin (map (\(k, _) -> forAll (genAliases k) $
+                         \aliases -> conjoin (map (flip AccountMap.addressWouldClashPure am) aliases))
+                       inputs)
+
+-- |Check that for protocol versions P1 and P2 addressWouldClash implies
+-- equality of addresses. This test is only meant to be instantiated with P1 and
+-- P2 protocol versions since it should fail for protocol version 3.
+-- See 'checkClashesP3' for that protocol version.
+checkClashesP1P2 :: forall pv . IsProtocolVersion pv => Proxy pv -> Word -> Spec
+checkClashesP1P2 Proxy lvl = it ("check aliases for protocol version " ++ show (demoteProtocolVersion (protocolVersion @pv))) $
+    withMaxSuccess (10000 * fromIntegral lvl) $ property $
+    forAll genInputs $ \(inputs, _) -> 
+       let mkPrefix (AccountAddress addr, _) = take 29 . FBS.unpack $ addr
+           withUniquePrefixes = nubBy ((==) `on` mkPrefix) . sortOn mkPrefix $ inputs
+           am = constructAccountMap @pv withUniquePrefixes
+       in conjoin (map (\(addr, _) -> forAll (genAliases addr) $
+                         \aliases -> conjoin (map (\alias -> alias == addr || not (AccountMap.addressWouldClashPure alias am)) aliases))
+                       withUniquePrefixes)
+
 
 tests :: Word -> Spec
-tests lvl = describe "GlobalStateTests.AccountTrie" $ do
-              nodeValueLenSerializationTest lvl
-              insertionTests lvl
-              persistentInsertionTests lvl
-              persistentToListTests lvl
+tests lvl = do
+  describe "GlobalStateTests.AccountTrie" $ do
+    insertionTests lvl
+    emptyPrefixTest lvl
+    exactPrefixTest lvl
+    allPrefixes lvl
+  describe "GlobalStateTests.AccountMap" $ do
+    checkClashesP1P2 (Proxy @'P1) lvl
+    checkClashesP1P2 (Proxy @'P2) lvl
+    checkClashesP3 lvl

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/Accounts.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/Accounts.hs
@@ -135,12 +135,12 @@ randomActions = sized (ra Set.empty Map.empty)
               [exExAcc, getExAcc, unsafeGetExAcc, updateExAcc]
                 ++ if null rids then [] else [exExReg, recExReg]
       where
-        fresh s x
-            | x `Set.member` (Set.map snd s) = fresh s . snd =<< randAccount
+        fresh x
+            | x `Set.member` (Set.map snd s) = fresh . snd =<< randAccount
             | otherwise = return x
         putRandAcc = do
           (vk, addr) <- randAccount
-          freshAddr <- fresh s addr
+          freshAddr <- fresh addr
           acct <- randomizeAccount freshAddr vk
           (PutAccount acct :) <$> ra (Set.insert (vk, addr) s) rids (n -1)
         exRandAcc = do

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/Accounts.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/Accounts.hs
@@ -12,13 +12,13 @@ import Concordium.Crypto.FFIDataTypes
 import Concordium.GlobalState.Basic.BlockState.Account as BA
 import qualified Concordium.GlobalState.Basic.BlockState.AccountTable as BAT
 import qualified Concordium.GlobalState.Basic.BlockState.Accounts as B
+import qualified Concordium.GlobalState.AccountMap as AccountMap
 import qualified Concordium.GlobalState.Persistent.Account as PA
 import qualified Concordium.GlobalState.Persistent.BlockState.AccountReleaseSchedule as PA
 import qualified Concordium.GlobalState.Persistent.Accounts as P
 import qualified Concordium.GlobalState.Persistent.LFMBTree as L
 import Concordium.GlobalState.DummyData
 import Concordium.GlobalState.Persistent.BlobStore
-import qualified Concordium.GlobalState.Persistent.Trie as Trie
 import Concordium.ID.DummyData
 import qualified Concordium.ID.Types as ID
 import Concordium.Types
@@ -62,8 +62,8 @@ checkBinaryM bop x y sbop sx sy = do
 --  use registration ids.
 checkEquivalent :: (MonadBlobStore m, MonadFail m) => B.Accounts PV -> P.Accounts PV -> m ()
 checkEquivalent ba pa = do
-  pam <- Trie.toMap (P.accountMap pa)
-  checkBinary (==) (B.accountMap ba) pam "==" "Basic account map" "Persistent account map"
+  pam <- AccountMap.toMap (P.accountMap pa)
+  checkBinary (==) (AccountMap.toMapPure (B.accountMap ba)) pam "==" "Basic account map" "Persistent account map"
   let bat = BAT.toList (B.accountTable ba)
   pat <- L.toAscPairList (P.accountTable pa)
   checkBinaryM sameAccList bat pat "==" "Basic account table (as list)" "Persistent account table (as list)"

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/Accounts.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/Accounts.hs
@@ -143,10 +143,6 @@ randomActions = sized (ra Set.empty Map.empty)
           freshAddr <- fresh s addr
           acct <- randomizeAccount freshAddr vk
           (PutAccount acct :) <$> ra (Set.insert (vk, addr) s) rids (n -1)
-        putExAcc = do
-          (vk, addr) <- elements (Set.toList s)
-          acct <- randomizeAccount addr vk
-          (PutAccount acct :) <$> ra s rids (n -1)
         exRandAcc = do
           (_, addr) <- randAccount
           (Exists addr :) <$> ra s rids (n -1)

--- a/concordium-consensus/tests/globalstate/Spec.hs
+++ b/concordium-consensus/tests/globalstate/Spec.hs
@@ -8,7 +8,7 @@ import qualified GlobalStateTests.Instances(tests)
 import qualified GlobalStateTests.FinalizationSerializationSpec(tests)
 import qualified GlobalStateTests.Trie(tests)
 import qualified GlobalStateTests.LFMBTree(tests)
-import qualified GlobalStateTests.AccountTrie(tests)
+import qualified GlobalStateTests.AccountMap(tests)
 import qualified GlobalStateTests.PersistentTreeState(tests)
 import qualified GlobalStateTests.Accounts(tests)
 import qualified GlobalStateTests.BlockHash(tests)
@@ -36,4 +36,4 @@ main = atLevel $ \lvl -> hspec $ do
   GlobalStateTests.Instances.tests lvl
   GlobalStateTests.AccountReleaseScheduleTest.tests
   GlobalStateTests.Updates.tests
-  GlobalStateTests.AccountTrie.tests lvl
+  GlobalStateTests.AccountMap.tests lvl

--- a/concordium-consensus/tests/globalstate/Spec.hs
+++ b/concordium-consensus/tests/globalstate/Spec.hs
@@ -8,6 +8,7 @@ import qualified GlobalStateTests.Instances(tests)
 import qualified GlobalStateTests.FinalizationSerializationSpec(tests)
 import qualified GlobalStateTests.Trie(tests)
 import qualified GlobalStateTests.LFMBTree(tests)
+import qualified GlobalStateTests.AccountTrie(tests)
 import qualified GlobalStateTests.PersistentTreeState(tests)
 import qualified GlobalStateTests.Accounts(tests)
 import qualified GlobalStateTests.BlockHash(tests)
@@ -35,3 +36,4 @@ main = atLevel $ \lvl -> hspec $ do
   GlobalStateTests.Instances.tests lvl
   GlobalStateTests.AccountReleaseScheduleTest.tests
   GlobalStateTests.Updates.tests
+  GlobalStateTests.AccountTrie.tests lvl

--- a/concordium-consensus/tests/scheduler/SchedulerTests/AccountTransactionSpecs.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/AccountTransactionSpecs.hs
@@ -22,6 +22,7 @@ import Concordium.GlobalState.DummyData
 import Concordium.Types.DummyData
 
 import SchedulerTests.Helpers
+import SchedulerTests.TestUtils
 
 shouldReturnP :: Show a => IO a -> (a -> Bool) -> IO ()
 shouldReturnP action f = action >>= (`shouldSatisfy` f)

--- a/concordium-consensus/tests/scheduler/SchedulerTests/BakerTransactions.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/BakerTransactions.hs
@@ -36,6 +36,7 @@ import Concordium.Types.DummyData
 import Concordium.Crypto.DummyData
 
 import SchedulerTests.Helpers
+import SchedulerTests.TestUtils
 
 import qualified Concordium.GlobalState.Basic.BlockState.LFMBTree as L
 

--- a/concordium-consensus/tests/scheduler/SchedulerTests/BlockEnergyLimitSpec.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/BlockEnergyLimitSpec.hs
@@ -24,6 +24,7 @@ import Concordium.Types.DummyData
 import Concordium.Crypto.DummyData
 
 import SchedulerTests.Helpers
+import SchedulerTests.TestUtils
 
 shouldReturnP :: Show a => IO a -> (a -> Bool) -> IO ()
 shouldReturnP action f = action >>= (`shouldSatisfy` f)

--- a/concordium-consensus/tests/scheduler/SchedulerTests/ChainMetatest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/ChainMetatest.hs
@@ -24,6 +24,7 @@ import Concordium.Types.DummyData
 import Concordium.Crypto.DummyData
 
 import SchedulerTests.Helpers
+import SchedulerTests.TestUtils
 
 initialBlockState :: BlockState PV1
 initialBlockState = blockStateWithAlesAccount 1000000000 Acc.emptyAccounts

--- a/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
@@ -22,7 +22,3 @@ simpleTransferCostWithMemo1 memoSize = Cost.baseCost (Types.transactionHeaderSiz
 
 simpleTransferCostWithMemo2 :: Word64 -> Energy
 simpleTransferCostWithMemo2 memoSize = Cost.baseCost (Types.transactionHeaderSize + 41 + 2 + memoSize) 1 + Cost.simpleTransferCost
-
--- |Protocol version
-type PV1 = 'Types.P1
-type PV2 = 'Types.P2

--- a/concordium-consensus/tests/scheduler/SchedulerTests/InitContextTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/InitContextTest.hs
@@ -40,7 +40,7 @@ chainMeta = Types.ChainMetadata{ slotTime = 444 }
 
 senderAccount :: forall pv . IsProtocolVersion pv => Proxy pv -> Types.AccountAddress
 senderAccount Proxy
-  | demoteProtocolVersion (protocolVersion @pv) >= P3 = mkAlias alesAccount 17
+  | demoteProtocolVersion (protocolVersion @pv) >= P3 = createAlias alesAccount 17
   | otherwise = alesAccount
 
 transactionInputs :: forall pv . IsProtocolVersion pv => Proxy pv -> [TransactionJSON]

--- a/concordium-consensus/tests/scheduler/SchedulerTests/InitContextTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/InitContextTest.hs
@@ -25,6 +25,7 @@ import Concordium.Types.DummyData
 import Concordium.Crypto.DummyData
 
 import SchedulerTests.Helpers
+import SchedulerTests.TestUtils
 
 initialBlockState :: BlockState PV1
 initialBlockState = blockStateWithAlesAccount 1000000000 emptyAccounts

--- a/concordium-consensus/tests/scheduler/SchedulerTests/InitialAccountCreationSpec.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/InitialAccountCreationSpec.hs
@@ -21,6 +21,7 @@ import Concordium.GlobalState.DummyData
 import Concordium.Types.DummyData
 
 import SchedulerTests.Helpers
+import SchedulerTests.TestUtils
 
 shouldReturnP :: Show a => IO a -> (a -> Bool) -> IO ()
 shouldReturnP action f = action >>= (`shouldSatisfy` f)

--- a/concordium-consensus/tests/scheduler/SchedulerTests/RandomBakerTransactions.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/RandomBakerTransactions.hs
@@ -37,6 +37,7 @@ import Concordium.GlobalState.DummyData
 import Concordium.Crypto.DummyData
 
 import SchedulerTests.Helpers
+import SchedulerTests.TestUtils
 
 import qualified Data.List as List
 

--- a/concordium-consensus/tests/scheduler/SchedulerTests/ReceiveContextTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/ReceiveContextTest.hs
@@ -37,12 +37,12 @@ thomasAccount = AccountAddress $ pack $ take accountAddressSize $ repeat 2
 
 sender1 :: forall pv . IsProtocolVersion pv => Proxy pv -> Types.AccountAddress
 sender1 Proxy
-  | demoteProtocolVersion (protocolVersion @pv) >= P3 = mkAlias alesAccount 17
+  | demoteProtocolVersion (protocolVersion @pv) >= P3 = createAlias alesAccount 17
   | otherwise = alesAccount
 
 sender2 :: forall pv . IsProtocolVersion pv => Proxy pv -> Types.AccountAddress
 sender2 Proxy
-  | demoteProtocolVersion (protocolVersion @pv) >= P3 = mkAlias thomasAccount 77
+  | demoteProtocolVersion (protocolVersion @pv) >= P3 = createAlias thomasAccount 77
   | otherwise = thomasAccount
 
 

--- a/concordium-consensus/tests/scheduler/SchedulerTests/ReceiveContextTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/ReceiveContextTest.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-| Test that the init context of a contract is passed correctly by the scheduler. -}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-| Test that the receive context of a contract is passed correctly by the scheduler. -}
 module SchedulerTests.ReceiveContextTest where
 
 import Test.Hspec
@@ -7,11 +10,13 @@ import Test.HUnit
 import Lens.Micro.Platform
 import Control.Monad.IO.Class
 import Data.FixedByteString (pack)
+import Data.Proxy
 
 import qualified Concordium.Scheduler.Types as Types
 import qualified Concordium.Scheduler.EnvironmentImplementation as Types
 import qualified Concordium.Scheduler as Sch
 import Concordium.Scheduler.Runner
+import Concordium.Types.ProtocolVersion
 
 import Concordium.GlobalState.Basic.BlockState
 import Concordium.GlobalState.Basic.BlockState.Invariants
@@ -30,9 +35,26 @@ alesAccount, thomasAccount :: AccountAddress
 alesAccount = AccountAddress $ pack $ take accountAddressSize $ repeat 1
 thomasAccount = AccountAddress $ pack $ take accountAddressSize $ repeat 2
 
-initialBlockState :: BlockState PV1
-initialBlockState = createBlockState $ putAccountWithRegIds (mkAccount alesVK alesAccount 1000000000)
-                                     $ putAccountWithRegIds (mkAccount thomasVK thomasAccount 1000000000) emptyAccounts
+sender1 :: forall pv . IsProtocolVersion pv => Proxy pv -> Types.AccountAddress
+sender1 Proxy
+  | demoteProtocolVersion (protocolVersion @pv) >= P3 = mkAlias alesAccount 17
+  | otherwise = alesAccount
+
+sender2 :: forall pv . IsProtocolVersion pv => Proxy pv -> Types.AccountAddress
+sender2 Proxy
+  | demoteProtocolVersion (protocolVersion @pv) >= P3 = mkAlias thomasAccount 77
+  | otherwise = thomasAccount
+
+
+-- See the contract in /testdata/contracts/send/src/lib.rs from which the wasm
+-- module is derived. The contract calls check that the invoker or sender is the
+-- account address consisting of only 2's, and that the owner is an account
+-- consisting of only 1's. We set up the state with addresses different from
+-- those and use the above-mentioned addresses as alias for the same account.
+-- This only applies to protocol P3 and up.
+initialBlockState :: forall pv . IsProtocolVersion pv => BlockState pv
+initialBlockState = createBlockState $ putAccountWithRegIds (mkAccount alesVK (sender1 (Proxy @pv)) 1000000000)
+                                     $ putAccountWithRegIds (mkAccount thomasVK (sender2 (Proxy @pv)) 1000000000) emptyAccounts
 
 chainMeta :: Types.ChainMetadata
 chainMeta = Types.ChainMetadata{ slotTime = 444 }
@@ -73,15 +95,15 @@ type TestResult = ([(Types.BlockItem, Types.ValidResult)],
                    [(Types.Transaction, Types.FailureKind)],
                    [(Types.ContractAddress, Instance)])
 
-testReceive :: IO TestResult
-testReceive = do
+testReceive :: forall pv . IsProtocolVersion pv => Proxy pv -> IO TestResult
+testReceive Proxy = do
     transactions <- processUngroupedTransactions transactionInputs
     let (Sch.FilteredTransactions{..}, finState) =
           Types.runSI (Sch.filterTransactions dummyBlockSize dummyBlockTimeout transactions)
             chainMeta
             maxBound
             maxBound
-            initialBlockState
+            (initialBlockState @pv)
     let gs = finState ^. Types.ssBlockState
     case invariantBlockState gs (finState ^. Types.schedulerExecutionCosts) of
         Left f -> liftIO $ assertFailure $ f ++ " " ++ show gs
@@ -101,6 +123,10 @@ checkReceiveResult (suc, fails, instances) = do
 
 tests :: SpecWith ()
 tests =
-  describe "Receive context in transactions." $
-    specify "Passing receive context to contract." $
-      testReceive >>= checkReceiveResult
+  describe "Receive context in transactions." $ do
+    specify "Passing receive context to contract P1." $
+      testReceive (Proxy @'P1) >>= checkReceiveResult
+    specify "Passing receive context to contract P2." $
+      testReceive (Proxy @'P2) >>= checkReceiveResult
+    specify "Passing receive context to contract P3." $
+      testReceive (Proxy @'P3) >>= checkReceiveResult

--- a/concordium-consensus/tests/scheduler/SchedulerTests/ReceiveContextTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/ReceiveContextTest.hs
@@ -24,6 +24,7 @@ import Concordium.GlobalState.DummyData
 import Concordium.Crypto.DummyData
 
 import SchedulerTests.Helpers
+import SchedulerTests.TestUtils
 
 alesAccount, thomasAccount :: AccountAddress
 alesAccount = AccountAddress $ pack $ take accountAddressSize $ repeat 1

--- a/concordium-consensus/tests/scheduler/SchedulerTests/RejectReasons.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/RejectReasons.hs
@@ -24,6 +24,7 @@ import Concordium.Types.DummyData
 import Concordium.Crypto.DummyData
 
 import SchedulerTests.Helpers
+import SchedulerTests.TestUtils
 
 initialBlockState :: BlockState PV1
 initialBlockState = blockStateWithAlesAccount 1000000000 Acc.emptyAccounts

--- a/concordium-consensus/tests/scheduler/SchedulerTests/RejectReasonsRustContract.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/RejectReasonsRustContract.hs
@@ -5,6 +5,7 @@ import Test.Hspec
 import Test.HUnit
 
 import Data.Maybe (catMaybes)
+import Data.Text (Text)
 
 import qualified Concordium.Scheduler.Types as Types
 import qualified Concordium.Scheduler.EnvironmentImplementation as Types
@@ -25,7 +26,7 @@ import Concordium.Crypto.DummyData
 import Concordium.Wasm (ReceiveName(..))
 
 import SchedulerTests.Helpers
-import Data.Text (Text)
+import SchedulerTests.TestUtils
 
 initialBlockState :: BlockState PV1
 initialBlockState = blockStateWithAlesAccount 1000000000 Acc.emptyAccounts

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SimpleTransfersTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SimpleTransfersTest.hs
@@ -81,29 +81,29 @@ transactionsInput2 =
 transactionsInput3 :: [TransactionJSON]
 transactionsInput3 =
   -- transfer 10000 from A to A
-  [TJSON { payload = Transfer {toaddress = mkAlias alesAccount 0, amount = 10000 }
+  [TJSON { payload = Transfer {toaddress = createAlias alesAccount 0, amount = 10000 }
          , metadata = makeDummyHeader alesAccount 1 simpleTransferCost
          , keys = [(0, [(0, alesKP)])]
          }
   -- transfer 8800 from A to T
-  ,TJSON { payload = Transfer {toaddress = mkAlias thomasAccount 0, amount = 8800 }
+  ,TJSON { payload = Transfer {toaddress = createAlias thomasAccount 0, amount = 8800 }
          , metadata = makeDummyHeader alesAccount 2 simpleTransferCost
          , keys = [(0, [(0, alesKP)])]
          }
   -- transfer everything from from A to T
   -- the (100 *) is conversion between NRG and GTU
-  ,TJSON { payload = Transfer {toaddress = mkAlias thomasAccount 1, amount = 1000000 - 8800 - 3 * 100 * fromIntegral simpleTransferCost }
+  ,TJSON { payload = Transfer {toaddress = createAlias thomasAccount 1, amount = 1000000 - 8800 - 3 * 100 * fromIntegral simpleTransferCost }
          , metadata = makeDummyHeader alesAccount 3 simpleTransferCost
          , keys = [(0, [(0, alesKP)])]
          }
   -- transfer 10000 back from T to A
-  ,TJSON { payload = Transfer {toaddress = mkAlias alesAccount 1, amount = 100 * fromIntegral simpleTransferCost }
+  ,TJSON { payload = Transfer {toaddress = createAlias alesAccount 1, amount = 100 * fromIntegral simpleTransferCost }
          , metadata = makeDummyHeader thomasAccount 1 simpleTransferCost
          , keys = [(0, [(0, thomasKP)])]
          }
     -- the next transaction should fail because the balance on A is now exactly enough to cover the transfer cost
-  ,TJSON { payload = Transfer {toaddress = mkAlias thomasAccount 2, amount = 1 }
-         , metadata = makeDummyHeader (mkAlias alesAccount 4) 4 simpleTransferCost
+  ,TJSON { payload = Transfer {toaddress = createAlias thomasAccount 2, amount = 1 }
+         , metadata = makeDummyHeader (createAlias alesAccount 4) 4 simpleTransferCost
          , keys = [(0, [(0, alesKP)])]
          }
   ]
@@ -246,7 +246,7 @@ checkSimpleTransferResult3 (suc, fails, alesamount, thomasamount) = do
                     (init suc)
     rejectLast = case last suc of
                (_, Types.TxReject (Types.AmountTooLarge addr amnt)) -> do
-                 assertEqual "Sending from A" (Types.AddressAccount (mkAlias alesAccount 4)) addr
+                 assertEqual "Sending from A" (Types.AddressAccount (createAlias alesAccount 4)) addr
                  assertEqual "Exactly 1microGTU" 1 amnt
                err -> assertFailure $ "Incorrect result of the last transaction: " ++ show (snd err)
 

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SimpleTransfersTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SimpleTransfersTest.hs
@@ -24,6 +24,7 @@ import Concordium.Types.DummyData
 import Concordium.Crypto.DummyData
 import qualified Data.ByteString.Short as BSS
 
+import SchedulerTests.TestUtils
 import SchedulerTests.Helpers
 import Concordium.Types.ProtocolVersion (IsProtocolVersion)
 
@@ -37,6 +38,11 @@ initialBlockState = blockStateWithAlesAccount
 
 initialBlockState2 :: BlockState PV2
 initialBlockState2 = blockStateWithAlesAccount
+    1000000
+    (Acc.putAccountWithRegIds (mkAccount thomasVK thomasAccount 1000000) Acc.emptyAccounts)
+
+initialBlockState3 :: BlockState PV3
+initialBlockState3 = blockStateWithAlesAccount
     1000000
     (Acc.putAccountWithRegIds (mkAccount thomasVK thomasAccount 1000000) Acc.emptyAccounts)
 
@@ -67,6 +73,37 @@ transactionsInput2 =
     -- the next transaction should fail because the balance on A is now exactly enough to cover the transfer cost
   ,TJSON { payload = Transfer {toaddress = thomasAccount, amount = 1 }
          , metadata = makeDummyHeader alesAccount 4 simpleTransferCost
+         , keys = [(0, [(0, alesKP)])]
+         }
+  ]
+
+-- simple transfers to be tested with protocol version 3
+transactionsInput3 :: [TransactionJSON]
+transactionsInput3 =
+  -- transfer 10000 from A to A
+  [TJSON { payload = Transfer {toaddress = mkAlias alesAccount 0, amount = 10000 }
+         , metadata = makeDummyHeader alesAccount 1 simpleTransferCost
+         , keys = [(0, [(0, alesKP)])]
+         }
+  -- transfer 8800 from A to T
+  ,TJSON { payload = Transfer {toaddress = mkAlias thomasAccount 0, amount = 8800 }
+         , metadata = makeDummyHeader alesAccount 2 simpleTransferCost
+         , keys = [(0, [(0, alesKP)])]
+         }
+  -- transfer everything from from A to T
+  -- the (100 *) is conversion between NRG and GTU
+  ,TJSON { payload = Transfer {toaddress = mkAlias thomasAccount 1, amount = 1000000 - 8800 - 3 * 100 * fromIntegral simpleTransferCost }
+         , metadata = makeDummyHeader alesAccount 3 simpleTransferCost
+         , keys = [(0, [(0, alesKP)])]
+         }
+  -- transfer 10000 back from T to A
+  ,TJSON { payload = Transfer {toaddress = mkAlias alesAccount 1, amount = 100 * fromIntegral simpleTransferCost }
+         , metadata = makeDummyHeader thomasAccount 1 simpleTransferCost
+         , keys = [(0, [(0, thomasKP)])]
+         }
+    -- the next transaction should fail because the balance on A is now exactly enough to cover the transfer cost
+  ,TJSON { payload = Transfer {toaddress = mkAlias thomasAccount 2, amount = 1 }
+         , metadata = makeDummyHeader (mkAlias alesAccount 4) 4 simpleTransferCost
          , keys = [(0, [(0, alesKP)])]
          }
   ]
@@ -195,6 +232,25 @@ checkSimpleTransferResult2Memo (suc, fails, alesamount, thomasamount) = do
                  assertEqual "Exactly 1microGTU" 1 amnt
                err -> assertFailure $ "Incorrect result of the last transaction: " ++ show (snd err)
 
+checkSimpleTransferResult3 :: TestResult -> Assertion
+checkSimpleTransferResult3 (suc, fails, alesamount, thomasamount) = do
+--  assertEqual "Actual result" suc []
+  assertEqual "There should be no failed transactions." [] fails
+  rejectLast
+  assertBool "Initial transactions are accepted." nonreject
+  assertEqual "Amount on the A account." 0 alesamount 
+  assertEqual ("Amount on the T account." ++ show thomasamount) (2000000 - 5 * 100 * fromIntegral simpleTransferCost) thomasamount
+  where
+    nonreject = all (\case (_, Types.TxSuccess{}) -> True
+                           (_, Types.TxReject{}) -> False)
+                    (init suc)
+    rejectLast = case last suc of
+               (_, Types.TxReject (Types.AmountTooLarge addr amnt)) -> do
+                 assertEqual "Sending from A" (Types.AddressAccount (mkAlias alesAccount 4)) addr
+                 assertEqual "Exactly 1microGTU" 1 amnt
+               err -> assertFailure $ "Incorrect result of the last transaction: " ++ show (snd err)
+
+
 tests :: SpecWith ()
 tests =
   do
@@ -207,3 +263,6 @@ tests =
     describe "Simple transfers test with memo (with protocol version 2):" $
       specify "4 successful and 1 failed transaction" $
         testSimpleTransfer initialBlockState2 transactionsInput2Memo >>= checkSimpleTransferResult2Memo
+    describe "Simple transfers test (with protocol version 3):" $
+      specify "4 successful and 1 failed transaction" $
+        testSimpleTransfer initialBlockState3 transactionsInput3 >>= checkSimpleTransferResult3

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TestUtils.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TestUtils.hs
@@ -221,6 +221,6 @@ mkSpecs = mapM_ mkSpec
 -- the big endian representation of the given counter (modulo 2^24).
 mkAlias :: AccountAddress -> Word -> AccountAddress
 mkAlias (AccountAddress addr) count = AccountAddress ((addr .&. mask) .|. rest)
-    where rest = FBS.encodeInteger (toInteger (count `mod` 2^(24 :: Word)))
+    where rest = FBS.encodeInteger (toInteger (count .&. 0xffffff))
           mask = complement (FBS.encodeInteger 0xffffff) -- mask to clear out the last three bytes of the addr
 

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TestUtils.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TestUtils.hs
@@ -11,7 +11,7 @@ NOTE: This processes each transaction individually - for testing grouped transac
       'SchedulerTests.TransactionGroupingSpec' and 'SchedulerTests.TransactionGroupingSpec2'.
 -}
 module SchedulerTests.TestUtils(PV1, PV2, PV3, ResultSpec,TResultSpec(..),emptySpec,emptyExpect,TestCase(..),
-                                TestParameters(..),defaultParams, mkSpec,mkSpecs, mkAlias) where
+                                TestParameters(..),defaultParams, mkSpec,mkSpecs, createAlias) where
 
 import Test.Hspec
 
@@ -19,7 +19,6 @@ import Lens.Micro.Platform
 import Control.Monad
 import Data.List (foldl')
 import Data.Bits
-import qualified Data.FixedByteString as FBS
 
 import Concordium.Scheduler.Types
 import qualified Concordium.Scheduler.EnvironmentImplementation as Types
@@ -216,11 +215,3 @@ mkSpec TestCase{..} =
 -- | Make a 'Spec' for the given test cases. See 'mkSpec'.
 mkSpecs :: IsProtocolVersion pv => [TestCase pv] -> Spec
 mkSpecs = mapM_ mkSpec
-
--- |Make an account alias for the given account by setting the last 3 bytes to
--- the big endian representation of the given counter (modulo 2^24).
-mkAlias :: AccountAddress -> Word -> AccountAddress
-mkAlias (AccountAddress addr) count = AccountAddress ((addr .&. mask) .|. rest)
-    where rest = FBS.encodeInteger (toInteger (count .&. 0xffffff))
-          mask = complement (FBS.encodeInteger 0xffffff) -- mask to clear out the last three bytes of the addr
-

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TestUtils.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TestUtils.hs
@@ -222,5 +222,5 @@ mkSpecs = mapM_ mkSpec
 mkAlias :: AccountAddress -> Word -> AccountAddress
 mkAlias (AccountAddress addr) count = AccountAddress ((addr .&. mask) .|. rest)
     where rest = FBS.encodeInteger (toInteger (count `mod` 2^(24 :: Word)))
-          mask = complement (FBS.encodeInteger (255 + 255 * 256 + 255 * 256 * 256)) -- mask to clear out the last three bytes of the addr
+          mask = complement (FBS.encodeInteger 0xffffff) -- mask to clear out the last three bytes of the addr
 

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TransactionExpirySpec.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TransactionExpirySpec.hs
@@ -31,6 +31,7 @@ import Concordium.Types.DummyData
 import Concordium.Crypto.DummyData
 
 import SchedulerTests.Helpers
+import SchedulerTests.TestUtils
 
 shouldReturnP :: Show a => IO a -> (a -> Bool) -> IO ()
 shouldReturnP action f = action >>= (`shouldSatisfy` f)

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TransactionGroupingSpec2.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TransactionGroupingSpec2.hs
@@ -32,6 +32,7 @@ import Concordium.Types.DummyData
 import Concordium.Crypto.DummyData
 
 import SchedulerTests.Helpers
+import SchedulerTests.TestUtils
 
 -- * Definition of test cases
 

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TransfersWithScheduleTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TransfersWithScheduleTest.hs
@@ -212,8 +212,8 @@ testCases3 =
     , tcParameters = defaultParams {tpInitialBlockState=initialBlockState3, tpChainMeta=ChainMetadata { slotTime = 100 }}
     , tcTransactions = [
         -- should get rejected since sender = receiver, even if addresses are not exactly the same, but refer to the same account.
-        ( Runner.TJSON  { payload = Runner.TransferWithSchedule (mkAlias alesAccount 2) [(101, 10),(102, 11),(103, 12)],
-                          metadata = makeDummyHeader (mkAlias alesAccount 1) 1 100000,
+        ( Runner.TJSON  { payload = Runner.TransferWithSchedule (createAlias alesAccount 2) [(101, 10),(102, 11),(103, 12)],
+                          metadata = makeDummyHeader (createAlias alesAccount 1) 1 100000,
                           keys = [(0,[(0, alesKP)])]
                         }
         , (Reject $ ScheduledSelfTransfer alesAccount -- the rejection reason is meant to have the canonical address.

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TransfersWithScheduleTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TransfersWithScheduleTest.hs
@@ -29,6 +29,11 @@ initialBlockState2 = blockStateWithAlesAccount
     10000000000
     (Acc.putAccountWithRegIds (mkAccount thomasVK thomasAccount 10000000000) Acc.emptyAccounts)
 
+initialBlockState3 :: BlockState PV3
+initialBlockState3 = blockStateWithAlesAccount
+    10000000000
+    (Acc.putAccountWithRegIds (mkAccount thomasVK thomasAccount 10000000000) Acc.emptyAccounts)
+
 cdiKeys :: CredentialDeploymentInformation -> CredentialPublicKeys
 cdiKeys cdi = credPubKeys (NormalACWP cdi)
 
@@ -200,9 +205,29 @@ testCases2 =
     }
   ]  
 
+testCases3 :: [TestCase PV3]
+testCases3 =
+  [ TestCase
+    { tcName = "Transfers with schedule P3"
+    , tcParameters = defaultParams {tpInitialBlockState=initialBlockState3, tpChainMeta=ChainMetadata { slotTime = 100 }}
+    , tcTransactions = [
+        -- should get rejected since sender = receiver, even if addresses are not exactly the same, but refer to the same account.
+        ( Runner.TJSON  { payload = Runner.TransferWithSchedule (mkAlias alesAccount 2) [(101, 10),(102, 11),(103, 12)],
+                          metadata = makeDummyHeader (mkAlias alesAccount 1) 1 100000,
+                          keys = [(0,[(0, alesKP)])]
+                        }
+        , (Reject $ ScheduledSelfTransfer alesAccount -- the rejection reason is meant to have the canonical address.
+          , emptySpec
+          )
+        )
+      ]
+    }
+  ]
+
 
 
 tests :: Spec
 tests = do 
   describe "TransfersWithSchedule" $ mkSpecs testCases1 
   describe "TransfersWithScheduleAndMemo" $ mkSpecs testCases2
+  describe "TransfersWithScheduleP3" $ mkSpecs testCases3

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TransfersWithScheduleTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TransfersWithScheduleTest.hs
@@ -216,7 +216,7 @@ testCases3 =
                           metadata = makeDummyHeader (createAlias alesAccount 1) 1 100000,
                           keys = [(0,[(0, alesKP)])]
                         }
-        , (Reject $ ScheduledSelfTransfer alesAccount -- the rejection reason is meant to have the canonical address.
+        , (Reject $ ScheduledSelfTransfer (createAlias alesAccount 1) -- the rejection reason is meant to have the sender address.
           , emptySpec
           )
         )


### PR DESCRIPTION
## Purpose

Introduces support for protocol version 3. Closes #203 

## Changes

- Revise how we refer to accounts internally in the scheduler. Once we resolve an account address we always refer to the account via its index which is canonical (i.e., account indices and accounts are in 1-1 correspondence). This might also have some performance benefits since it removes lookups in the Trie.
- Consolidate the account map into a new structure AccountMap that is used both by the basic and persistent state implementations. The map allows lookups by prefix.
- The account non finalized table and the pending table are slightly revised. They no longer index transactions (or auxiliary data) by account addresses themselves, but rather by equivalence classes of account addresses. The intention is that all of these equivalence classes should refer to the same account. This should be the case unless somebody creates accounts that agree on the first 29 bytes of the address.
- Add tests for the account map.
- Introduce handling of migration from P2 to P3. This is currently still missing the correct hash of the update specification.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
