### PR TITLE
Use the existing Cargo.lock file when building static libraries.

### DIFF
--- a/scripts/static-libraries/build-static-libraries.sh
+++ b/scripts/static-libraries/build-static-libraries.sh
@@ -21,9 +21,6 @@ cd /build
 #############################################################################################################################
 ## Build the project
 
-cargo update --manifest-path /build/concordium-base/rust-src/Cargo.toml
-cargo check --manifest-path /build/concordium-base/rust-src/Cargo.toml
-
 stack build --profile --flag "concordium-consensus:-dynamic" --stack-yaml /build/concordium-consensus/stack.static.yaml
 
 for lib in $(find /build/concordium-consensus/.stack-work -type f -name "*.a" ! -name "*_p.a"); do


### PR DESCRIPTION
## Purpose

Fix build.

## Changes

Use the existing Cargo.lock file when building static libraries.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

