### PR TITLE
Skip missed submissions in case the collector is delayed for some time.

### DIFF
--- a/concordium-node/src/bin/collector.rs
+++ b/concordium-node/src/bin/collector.rs
@@ -160,8 +160,8 @@ async fn main() {
     // in such a case, try to make up the missed ticks by submitting statistics as
     // quickly as possible.
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-    #[allow(unreachable_code)]
     loop {
+        interval.tick().await;
         for (node_name, grpc_host) in conf.node_names.iter().zip(conf.grpc_hosts.iter()) {
             trace!("Processing node {}/{}", node_name, grpc_host);
             match collect_data(node_name.clone(), grpc_host.to_owned(), &conf).await {
@@ -169,7 +169,16 @@ async fn main() {
                     trace!("Node data collected successfully from {}/{}", node_name, grpc_host);
                     match rmp_serde::encode::to_vec(&node_info) {
                         Ok(msgpack) => {
-                            let client = reqwest::Client::new();
+                            let client_builder = reqwest::Client::builder()
+                                .connect_timeout(Duration::from_millis(conf.collector_interval))
+                                .timeout(Duration::from_millis(conf.collector_interval));
+                            let client = match client_builder.build() {
+                                Ok(client) => client,
+                                Err(e) => {
+                                    error!("Error constructing a network client: {}", e);
+                                    continue;
+                                }
+                            };
                             match client.post(&conf.collector_url).body(msgpack).send().await {
                                 Ok(_) => trace!("Payload sent successfully to collector backend"),
                                 Err(e) => error!(
@@ -189,8 +198,6 @@ async fn main() {
                 }
             }
         }
-        trace!("Sleeping for {} ms", conf.collector_interval);
-        interval.tick().await;
     }
 }
 

--- a/concordium-node/src/bin/collector.rs
+++ b/concordium-node/src/bin/collector.rs
@@ -154,6 +154,12 @@ async fn main() {
     }
 
     let mut interval = tokio::time::interval(Duration::from_millis(conf.collector_interval));
+    // If for some reason we cannot submit the statistics for a given period, we
+    // skip it. This also handles cases such as when a computer goes to sleep. By
+    // default the behaviour is [MissedTickBehaviour::Burst] which would,
+    // in such a case, try to make up the missed ticks by submitting statistics as
+    // quickly as possible.
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     #[allow(unreachable_code)]
     loop {
         for (node_name, grpc_host) in conf.node_names.iter().zip(conf.grpc_hosts.iter()) {


### PR DESCRIPTION
## Purpose

In case the collector is suspended, or the computer goes to sleep, the current behaviour (before this commit) would be that the collector would query and submit in quick succession to make up for the lost time. This is undesirable and not useful.

## Changes

Skip any missed submissions.

In order to prevent indefinite hangs, also add a timeout to request submission.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.