### PR TITLE
Fix regression in transaction verification logic.

### DIFF
--- a/concordium-consensus/src/Concordium/TransactionVerification.hs
+++ b/concordium-consensus/src/Concordium/TransactionVerification.hs
@@ -273,7 +273,7 @@ verifyNormalTransaction meta =
     unless (Tx.transactionGasAmount meta >= cost) $ throwError $ NotOk NormalTransactionDepositInsufficient
     -- Check that the required energy does not exceed the maximum allowed for a block
     maxEnergy <- lift getMaxBlockEnergy
-    unless (maxEnergy > Tx.transactionGasAmount meta) $ throwError $ NotOk NormalTransactionEnergyExceeded
+    when (Tx.transactionGasAmount meta > maxEnergy) $ throwError $ NotOk NormalTransactionEnergyExceeded
     -- Check that the sender account exists
     let addr = Tx.transactionSender meta
     macc <- lift (getAccount addr)


### PR DESCRIPTION
## Purpose

Transactions which were previously (in node version 3.*) accepted were now rejected. Specifically
transactions that allow for maxBlockEnergy amount of energy to be used should be
allowed since they were allowed by previous protocol and node versions.

Fixes #318

## Changes

- Correct the check for maximum block energy.
- Add regression test.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.