### PR TITLE
Tweak `in_baking_committee` to work around issue #261

### DIFF
--- a/concordium-node/src/consensus_ffi/helpers.rs
+++ b/concordium-node/src/consensus_ffi/helpers.rs
@@ -360,10 +360,10 @@ impl TryFrom<i64> for ConsensusFfiResponse {
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum ConsensusIsInBakingCommitteeResponse {
+    ActiveInCommittee,
     NotInCommittee,
     AddedButNotActiveInCommittee,
     AddedButWrongKeys,
-    ActiveInCommittee,
 }
 
 impl TryFrom<u8> for ConsensusIsInBakingCommitteeResponse {

--- a/concordium-node/src/rpc.rs
+++ b/concordium-node/src/rpc.rs
@@ -435,8 +435,13 @@ impl P2p for RpcServerImpl {
             SystemTime::now().duration_since(UNIX_EPOCH).expect("Time went backwards").as_secs();
         Ok(Response::new(match self.consensus {
             Some(ref consensus) => {
-                let (consensus_baking_committee_status, consensus_baker_id) =
+                let (consensus_baking_committee_status, has_baker_id, pre_baker_id) =
                     consensus.in_baking_committee();
+                let consensus_baker_id = if has_baker_id {
+                    Some(pre_baker_id)
+                } else {
+                    None
+                };
                 let consensus_running = consensus.is_consensus_running();
                 let consensus_baker_running = consensus_running && consensus.is_baking();
 


### PR DESCRIPTION
## Purpose

Fix #261.

## Changes

Change the return type of `in_baking_committee` to work around the fact that on Windows the `node_info` endpoint reports  baker ID being 0 (if there is a baker), even when it should be something else.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
