### PR TITLE
Fixes #162: Remove the need to enter a name, when a node is not going…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@
 - Fix issue #244: Collector to keep querying. Remove the parameter for maximum allowed
   times a gRPC call can fail and keeps `node-collector` querying forever.
 - `GetAccountInfo` endpoint supports querying the account via the account index.
-- Mac installer: Users now can leave one of the (but not both) net configurations empty
-  when they don't want to configure e node for it.
+- Mac installer: Users now can leave one (but not both) of the net configurations empty
+  when they don't want to configure a node for it. On the initial installation, leaving a net configuration empty means that the start/stop app shortcuts and the application support folder for that net won't be installed.
 
 ## concordium-node 3.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 - Fix issue #244: Collector to keep querying. Remove the parameter for maximum allowed
   times a gRPC call can fail and keeps `node-collector` querying forever.
 - `GetAccountInfo` endpoint supports querying the account via the account index.
+- Mac installer: Users now can leave one of the (but not both) net configurations empty
+  when they don't want to configure e node for it.
 
 ## concordium-node 3.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,9 @@
   times a gRPC call can fail and keeps `node-collector` querying forever.
 - `GetAccountInfo` endpoint supports querying the account via the account index.
 - Mac installer: Users now can leave one (but not both) of the net configurations empty
-  when they don't want to configure a node for it. On the initial installation, leaving a net configuration empty means that the start/stop app shortcuts and the application support folder for that net won't be installed.
+  when they don't want to configure a node for it. 
+  - On the initial installation, leaving a net configuration empty means that
+    the start/stop app shortcuts and the application support folder for that net won't be installed.
 
 ## concordium-node 3.0.1
 

--- a/scripts/distribution/macOS-package/NodeConfigurationInstallerPlugin/NodeConfigurationInstallerPlugin/Base.lproj/MyInstallerPane.xib
+++ b/scripts/distribution/macOS-package/NodeConfigurationInstallerPlugin/NodeConfigurationInstallerPlugin/Base.lproj/MyInstallerPane.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19142.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19142.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -58,6 +58,9 @@
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="cellTitle"/>
                                         </buttonCell>
+                                        <connections>
+                                            <action selector="onChangeInMainnetOptions:" target="Qsn-FY-4qK" id="aMc-ix-wus"/>
+                                        </connections>
                                     </button>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="LQe-C5-BaQ">
                                         <rect key="frame" x="-2" y="103" width="156" height="30"/>
@@ -67,6 +70,9 @@
 installation is complete</string>
                                             <font key="font" metaFont="cellTitle"/>
                                         </buttonCell>
+                                        <connections>
+                                            <action selector="onChangeInMainnetOptions:" target="Qsn-FY-4qK" id="Fwa-BZ-AxI"/>
+                                        </connections>
                                     </button>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eb0-B9-ujV">
                                         <rect key="frame" x="-2" y="55" width="153" height="30"/>
@@ -76,6 +82,9 @@ installation is complete</string>
 dashboard</string>
                                             <font key="font" metaFont="cellTitle"/>
                                         </buttonCell>
+                                        <connections>
+                                            <action selector="onChangeInMainnetOptions:" target="Qsn-FY-4qK" id="O1d-e8-mkV"/>
+                                        </connections>
                                     </button>
                                     <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="1" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" ambiguous="YES" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="iBl-6w-lGX">
                                         <rect key="frame" x="0.0" y="0.0" width="173" height="37"/>
@@ -139,6 +148,9 @@ dashboard</string>
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="cellTitle"/>
                                         </buttonCell>
+                                        <connections>
+                                            <action selector="onChangeInTestnetOptions:" target="Qsn-FY-4qK" id="ryM-o2-VYh"/>
+                                        </connections>
                                     </button>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hFo-wT-utD">
                                         <rect key="frame" x="-2" y="103" width="156" height="30"/>
@@ -148,6 +160,9 @@ dashboard</string>
 installation is complete</string>
                                             <font key="font" metaFont="cellTitle"/>
                                         </buttonCell>
+                                        <connections>
+                                            <action selector="onChangeInTestnetOptions:" target="Qsn-FY-4qK" id="qWG-rd-DrH"/>
+                                        </connections>
                                     </button>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="E6D-gA-wdc">
                                         <rect key="frame" x="-2" y="55" width="153" height="30"/>
