### PR TITLE
Include final P4 update hash. Bump version to 4.0.11.

### DIFF
--- a/concordium-consensus/src/Concordium/ProtocolUpdate/P3/ProtocolP4.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/P3/ProtocolP4.hs
@@ -77,7 +77,7 @@ import Concordium.Kontrol
 -- |The hash that identifies a update from P3 to P4 protocol.
 -- This is the hash of the published specification document.
 updateHash :: SHA256.Hash
-updateHash = read "0000000000000000000000000000000000000000000000000000000000000000"
+updateHash = read "20c6f246713e573fb5bfdf1e59c0a6f1a37cded34ff68fda4a60aa2ed9b151aa"
 
 -- |Construct the genesis data for a P3.ProtocolP4 update.
 -- It is assumed that the last finalized block is the terminal block of the old chain:

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_node"
-version = "4.0.10"
+version = "4.0.11"
 dependencies = [
  "anyhow",
  "app_dirs2",

--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium_node"
-version = "4.0.10" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
+version = "4.0.11" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
 description = "Concordium Node"
 authors = ["Concordium <developers@concordium.com>"]
 exclude = [".gitignore", ".gitlab-ci.yml", "test/**/*","**/**/.gitignore","**/**/.gitlab-ci.yml"]

--- a/service/windows/installer/Node.wxs
+++ b/service/windows/installer/Node.wxs
@@ -2,9 +2,9 @@
 <!-- When updating the product version, the Product Id should be refreshed, otherwise it will not be
     possible to upgrade an existing installation.
 -->
-<?define VersionNumber="4.0.10" ?>
+<?define VersionNumber="4.0.11" ?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:Util="http://schemas.microsoft.com/wix/UtilExtension">
-    <Product Name="Concordium Node" Manufacturer="Concordium Software" Id="412f2714-b700-41e9-b0b5-9ea6ca7daad2" UpgradeCode="297295b4-c716-4d33-8170-0f6136663bfd" Language="1033" Codepage="1252" Version="$(var.VersionNumber)">
+    <Product Name="Concordium Node" Manufacturer="Concordium Software" Id="530d8d8a-417a-4caa-aeb1-b7088d69d973" UpgradeCode="297295b4-c716-4d33-8170-0f6136663bfd" Language="1033" Codepage="1252" Version="$(var.VersionNumber)">
         <Package Id="*" Keywords="Concordium Installer" Description="Concordium Node $(var.VersionNumber) Installer" Manufacturer="Concordium Software" InstallerVersion="500" Languages="1033" Compressed="yes" InstallScope="perMachine" />
         <MajorUpgrade Schedule="afterInstallValidate" DowngradeErrorMessage="The currently-installed version of [ProductName] is newer than the version you are trying to install. The installation cannot continue. If you wish to install this version, please remove the newer version first." />
         <Media Id="1" Cabinet="Node.cab" EmbedCab="yes" />


### PR DESCRIPTION
## Purpose

Include the correct specification hash, see https://github.com/Concordium/concordium-update-proposals

Bump version to 4.0.11