### PR TITLE
Fix setExecutable error on macOS (Monterey +)

### DIFF
--- a/scripts/distribution/macOS-package/build.sh
+++ b/scripts/distribution/macOS-package/build.sh
@@ -264,7 +264,7 @@ function signBinaries() {
     # Find and sign all the binaries and dylibs.
     find "$payloadDir/Library" \
         -type f \
-        -execdir sudo codesign -f --options runtime -s "$developerIdApplication" {} \;
+        -execdir sudo codesign -f --entitlement "$buildDir/entitlements.plist" --options runtime -s "$developerIdApplication" {} \;
 
     # Sign the installer plugin.
     sudo codesign -f --options runtime -s "$developerIdApplication" \

--- a/scripts/distribution/macOS-package/template/entitlements.plist
+++ b/scripts/distribution/macOS-package/template/entitlements.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- This entitlement should be removed once
+         https://gitlab.haskell.org/ghc/ghc/-/issues/18376 is fixed. -->
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Purpose

Closes #301 

With #243, we pass a closure for accessing the blobstore across FFI. On macOS Monterey (and *very likely* future versions of macOS) this causes the signed node to be unable to run (see #301). This is because of an issue in GHC: https://gitlab.haskell.org/ghc/ghc/-/issues/18376.

This fix is a workaround, that slacks the restrictions on the sandbox that signed macOS apps are put into.

## Changes

- Adds an entitlements file which [allows unsigned executable memory](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_cs_allow-unsigned-executable-memory) (should be removed once the GHC issue is fixed)

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.