### PR TITLE
Fix installer bug causing Continue to be disabled

### DIFF
--- a/scripts/distribution/macOS-package/NodeConfigurationInstallerPlugin/NodeConfigurationInstallerPlugin/InstallerSections.plist
+++ b/scripts/distribution/macOS-package/NodeConfigurationInstallerPlugin/NodeConfigurationInstallerPlugin/InstallerSections.plist
@@ -7,6 +7,7 @@
 		<string>Introduction</string>
 		<string>ReadMe</string>
 		<string>License</string>
+		<string>Target</string>
 		<string>NodeConfigurationInstallerPlugin.bundle</string>
 		<string>PackageSelection</string>
 		<string>Install</string>


### PR DESCRIPTION
## Purpose

Closes #344.

Originally, I removed the Target section from the installer, because it was not needed for our use case. According to the documentation I read at the time, this should be OK to do.

However, researching the issue again now, I found out that removing any of the default sections of the installer can cause erratic problems _when using installer plugins_.

Testing the solution on two M1 macs seems to confirm the previous statement.

## Changes

- Add the `Target` section to the installer.
  - This requires the user to select which disk they want the node installed on 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.