### PR TITLE
Docker: Migrate images to Docker Hub

### DIFF
--- a/jenkinsfiles/master.Jenkinsfile
+++ b/jenkinsfiles/master.Jenkinsfile
@@ -2,14 +2,18 @@
 pipeline {
     agent any
     environment {
-        ecr_repo_domain = '192549843005.dkr.ecr.eu-west-1.amazonaws.com'
         universal_image_repo = 'concordium/universal'
         universal_image_name = "${universal_image_repo}:${image_tag}"
     }
     stages {
-        stage('ecr-login') {
+        stage('dockerhub-login') {
+            environment {
+                // Defines 'CRED_USR' and 'CRED_PSW'
+                // (see 'https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#handling-credentials').
+                CRED = credentials('jenkins-dockerhub')
+            }
             steps {
-                ecrLogin(env.ecr_repo_domain, 'eu-west-1')
+                sh 'docker login --username "${CRED_USR}" --password "${CRED_PSW}"'
             }
         }
         stage('build-universal') {
@@ -32,7 +36,7 @@ pipeline {
         }
         stage('build-bootstrapper') {
             environment {
-                image_repo = "${ecr_repo_domain}/concordium/bootstrapper"
+                image_repo = "concordium/bootstrapper"
                 image_name = "${image_repo}:${image_tag}"
             }
             steps {
@@ -49,7 +53,7 @@ pipeline {
         }
         stage('build-node') {
             environment {
-                image_repo = "${ecr_repo_domain}/concordium/node"
+                image_repo = "concordium/node"
                 image_name = "${image_repo}:${image_tag}"
             }
             steps {
@@ -66,7 +70,7 @@ pipeline {
         }
         stage('build-collector') {
             environment {
-                image_repo = "${ecr_repo_domain}/concordium/node-collector"
+                image_repo = "concordium/node-collector"
                 image_name = "${image_repo}:${image_tag}"
             }
             steps {

--- a/scripts/docker/README.md
+++ b/scripts/docker/README.md
@@ -18,7 +18,7 @@ The node-related binaries are built by the pipeline `master.Jenkinsfile` in the 
 
 ## Docker Compose
 
-The following example shows a (reasonably) minimal setup of a node and an accompanying collector:
+The following example shows a (reasonably) minimal configuration of a node and an accompanying collector:
 
 ```yaml
 version: '3'
@@ -62,14 +62,14 @@ networks:
   concordium:
 ```
 
-Run the script using `docker-compose`; for example:
+Run the deployment using `docker-compose`; for example:
 
 ```shell
 export NODE_NAME="<name>"
-export NODE_IMAGE="192549843005.dkr.ecr.eu-west-1.amazonaws.com/concordium/node:<tag>"
-export NODE_COLLECTOR_IMAGE="192549843005.dkr.ecr.eu-west-1.amazonaws.com/concordium/node-collector:<tag>"
+export NODE_IMAGE="concordium/node:<tag>"
+export NODE_COLLECTOR_IMAGE="concordium/node-collector:<tag>"
 export DOMAIN=mainnet.concordium.software # alternative values: 'stagenet.concordium.com', 'testnet.concordium.com'
-export GENESIS_DATA_FILE="/path/to/genesis.dat"
-export BAKER_CREDENTIALS_FILE="/path/to/baker-credentials.json"
+export GENESIS_DATA_FILE="/absolute/path/to/genesis.dat"
+export BAKER_CREDENTIALS_FILE="/absolute/path/to/baker-credentials.json"
 docker-compose up
 ```


### PR DESCRIPTION
## Purpose

Make Docker images of node, collector, and bootstrapper publicly available.

## Changes

Migrate images to Docker Hub.