@@ -157,6 +172,9 @@ installation is complete</string>
 dashboard</string>
                                             <font key="font" metaFont="cellTitle"/>
                                         </buttonCell>
+                                        <connections>
+                                            <action selector="onChangeInTestnetOptions:" target="Qsn-FY-4qK" id="KgP-zL-cll"/>
+                                        </connections>
                                     </button>
                                     <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="1" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" ambiguous="YES" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8yU-7r-OGL">
                                         <rect key="frame" x="0.0" y="0.0" width="173" height="37"/>

--- a/scripts/distribution/macOS-package/NodeConfigurationInstallerPlugin/NodeConfigurationInstallerPlugin/MyInstallerPane.h
+++ b/scripts/distribution/macOS-package/NodeConfigurationInstallerPlugin/NodeConfigurationInstallerPlugin/MyInstallerPane.h
@@ -21,4 +21,8 @@
 @property IBOutlet NSTextField *oTestnetNodeNameDescriptor;
 @property IBOutlet NSTextField *oTestnetNodeName;
 
+// Event handlers
+- (IBAction)onChangeInMainnetOptions:(id)sender;
+- (IBAction)onChangeInTestnetOptions:(id)sender;
+
 @end

--- a/scripts/distribution/macOS-package/NodeConfigurationInstallerPlugin/NodeConfigurationInstallerPlugin/MyInstallerPane.m
+++ b/scripts/distribution/macOS-package/NodeConfigurationInstallerPlugin/NodeConfigurationInstallerPlugin/MyInstallerPane.m
@@ -202,10 +202,14 @@
 // Handles the changes in the Mainnet options
 - (IBAction)onChangeInMainnetOptions:(id)sender {
     [self enableOrDisableMainnetNodeNameField];
+    // Disable 'Continue' button if both net configurations are empty.
+    [self setNextEnabled:(self.oMainnetNodeName.isEnabled || self.oTestnetNodeName.isEnabled)];
 }
 
 // Handles the changes in the Testnet options
 - (IBAction)onChangeInTestnetOptions:(id)sender {
     [self enableOrDisableTestnetNodeNameField];
+    // Disable 'Continue' button if both net configurations are empty.
+    [self setNextEnabled:(self.oMainnetNodeName.isEnabled || self.oTestnetNodeName.isEnabled)];
 }
 @end

