### PR TITLE
Fixes #259: Expose foundation account address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
   which they returned previously.
 - Fix issue #244: Collector to keep querying. Remove the parameter for maximum allowed
   times a gRPC call can fail and keeps `node-collector` querying forever.
+- Fix the issue #259: Expose foundation account address. The account information now can
+  be queried by using an account index as well.
 
 ## concordium-node 3.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,7 @@
   which they returned previously.
 - Fix issue #244: Collector to keep querying. Remove the parameter for maximum allowed
   times a gRPC call can fail and keeps `node-collector` querying forever.
-- Fix the issue #259: Expose foundation account address. The account information now can
-  be queried by using an account index as well.
+- `GetAccountInfo` endpoint supports querying the account via the account index.
 
 ## concordium-node 3.0.1
 

--- a/concordium-consensus/src/Concordium/External.hs
+++ b/concordium-consensus/src/Concordium/External.hs
@@ -891,16 +891,16 @@ decodeBlockHash blockcstr = readMaybe <$> peekCString blockcstr
 decodeAccountAddress :: CString -> IO (Either String AccountAddress)
 decodeAccountAddress acctstr = addressFromBytes <$> BS.packCString acctstr
 
--- |Decode a null-terminated string as either an account address (base-58), account index (Int) or a
+-- |Decode a null-terminated string as either an account address (base-58), account index (AccountIndex) or a
 -- credential registration ID (base-16).
 decodeAccountAddressOrCredId :: CString -> IO (Maybe AccountIdentifier)
 decodeAccountAddressOrCredId str = do
     bs <- BS.packCString str
     return $ case addressFromBytes bs of
-        Left _ -> Just $ 
+        Left _ ->
             case bsDeserializeBase16 bs of
-                Nothing -> AI $ read (BS.unpack bs)
-                Just cid -> CID cid
+                Nothing -> AI <$> readMaybe (BS.unpack bs)
+                Just cid -> Just $ CID cid
         Right acc -> Just $ AA acc
 
 -- |Decode an instance address from a null-terminated JSON-encoded string.

--- a/concordium-consensus/src/Concordium/External.hs
+++ b/concordium-consensus/src/Concordium/External.hs
@@ -891,14 +891,17 @@ decodeBlockHash blockcstr = readMaybe <$> peekCString blockcstr
 decodeAccountAddress :: CString -> IO (Either String AccountAddress)
 decodeAccountAddress acctstr = addressFromBytes <$> BS.packCString acctstr
 
--- |Decode a null-terminated string as either an account address (base-58) or a
+-- |Decode a null-terminated string as either an account address (base-58), account index (Int) or a
 -- credential registration ID (base-16).
-decodeAccountAddressOrCredId :: CString -> IO (Maybe (Either CredentialRegistrationID AccountAddress))
+decodeAccountAddressOrCredId :: CString -> IO (Maybe AccountIdentifier)
 decodeAccountAddressOrCredId str = do
     bs <- BS.packCString str
     return $ case addressFromBytes bs of
-        Left _ -> Left <$> bsDeserializeBase16 bs
-        Right acc -> Just $ Right acc
+        Left _ -> Just $ 
+            case bsDeserializeBase16 bs of
+                Nothing -> AI $ read (BS.unpack bs)
+                Just cid -> CID cid
+        Right acc -> Just $ AA acc
 
 -- |Decode an instance address from a null-terminated JSON-encoded string.
 decodeInstanceAddress :: CString -> IO (Maybe ContractAddress)

