### PR TITLE
Fix issues from Paired state

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
@@ -1122,7 +1122,7 @@ class (BlockStateQuery m) => BlockStateOperations m where
   bsoGetEpochBlocksBaked :: UpdatableBlockState m -> m (Word64, [(BakerId, Word64)])
 
   -- |Record that the given baker has baked a block in the current epoch. It is a precondition that
-  -- the given baker is active.
+  -- the given baker is a current-epoch baker.
   bsoNotifyBlockBaked :: UpdatableBlockState m -> BakerId -> m (UpdatableBlockState m)
 
   -- |Clear the tracking of baked blocks in the current epoch.

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -2660,8 +2660,8 @@ instance (MonadIO m, PersistentState r m) => ContractStateOperations (Persistent
   thawContractState (Instances.InstanceStateV1 inst) = liftIO . flip StateV1.thaw inst . fst =<< getCallbacks
   stateSizeV0 (Instances.InstanceStateV0 inst) = return (Wasm.contractStateSize inst)
   getV1StateContext = asks blobLoadCallback
-  contractStateToByteString (Instances.InstanceStateV0 st) = return (Wasm.contractState st)
-  contractStateToByteString (Instances.InstanceStateV1 st) = StateV1.toByteString st
+  contractStateToByteString (Instances.InstanceStateV0 st) = return (encode st)
+  contractStateToByteString (Instances.InstanceStateV1 st) = runPut . putByteStringLen <$> StateV1.toByteString st
   {-# INLINE thawContractState #-}
   {-# INLINE stateSizeV0 #-}
   {-# INLINE getV1StateContext #-}


### PR DESCRIPTION


## Purpose

Fix issues arising from testing the persistent and in-memory state against each other with the paired state.

Closes #331

## Changes

Fixes:
- Basic: pending change is not cleared on delegators reducing stake
- Basic: passive delegation does not add to the total staked capital
- Basic & Persistent: V0 contract state should be encoded in `contractStateToByteString`
- Persistent: V1 contract state should be encoded with its length in `contractStateToByteString`

Revise assertion handling in Paired.hs to give more useful information on failures.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
