### PR TITLE
Remove database migration on package install.

### DIFF
--- a/scripts/distribution/ubuntu-packages/template/debian/postinst
+++ b/scripts/distribution/ubuntu-packages/template/debian/postinst
@@ -24,23 +24,5 @@ else
     echo "To update settings edit the file."
 fi
 
-# Migrate previous state directories. The original concordium-node package.
-# stored state directories in /var/lib/concordium/$HASH. This causes some issues
-# with systemd and DynamicUser sandboxing, so in version 1.1.0 and onward we put
-# state directories in /var/lib/concordium-$HASH so that they are completely
-# disjoint. This postinst script is responsible for migration from the old to
-# the new directories.
-
-if [[ -d "/var/lib/concordium/${build_genesis_hash}/data" && -d "/var/lib/concordium/${build_genesis_hash}/config" ]];
-then
-    echo "Migrating existing database directory to '/var/lib/concordium-${build_genesis_hash}'."
-    # At this point the target data directory contains genesis.dat so we have to move the contents
-    # instead of just the directory to avoid conflicts.
-    mv /var/lib/concordium/${build_genesis_hash}/data/* /var/lib/concordium-${build_genesis_hash}/data/
-    rmdir /var/lib/concordium/${build_genesis_hash}/data
-    # The target config directory should be empty at this point, so it is OK to just move.
-    mv /var/lib/concordium/${build_genesis_hash}/config /var/lib/concordium-${build_genesis_hash}/
-fi
-
 # include automatically generated postinst scripts after we've update the override files.
 #DEBHELPER#


### PR DESCRIPTION
## Purpose

This was needed since the first version of the package did not use sandboxing.
It is no longer needed since version 1.1 already has everything in the right place.

## Changes

Remove database migration on  postinstall.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
