### PR TITLE
Add option to generate an extra CCD drop account to the genesis script.

### DIFF
--- a/scripts/genesis/README.md
+++ b/scripts/genesis/README.md
@@ -24,6 +24,9 @@ Expected env vars:
 Supported env vars:
 * `EXTRA_ACCOUNTS_TEMPLATE`, `NUM_EXTRA_ACCOUNTS`, `EXTRA_ACCOUNTS_BALANCE`:
   The naming to use for extra accounts (this enables them being generated), how many to create, and with what balance.
+* `DROP_ACCOUNT_BALANCE` will, if set to a CCD amount, generate another extra account in the
+  folder `drop`. Note that if you set this and `EXTRA_ACCOUNTS_TEMPLATE` then
+  the latter is different from `drop`.
 * See the source code of the script for more.
 
 ### Example build command


### PR DESCRIPTION
## Purpose

Add option to generate an extra CCD drop account to the genesis script.

Use as, e.g.,  
```
DROP_ACCOUNT_BALANCE=3000000.0 USE_DOCKER= PURGE= NUM_BAKERS=1 ./generate-test-genesis.py
```

## Changes

- Add handling of a new environment variable to the script.
- Update documentation.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

