### PR TITLE
Finalization persistence in a single LMDB transaction

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/Basic/TreeState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/TreeState.hs
@@ -156,6 +156,7 @@ instance (bs ~ BlockState m, BS.BlockStateStorage m, Monad m, MonadIO m, MonadSt
             blockTable . at' (getHash block) ?= TS.BlockAlive blockP
             return blockP
     markDead bh = blockTable . at' bh ?= TS.BlockDead
+    type MarkFin (PureTreeStateMonad pv bs m) = ()
     markFinalized bh fr = use (blockTable . at' bh) >>= \case
             Just (TS.BlockAlive bp) -> do
               blockTable . at' bh ?= TS.BlockFinalized bp fr
@@ -177,6 +178,7 @@ instance (bs ~ BlockState m, BS.BlockStateStorage m, Monad m, MonadIO m, MonadSt
     getFinalizedAtIndex finIndex = fmap snd . Seq.lookup (fromIntegral finIndex) <$> use finalizationList
     getRecordAtIndex finIndex = fmap fst . Seq.lookup (fromIntegral finIndex) <$> use finalizationList
     getFinalizedAtHeight bHeight = preuse (finalizedByHeightTable . ix bHeight)
+    wrapupFinalization _ _ = return ()
     getBranches = use branches
     putBranches brs = branches .= brs
     takePendingChildren bh = possiblyPendingTable . at' bh . non [] <<.= []
@@ -289,6 +291,7 @@ instance (bs ~ BlockState m, BS.BlockStateStorage m, Monad m, MonadIO m, MonadSt
             when (slot > results ^. tsSlot) $ transactionTable . ttHashMap . at' trHash . mapped . _2 %= updateSlot slot
             return $ TS.Duplicate tr'
 
+    type FinTrans (PureTreeStateMonad pv bs m) = ()
     finalizeTransactions bh slot = mapM_ finTrans
         where
             finTrans WithMetadata{wmdData=NormalTransaction tr,..} = do

--- a/concordium-consensus/src/Concordium/GlobalState/Paired.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Paired.hs
@@ -35,6 +35,7 @@ import Concordium.GlobalState.BlockPointer
 import Concordium.GlobalState.TreeState as TS
 import Concordium.GlobalState
 import Concordium.Logger (MonadLogger(..))
+import Control.Arrow ((&&&))
 
 -- |Monad for coercing reader and state types.
 newtype ReviseRSM r s m a = ReviseRSM (m a)
@@ -769,9 +770,9 @@ instance (C.HasGlobalStateContext (PairGSContext lc rc) r,
               assert (rec1 == rec2) $ -- TODO: Perhaps they don't have to be the same
                 return $ Just rec1
             _ -> error $ "getRecordAtindex (Paired): no match " ++ show r1 ++ ", " ++ show r2
-    wrapupFinalization mfs fts = do
-      coerceGSML (wrapupFinalization (fst <$> mfs) (fst <$> fts))
-      coerceGSMR (wrapupFinalization (snd <$> mfs) (snd <$> fts))
+    wrapupFinalization finRec mffts = do
+      coerceGSML (wrapupFinalization finRec ((fst . fst &&& fst . snd) <$> mffts))
+      coerceGSMR (wrapupFinalization finRec ((snd . fst &&& snd . snd) <$> mffts))
     getBranches = do
         r1 <- coerceGSML getBranches
         r2 <- coerceGSMR getBranches

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
@@ -571,7 +571,7 @@ instance (MonadLogger (PersistentTreeStateMonad pv ati bs m),
         msb <- readFinalizedBlockAtHeight bHeight
         mapM constructBlock msb
 
-    wrapupFinalization mfs fts = use lastFinalizationRecord >>= \lfr -> writeFinalizationComposite lfr mfs (concat fts)
+    wrapupFinalization = writeFinalizationComposite
 
     getBranches = use branches
     putBranches brs = branches .= brs

--- a/concordium-consensus/src/Concordium/GlobalState/TreeState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/TreeState.hs
@@ -60,11 +60,11 @@ instance Show (BlockStatus bp pb) where
     show (BlockFinalized _ _) = "Finalized"
     show (BlockPending _) = "Pending"
 
--- |Branches of a tree represented as a sequence, ordered by height above the last
--- finalized block, of lists of block pointers.  The blocks in the branches should
--- be exactly the live blocks.  If a block is in the branches, then either it is at
--- the lowest level and its parent is the last finalized block, or its parent is also
--- in the branches at the level below.
+-- |Branches of a tree represented as a sequence of lists of block pointers. All pointers within a
+-- list point to blocks of equal height above the last finalized block. The sequence is ordered by
+-- the block height. The blocks in the branches should be exactly the live blocks.  If a block is in
+-- the branches, then either it is at the lowest level and its parent is the last finalized block,
+-- or its parent is also in the branches at the level below.
 type Branches m = Seq.Seq [BlockPointerType m]
 
 -- |Result of trying to add a transaction to the transaction table.

--- a/concordium-consensus/src/Concordium/GlobalState/TreeState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/TreeState.hs
@@ -187,7 +187,7 @@ class (Eq (BlockPointerType m),
     getFinalizedAtHeight :: BlockHeight -> m (Maybe (BlockPointerType m))
 
     -- |Persist finalization, if the tree state implementation supports it
-    wrapupFinalization :: [MarkFin m] -> [FinTrans m] -> m ()
+    wrapupFinalization :: FinalizationRecord -> [(MarkFin m, FinTrans m)] -> m ()
 
     -- * Operations on branches
     -- |Get the branches.
@@ -377,7 +377,7 @@ instance (Monad (t m), MonadTrans t, TreeStateMonad pv m) => TreeStateMonad pv (
     getFinalizedAtIndex = lift . getFinalizedAtIndex
     getRecordAtIndex = lift . getRecordAtIndex
     getFinalizedAtHeight = lift . getFinalizedAtHeight
-    wrapupFinalization mfs = lift . wrapupFinalization mfs
+    wrapupFinalization finRec = lift . wrapupFinalization finRec
     getBranches = lift getBranches
     putBranches = lift . putBranches
     takePendingChildren = lift . takePendingChildren

--- a/concordium-consensus/src/Concordium/Skov/Update.hs
+++ b/concordium-consensus/src/Concordium/Skov/Update.hs
@@ -10,6 +10,7 @@ import Data.Foldable
 import Data.List (intercalate)
 import GHC.Stack
 import Data.Maybe (fromMaybe)
+import Data.Time (diffUTCTime)
 
 import Concordium.Types
 import Concordium.Types.Accounts
@@ -139,6 +140,7 @@ processFinalization :: forall pv m. (TreeStateMonad pv m, SkovMonad pv m, OnSkov
 processFinalization newFinBlock finRec@FinalizationRecord{..} = do
     nextFinIx <- getNextFinalizationIndex
     when (nextFinIx == finalizationIndex) $ do
+        startTime <- currentTime
         -- We actually have a new block to finalize.
         logEvent Skov LLInfo $ "Block " ++ show (bpHash newFinBlock) ++ " is finalized at height " ++ show (theBlockHeight $ bpHeight newFinBlock) ++ " with finalization delta=" ++ show finalizationDelay
         updateFinalizationStatistics
@@ -249,6 +251,8 @@ processFinalization newFinBlock finRec@FinalizationRecord{..} = do
         -- purge pending blocks with slot numbers predating the last finalized slot
         purgePending
         onFinalize finRec newFinBlock
+        endTime <- currentTime
+        logEvent Skov LLDebug $ "Processed finalization in " ++ show (diffUTCTime endTime startTime)
 
 -- |Try to add a block to the tree.  
 -- Besides taking the `PendingBlock` this function takes a list

--- a/concordium-consensus/src/Concordium/Skov/Update.hs
+++ b/concordium-consensus/src/Concordium/Skov/Update.hs
@@ -7,6 +7,7 @@ import Control.Monad
 import qualified Data.Sequence as Seq
 import Lens.Micro.Platform
 import Data.Foldable
+import Data.List (intercalate)
 import GHC.Stack
 import Data.Maybe (fromMaybe)
 
@@ -147,9 +148,6 @@ processFinalization newFinBlock finRec@FinalizationRecord{..} = do
         -- This is to ensure that the focus block is always a live (or finalized) block.
         unless focusBlockSurvives $ updateFocusBlockTo newFinBlock
         lastFinHeight <- getLastFinalizedHeight
-        -- Add the finalization to the finalization list
-        -- TODO: The way this is stored will probably change.
-        addFinalization newFinBlock finRec
         -- Prune the branches, which consist of all the non-finalized blocks
         -- grouped by block height.
         oldBranches <- getBranches
@@ -164,34 +162,40 @@ processFinalization newFinBlock finRec@FinalizationRecord{..} = do
         -- Instead of marking blocks dead immediately we accumulate them
         -- and a return a list. The reason for doing this is that we never
         -- have to look up a parent block that is already marked dead.
-        let
-            pruneTrunk :: [BlockPointerType m] -- ^List of blocks to remove.
+        let pruneTrunk :: [BlockPointerType m] -- ^List of blocks to remove.
                        -> BlockPointerType m -- ^The block that was finalized.
                        -> Branches m
-                       -> m [BlockPointerType m]
+                       -> m ([BlockPointerType m], [BlockPointerType m])
                        -- ^ The return value is a list of blocks to mark dead, ordered
                        -- by increasing height.
-            pruneTrunk toRemove _ Seq.Empty = return toRemove
+            pruneTrunk toRemove _ Seq.Empty = return ([], toRemove)
             pruneTrunk toRemove keeper (brs Seq.:|> l) = do
                 parent <- bpParent keeper
                 let toRemove1 = filter (/= keeper) l ++ toRemove
-                toRemove2 <- pruneTrunk toRemove1 parent brs
-                -- mark blocks as finalized now, so that blocks are marked finalized by increasing height
-                markFinalized (getHash keeper) finRec
-                logEvent Skov LLDebug $ "Block " ++ show keeper ++ " marked finalized"
-                -- Finalize the transactions of the surviving block.
-                -- (This is handled in order of finalization.)
-                finalizeTransactions (getHash keeper) (blockSlot keeper) (blockTransactions keeper)
-                ati <- bpTransactionAffectSummaries keeper
-                bcTime <- getSlotTimestamp (blockSlot keeper)
-                let ctx = BlockContext{
-                        bcHash = getHash keeper,
-                        bcHeight = bpHeight keeper,
-                        ..}
-                flushBlockSummaries ctx ati =<< getSpecialOutcomes =<< blockState keeper
-                return toRemove2
-
-        toRemoveFromTrunk <- pruneTrunk [] newFinBlock (Seq.take pruneHeight oldBranches)
+                (toFinalize, toRemove2) <- pruneTrunk toRemove1 parent brs
+                return (keeper : toFinalize, toRemove2)
+        (toFinalize, toRemoveFromTrunk) <- pruneTrunk [] newFinBlock (Seq.take pruneHeight oldBranches)
+        -- Add the finalization to the finalization list
+        addFinalization newFinBlock finRec
+        -- mark blocks as finalized in the order returned by `pruneTrunk`, so that blocks are marked
+        -- finalized by increasing height
+        mfs <- forM toFinalize $ \block -> do
+          markFinalized (getHash block) finRec
+        -- Finalize the transactions of surviving blocks in the order of their finalization.
+        fts <- forM toFinalize $ \block -> do
+          finalizeTransactions (getHash block) (blockSlot block) (blockTransactions block)
+        forM_ toFinalize $ \block -> do
+          ati <- bpTransactionAffectSummaries block
+          bcTime <- getSlotTimestamp (blockSlot block)
+          let ctx = BlockContext{
+                bcHash = getHash block,
+                bcHeight = bpHeight block,
+                ..}
+          flushBlockSummaries ctx ati =<< getSpecialOutcomes =<< blockState block
+        -- block states and transaction statuses need to be added into the same LMDB transaction
+        -- with the finalization record, if persistent tree state is used
+        wrapupFinalization mfs fts
+        logEvent Skov LLDebug $ "Blocks " ++ intercalate ", " (map show toFinalize) ++ " marked finalized"
         -- Archive the states of blocks up to but not including the new finalized block
         let doArchive b = case compare (bpHeight b) lastFinHeight of
                 LT -> return ()

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/PersistentTreeState.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/PersistentTreeState.hs
@@ -100,8 +100,9 @@ testFinalizeABlock = do
   blockPtr :: BlockPointerType TestM <- makeLiveBlock pb genesisBlock genesisBlock state () now' 0
   let frec = FinalizationRecord 1 (bpHash blockPtr) (FinalizationProof [1] (sign "Hello" sk)) 0
   -- Add the finalization to the tree state
-  markFinalized (bpHash blockPtr) frec
+  mf <- markFinalized (bpHash blockPtr) frec
   addFinalization blockPtr frec
+  wrapupFinalization [mf] []
   -- Was updated as the last finalized?
   (b, fr) <- getLastFinalized
   liftIO $ do
@@ -140,8 +141,9 @@ testFinalizeABlock = do
   blockPtr2 :: BlockPointerType TestM <- makeLiveBlock pb2 blockPtr genesisBlock state () now''' 0
   let frec2 = FinalizationRecord 2 (bpHash blockPtr2) (FinalizationProof [1] (sign "Hello" sk)) 0
   -- Add the finalization to the tree state
-  markFinalized (bpHash blockPtr2) frec2
+  mf2 <- markFinalized (bpHash blockPtr2) frec2
   addFinalization blockPtr2 frec2
+  wrapupFinalization [mf2] []
   --- The database should now contain 3 items, check them
   theDB <- use db
   (storedBlocks, finRecs) <- liftIO $ do

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/PersistentTreeState.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/PersistentTreeState.hs
@@ -102,7 +102,7 @@ testFinalizeABlock = do
   -- Add the finalization to the tree state
   mf <- markFinalized (bpHash blockPtr) frec
   addFinalization blockPtr frec
-  wrapupFinalization [mf] []
+  wrapupFinalization frec [(mf, [])]
   -- Was updated as the last finalized?
   (b, fr) <- getLastFinalized
   liftIO $ do
@@ -143,7 +143,7 @@ testFinalizeABlock = do
   -- Add the finalization to the tree state
   mf2 <- markFinalized (bpHash blockPtr2) frec2
   addFinalization blockPtr2 frec2
-  wrapupFinalization [mf2] []
+  wrapupFinalization frec2 [(mf2, [])]
   --- The database should now contain 3 items, check them
   theDB <- use db
   (storedBlocks, finRecs) <- liftIO $ do


### PR DESCRIPTION
Combined persisting finalization records, finalized block state and finalized
transaction statuses into a single LMDB transaction.

Closes #135

## Purpose

At the moment, there are no less than two LMDB write transactions happening on each finalization: one to store the finalization record and one for for each block being marked as finalized. Additionally, block transaction statuses might be updated too, in a separate LMDB write transaction. If a node shuts down before all these transactions are committed, the node state becomes inconsistent which might prevent the node to start again.

## Changes

I added the `writeFinalizationComposite` function in `Concordium.GlobalState.LMDB.Helpers` to write the finalization record, blocks marked as finalized and block transaction statuses in a single LMDB transaction. I also moved the LMDB write effects outside the `pruneTrunk` function (in `processFinalization`), to make it possible to call `writeFinalizationComposite` without relying on monadic state to collect its arguments.

I also added the `wrapupFinalization` operation in `TreeState` which is defined through `writeFinalizationComposite` in the persistent implementation and as a no-op in the in-memory implementation.

A more elegant and generic solution would be to come up with a composition operation on LMDB transactions. I'm not sure if now would be a good time to work on one since the only part of the node that requires LMDB transaction composition is finalization.

<s>Since I added a new operation to `TreeState`, I also had to give it a `Paired` implementation. I'm sure I didn't do the right thing there, and I'll gladly take comments on that.</s> Fixed thanks to Thomas!

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
