### PR TITLE
Improve missing config dir error

### DIFF
--- a/concordium-node/src/configuration.rs
+++ b/concordium-node/src/configuration.rs
@@ -883,31 +883,30 @@ impl AppPreferences {
     /// Creates an `AppPreferences` object.
     pub fn new(override_conf: PathBuf, override_data: PathBuf) -> anyhow::Result<Self> {
         let file_path = Self::calculate_config_file_path(&override_conf, APP_PREFERENCES_MAIN);
-        let mut new_prefs =
-            if let Ok(file) = OpenOptions::new().open(&file_path) {
-                let mut reader = BufReader::new(&file);
-                let load_result = PreferencesMap::<String>::load_from(&mut reader);
-                let prefs = load_result.unwrap_or_else(|_| PreferencesMap::<String>::new());
+        let mut new_prefs = if let Ok(file) = OpenOptions::new().open(&file_path) {
+            let mut reader = BufReader::new(&file);
+            let load_result = PreferencesMap::<String>::load_from(&mut reader);
+            let prefs = load_result.unwrap_or_else(|_| PreferencesMap::<String>::new());
 
-                AppPreferences {
-                    preferences_map:     prefs,
-                    override_data_dir:   override_data,
-                    override_config_dir: override_conf,
-                }
-            } else {
-                info!("Node configuration file not found. Creating a new one.");
+            AppPreferences {
+                preferences_map:     prefs,
+                override_data_dir:   override_data,
+                override_config_dir: override_conf,
+            }
+        } else {
+            info!("Node configuration file not found. Creating a new one.");
 
-                let _ = File::create(&file_path).with_context(|| {
-                    format!("Could not create configuration file: '{}'", file_path.as_path().display())
-                })?;
-                let prefs = PreferencesMap::<String>::new();
+            let _ = File::create(&file_path).with_context(|| {
+                format!("Could not create configuration file: '{}'", file_path.as_path().display())
+            })?;
+            let prefs = PreferencesMap::<String>::new();
 
-                AppPreferences {
-                    preferences_map:     prefs,
-                    override_data_dir:   override_data,
-                    override_config_dir: override_conf,
-                }
-            };
+            AppPreferences {
+                preferences_map:     prefs,
+                override_data_dir:   override_data,
+                override_config_dir: override_conf,
+            }
+        };
         new_prefs.set_config(APP_PREFERENCES_KEY_VERSION, Some(super::VERSION));
         Ok(new_prefs)
     }

--- a/concordium-node/src/configuration.rs
+++ b/concordium-node/src/configuration.rs
@@ -884,7 +884,7 @@ impl AppPreferences {
     pub fn new(override_conf: PathBuf, override_data: PathBuf) -> anyhow::Result<Self> {
         let file_path = Self::calculate_config_file_path(&override_conf, APP_PREFERENCES_MAIN);
         let mut new_prefs =
-            if let Ok(file) = OpenOptions::new().read(true).write(true).open(&file_path) {
+            if let Ok(file) = OpenOptions::new().open(&file_path) {
                 let mut reader = BufReader::new(&file);
                 let load_result = PreferencesMap::<String>::load_from(&mut reader);
                 let prefs = load_result.unwrap_or_else(|_| PreferencesMap::<String>::new());
@@ -895,8 +895,10 @@ impl AppPreferences {
                     override_config_dir: override_conf,
                 }
             } else {
+                info!("Node configuration file not found. Creating a new one.");
+
                 let _ = File::create(&file_path).with_context(|| {
-                    format!("Can't write to config file: '{}'", file_path.as_path().display())
+                    format!("Could not create configuration file: '{}'", file_path.as_path().display())
                 })?;
                 let prefs = PreferencesMap::<String>::new();
 

--- a/concordium-node/src/configuration.rs
+++ b/concordium-node/src/configuration.rs
@@ -883,40 +883,29 @@ impl AppPreferences {
     /// Creates an `AppPreferences` object.
     pub fn new(override_conf: PathBuf, override_data: PathBuf) -> anyhow::Result<Self> {
         let file_path = Self::calculate_config_file_path(&override_conf, APP_PREFERENCES_MAIN);
-        let mut new_prefs = if let Ok(file) = OpenOptions::new().read(true).write(true).open(&file_path) {
-            let mut reader = BufReader::new(&file);
-            let load_result = PreferencesMap::<String>::load_from(&mut reader);
-            let prefs = load_result.unwrap_or_else(|_| PreferencesMap::<String>::new());
+        let mut new_prefs =
+            if let Ok(file) = OpenOptions::new().read(true).write(true).open(&file_path) {
+                let mut reader = BufReader::new(&file);
+                let load_result = PreferencesMap::<String>::load_from(&mut reader);
+                let prefs = load_result.unwrap_or_else(|_| PreferencesMap::<String>::new());
 
-            AppPreferences {
-                preferences_map:     prefs,
-                override_data_dir:   override_data,
-                override_config_dir: override_conf,
-            }
-        } else {
-            let _ = File::create(&file_path).with_context(|| format!("Can't write to config file: '{}'", file_path.as_path().display()))?;
-            let prefs = PreferencesMap::<String>::new();
+                AppPreferences {
+                    preferences_map:     prefs,
+                    override_data_dir:   override_data,
+                    override_config_dir: override_conf,
+                }
+            } else {
+                let _ = File::create(&file_path).with_context(|| {
+                    format!("Can't write to config file: '{}'", file_path.as_path().display())
+                })?;
+                let prefs = PreferencesMap::<String>::new();
 
-            AppPreferences {
-                preferences_map:     prefs,
-                override_data_dir:   override_data,
-                override_config_dir: override_conf,
-            }
-            // _ => match File::create(&file_path) {
-            //     Ok(_) => {
-            //         let prefs = PreferencesMap::<String>::new();
-            //         let app_prefs = AppPreferences {
-            //             preferences_map:     prefs,
-            //             override_data_dir:   override_data,
-            //             override_config_dir: override_conf,
-            //         };
-
-            //         Ok(app_prefs)
-            //     }
-            //     Err(e) => {
-            //         panic!("Can't write to config file '{}': {}", file_path.as_path().display(), e)
-            //     }
-        };
+                AppPreferences {
+                    preferences_map:     prefs,
+                    override_data_dir:   override_data,
+                    override_config_dir: override_conf,
+                }
+            };
         new_prefs.set_config(APP_PREFERENCES_KEY_VERSION, Some(super::VERSION));
         Ok(new_prefs)
     }

--- a/concordium-node/src/utils.rs
+++ b/concordium-node/src/utils.rs
@@ -93,7 +93,7 @@ pub fn get_config_and_logging_setup() -> anyhow::Result<(config::Config, config:
     let app_prefs = config::AppPreferences::new(
         conf.common.config_dir.to_owned(),
         conf.common.data_dir.to_owned(),
-    );
+    )?;
 
     if conf.common.print_config {
         info!("Config:{:?}\n", conf);


### PR DESCRIPTION
## Purpose

Improve error message when node is started with missing configuration directory.

Fixes #198.

## Changes

- Provide error message with `anyhow::Context`

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
