### PR TITLE
Fix crash when active finalizer is not a baker

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/LFMBTree.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/LFMBTree.hs
@@ -54,7 +54,6 @@ import qualified Concordium.Crypto.SHA256 as H
 import Concordium.Types.HashableTo
 import Data.Bits
 import Data.Foldable (foldl', toList)
-import Data.Serialize
 import Data.Word
 import Prelude hiding (lookup)
 import Control.Monad (join)

--- a/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
@@ -1006,10 +1006,12 @@ class (BlockStateQuery m) => BlockStateOperations m where
   -- as 'bsoRotateCurrentCapitalDistribution' resets the rewards to bakers.
   bsoUpdateAccruedTransactionFeesBaker :: AccountVersionFor (MPV m) ~ 'AccountV1 => UpdatableBlockState m -> BakerId -> AmountDelta -> m (UpdatableBlockState m)
 
-  -- |Mark that the given baker has signed a finalization proof included in a block during the
-  -- reward period. It is a precondition that the given baker is a current-epoch baker.
+  -- |Mark that the given bakers have signed a finalization proof included in a block during the
+  -- reward period. Any baker ids that are not current-epoch bakers will be ignored.
+  -- (This is significant, as the finalization record in a block may be signed by a finalizer that
+  -- has since been removed as a baker.)
   -- Note, the finalization-awake status is reset by 'bsoRotateCurrentCapitalDistribution'.
-  bsoMarkFinalizationAwakeBaker :: AccountVersionFor (MPV m) ~ 'AccountV1 => UpdatableBlockState m -> BakerId -> m (UpdatableBlockState m)
+  bsoMarkFinalizationAwakeBakers :: AccountVersionFor (MPV m) ~ 'AccountV1 => UpdatableBlockState m -> [BakerId] -> m (UpdatableBlockState m)
 
   -- |Update the transaction fee rewards accrued to be distributed to the passive delegators.
   -- Note, unlike 'bsoUpdateAccruedTransactionFeesBaker', this is __not__ reset by
@@ -1352,7 +1354,7 @@ instance (Monad (t m), MonadTrans t, BlockStateOperations m) => BlockStateOperat
   bsoSetPaydayEpoch s e = lift $ bsoSetPaydayEpoch s e
   bsoSetPaydayMintRate s r = lift $ bsoSetPaydayMintRate s r
   bsoUpdateAccruedTransactionFeesBaker s bid f = lift $ bsoUpdateAccruedTransactionFeesBaker s bid f
-  bsoMarkFinalizationAwakeBaker s bid = lift $ bsoMarkFinalizationAwakeBaker s bid
+  bsoMarkFinalizationAwakeBakers s bids = lift $ bsoMarkFinalizationAwakeBakers s bids
   bsoUpdateAccruedTransactionFeesPassive s f = lift $ bsoUpdateAccruedTransactionFeesPassive s f
   bsoGetAccruedTransactionFeesPassive = lift . bsoGetAccruedTransactionFeesPassive
   bsoUpdateAccruedTransactionFeesFoundationAccount s f = lift $ bsoUpdateAccruedTransactionFeesFoundationAccount s f

--- a/concordium-consensus/src/Concordium/GlobalState/Paired.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Paired.hs
@@ -725,9 +725,9 @@ instance (MonadLogger m, C.HasGlobalStateContext (PairGSContext lc rc) r, BlockS
         bs1' <- coerceBSML $ bsoUpdateAccruedTransactionFeesBaker bs1 bid f
         bs2' <- coerceBSMR $ bsoUpdateAccruedTransactionFeesBaker bs2 bid f
         return (bs1', bs2')
-    bsoMarkFinalizationAwakeBaker (bs1, bs2) bid = do
-        bs1' <- coerceBSML $ bsoMarkFinalizationAwakeBaker bs1 bid
-        bs2' <- coerceBSMR $ bsoMarkFinalizationAwakeBaker bs2 bid
+    bsoMarkFinalizationAwakeBakers (bs1, bs2) bids = do
+        bs1' <- coerceBSML $ bsoMarkFinalizationAwakeBakers bs1 bids
+        bs2' <- coerceBSMR $ bsoMarkFinalizationAwakeBakers bs2 bids
         return (bs1', bs2')
     bsoUpdateAccruedTransactionFeesPassive (bs1, bs2) f = do
         bs1' <- coerceBSML $ bsoUpdateAccruedTransactionFeesPassive bs1 f

--- a/concordium-consensus/src/Concordium/GlobalState/Rewards.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Rewards.hs
@@ -109,6 +109,7 @@ data BlockRewardDetailsHash (av :: AccountVersion) where
     BlockRewardDetailsHashV1 :: !PoolRewardsHash -> BlockRewardDetailsHash 'AccountV1
 
 deriving instance Show (BlockRewardDetailsHash av)
+deriving instance Eq (BlockRewardDetailsHash av)
 
 -- |SHA256 hash of 'BlockRewardDetailsHash'.
 brdHash :: BlockRewardDetailsHash av -> H.Hash

--- a/concordium-consensus/src/Concordium/Scheduler/TreeStateEnvironment.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/TreeStateEnvironment.hs
@@ -835,7 +835,7 @@ addAwakeFinalizers
     -> m (UpdatableBlockState m)
 addAwakeFinalizers Nothing bs = return bs
 addAwakeFinalizers (Just FinalizerInfo{..}) bs0 =
-    foldM bsoMarkFinalizationAwakeBaker bs0 committeeSigners
+    bsoMarkFinalizationAwakeBakers bs0 committeeSigners
 
 -- |Parameters used by 'mintAndReward' that are determined by 'updateBirkParameters'.
 -- 'updateBirkParameters' determines these, since it makes state changes that would make them

--- a/concordium-consensus/tests/scheduler/GlobalStateMock.hs
+++ b/concordium-consensus/tests/scheduler/GlobalStateMock.hs
@@ -181,7 +181,7 @@ data BlockStateOperationsAction pv a where
     BsoRewardAccount :: MockUpdatableBlockState -> AccountIndex -> Amount -> BlockStateOperationsAction pv (Maybe AccountAddress, MockUpdatableBlockState)
     BsoGetBakerPoolRewardDetails :: AccountVersionFor pv ~ 'AccountV1 => MockUpdatableBlockState -> BlockStateOperationsAction pv (Map.Map BakerId BakerPoolRewardDetails)
     BsoUpdateAccruedTransactionFeesBaker :: AccountVersionFor pv ~ 'AccountV1 => MockUpdatableBlockState -> BakerId -> AmountDelta -> BlockStateOperationsAction pv MockUpdatableBlockState
-    BsoMarkFinalizationAwakeBaker :: AccountVersionFor pv ~ 'AccountV1 => MockUpdatableBlockState -> BakerId -> BlockStateOperationsAction pv MockUpdatableBlockState
+    BsoMarkFinalizationAwakeBakers :: AccountVersionFor pv ~ 'AccountV1 => MockUpdatableBlockState -> [BakerId] -> BlockStateOperationsAction pv MockUpdatableBlockState
     BsoUpdateAccruedTransactionFeesPassive :: AccountVersionFor pv ~ 'AccountV1 => MockUpdatableBlockState -> AmountDelta -> BlockStateOperationsAction pv MockUpdatableBlockState
     BsoGetAccruedTransactionFeesPassive :: AccountVersionFor pv ~ 'AccountV1 => MockUpdatableBlockState -> BlockStateOperationsAction pv Amount
     BsoUpdateAccruedTransactionFeesFoundationAccount :: AccountVersionFor pv ~ 'AccountV1 => MockUpdatableBlockState -> AmountDelta -> BlockStateOperationsAction pv MockUpdatableBlockState


### PR DESCRIPTION
## Purpose
Fix a crash bug when a finalizer that signs a finalization record is no longer a baker, and so cannot be marked as awake.

Closes #308 

## Changes

- The previous `bsoMarkFinalizationAwakeBaker` (which only tolerates marking current-epoch bakers as finalization-awake) is replaced with `bsoMarkFinalizationAwakeBakers` (which ignores any baker ids that are no longer considered bakers in the current epoch).
- `bsoMarkFinalizationAwakeBakers` is refined 

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
