### PR TITLE
Return BakerRemoved event when baker is removed.

### DIFF
--- a/concordium-consensus/src/Concordium/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler.hs
@@ -1570,11 +1570,11 @@ handleConfigureBaker
               else return (TxReject InvalidProof, energyCost, usedEnergy)
         kResult energyCost usedEnergy BI.BakerConfigureUpdate{} (BI.BCSuccess changes bid) = do
             let events = changes <&> \case
-                  BI.BakerConfigureStakeIncreased newStake
+                  BI.BakerConfigureStakeIncreased newStake ->
+                    BakerStakeIncreased bid senderAddress newStake
+                  BI.BakerConfigureStakeReduced newStake
                     | newStake == 0 -> BakerRemoved bid senderAddress
-                    | otherwise -> BakerStakeIncreased bid senderAddress newStake
-                  BI.BakerConfigureStakeReduced newStake ->
-                    BakerStakeDecreased bid senderAddress newStake
+                    | otherwise -> BakerStakeDecreased bid senderAddress newStake
                   BI.BakerConfigureRestakeEarnings newRestakeEarnings ->
                      BakerSetRestakeEarnings bid senderAddress newRestakeEarnings
                   BI.BakerConfigureOpenForDelegation newOpenStatus ->


### PR DESCRIPTION
## Purpose

A minor bug was found where if a baker was removed (in P4), the `BakerStakeDecreased` was returned instead of the `BakerRemoved` event. 

## Changes

* The above bug has been fixed.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