--- a/scripts/distribution/macOS-package/NodeConfigurationInstallerPlugin/NodeConfigurationInstallerPlugin/MyInstallerPane.m
+++ b/scripts/distribution/macOS-package/NodeConfigurationInstallerPlugin/NodeConfigurationInstallerPlugin/MyInstallerPane.m
@@ -148,7 +148,7 @@
 // - cannot start or end with spaces
 - (BOOL) nodeNameIsValid:(NSTextField*)nodeNameField
 {
-    // If the node name field is disabled no  need to check the name validity
+    // If the node name field is disabled there's no need to check the name validity.
     if (!nodeNameField.isEnabled) {
         return TRUE;
     }

--- a/scripts/distribution/macOS-package/template/scripts/postinstall
+++ b/scripts/distribution/macOS-package/template/scripts/postinstall
@@ -82,35 +82,52 @@ function configureService() {
     fi
 }
 
-function configureServices () {
+# Uninstalls apps and support files related to a net.
+function uninstallNet() {
+    local netName=${1:?"Missing net name to uninstall"}
+    echo "-- Removing $netName node apps and support files"
+    rm -rf "/Applications/Concordium Node/Concordium Node Start $netName.app"
+    rm -rf "/Applications/Concordium Node/Concordium Node Stop $netName.app"
+    rm -rf "/Library/Application Support/Concordium Node/$netName/"
+}
+
+function configureServices() {
 
     # Use data from install configuration
     echo 'Configuring services'
     source "/tmp/software.concordium.node.install.config"
 
-    echo "-- Mainnet:"
-    configureService \
-        "MAINNET" \
-        "/tmp/Concordium Node/LaunchDaemons/software.concordium.mainnet.node.plist" \
-        "/tmp/Concordium Node/LaunchDaemons/software.concordium.mainnet.node-collector.plist" \
-        "/Library/Concordium Node/LaunchDaemons/software.concordium.mainnet.node.plist" \
-        "/Library/Concordium Node/LaunchDaemons/software.concordium.mainnet.node-collector.plist" \
-        "$CONCORDIUM_NODE_INSTALL_MAINNET_RUN_ON_STARTUP" \
-        "$CONCORDIUM_NODE_INSTALL_MAINNET_REPORT_TO_NETWORK_DASHBOARD" \
-        "$CONCORDIUM_NODE_INSTALL_MAINNET_RUN_AFTER_INSTALL" \
-        "$CONCORDIUM_NODE_INSTALL_MAINNET_NODE_NAME"
+    if [ -z "$CONCORDIUM_NODE_INSTALL_MAINNET_NODE_NAME" ]; then
+        uninstallNet "Mainnet"
+    else
+        echo "-- Mainnet:"
+        configureService \
+            "MAINNET" \
+            "/tmp/Concordium Node/LaunchDaemons/software.concordium.mainnet.node.plist" \
+            "/tmp/Concordium Node/LaunchDaemons/software.concordium.mainnet.node-collector.plist" \
+            "/Library/Concordium Node/LaunchDaemons/software.concordium.mainnet.node.plist" \
+            "/Library/Concordium Node/LaunchDaemons/software.concordium.mainnet.node-collector.plist" \
+            "$CONCORDIUM_NODE_INSTALL_MAINNET_RUN_ON_STARTUP" \
+            "$CONCORDIUM_NODE_INSTALL_MAINNET_REPORT_TO_NETWORK_DASHBOARD" \
+            "$CONCORDIUM_NODE_INSTALL_MAINNET_RUN_AFTER_INSTALL" \
+            "$CONCORDIUM_NODE_INSTALL_MAINNET_NODE_NAME"
+    fi
 
-    echo "-- Testnet:"
-    configureService \
-        "TESTNET" \
-        "/tmp/Concordium Node/LaunchDaemons/software.concordium.testnet.node.plist" \
-        "/tmp/Concordium Node/LaunchDaemons/software.concordium.testnet.node-collector.plist" \
-        "/Library/Concordium Node/LaunchDaemons/software.concordium.testnet.node.plist" \
-        "/Library/Concordium Node/LaunchDaemons/software.concordium.testnet.node-collector.plist" \
-        "$CONCORDIUM_NODE_INSTALL_TESTNET_RUN_ON_STARTUP" \
-        "$CONCORDIUM_NODE_INSTALL_TESTNET_REPORT_TO_NETWORK_DASHBOARD" \
-        "$CONCORDIUM_NODE_INSTALL_TESTNET_RUN_AFTER_INSTALL" \
-        "$CONCORDIUM_NODE_INSTALL_TESTNET_NODE_NAME"
+    if [ -z "$CONCORDIUM_NODE_INSTALL_TESTNET_NODE_NAME" ]; then
+        uninstallNet "Testnet"
+    else
+        echo "-- Testnet:"
+        configureService \
+            "TESTNET" \
+            "/tmp/Concordium Node/LaunchDaemons/software.concordium.testnet.node.plist" \
+            "/tmp/Concordium Node/LaunchDaemons/software.concordium.testnet.node-collector.plist" \
+            "/Library/Concordium Node/LaunchDaemons/software.concordium.testnet.node.plist" \
+            "/Library/Concordium Node/LaunchDaemons/software.concordium.testnet.node-collector.plist" \
+            "$CONCORDIUM_NODE_INSTALL_TESTNET_RUN_ON_STARTUP" \
+            "$CONCORDIUM_NODE_INSTALL_TESTNET_REPORT_TO_NETWORK_DASHBOARD" \
+            "$CONCORDIUM_NODE_INSTALL_TESTNET_RUN_AFTER_INSTALL" \
+            "$CONCORDIUM_NODE_INSTALL_TESTNET_NODE_NAME"
+    fi
 }
 
 function main (){


### PR DESCRIPTION
… to be run anyway.

This is a fix for the native mac node installer.

## Purpose

Remove the need to enter a name, when a node is not going to be run anyway.

## Changes

Changed the relevant checks in the installer.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
