### PR TITLE
Make mac build script more robust

### DIFF
--- a/scripts/distribution/macOS-package/build.sh
+++ b/scripts/distribution/macOS-package/build.sh
@@ -2,13 +2,12 @@
 set -euo pipefail
 
 readonly version=${1:?"Please provide a version number (e.g. '1.0.2')"}
-readonly year="2021" # Used for copyright notices.
+year="$(date +"%Y")" # Used for copyright notices.
+readonly year
 
 readonly teamId="K762RM4LQ3"
 readonly developerIdApplication="Developer ID Application: Concordium Software Aps ($teamId)"
 readonly developerIdInstaller="Developer ID Installer: Concordium Software Aps ($teamId)"
-
-readonly ghcVariant="x86_64-osx-ghc-8.10.4"
 
 # Get the location of this script.
 macPackageDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
@@ -24,8 +23,13 @@ readonly buildDir="$macPackageDir/build"
 readonly payloadDir="$buildDir/payload"
 
 readonly pkgFile="$buildDir/packages/concordium-node.pkg"
-readonly productFile="$buildDir/packages/concordium-node-$version.pkg"
-readonly signedProductFile="$buildDir/packages/concordium-node-$version-signed.pkg"
+readonly productFile="$buildDir/packages/concordium-node-$version-unsigned.pkg"
+readonly signedProductFile="$buildDir/packages/concordium-node-$version.pkg"
+
+ghcVersion="$(stack --stack-yaml "$consensusDir/stack.yaml" ghc -- --version | cut -d' ' -f8)" # Get the GHC version used in Consensus.
+readonly ghcVersion
+
+readonly ghcVariant="x86_64-osx-ghc-$ghcVersion"
 
 # Log info in green color.
 logInfo () {
@@ -37,6 +41,7 @@ logInfo () {
 function printVersions() {
     logInfo "Printing versions:"
     echo "stack version: $(stack --version)"
+    echo "stack GHC version: $ghcVersion"
     echo "cargo version: $(cargo --version)"
     echo "flatc version: $(flatc --version)"
     echo "protoc version: $(protoc --version)"


### PR DESCRIPTION
## Purpose

Make a number of small improvements to the mac build script. Improves robustness and reduces the risk of errors.

## Changes

- Automatically get the current year (used for copyright notices)
- Automatically get the GHC version used in consensus (used when linking)
  - This avoids issues with linking against old builds when changing the GHC version in consensus
- Print the GHC version
- Rename pkg files
  - The signed pkg we distribute does not have a `-signed` suffix, so, previously, we manually removed it.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.