### PR TITLE
Ignore html files so that github displays a more appropriate language.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,6 @@
 deps/** linguist-vendored
-scripts/CMakeLists.txt linguist-detectable=false
-scripts/CXXFeatureCheck.cmake linguist-detectable=false
+*.html linguist-detectable=false
 *.dll filter=lfs diff=lfs merge=lfs -text linguist-vendored
 *.dll.a filter=lfs diff=lfs merge=lfs -text linguist-vendored
 *.a filter=lfs diff=lfs merge=lfs -text linguist-vendored
 *.pc filter=lfs diff=lfs merge=lfs -text linguist-vendored
-deps/static-libs filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
## Purpose

Make github ignore .html files when calculating which language this repo is in.
