### PR TITLE
Added build dependency management through nix-shell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+eval "$(lorri direnv)"
+

--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,0 @@
-eval "$(lorri direnv)"
-

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ hie.yaml
 **/**/TAGS
 .DS_Store
 /concordium-node/*.log
+.envrc
 
 # MacOS distribution
 /scripts/distribution/macOS-package/tools

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,18 @@
+let
+  # 'stack --nix' will look for a GHC in the user channels
+  # we don't want a GHC from an unknown user channel,
+  # but a GHC from a known, build environment-specific channel
+  # thus, please use 'stack --no-nix --system-ghc' instead
+  pkgs2105 = import (builtins.fetchTarball "channel:nixos-21.05") {};
+  pkgs2111 = import (builtins.fetchTarball "channel:nixos-21.11") {};
+  ghc = pkgs2105.haskell.packages.ghc8104.ghcWithPackages (p: with p; [ stack haskell-language-server ]);
+in
+pkgs2105.mkShell {
+
+  nativeBuildInputs = with pkgs2105; [ ghc cargo ];
+
+  buildInputs = with pkgs2105; [ postgresql unbound lmdb pkgs2111.flatbuffers protobuf zlib ];
+
+  PROTOC = "${pkgs2105.protobuf}/bin/protoc";
+  
+}


### PR DESCRIPTION
## Purpose

This pull request adds a Nix expression which evaluates to a shell environment containing all non-Haskell and non-Rust dependencies necessary to build `concordium-node`. It removes the need to manually install these dependencies by following the [build checklist](https://concordium.atlassian.net/wiki/spaces/GEN/pages/606666786/How-to-build+Your+Own+Node).

The major advantage of defining this environment as a Nix expression is that it becomes easily reproducible with a single command (`nix-shell`). It's useful, for example, when setting up the development environment for `concordium-node` on a new machine or to make sure that all developers in a team use exactly the same development environment.

## Changes

The added `shell.nix` file is the conventional location for package and shell environment definitions under the Nix package manager. Additionally, the `.envrc` file provides integration of said environment with [`direnv`](https://direnv.net/) and [`lorri`](https://github.com/nix-community/lorri) (a build server which removes the need to launch `nix-shell` manually when `shell.nix` changes).   

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
