### PR TITLE
Genesis: Document parameters for generating extra accounts

### DIFF
--- a/scripts/genesis/README.md
+++ b/scripts/genesis/README.md
@@ -19,6 +19,11 @@ Expected env vars:
 * `NUM_BAKERS`: Number of bakers to define.
 * `GENESIS_DIR`: Output directory. Defaults to `/work/out`.
 
+Supported env vars:
+* `EXTRA_ACCOUNTS_TEMPLATE`, `NUM_EXTRA_ACCOUNTS`, `EXTRA_ACCOUNTS_BALANCE`:
+  The naming to use for extra accounts (this enables them being generated), how many to create, and with what balance.
+* See the source code of the script for more.
+
 ### Example build command
 
 ```shell
@@ -28,7 +33,7 @@ docker build -t generate-test-genesis .
 ### Example run command
 
 ```shell
-docker run -e NUM_BAKERS=5 -v "$PWD:/work" generate-test-genesis
+docker run -e NUM_BAKERS=5 -e EXTRA_ACCOUNTS_TEMPLATE=extra -e NUM_EXTRA_ACCOUNTS=10 -e EXTRA_ACCOUNTS_BALANCE=1000000000000 -v "$PWD:/work" generate-test-genesis
 ```
 
 The files are created with owner `root` so one might want to update their ownership:
@@ -36,3 +41,5 @@ The files are created with owner `root` so one might want to update their owners
 ```shell
 chown -R <id>:<group> ./out
 ```
+
+Remember to also include `genesis.json` when persisting the generated data, as that file is not copied into `./out`.

--- a/scripts/genesis/genesis.json
+++ b/scripts/genesis/genesis.json
@@ -1,10 +1,10 @@
 {
   "v": 2,
   "value": {
-    "genesisTime": 1628241804000,
+    "genesisTime": 1637307534000,
     "slotDuration": 250,
     "leadershipElectionNonce": "5bb78b5f359007c9532e17e474ff188c30bbd999147f6721d870f7ab2004e438",
-    "epochLength": 14400,
+    "epochLength": 3600,
     "maxBlockEnergy": 3000000,
     "finalizationParameters": {
       "minimumSkip": 0,
@@ -21,26 +21,26 @@
       "electionDifficulty": 0.025,
       "euroPerEnergy": 0.000001,
       "microGTUPerEuro": 100000000,
-      "bakerCooldownEpochs": 166,
+      "bakerCooldownEpochs": 1,
       "accountCreationLimit": 10,
       "foundationAccount": "4NyqjcJwKAckGE3gMGDJeqcyLZQxtfnDFTdvg74xYUU8myQTrB",
       "minimumThresholdForBaking": "300000000000",
       "rewardParameters": {
-          "mintDistribution": {
-              "mintPerSlot": 0.0000000007555665,
-              "bakingReward": 0.6,
-              "finalizationReward": 0.3
-          },
-          "transactionFeeDistribution": {
-              "baker": 0.45,
-              "gasAccount": 0.45
-          },
-          "gASRewards": {
-              "baker": 0.25,
-              "finalizationProof": 0.005,
-              "accountCreation": 0.002,
-              "chainUpdate": 0.005
-          }
+        "mintDistribution": {
+          "mintPerSlot": 0.0000000007555665,
+          "bakingReward": 0.6,
+          "finalizationReward": 0.3
+        },
+        "transactionFeeDistribution": {
+          "baker": 0.45,
+          "gasAccount": 0.45
+        },
+        "gASRewards": {
+          "baker": 0.25,
+          "finalizationProof": 0.005,
+          "accountCreation": 0.002,
+          "chainUpdate": 0.005
+        }
       }
     }
   }


### PR DESCRIPTION
## Purpose

When generating a new genesis data set for testing, we usually want to include extra non-baker accounts for testers and the GTU-drop feature to use.

## Changes

Documents parameters for generating extra accounts for new genesis data sets. Also update `genesis.json` to match what is currently used on stagenet.