### PR TITLE
Drop connections on unrecognized update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   `GetNextAccountNonce` by any alias.
 - `GetAccountInfo` object has an additional field `accountAddress` that contains
   the canonical address of the account.
+- The node now drops all connections on an unrecognized protocol update and
+  refuses to accept new transactions.
 
 ## concordium-node 1.1.3
 

--- a/concordium-consensus/src/Concordium/External.hs
+++ b/concordium-consensus/src/Concordium/External.hs
@@ -204,10 +204,12 @@ type RegenesisCallback = Ptr RegenesisArc -> Ptr Word8 -> IO ()
 foreign import ccall "dynamic" invokeRegenesisCallback :: FunPtr RegenesisCallback -> RegenesisCallback
 
 -- |Helper for invoking a 'RegenesisCallback' function.
-callRegenesisCallback :: FunPtr RegenesisCallback -> RegenesisRef -> BlockHash -> IO ()
-callRegenesisCallback cb rgRef (BlockHash (SHA256.Hash bh)) = withForeignPtr rgRef $ \rg ->
+callRegenesisCallback :: FunPtr RegenesisCallback -> RegenesisRef -> Maybe BlockHash -> IO ()
+callRegenesisCallback cb rgRef (Just (BlockHash (SHA256.Hash bh))) = withForeignPtr rgRef $ \rg ->
     FBS.withPtrReadOnly bh $ \ptr ->
         invokeRegenesisCallback cb rg ptr
+callRegenesisCallback cb rgRef Nothing = withForeignPtr rgRef $ \rg ->
+    invokeRegenesisCallback cb rg nullPtr
 
 -- |Abstract type representing the rust Arc object used for tracking genesis blocks.
 -- A pointer of this type is passed to consensus at start up and must be passed to each call of

--- a/concordium-consensus/test-runners/app/Main.hs
+++ b/concordium-consensus/test-runners/app/Main.hs
@@ -287,11 +287,12 @@ callbacks myPeerId peersRef monitorChan = Callbacks{..}
         toAllPeers myPeerId peersRef MessageFinalizationRecord gi bs
     notifyCatchUpStatus gi bs =
         toAllPeers myPeerId peersRef MessageCatchUpStatus gi bs
-    notifyRegenesis gbh = do
+    notifyRegenesis (Just gbh) = do
         writeChan monitorChan $ MERegenesis gbh
         peers <- readIORef peersRef
         forM_ (Map.lookup myPeerId peers) $ \myPeer ->
             forM_ peers $ \peer -> markPeerPending myPeer (peerId peer)
+    notifyRegenesis Nothing = return ()
 
 -- |Construct a 'MultiVersionConfiguration' to use for each baker node.
 config :: FilePath -> BakerIdentity -> MultiVersionConfiguration DiskTreeDiskBlockConfig (BufferedFinalization ThreadTimer)

--- a/concordium-consensus/test-runners/catchup/Main.hs
+++ b/concordium-consensus/test-runners/catchup/Main.hs
@@ -301,11 +301,12 @@ callbacks myPeerId peersRef monitorChan = Callbacks{..}
         toAllPeers myPeerId peersRef MessageFinalizationRecord gi bs
     notifyCatchUpStatus gi bs =
         toAllPeers myPeerId peersRef MessageCatchUpStatus gi bs
-    notifyRegenesis gbh = do
+    notifyRegenesis (Just gbh) = do
         writeChan monitorChan $ MERegenesis gbh
         peers <- readIORef peersRef
         forM_ (Map.lookup myPeerId peers) $ \myPeer ->
             forM_ peers $ \peer -> markPeerPending myPeer (peerId peer)
+    notifyRegenesis Nothing = return ()
 
 -- |Construct a 'MultiVersionConfiguration' to use for each baker node.
 config :: FilePath -> BakerIdentity -> MultiVersionConfiguration DiskTreeDiskBlockConfig (BufferedFinalization ThreadTimer)

--- a/concordium-node/src/bin/bootstrap_checker.rs
+++ b/concordium-node/src/bin/bootstrap_checker.rs
@@ -40,11 +40,11 @@ fn main() -> anyhow::Result<()> {
         "Bootstrapper can't run without specifying genesis hashes."
     );
 
-    let (node, poll) =
+    let (node, server, poll) =
         P2PNode::new(conf.common.id, &conf, PeerType::Node, stats_export_service, regenesis_arc)
             .context("Failed to create the node.")?;
 
