### PR TITLE
Don't use the partial record selector to allow updating 1 -> 2 -> 3.

### DIFF
--- a/concordium-consensus/src/Concordium/ProtocolUpdate/P1/ProtocolP2.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/P1/ProtocolP2.hs
@@ -84,7 +84,7 @@ updateRegenesis = do
     -- Core parameters are derived from the old genesis, apart from genesis time which is set for
     -- the time of the last finalized block.
     gd <- getGenesisData
-    let core = (P1.genesisCore $ unGDP1 gd) { GenesisData.genesisTime = regenesisTime }
+    let core = (P1._core $ unGDP1 gd) { GenesisData.genesisTime = regenesisTime }
     -- genesisFirstGenesis is the block hash of the previous genesis, if it is initial,
     -- or the genesisFirstGenesis of the previous genesis otherwise.
     let genesisFirstGenesis = case gd of

--- a/concordium-consensus/src/Concordium/ProtocolUpdate/P2/ProtocolP3.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/P2/ProtocolP3.hs
@@ -85,7 +85,7 @@ updateRegenesis = do
     -- Core parameters are derived from the old genesis, apart from genesis time which is set for
     -- the time of the last finalized block.
     gd <- getGenesisData
-    let core = (P2.genesisCore $ unGDP2 gd) { GenesisData.genesisTime = regenesisTime }
+    let core = (P2._core $ unGDP2 gd) { GenesisData.genesisTime = regenesisTime }
     -- genesisFirstGenesis is the block hash of the previous genesis, if it is initial,
     -- or the genesisFirstGenesis of the previous genesis otherwise.
     let genesisFirstGenesis = case gd of


### PR DESCRIPTION
## Purpose

`genesisCore` is a partial record selector so it fails on the second update.

## Changes

Use the correct core function to extract the genesis core.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
