### PR TITLE
Fix starvation in lock acquire by explicitly yielding control even without allocations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - The macOS installer no longer overwrites the service files when reinstalling.
 - Cache smart contract modules on startup from existing state to improve smart
   contract execution.
+- Fix a starvation bug in some cases of parallel node queries.
 
 ## concordium-node 3.0.0
 - Fix a bug due to incorrect use of LMDB database environments where a node


### PR DESCRIPTION
## Purpose

The node sometimes seems to deadlock (it is not a deadlock, it is a kind of livelock) when queried. The cause seems to be an optimization flag (-fomit-yield) by GHC enabled by -O2 together witth the following behaviour of GHC.

From the [GHC documentation](https://hackage.haskell.org/package/base-4.16.0.0/docs/Control-Concurrent.html)

> GHC implements pre-emptive multitasking: the execution of threads are interleaved in a random fashion. More specifically, a thread may be pre-empted whenever it allocates some memory, which unfortunately means that tight loops which do no allocation tend to lock out other threads (this only seems to happen with pathological benchmark-style code, however).

Fixes #231 

## Changes

Explicitly yield in the non-allocating loop to account for the GHC optimization and allow pre-empting the thread.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.