### PR TITLE
Macos build fix

### DIFF
--- a/concordium-node/README.md
+++ b/concordium-node/README.md
@@ -2,7 +2,7 @@
 ## Dependencies to build the project
 * Rust (stable 1.53 for using static libraries)
 * binutils >= 2.22
-  * for macOS, install Xcode and use what is included with that instead, as these are tailored to the OS version.
+  * For macOS one should use the binutils provided by Xcode.
 * cmake >= 3.8.0
 * [flatc](http://google.github.io/flatbuffers/flatbuffers_guide_building.html)
   v2.0.0 is what we currently use. Either build from the v2.0.0 tag of the repository using CMake and copy the `flatc` binary somewhere in your PATH, or download a released binary from https://github.com/google/flatbuffers/releases/tag/v2.0.0 and place it somewhere in your PATH.

--- a/concordium-node/README.md
+++ b/concordium-node/README.md
@@ -2,6 +2,7 @@
 ## Dependencies to build the project
 * Rust (stable 1.53 for using static libraries)
 * binutils >= 2.22
+  * for macOS, install Xcode and use what is included with that instead, as these are tailored to the OS version.
 * cmake >= 3.8.0
 * [flatc](http://google.github.io/flatbuffers/flatbuffers_guide_building.html)
   v2.0.0 is what we currently use. Either build from the v2.0.0 tag of the repository using CMake and copy the `flatc` binary somewhere in your PATH, or download a released binary from https://github.com/google/flatbuffers/releases/tag/v2.0.0 and place it somewhere in your PATH.

--- a/concordium-node/build.rs
+++ b/concordium-node/build.rs
@@ -104,20 +104,14 @@ fn main() -> std::io::Result<()> {
                     println!("cargo:rustc-link-search=native={}", extra_libs_path);
                 }
                 let ghc_lib_dir = link_ghc_libs()?;
+                let lib_path = if cfg!(target_os = "linux") { "LD_LIBRARY_PATH" } else { "DYLD_LIBRARY_PATH" };
 
-                if cfg!(target_os = "linux") {
-                    println!(
-                        "cargo:rustc-env=LD_LIBRARY_PATH={}:{}",
-                        ghc_lib_dir.as_path().to_string_lossy(),
-                        local_package.as_path().to_string_lossy()
-                    );
-                } else {
-                    println!(
-                        "cargo:rustc-env=DYLD_LIBRARY_PATH={}:{}",
-                        ghc_lib_dir.as_path().to_string_lossy(),
-                        local_package.as_path().to_string_lossy()
-                    );
-                }
+                println!(
+                    "cargo:rustc-env={}={}:{}",
+                    lib_path,
+                    ghc_lib_dir.as_path().to_string_lossy(),
+                    local_package.as_path().to_string_lossy()
+                );
             }
         }
     }

--- a/concordium-node/build.rs
+++ b/concordium-node/build.rs
@@ -104,11 +104,36 @@ fn main() -> std::io::Result<()> {
                     println!("cargo:rustc-link-search=native={}", extra_libs_path);
                 }
                 let ghc_lib_dir = link_ghc_libs()?;
-                println!(
-                    "cargo:rustc-env=LD_LIBRARY_PATH={}:{}",
-                    ghc_lib_dir.as_path().to_string_lossy(),
-                    local_package.as_path().to_string_lossy()
-                );
+
+                if cfg!(target_os = "linux") {
+                    println!(
+                        "cargo:rustc-env=LD_LIBRARY_PATH={}:{}",
+                        ghc_lib_dir.as_path().to_string_lossy(),
+                        local_package.as_path().to_string_lossy()
+                    );
+                } else {
+                    println!(
+                        "cargo:rustc-env=DYLD_LIBRARY_PATH={}:{}",
+                        ghc_lib_dir.as_path().to_string_lossy(),
+                        local_package.as_path().to_string_lossy()
+                    );
+                }
+                // #[cfg(linux)]
+                // {
+                //     println!(
+                //         "cargo:rustc-env=LD_LIBRARY_PATH={}:{}",
+                //         ghc_lib_dir.as_path().to_string_lossy(),
+                //         local_package.as_path().to_string_lossy()
+                //     );
+                // }
+                // #[cfg(macos)]
+                // {
+                //     println!(
+                //         "cargo:rustc-env=DYLD_LIBRARY_PATH={}:{}",
+                //         ghc_lib_dir.as_path().to_string_lossy(),
+                //         local_package.as_path().to_string_lossy()
+                //     );
+                // }
             }
         }
     }

--- a/concordium-node/build.rs
+++ b/concordium-node/build.rs
@@ -104,7 +104,11 @@ fn main() -> std::io::Result<()> {
                     println!("cargo:rustc-link-search=native={}", extra_libs_path);
                 }
                 let ghc_lib_dir = link_ghc_libs()?;
-                let lib_path = if cfg!(target_os = "linux") { "LD_LIBRARY_PATH" } else { "DYLD_LIBRARY_PATH" };
+                let lib_path = if cfg!(target_os = "linux") {
+                    "LD_LIBRARY_PATH"
+                } else {
+                    "DYLD_LIBRARY_PATH"
+                };
 
                 println!(
                     "cargo:rustc-env={}={}:{}",

--- a/concordium-node/build.rs
+++ b/concordium-node/build.rs
@@ -118,22 +118,6 @@ fn main() -> std::io::Result<()> {
                         local_package.as_path().to_string_lossy()
                     );
                 }
-                // #[cfg(linux)]
-                // {
-                //     println!(
-                //         "cargo:rustc-env=LD_LIBRARY_PATH={}:{}",
-                //         ghc_lib_dir.as_path().to_string_lossy(),
-                //         local_package.as_path().to_string_lossy()
-                //     );
-                // }
-                // #[cfg(macos)]
-                // {
-                //     println!(
-                //         "cargo:rustc-env=DYLD_LIBRARY_PATH={}:{}",
-                //         ghc_lib_dir.as_path().to_string_lossy(),
-                //         local_package.as_path().to_string_lossy()
-                //     );
-                // }
             }
         }
     }


### PR DESCRIPTION
## Purpose

Fixes required for node to build and run on macos monterey. Specifically, this aligns looking up libraries on macOS with how it works on linux using `DYLD_LIBRARY_PATH` for macOS.

## Changes

- Added condition for using different environment variables for lib lookup on mac and linux
- Added note for `binutils` dependency on macos

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.