### PR TITLE
Tweaks to genesis generation script.

### DIFF
--- a/scripts/genesis/README.md
+++ b/scripts/genesis/README.md
@@ -27,6 +27,8 @@ Supported env vars:
 * `DROP_ACCOUNT_BALANCE` will, if set to a CCD amount, generate another extra account in the
   folder `drop`. Note that if you set this and `EXTRA_ACCOUNTS_TEMPLATE` then
   the latter is different from `drop`.
+* `GENESIS_VERSION` sets the genesis version to use. This should be 2 more than the protocol version
+  used at genesis, and defaults to 6 (protocol version 4) if not set.
 * See the source code of the script for more.
 
 ### Example build command

--- a/scripts/genesis/generate-test-genesis.py
+++ b/scripts/genesis/generate-test-genesis.py
@@ -128,6 +128,9 @@ DROP_ACCOUNT_BALANCE=os.environ.get("DROP_ACCOUNT_BALANCE")
 # Helper defined constants
 GLOBAL_FILE = os.path.join(GENESIS_DIR, "global.json")
 
+# Genesis data version
+GENESIS_VERSION = os.environ.get("GENESIS_VERSION", default = "6")
+
 # Create cryptographic parameters, identity providers, and anonymity revokers
 def create_base_parameters():
     if os.path.exists(GENESIS_DIR):
@@ -174,6 +177,7 @@ def create_accounts(template = "foundation-account", num = "1", balance = FOUNDA
                           "--ip-info", os.path.join(GENESIS_DIR, "identity_provider-0.pub.json"),
                           "--global", GLOBAL_FILE,
                           "--num", num,
+                          "--num-keys", NUM_KEYS,
                           "--balance", balance,
                           "--template", template,
                           "--out-dir", accounts_dir)
@@ -263,7 +267,7 @@ def combine(foundation_account, extra = None, drop = None):
                           f"--crypto-params={GLOBAL_FILE}",
                           f"--accounts={accounts}",
                           f"--update-keys={authorizations}",
-                          "--gdver=6",
+                          f"--gdver={GENESIS_VERSION}",
                           "genesis-tmp.json",
                           out_genesis)
     if res != 0:


### PR DESCRIPTION
## Purpose

Minor improvements to the genesis generation script.

## Changes

- Add a parameter `GENESIS_VERSION` that sets the genesis data version to generate.
- Respect `NUM_KEYS` when creating foundation and extra accounts.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
