### PR TITLE
Reuse verification results 

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/TreeState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/TreeState.hs
@@ -71,7 +71,7 @@ type Branches m = Seq.Seq [BlockPointerType m]
 -- |Result of trying to add a transaction to the transaction table.
 data AddTransactionResult =
   -- |Transaction is a duplicate of the given transaction.
-  Duplicate !BlockItem |
+  Duplicate !BlockItem (Maybe TVer.VerificationResult) |
   -- |The transaction was newly added.
   Added !BlockItem !TVer.VerificationResult |
   -- |The nonce of the transaction is not later than the last finalized transaction for the sender.

--- a/concordium-consensus/src/Concordium/Skov/Update.hs
+++ b/concordium-consensus/src/Concordium/Skov/Update.hs
@@ -616,7 +616,7 @@ doReceiveTransactionInternal origin tr ts slot = do
           return (Just (bi, Just verRes), transactionVerificationResultToUpdateResult verRes)
         -- Note we just pass in the `GenericDuplicate` verification result here as we don't want to
         -- lookup the actual verification result for the transaction.
-        Duplicate tx -> return (Just (tx, Nothing), ResultDuplicate)
+        Duplicate tx mVerRes -> return (Just (tx, mVerRes), ResultDuplicate)
         ObsoleteNonce -> return (Nothing, ResultStale)
         NotAdded verRes -> return (Nothing, transactionVerificationResultToUpdateResult verRes)
   where


### PR DESCRIPTION
## Purpose
Reuse verification results when executing blocks containing already received transactions.


## Changes

_Describe the changes that were needed.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