-    spawn(&node, poll, None);
+    spawn(&node, server, poll, None);
 
     if !conf.connection.no_bootstrap_dns {
         attempt_bootstrap(&node);

--- a/concordium-node/src/bin/bootstrapper.rs
+++ b/concordium-node/src/bin/bootstrapper.rs
@@ -40,7 +40,7 @@ fn main() -> anyhow::Result<()> {
         "Bootstrapper can't run without specifying genesis hashes."
     );
 
-    let (node, poll) = P2PNode::new(
+    let (node, server, poll) = P2PNode::new(
         conf.common.id,
         &conf,
         PeerType::Bootstrapper,
@@ -52,7 +52,7 @@ fn main() -> anyhow::Result<()> {
     #[cfg(feature = "instrumentation")]
     start_push_gateway(&conf.prometheus, &node.stats, node.id());
 
-    spawn(&node, poll, None);
+    spawn(&node, server, poll, None);
 
     node.join().expect("Node thread panicked!");
 

--- a/concordium-node/src/bin/cli.rs
+++ b/concordium-node/src/bin/cli.rs
@@ -193,7 +193,7 @@ async fn main() -> anyhow::Result<()> {
                     if err.is_cancelled() {
                         info!("RPC server was successfully shutdown by force.");
                     } else if err.is_panic() {
-                        error!("RPC server panicked!");
+                        error!("RPC server panicked: {}", err);
                     }
                 }
             }

--- a/concordium-node/src/bin/cli.rs
+++ b/concordium-node/src/bin/cli.rs
@@ -178,7 +178,6 @@ async fn main() -> anyhow::Result<()> {
     if shutdown_signal.await.is_err() {
         error!("Shutdown signal handler was dropped unexpectedly. Shutting down.");
     }
-    println!("Hello");
 
     // Message rpc to shutdown first
     if let Some(task) = rpc_server_task {

--- a/concordium-node/src/bin/database_emitter.rs
+++ b/concordium-node/src/bin/database_emitter.rs
@@ -30,7 +30,7 @@ fn main() -> anyhow::Result<()> {
 
     let stats_export_service = instantiate_stats_export_engine(&conf)?;
 
-    let (node, poll) = P2PNode::new(
+    let (node, server, poll) = P2PNode::new(
         conf.common.id,
         &conf,
         PeerType::Node,
@@ -39,7 +39,7 @@ fn main() -> anyhow::Result<()> {
     )
     .context("Failed to create the node")?;
 
-    spawn(&node, poll, None);
+    spawn(&node, server, poll, None);
 
     conf.connection.connect_to.iter().for_each(
         |host: &String| match ToSocketAddrs::to_socket_addrs(&host) {

--- a/concordium-node/src/consensus_ffi/catch_up.rs
+++ b/concordium-node/src/consensus_ffi/catch_up.rs
@@ -89,4 +89,11 @@ impl PeerList {
             }
         }
     }
+
+    /// Clear all pending peers.
+    pub fn clear(&mut self) {
+        self.peer_states.clear();
+        self.catch_up_peer = None;
+        self.pending_queue.clear();
+    }
 }

--- a/concordium-node/src/consensus_ffi/consensus.rs
+++ b/concordium-node/src/consensus_ffi/consensus.rs
@@ -328,6 +328,9 @@ pub struct Regenesis {
     /// A flag that is set to indicate that peers should be added to the
     /// catch-up queue.
     pub trigger_catchup: AtomicBool,
+    /// A flag that is set to indicate to drop all network connections.
+    /// Triggered on an unrecognized protocol update.
+    pub stop_network: AtomicBool,
 }
 
 impl Default for Regenesis {
@@ -335,6 +338,7 @@ impl Default for Regenesis {
         Regenesis {
             blocks:          RwLock::new(vec![]),
             trigger_catchup: AtomicBool::new(false),
+            stop_network: AtomicBool::new(false),
         }
     }
 }
@@ -344,6 +348,7 @@ impl Regenesis {
         Regenesis {
             blocks:          RwLock::new(regenesis_blocks),
             trigger_catchup: AtomicBool::new(false),
+            stop_network: AtomicBool::new(false),
         }
     }
 }

--- a/concordium-node/src/consensus_ffi/consensus.rs
+++ b/concordium-node/src/consensus_ffi/consensus.rs
@@ -330,7 +330,7 @@ pub struct Regenesis {
     pub trigger_catchup: AtomicBool,
     /// A flag that is set to indicate to drop all network connections.
     /// Triggered on an unrecognized protocol update.
-    pub stop_network: AtomicBool,
+    pub stop_network:    AtomicBool,
 }
 
 impl Default for Regenesis {
@@ -338,7 +338,7 @@ impl Default for Regenesis {
         Regenesis {
             blocks:          RwLock::new(vec![]),
             trigger_catchup: AtomicBool::new(false),
-            stop_network: AtomicBool::new(false),
+            stop_network:    AtomicBool::new(false),
         }
     }
 }
@@ -348,7 +348,7 @@ impl Regenesis {
         Regenesis {
             blocks:          RwLock::new(regenesis_blocks),
             trigger_catchup: AtomicBool::new(false),
-            stop_network: AtomicBool::new(false),
+            stop_network:    AtomicBool::new(false),
         }
     }
 }

--- a/concordium-node/src/p2p/connectivity.rs
+++ b/concordium-node/src/p2p/connectivity.rs
@@ -352,6 +352,16 @@ impl P2PNode {
 
         Ok(serialized)
     }
+
+    /// Check whether the network layer has been stopped.
+    pub fn is_network_stopped(&self) -> bool {
+        self.config.regenesis_arc.stop_network.load(Ordering::Acquire)
+    }
+
+    /// Signal that the network layer should be stopped.
+    pub fn stop_network(&self) {
+        self.config.regenesis_arc.stop_network.store(true, Ordering::Release);
+    }
 }
 
 #[derive(Debug, Error)]

--- a/concordium-node/src/p2p/maintenance.rs
+++ b/concordium-node/src/p2p/maintenance.rs
@@ -745,6 +745,12 @@ pub fn spawn(
         // close all connections. At this point no data will be read or written
         // to connections since the connection loop has terminated. This frees up
         // resources.
+        // TODO: This is ugly. Ideally we'd drop the entire connection handler here with
+        // all the data that pertains to it, including all connections and
+        // peers. However that requires a more substantial refactoring since the
+        // connection handler is used in many different places, including in the rpc
+        // module. If we did that there would be no need for clearing connection
+        // collections here.
         lock_or_die!(node.conn_candidates()).clear();
         write_or_die!(node.connections()).clear();
         write_or_die!(node.peers).clear();

--- a/concordium-node/src/p2p/maintenance.rs
+++ b/concordium-node/src/p2p/maintenance.rs
@@ -570,7 +570,7 @@ impl P2PNode {
     pub fn close(&self) -> bool {
         // First notify the maintenance thread to stop processing new connections or
         // network packets.
-        self.config.regenesis_arc.stop_network.store(true, Ordering::Release);
+        self.stop_network();
         // Then process all messages we still have in the inbound Consensus queues.
         CALLBACK_QUEUE.stop().is_ok()
     }
@@ -649,7 +649,7 @@ pub fn spawn(
         //   allocated thread pool
         // - occasionally (dictated by the housekeeping_interval) do connection
         //   housekeeping, checking whether peers and connections are active.
-        while !node.config.regenesis_arc.stop_network.load(Ordering::Acquire) {
+        while !node.is_network_stopped() {
             // check for new events or wait
             if let Err(e) = poll.poll(&mut events, Some(poll_interval)) {
                 error!("{}", e);

--- a/concordium-node/src/rpc.rs
+++ b/concordium-node/src/rpc.rs
@@ -120,6 +120,14 @@ impl P2p for RpcServerImpl {
         req: Request<PeerConnectRequest>,
     ) -> Result<Response<BoolResponse>, Status> {
         authenticate!(req, self.access_token);
+
+        if self.node.config.regenesis_arc.stop_network.load(Ordering::Acquire) {
+            return Err(Status::new(
+                Code::FailedPrecondition,
+                "The network is stopped due to unrecognized protocol update.",
+            ));
+        }
+
         let req = req.get_ref();
 
         let ip = if let Some(ref ip) = req.ip {
@@ -216,6 +224,14 @@ impl P2p for RpcServerImpl {
         use ConsensusFfiResponse::*;
 
         authenticate!(req, self.access_token);
+
+        if self.node.config.regenesis_arc.stop_network.load(Ordering::Acquire) {
+            return Err(Status::new(
+                Code::FailedPrecondition,
+                "The network is stopped due to unrecognized protocol update.",
+            ));
+        }
+
         if let Some(ref consensus) = self.consensus {
             let req = req.get_ref();
             let transaction = &req.payload;

--- a/concordium-node/src/rpc.rs
+++ b/concordium-node/src/rpc.rs
@@ -122,8 +122,7 @@ impl P2p for RpcServerImpl {
         authenticate!(req, self.access_token);
 
         if self.node.config.regenesis_arc.stop_network.load(Ordering::Acquire) {
-            return Err(Status::new(
-                Code::FailedPrecondition,
+            return Err(Status::failed_precondition(
                 "The network is stopped due to unrecognized protocol update.",
             ));
         }
@@ -157,6 +156,13 @@ impl P2p for RpcServerImpl {
         req: Request<PeerConnectRequest>,
     ) -> Result<Response<BoolResponse>, Status> {
         authenticate!(req, self.access_token);
+
+        if self.node.config.regenesis_arc.stop_network.load(Ordering::Acquire) {
+            return Err(Status::failed_precondition(
+                "The network is stopped due to unrecognized protocol update.",
+            ));
+        }
+
         let req = req.get_ref();
 
         let ip_addr = if let Some(ref ip) = req.ip {
@@ -226,8 +232,7 @@ impl P2p for RpcServerImpl {
         authenticate!(req, self.access_token);
 
         if self.node.config.regenesis_arc.stop_network.load(Ordering::Acquire) {
-            return Err(Status::new(
-                Code::FailedPrecondition,
+            return Err(Status::failed_precondition(
                 "The network is stopped due to unrecognized protocol update.",
             ));
         }
@@ -301,6 +306,13 @@ impl P2p for RpcServerImpl {
         req: Request<NetworkChangeRequest>,
     ) -> Result<Response<BoolResponse>, Status> {
         authenticate!(req, self.access_token);
+
+        if self.node.config.regenesis_arc.stop_network.load(Ordering::Acquire) {
+            return Err(Status::failed_precondition(
+                "The network is stopped due to unrecognized protocol update.",
+            ));
+        }
+
         let req = req.get_ref();
         if let Some(id) = req.network_id {
             if id > 0 && id < 100_000 {
@@ -323,6 +335,13 @@ impl P2p for RpcServerImpl {
         req: Request<NetworkChangeRequest>,
     ) -> Result<Response<BoolResponse>, Status> {
         authenticate!(req, self.access_token);
+
+        if self.node.config.regenesis_arc.stop_network.load(Ordering::Acquire) {
+            return Err(Status::failed_precondition(
+                "The network is stopped due to unrecognized protocol update.",
+            ));
+        }
+
         let req = req.get_ref();
         if let Some(id) = req.network_id {
             if id > 0 && id < 100_000 {

--- a/concordium-node/src/rpc.rs
+++ b/concordium-node/src/rpc.rs
@@ -121,7 +121,7 @@ impl P2p for RpcServerImpl {
     ) -> Result<Response<BoolResponse>, Status> {
         authenticate!(req, self.access_token);
 
-        if self.node.config.regenesis_arc.stop_network.load(Ordering::Acquire) {
+        if self.node.is_network_stopped() {
             return Err(Status::failed_precondition(
                 "The network is stopped due to unrecognized protocol update.",
             ));
@@ -157,7 +157,7 @@ impl P2p for RpcServerImpl {
     ) -> Result<Response<BoolResponse>, Status> {
         authenticate!(req, self.access_token);
 
-        if self.node.config.regenesis_arc.stop_network.load(Ordering::Acquire) {
+        if self.node.is_network_stopped() {
             return Err(Status::failed_precondition(
                 "The network is stopped due to unrecognized protocol update.",
             ));
@@ -231,7 +231,7 @@ impl P2p for RpcServerImpl {
 
         authenticate!(req, self.access_token);
 
-        if self.node.config.regenesis_arc.stop_network.load(Ordering::Acquire) {
+        if self.node.is_network_stopped() {
             return Err(Status::failed_precondition(
                 "The network is stopped due to unrecognized protocol update.",
             ));
@@ -307,7 +307,7 @@ impl P2p for RpcServerImpl {
     ) -> Result<Response<BoolResponse>, Status> {
         authenticate!(req, self.access_token);
 
-        if self.node.config.regenesis_arc.stop_network.load(Ordering::Acquire) {
+        if self.node.is_network_stopped() {
             return Err(Status::failed_precondition(
                 "The network is stopped due to unrecognized protocol update.",
             ));
@@ -336,7 +336,7 @@ impl P2p for RpcServerImpl {
     ) -> Result<Response<BoolResponse>, Status> {
         authenticate!(req, self.access_token);
 
-        if self.node.config.regenesis_arc.stop_network.load(Ordering::Acquire) {
+        if self.node.is_network_stopped() {
             return Err(Status::failed_precondition(
                 "The network is stopped due to unrecognized protocol update.",
             ));

--- a/concordium-node/src/test_utils.rs
+++ b/concordium-node/src/test_utils.rs
@@ -119,9 +119,9 @@ pub fn make_node_and_sync(
     let regenesis_arc = Arc::new(Regenesis::from_blocks(regenesis_blocks));
 
     let stats = Arc::new(StatsExportService::new().unwrap());
-    let (node, poll) = P2PNode::new(None, &config, node_type, stats, regenesis_arc)?;
+    let (node, server, poll) = P2PNode::new(None, &config, node_type, stats, regenesis_arc)?;
 
-    spawn(&node, poll, None);
+    spawn(&node, server, poll, None);
     Ok((node, DeletePermission {
         _private: (),
     }))


### PR DESCRIPTION
## Purpose

Drop connections upon an urecognized protocol update.

Closes #197 

## Changes

- On an unrecognized protocol update drop all connections and peers, and block sending of transactions.
- Additionally fixes an issue where the node would not stop if there is an active grpc connection.
  We now have a timeout in case the rpc server does not shut down in due time.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