--- a/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState.hs
@@ -397,6 +397,10 @@ instance (IsProtocolVersion pv, Monad m) => BS.BlockStateQuery (PureBlockStateMo
            Nothing -> return Nothing
            Just ai -> return $ (ai, ) <$> bs ^? blockAccounts . Accounts.indexedAccount ai
 
+    {-# INLINE getAccountByIndex #-}
+    getAccountByIndex bs ai =
+      return $ (ai, ) <$> bs ^? blockAccounts . Accounts.indexedAccount ai
+
     {-# INLINE getBakerAccount #-}
     getBakerAccount bs (BakerId ai) =
       return $ bs ^? blockAccounts . Accounts.indexedAccount ai

--- a/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
@@ -203,6 +203,9 @@ class AccountOperations m => BlockStateQuery m where
     -- |Query an account by the id of the credential that belonged to it.
     getAccountByCredId :: BlockState m -> CredentialRegistrationID -> m (Maybe (AccountIndex, Account m))
 
+    -- |Query an account by the account index that belonged to it.
+    getAccountByIndex :: BlockState m -> AccountIndex -> m (Maybe (AccountIndex, Account m))
+
     -- |Get the contract state from the contract table of the state instance.
     getContractInstance :: BlockState m -> ContractAddress -> m (Maybe Instance)
 
@@ -644,6 +647,7 @@ instance (Monad (t m), MonadTrans t, BlockStateQuery m) => BlockStateQuery (MGST
   getAccount s = lift . getAccount s
   accountExists s = lift . accountExists s
   getAccountByCredId s = lift . getAccountByCredId s
+  getAccountByIndex s = lift . getAccountByIndex s
   getBakerAccount s = lift . getBakerAccount s
   getContractInstance s = lift . getContractInstance s
   getModuleList = lift . getModuleList
@@ -674,6 +678,7 @@ instance (Monad (t m), MonadTrans t, BlockStateQuery m) => BlockStateQuery (MGST
   {-# INLINE getAccount #-}
   {-# INLINE accountExists #-}
   {-# INLINE getAccountByCredId #-}
+  {-# INLINE getAccountByIndex #-}
   {-# INLINE getBakerAccount #-}
   {-# INLINE getContractInstance #-}
   {-# INLINE getModuleList #-}

--- a/concordium-consensus/src/Concordium/GlobalState/Paired.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Paired.hs
@@ -209,6 +209,17 @@ instance (Monad m, C.HasGlobalStateContext (PairGSContext lc rc) r, BlockStateQu
             return Nothing
           (Nothing, _) -> error $ "Cannot get account with credid " ++ show cid ++ " in left implementation"
           (_, Nothing) -> error $ "Cannot get account with credid " ++ show cid ++ " in right implementation"
+    getAccountByIndex (ls, rs) idx = do
+        a1 <- coerceBSML (getAccountByIndex ls idx)
+        a2 <- coerceBSMR (getAccountByIndex rs idx)
+        case (a1, a2) of
+          (Just (ai1, a1'), Just (ai2, a2')) ->
+            assert ((getHash a1' :: H.Hash) == getHash a2' && ai1 == ai2) $
+              return $ Just (ai1, (a1', a2'))
+          (Nothing, Nothing) ->
+            return Nothing
+          (Nothing, _) -> error $ "Cannot get account by index " ++ show idx ++ " in left implementation"
+          (_, Nothing) -> error $ "Cannot get account by index " ++ show idx ++ " in right implementation"
     getBakerAccount (ls, rs) bid = do
         a1 <- coerceBSML (getBakerAccount ls bid)
         a2 <- coerceBSMR (getBakerAccount rs bid)

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -889,6 +889,10 @@ doGetAccountByCredId pbs cid = do
         bsp <- loadPBS pbs
         Accounts.getAccountByCredId cid (bspAccounts bsp)
 
+doGetAccountByIndex :: (IsProtocolVersion pv, MonadBlobStore m) => PersistentBlockState pv -> AccountIndex -> m (Maybe (AccountIndex, PersistentAccount pv))
+doGetAccountByIndex pbs idx = do
+        bsp <- loadPBS pbs
+        fmap (idx, ) <$> Accounts.indexedAccount idx (bspAccounts bsp)
 
 doGetAccountIndex :: (IsProtocolVersion pv, MonadBlobStore m) => PersistentBlockState pv -> AccountAddress -> m (Maybe AccountIndex)
 doGetAccountIndex pbs addr = do
@@ -1276,6 +1280,7 @@ instance (IsProtocolVersion pv, PersistentState r m) => BlockStateQuery (Persist
     getAccount = doGetAccount . hpbsPointers
     accountExists = doGetAccountExists . hpbsPointers
     getAccountByCredId = doGetAccountByCredId . hpbsPointers
+    getAccountByIndex = doGetAccountByIndex . hpbsPointers
     getContractInstance = doGetInstance . hpbsPointers
     getModuleList = doGetModuleList . hpbsPointers
     getAccountList = doAccountList . hpbsPointers

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -472,9 +472,9 @@ getAccountInfo blockHash acct =
             ( \bp -> do
                 bs <- blockState bp
                 macc <- case acct of 
-                                AA addr -> BS.getAccount bs addr
-                                AI idx -> BS.getAccountByIndex bs idx
-                                CID crid -> BS.getAccountByCredId bs crid
+                                AccAddress addr -> BS.getAccount bs addr
+                                AccIndex idx -> BS.getAccountByIndex bs idx
+                                CredRegID crid -> BS.getAccountByCredId bs crid
                 forM macc $ \(aiAccountIndex, acc) -> do
                     aiAccountNonce <- BS.getAccountNonce acc
                     aiAccountAmount <- BS.getAccountAmount acc

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -459,19 +459,21 @@ getModuleList :: BlockHash -> MVR gsconf finconf (Maybe [ModuleRef])
 getModuleList = liftSkovQueryBlock $ BS.getModuleList <=< blockState
 
 -- |Get the details of an account in the block state.
--- The account can be given either via an address, or via a credential registration id.
+-- The account can be given via an address, an account index or a credential registration id.
 -- In the latter case we lookup the account the credential is associated with, even if it was
 -- removed from the account.
 getAccountInfo ::
     BlockHash ->
-    Either CredentialRegistrationID AccountAddress ->
+    AccountIdentifier ->
     MVR gsconf finconf (Maybe AccountInfo)
 getAccountInfo blockHash acct =
     join
         <$> liftSkovQueryBlock
             ( \bp -> do
                 bs <- blockState bp
-                macc <- either (BS.getAccountByCredId bs) (BS.getAccount bs) acct
+                macc <- case acct of AA addr -> BS.getAccount bs addr
+                                     AI idx -> BS.getAccountByIndex bs idx
+                                     CID crid -> BS.getAccountByCredId bs crid
                 forM macc $ \(aiAccountIndex, acc) -> do
                     aiAccountNonce <- BS.getAccountNonce acc
                     aiAccountAmount <- BS.getAccountAmount acc

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -471,9 +471,10 @@ getAccountInfo blockHash acct =
         <$> liftSkovQueryBlock
             ( \bp -> do
                 bs <- blockState bp
-                macc <- case acct of AA addr -> BS.getAccount bs addr
-                                     AI idx -> BS.getAccountByIndex bs idx
-                                     CID crid -> BS.getAccountByCredId bs crid
+                macc <- case acct of 
+                                AA addr -> BS.getAccount bs addr
+                                AI idx -> BS.getAccountByIndex bs idx
+                                CID crid -> BS.getAccountByCredId bs crid
                 forM macc $ \(aiAccountIndex, acc) -> do
                     aiAccountNonce <- BS.getAccountNonce acc
                     aiAccountAmount <- BS.getAccountAmount acc


### PR DESCRIPTION

## Purpose

Adds the option of querying AccountInfo by using account index value.

## Changes

Modified the functions to query the account info such that they can also use account index as input.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
