### PR TITLE
Add configuration setting for "keep-alive".

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -41,7 +41,7 @@ on:
   workflow_dispatch: # allow manual trigger
 
 env:
-  dummy: 2                 # change to force cache invalidation
+  dummy: 3                 # change to force cache invalidation
   CARGO_TERM_COLOR: always # implicitly adds '--color=always' to all cargo commands
   TEST_LEVEL: 1            # for stack tests
 

--- a/concordium-node/src/configuration.rs
+++ b/concordium-node/src/configuration.rs
@@ -73,9 +73,9 @@ pub const MAX_PEER_NETWORKS: usize = 20;
 /// Database subdirectory name
 pub const DATABASE_SUB_DIRECTORY_NAME: &str = "database-v4";
 /// The factor "max_normal_keep_alive" needs to be greater than
-/// "housekeeping_interval" by. Decreasing this increases risk of inactive nodes
+/// "housekeeping_interval" by. Decreasing this increases risk of nodes
 /// being dropped prematurely.
-const HOUSE_KEEPING_INTERVALS_PER_NORMAL_KEEP_ALIVE: u8 = 3;
+const KEEP_ALIVE_FACTOR: u8 = 3;
 
 #[cfg(feature = "database_emitter")]
 #[derive(StructOpt, Debug)]
@@ -871,12 +871,11 @@ pub fn parse_config() -> anyhow::Result<Config> {
 
     ensure!(
         conf.connection.max_normal_keep_alive
-            >= conf.connection.housekeeping_interval
-                * (HOUSE_KEEPING_INTERVALS_PER_NORMAL_KEEP_ALIVE as u64),
+            >= conf.connection.housekeeping_interval * (KEEP_ALIVE_FACTOR as u64),
         "max-normal-keep-alive ({}) should be at least {} times greater than the value of \
          housekeeping-interval ({})",
         conf.connection.max_normal_keep_alive,
-        HOUSE_KEEPING_INTERVALS_PER_NORMAL_KEEP_ALIVE,
+        KEEP_ALIVE_FACTOR,
         conf.connection.housekeeping_interval
     );
 

--- a/concordium-node/src/configuration.rs
+++ b/concordium-node/src/configuration.rs
@@ -72,6 +72,7 @@ pub const SOFT_BAN_DURATION_SECS: u64 = 300;
 pub const MAX_PEER_NETWORKS: usize = 20;
 /// Database subdirectory name
 pub const DATABASE_SUB_DIRECTORY_NAME: &str = "database-v4";
+const HOUSE_KEEPING_INTERVALS_PER_NORMAL_KEEP_ALIVE: u8 = 3;
 
 #[cfg(feature = "database_emitter")]
 #[derive(StructOpt, Debug)]
@@ -516,7 +517,7 @@ pub struct ConnectionConfig {
         default_value = "120",
         env = "CONCORDIUM_NODE_MAX_NORMAL_KEEP_ALIVE"
     )]
-    pub max_normal_keep_alive: u64,
+    pub max_normal_keep_alive: u16,
 }
 
 #[derive(StructOpt, Debug)]
@@ -866,10 +867,13 @@ pub fn parse_config() -> anyhow::Result<Config> {
     );
 
     ensure!(
-        conf.connection.max_normal_keep_alive > conf.connection.housekeeping_interval * 3,
-        "max-normal-keep-alive ({}) should be at least 3 times greater than the value of \
+        (conf.connection.max_normal_keep_alive as u64)
+            > conf.connection.housekeeping_interval
+                * (HOUSE_KEEPING_INTERVALS_PER_NORMAL_KEEP_ALIVE as u64),
+        "max-normal-keep-alive ({}) should be at least {} times greater than the value of \
          housekeeping-interval ({})",
         conf.connection.max_normal_keep_alive,
+        HOUSE_KEEPING_INTERVALS_PER_NORMAL_KEEP_ALIVE,
         conf.connection.housekeeping_interval
     );
 

--- a/concordium-node/src/configuration.rs
+++ b/concordium-node/src/configuration.rs
@@ -63,8 +63,6 @@ pub const DUMP_SWITCH_QUEUE_DEPTH: usize = 0;
 pub const UNREACHABLE_EXPIRATION_SECS: u64 = 86_400;
 /// Maximum time (in ms) a bootstrapper can hold a connection to a node.
 pub const MAX_BOOTSTRAPPER_KEEP_ALIVE: u64 = 20_000;
-/// Maximum time (in ms) a node can hold an inactive connection to a peer.
-pub const MAX_NORMAL_KEEP_ALIVE: u64 = 1_200_000;
 /// Maximum time (in ms) a connection can be kept without concluding a
 /// handshake.
 pub const MAX_PREHANDSHAKE_KEEP_ALIVE: u64 = 10_000;
@@ -511,6 +509,13 @@ pub struct ConnectionConfig {
         env = "CONCORDIUM_NODE_CONNECTION_DEDUPLICATION_HASHING_ALGORITHM"
     )]
     pub deduplication_hashing_algorithm: DeduplicationHashAlgorithm,
