### PR TITLE
Use the lock file that is in the repository.

### DIFF
--- a/scripts/static-binaries/build-on-ubuntu.sh
+++ b/scripts/static-binaries/build-on-ubuntu.sh
@@ -47,10 +47,10 @@ rustup default "$rust_toolchain_version"
 # Must be kept in sync with 'base-images/base.Dockerfile'.
 # See 'https://gitlab.com/Concordium/devops/-/commit/f41ac413c3583ec53d06a2c0fe5c8795e35f1a46'.
 git clone https://github.com/google/flatbuffers.git
-( cd flatbuffers && git checkout "$flatbuffers_version" && cmake -G "Unix Makefiles" && make -j$(nproc) && make install )
+( cd flatbuffers && git checkout "$flatbuffers_version" && cmake -G "Unix Makefiles" && make -j"$(nproc)" && make install )
 
 # Build all the binaries and copy them to ./bin/
-cargo generate-lockfile --manifest-path concordium-node/Cargo.toml
-cargo install --path $(pwd)/concordium-node/ --locked --features=static,$extra_features --root $(pwd)
+# This requires an up-to-date lockfile which should be committed to the repository.
+cargo install --path "$(pwd)/concordium-node/" --locked --features=static,$extra_features --root "$(pwd)"
 # Strip all the generated binaries to remove debugging and unused symbols
-strip $(pwd)/bin/*
+strip "$(pwd)/bin/*"


### PR DESCRIPTION
## Purpose

Building the node on ubuntu should not refresh the lockfile, it should use the one in the repository.

## Changes

Do not regenerate the lockfile.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.