### PR TITLE
Release node version 3.0.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased changes
+## concordium-node 3.0.0
 - Fix a bug due to incorrect use of LMDB database environments where a node
   would crash if queried at specific times.
 - Faster state queries by avoiding locking the block state file when reading.

--- a/concordium-consensus/src/Concordium/ProtocolUpdate/P2/ProtocolP3.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/P2/ProtocolP3.hs
@@ -69,7 +69,6 @@ import Concordium.Kontrol
 
 -- |The hash that identifies a update from P2 to P3 protocol.
 -- This is the hash of the published specification document.
--- TODO: Write the document, insert correct hash.
 updateHash :: SHA256.Hash
 updateHash = read "ec9f7733e872ed0b8f1f386d12c5c725379fc609ce246ffdce28cfb9163ea350"
 

--- a/concordium-consensus/src/Concordium/ProtocolUpdate/P2/ProtocolP3.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/P2/ProtocolP3.hs
@@ -71,7 +71,7 @@ import Concordium.Kontrol
 -- This is the hash of the published specification document.
 -- TODO: Write the document, insert correct hash.
 updateHash :: SHA256.Hash
-updateHash = read "0000000000000000000000000000000000000000000000000000000000000000"
+updateHash = read "ec9f7733e872ed0b8f1f386d12c5c725379fc609ce246ffdce28cfb9163ea350"
 
 -- |Construct the genesis data for a P2.ProtocolP3 update.
 -- It is assumed that the last finalized block is the terminal block of the old chain:

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_node"
-version = "1.1.3"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "app_dirs2",

--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium_node"
-version = "1.1.3" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
+version = "3.0.0" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
 description = "Concordium Node"
 authors = ["Concordium <developers@concordium.com>"]
 exclude = [".gitignore", ".gitlab-ci.yml", "test/**/*","**/**/.gitignore","**/**/.gitlab-ci.yml"]

--- a/service/windows/installer/Node.wxs
+++ b/service/windows/installer/Node.wxs
@@ -2,9 +2,9 @@
 <!-- When updating the product version, the Product Id should be refreshed, otherwise it will not be
     possible to upgrade an existing installation.
 -->
-<?define VersionNumber="1.1.3" ?>
+<?define VersionNumber="3.0.0" ?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:Util="http://schemas.microsoft.com/wix/UtilExtension">
-    <Product Name="Concordium Node" Manufacturer="Concordium Software" Id="8c92955b-383a-4f86-ba06-b39aa117493f" UpgradeCode="297295b4-c716-4d33-8170-0f6136663bfd" Language="1033" Codepage="1252" Version="$(var.VersionNumber)">
+    <Product Name="Concordium Node" Manufacturer="Concordium Software" Id="fd13b347-c852-409d-b13b-1365b1e386c2" UpgradeCode="297295b4-c716-4d33-8170-0f6136663bfd" Language="1033" Codepage="1252" Version="$(var.VersionNumber)">
         <Package Id="*" Keywords="Concordium Installer" Description="Concordium Node $(var.VersionNumber) Installer" Manufacturer="Concordium Software" InstallerVersion="500" Languages="1033" Compressed="yes" InstallScope="perMachine" />
         <MajorUpgrade Schedule="afterInstallValidate" DowngradeErrorMessage="The currently-installed version of [ProductName] is newer than the version you are trying to install. The installation cannot continue. If you wish to install this version, please remove the newer version first." />
         <Media Id="1" Cabinet="Node.cab" EmbedCab="yes" />


### PR DESCRIPTION
## Purpose

Bump node version to 3 to match the protocol version and add the protocol specification hash.

## Changes

The only code change is the updated specification hash.