+    #[structopt(
+        long = "max-normal-keep-alive",
+        help = "Max seconds to hold connection to dead \"normal\" node before discarding",
+        default_value = "120",
+        env = "CONCORDIUM_NODE_MAX_NORMAL_KEEP_ALIVE"
+    )]
+    pub max_normal_keep_alive: u64,
 }
 
 #[derive(StructOpt, Debug)]

--- a/concordium-node/src/configuration.rs
+++ b/concordium-node/src/configuration.rs
@@ -511,7 +511,8 @@ pub struct ConnectionConfig {
     pub deduplication_hashing_algorithm: DeduplicationHashAlgorithm,
     #[structopt(
         long = "max-normal-keep-alive",
-        help = "Max seconds to hold connection to dead \"normal\" node before discarding",
+        help = "Max seconds to hold connection to dead \"normal\" node before discarding. Must be \
+                at least 3 times greater than the value of \"housekeeping-interval\".",
         default_value = "120",
         env = "CONCORDIUM_NODE_MAX_NORMAL_KEEP_ALIVE"
     )]

--- a/concordium-node/src/configuration.rs
+++ b/concordium-node/src/configuration.rs
@@ -864,6 +864,14 @@ pub fn parse_config() -> anyhow::Result<Config> {
         "wait-until-minimum-nodes must be lower than or equal to peer-list-size"
     );
 
