### PR TITLE
Fix the genesis example script. The genesis tool has gdver, not the key generation one.

### DIFF
--- a/scripts/genesis/generate-test-genesis.py
+++ b/scripts/genesis/generate-test-genesis.py
@@ -208,8 +208,7 @@ def generate_update_keys():
                           "--add-anonymity-revoker", "3:37,38,39,40,41",
                           "--add-identity-provider", "3:42,43,44,45,46",
                           "--cooldown", "3:47,48,49,50,51",
-                          "--time", "3:52,53,54,55,56",
-                          "--gdver=6"
+                          "--time", "3:52,53,54,55,56"
                           )
     if res != 0:
         raise Exception(f"Could not generate update keys.")
@@ -252,6 +251,7 @@ def combine(foundation_account, extra = None):
                           f"--crypto-params={GLOBAL_FILE}",
                           f"--accounts={accounts}",
                           f"--update-keys={authorizations}",
+                          "--gdver=6",
                           "genesis-tmp.json",
                           out_genesis)
     if res != 0:


### PR DESCRIPTION
## Purpose

Fix the genesis generation script.

## Changes

Correct the placement of `gdver` parameter.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