+    ensure!(
+        conf.connection.max_normal_keep_alive > conf.connection.housekeeping_interval * 3,
+        "max-normal-keep-alive ({}) should be at least 3 times greater than the value of \
+         housekeeping-interval ({})",
+        conf.connection.max_normal_keep_alive,
+        conf.connection.housekeeping_interval
+    );
+
     #[cfg(feature = "instrumentation")]
     {
         ensure!(

--- a/concordium-node/src/configuration.rs
+++ b/concordium-node/src/configuration.rs
@@ -73,8 +73,8 @@ pub const MAX_PEER_NETWORKS: usize = 20;
 /// Database subdirectory name
 pub const DATABASE_SUB_DIRECTORY_NAME: &str = "database-v4";
 
-// In order to avoid premature connection drops, it is estimated that the KEEP_ALIVE_FACTOR should
-// be kept above 3.
+// In order to avoid premature connection drops, it is estimated that the
+// KEEP_ALIVE_FACTOR should be kept above 3.
 /// The factor "max_normal_keep_alive" needs to be greater than
 /// "housekeeping_interval" by. Decreasing this increases risk of nodes
 /// being dropped prematurely.

--- a/concordium-node/src/configuration.rs
+++ b/concordium-node/src/configuration.rs
@@ -72,6 +72,9 @@ pub const SOFT_BAN_DURATION_SECS: u64 = 300;
 pub const MAX_PEER_NETWORKS: usize = 20;
 /// Database subdirectory name
 pub const DATABASE_SUB_DIRECTORY_NAME: &str = "database-v4";
+
+// In order to avoid premature connection drops, it is estimated that the KEEP_ALIVE_FACTOR should
+// be kept above 3.
 /// The factor "max_normal_keep_alive" needs to be greater than
 /// "housekeeping_interval" by. Decreasing this increases risk of nodes
 /// being dropped prematurely.

--- a/concordium-node/src/p2p/connectivity.rs
+++ b/concordium-node/src/p2p/connectivity.rs
@@ -564,6 +564,7 @@ pub fn connection_housekeeping(node: &Arc<P2PNode>) -> bool {
 
     let curr_stamp = get_current_stamp();
     let peer_type = node.peer_type();
+    let max_keep_alive_ms = node.config.max_normal_keep_alive * 1000;
 
     let is_conn_faulty = |conn: &Connection| -> bool {
         if let Some(max_latency) = node.config.max_latency {
@@ -575,7 +576,7 @@ pub fn connection_housekeeping(node: &Arc<P2PNode>) -> bool {
 
     let is_conn_inactive = |conn: &Connection| -> bool {
         (peer_type == PeerType::Node
-            && conn.last_seen() + config::MAX_NORMAL_KEEP_ALIVE < curr_stamp)
+            && conn.last_seen() + max_keep_alive_ms < curr_stamp)
             || (peer_type == PeerType::Bootstrapper
                 && conn.stats.created + config::MAX_BOOTSTRAPPER_KEEP_ALIVE < curr_stamp)
     };

--- a/concordium-node/src/p2p/connectivity.rs
+++ b/concordium-node/src/p2p/connectivity.rs
@@ -564,7 +564,6 @@ pub fn connection_housekeeping(node: &Arc<P2PNode>) -> bool {
 
     let curr_stamp = get_current_stamp();
     let peer_type = node.peer_type();
-    let max_keep_alive_ms = node.config.max_normal_keep_alive * 1000;
 
     let is_conn_faulty = |conn: &Connection| -> bool {
         if let Some(max_latency) = node.config.max_latency {
@@ -575,7 +574,8 @@ pub fn connection_housekeeping(node: &Arc<P2PNode>) -> bool {
     };
 
     let is_conn_inactive = |conn: &Connection| -> bool {
-        (peer_type == PeerType::Node && conn.last_seen() + max_keep_alive_ms < curr_stamp)
+        (peer_type == PeerType::Node
+            && conn.last_seen() + node.config.max_normal_keep_alive_ms < curr_stamp)
             || (peer_type == PeerType::Bootstrapper
                 && conn.stats.created + config::MAX_BOOTSTRAPPER_KEEP_ALIVE < curr_stamp)
     };

--- a/concordium-node/src/p2p/connectivity.rs
+++ b/concordium-node/src/p2p/connectivity.rs
@@ -575,8 +575,7 @@ pub fn connection_housekeeping(node: &Arc<P2PNode>) -> bool {
     };
 
     let is_conn_inactive = |conn: &Connection| -> bool {
-        (peer_type == PeerType::Node
-            && conn.last_seen() + max_keep_alive_ms < curr_stamp)
+        (peer_type == PeerType::Node && conn.last_seen() + max_keep_alive_ms < curr_stamp)
             || (peer_type == PeerType::Bootstrapper
                 && conn.stats.created + config::MAX_BOOTSTRAPPER_KEEP_ALIVE < curr_stamp)
     };

--- a/concordium-node/src/p2p/maintenance.rs
+++ b/concordium-node/src/p2p/maintenance.rs
@@ -94,6 +94,7 @@ pub struct NodeConfig {
     pub events_queue_size: usize,
     pub deduplication_hashing_algorithm: DeduplicationHashAlgorithm,
     pub regenesis_arc: Arc<Regenesis>,
+    pub max_normal_keep_alive: u64,
 }
 
 /// The collection of connections to peer nodes.
@@ -372,6 +373,7 @@ impl P2PNode {
             events_queue_size: conf.connection.events_queue_size,
             deduplication_hashing_algorithm: conf.connection.deduplication_hashing_algorithm,
             regenesis_arc,
+            max_normal_keep_alive: conf.connection.max_normal_keep_alive,
         };
 
         let connection_handler = ConnectionHandler::new(conf, server);

--- a/concordium-node/src/p2p/maintenance.rs
+++ b/concordium-node/src/p2p/maintenance.rs
@@ -373,7 +373,7 @@ impl P2PNode {
             events_queue_size: conf.connection.events_queue_size,
             deduplication_hashing_algorithm: conf.connection.deduplication_hashing_algorithm,
             regenesis_arc,
-            max_normal_keep_alive_ms: (conf.connection.max_normal_keep_alive as u64) * 1000,
+            max_normal_keep_alive_ms: conf.connection.max_normal_keep_alive * 1000,
         };
 
         let connection_handler = ConnectionHandler::new(conf, server);

--- a/concordium-node/src/p2p/maintenance.rs
+++ b/concordium-node/src/p2p/maintenance.rs
@@ -94,7 +94,7 @@ pub struct NodeConfig {
     pub events_queue_size: usize,
     pub deduplication_hashing_algorithm: DeduplicationHashAlgorithm,
     pub regenesis_arc: Arc<Regenesis>,
-    pub max_normal_keep_alive: u64,
+    pub max_normal_keep_alive_ms: u64,
 }
 
 /// The collection of connections to peer nodes.
@@ -373,7 +373,7 @@ impl P2PNode {
             events_queue_size: conf.connection.events_queue_size,
             deduplication_hashing_algorithm: conf.connection.deduplication_hashing_algorithm,
             regenesis_arc,
-            max_normal_keep_alive: conf.connection.max_normal_keep_alive,
+            max_normal_keep_alive_ms: (conf.connection.max_normal_keep_alive * 1000) as u64,
         };
 
         let connection_handler = ConnectionHandler::new(conf, server);

--- a/concordium-node/src/p2p/maintenance.rs
+++ b/concordium-node/src/p2p/maintenance.rs
@@ -373,7 +373,7 @@ impl P2PNode {
             events_queue_size: conf.connection.events_queue_size,
             deduplication_hashing_algorithm: conf.connection.deduplication_hashing_algorithm,
             regenesis_arc,
-            max_normal_keep_alive_ms: (conf.connection.max_normal_keep_alive * 1000) as u64,
+            max_normal_keep_alive_ms: (conf.connection.max_normal_keep_alive as u64) * 1000,
         };
 
         let connection_handler = ConnectionHandler::new(conf, server);


### PR DESCRIPTION
## Purpose

Reduce the time a potentially dead connection is kept.

Fixes #160 

#### Note
I have only tested that the relation between **housekeeping-interval** and **keep-alive** is ensured. I have not tested that the connection is indeed dropped after the time specified instead of the previous hardcoded 20 minutes.

## Changes

- Moved keep-alive constant to configuration setting
- Ensure correct relation between housekeeping-interval and keep-alive settings

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
     hard-to-understand areas.