### PR TITLE
Avoid loading genesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unrelease changes
 
+- Improve startup time by avoiding to process already processed protocol
+  updates.
+- Decrease memory usage by not storing genesis blocks. This has the effect that
+  the database of node versions >= 4.1.* are not compatible with those of < 4.1.
+
+## 4.0.11
 - The `SendTransaction` function exposed via the gRPC interface now provides the caller with detailed error messages if the 
   transaction was rejected instead of just `False`. The function still returns `True` if 
   the transaction was accepted.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## Unrelease changes
 
-- Improve startup time by avoiding to process already processed protocol
+- Improve startup time by avoiding processing already processed protocol
   updates.
 - Decrease memory usage by not storing genesis blocks. This has the effect that
-  the database of node versions >= 4.1.* are not compatible with those of < 4.1.
+  the database produced by node versions >= 4.2.* cannot be used by node
+  versions <= 4.1. The other direction works.
 
 ## 4.0.11
 - The `SendTransaction` function exposed via the gRPC interface now provides the caller with detailed error messages if the 

--- a/concordium-consensus/src/Concordium/GlobalState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState.hs
@@ -489,11 +489,8 @@ instance GlobalStateConfig DiskTreeDiskBlockConfig where
                 `onException` liftIO (destroyBlobStore pbscBlobStore)
         return (pbsc, isd, NoLogContext)
 
-    activateGlobalState _ pbsc uninitState = do
-      logEvent GlobalState LLDebug "Activating global state."
-      rv <- activateSkovPersistentData pbsc uninitState
-      logEvent GlobalState LLDebug "Global state activated."
-      return rv
+    activateGlobalState _ pbsc uninitState = 
+      activateSkovPersistentData pbsc uninitState
 
     shutdownGlobalState _ _ PersistentBlockStateContext{..} st _ = do
         closeBlobStore pbscBlobStore
@@ -544,7 +541,7 @@ instance GlobalStateConfig DiskTreeDiskBlockWithLogConfig where
                 `onException` liftIO (destroyAllResources dbHandle >> destroyBlobStore pbscBlobStore)
         return (pbsc, isd, transactionLogContext)
 
-    activateGlobalState _ pbsc uninitState = do
+    activateGlobalState _ pbsc uninitState =
       activateSkovPersistentData pbsc uninitState
 
     shutdownGlobalState _ _ PersistentBlockStateContext{..} st transactionLogContext = do

--- a/concordium-consensus/src/Concordium/GlobalState/Basic/BlockPointer.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/BlockPointer.hs
@@ -53,7 +53,7 @@ makeGenesisBasicBlockPointer :: forall pv s. IsProtocolVersion pv => GenesisData
 makeGenesisBasicBlockPointer genData _bpState = theBlockPointer
     where
         theBlockPointer = BlockPointer {_bpInfo=BasicBlockPointerData{..},_bpATI=(),..}
-        _bpBlock = GenesisBlock genData
+        _bpBlock = GenesisBlock (genesisConfiguration genData)
         _bpHash = getHash _bpBlock
         _bpParent = Identity theBlockPointer
         _bpLastFinalized = Identity theBlockPointer

--- a/concordium-consensus/src/Concordium/GlobalState/Basic/TreeState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/TreeState.hs
@@ -58,7 +58,7 @@ data SkovData (pv :: ProtocolVersion) bs = SkovData {
     -- |Branches of the tree by height above the last finalized block
     _branches :: !(Seq.Seq [BasicBlockPointer pv bs]),
     -- |Genesis data
-    _genesisData :: !TS.GenesisConfiguration,
+    _genesisData :: !GenesisConfiguration,
     -- |Block pointer to genesis block
     _genesisBlockPointer :: !(BasicBlockPointer pv bs),
     -- |Current focus block
@@ -104,11 +104,7 @@ initialSkovData rp gd genState = do
             _possiblyPendingQueue = MPQ.empty,
             _finalizationList = Seq.singleton (gbfin, gb),
             _branches = Seq.empty,
-            _genesisData = TS.GenesisConfiguration {
-                _gcCore = coreGenesisParameters gd,
-                _gcCurrentHash = genesisBlockHash gd,
-                _gcFirstGenesis = firstGenesisBlockHash gd
-                },
+            _genesisData = genesisConfiguration gd,
             _genesisBlockPointer = gb,
             _focusBlock = gb,
             _pendingTransactions = emptyPendingTransactionTable,

--- a/concordium-consensus/src/Concordium/GlobalState/Basic/TreeState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/TreeState.hs
@@ -297,7 +297,6 @@ instance (bs ~ BlockState m, BS.BlockStateStorage m, Monad m, MonadIO m, MonadSt
             let mVerRes = case results of
                  Received _ verRes -> Just verRes
                  Committed _ verRes _ -> Just verRes
-                 Finalized {} -> Nothing
             when (slot > results ^. tsSlot) $ transactionTable . ttHashMap . at' trHash . mapped . _2 %= updateSlot slot
             return $ TS.Duplicate tr' mVerRes
 

--- a/concordium-consensus/src/Concordium/GlobalState/Basic/TreeState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/TreeState.hs
@@ -58,7 +58,7 @@ data SkovData (pv :: ProtocolVersion) bs = SkovData {
     -- |Branches of the tree by height above the last finalized block
     _branches :: !(Seq.Seq [BasicBlockPointer pv bs]),
     -- |Genesis data
-    _genesisData :: !(GenesisData pv),
+    _genesisData :: !TS.GenesisConfiguration,
     -- |Block pointer to genesis block
     _genesisBlockPointer :: !(BasicBlockPointer pv bs),
     -- |Current focus block
@@ -104,7 +104,11 @@ initialSkovData rp gd genState = do
             _possiblyPendingQueue = MPQ.empty,
             _finalizationList = Seq.singleton (gbfin, gb),
             _branches = Seq.empty,
-            _genesisData = gd,
+            _genesisData = TS.GenesisConfiguration {
+                _gcCore = coreGenesisParameters gd,
+                _gcCurrentHash = genesisBlockHash gd,
+                _gcFirstGenesis = firstGenesisBlockHash gd
+                },
             _genesisBlockPointer = gb,
             _focusBlock = gb,
             _pendingTransactions = emptyPendingTransactionTable,

--- a/concordium-consensus/src/Concordium/GlobalState/Block.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Block.hs
@@ -293,7 +293,7 @@ instance forall pv. (IsProtocolVersion pv) => DecodeBlock pv BakedBlock where
 -- * BlockData
 data Block (pv :: ProtocolVersion)
     = GenesisBlock !GenesisConfiguration
-    -- ^A genesis block with the given hash.
+    -- ^A genesis block with the given configuration.
     | NormalBlock !BakedBlock
     -- ^A baked (i.e. non-genesis) block
 

--- a/concordium-consensus/src/Concordium/GlobalState/Block.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Block.hs
@@ -333,17 +333,6 @@ instance (IsProtocolVersion pv) => EncodeBlock pv (Block pv) where
     putBlock _ (GenesisBlock gd) = put genesisSlot >> (putGenesisConfiguration gd)
     putBlock spv (NormalBlock bb) = putBlock spv bb
 
--- |The metadata is the arrival time of the block together with the genesis hash
--- of the current protocol version. The latter is only used when deserializing
--- genesis blocks.
-type instance DecodeBlockMetadata (Block pv) = (TransactionTime, BlockHash)
-
-instance forall pv. (IsProtocolVersion pv) => DecodeBlock pv (Block pv) where
-    getBlock _ (arrivalTime, genHash) = do
-        sl <- get
-        if sl == 0 then GenesisBlock <$> getGenesisConfiguration (protocolVersion @pv) genHash
-        else NormalBlock <$> getBakedBlockAtSlot (protocolVersion @pv) sl arrivalTime
-
 -- |A baked block, pre-hashed with its arrival time.
 --
 -- All instances of this type will implement automatically:

--- a/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
@@ -88,6 +88,7 @@ import Concordium.ID.Types (AccountCredential, CredentialRegistrationID)
 import Concordium.Crypto.EncryptedTransfers
 import Concordium.GlobalState.ContractStateFFIHelpers (LoadCallback)
 import qualified Concordium.GlobalState.ContractStateV1 as StateV1
+import Concordium.GlobalState.Persistent.LMDB (FixedSizeSerialization)
 
 -- |Hash associated with birk parameters.
 newtype BirkParametersHash (pv :: ProtocolVersion) = BirkParametersHash {birkParamHash :: H.Hash}
@@ -1150,7 +1151,7 @@ class (BlockStateQuery m) => BlockStateOperations m where
   bsoSetRewardAccounts :: UpdatableBlockState m -> RewardAccounts -> m (UpdatableBlockState m)
 
 -- | Block state storage operations
-class (BlockStateOperations m, Serialize (BlockStateRef m)) => BlockStateStorage m where
+class (BlockStateOperations m, FixedSizeSerialization (BlockStateRef m)) => BlockStateStorage m where
     -- |Derive a mutable state instance from a block state instance. The mutable
     -- state instance supports all the operations needed by the scheduler for
     -- block execution. Semantically the 'UpdatableBlockState' must be a copy,

--- a/concordium-consensus/src/Concordium/GlobalState/LMDB/Helpers.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/LMDB/Helpers.hs
@@ -541,7 +541,7 @@ loadRecord txn dbi key = do
     case mval of
       Nothing -> return Nothing
       Just bval -> decodeValue prox key bval >>= \case
-        Left err -> error err -- return Nothing
+        Left _ -> return Nothing
         Right val -> return (Just val)
   where
     prox :: Proxy db

--- a/concordium-consensus/src/Concordium/GlobalState/LMDB/Helpers.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/LMDB/Helpers.hs
@@ -39,7 +39,8 @@ module Concordium.GlobalState.LMDB.Helpers (
   loadAll,
 
   -- * Low level operations.
-  byteStringFromMDB_val
+  byteStringFromMDB_val,
+  unsafeByteStringFromMDB_val
                                            )
 where
 
@@ -62,6 +63,7 @@ import Foreign.Marshal.Alloc
 import Foreign.Ptr
 import Foreign.Storable
 import Lens.Micro.Platform
+import Data.ByteString.Unsafe (unsafePackCStringLen)
 
 -- |State of a reader-writer lock.
 data RWState =
@@ -314,10 +316,10 @@ class MDBDatabase db where
   encodeValue :: Proxy db -> DBValue db -> LBS.ByteString
   default encodeValue :: (S.Serialize (DBValue db)) => Proxy db -> DBValue db -> LBS.ByteString
   encodeValue _ = S.encodeLazy
-  -- |Decode a value. The result should not retain the pointer.
-  decodeValue :: Proxy db -> MDB_val -> IO (Either String (DBValue db))
-  default decodeValue :: (S.Serialize (DBValue db)) => Proxy db -> MDB_val -> IO (Either String (DBValue db))
-  decodeValue _ v = S.decode <$> byteStringFromMDB_val v
+  -- |Decode a value at the given key. The result should not retain the pointer.
+  decodeValue :: Proxy db -> DBKey db -> MDB_val -> IO (Either String (DBValue db))
+  default decodeValue :: (S.Serialize (DBValue db)) => Proxy db -> DBKey db -> MDB_val -> IO (Either String (DBValue db))
+  decodeValue _ _ v = S.decode <$> byteStringFromMDB_val v
 
 -- |Run a transaction in an LMDB environment. The second argument specifies if
 -- the transaction is read-only. This will acquire a read lock so the given IO
@@ -349,6 +351,10 @@ withMDB_val bs a = BS.unsafeUseAsCStringLen bs $ \(ptr, plen) -> a $ MDB_val (fr
 -- |Create a 'ByteString' from an 'MDB_val'.  This creates a copy.
 byteStringFromMDB_val :: MDB_val -> IO ByteString
 byteStringFromMDB_val (MDB_val len ptr) = packCStringLen (coerce ptr, fromIntegral len)
+
+-- |Create a 'ByteString' from an 'MDB_val'.  This does not create a copy and must be consumed in a transaction.
+unsafeByteStringFromMDB_val :: MDB_val -> IO ByteString
+unsafeByteStringFromMDB_val (MDB_val len ptr) = unsafePackCStringLen (coerce ptr, fromIntegral len)
 
 -- |Write a lazy 'LBS.ByteString' into an 'MDB_val'.
 -- The destination must have the same size as the source.
@@ -447,7 +453,7 @@ getCursor movement (Cursor pc) = getPrimitiveCursor movement pc >>= mapM decodeK
   where
     decodeKV (keyv, valv) = runExceptT $ do
       key <- ExceptT $ decodeKey prox keyv
-      val <- ExceptT $ decodeValue prox valv
+      val <- ExceptT $ decodeValue prox key valv
       return (key, val)
     prox :: Proxy db
     prox = Proxy
@@ -534,8 +540,8 @@ loadRecord txn dbi key = do
     mval <- withMDB_val (encodeKey prox key) $ mdb_get' txn (mdbDatabase dbi)
     case mval of
       Nothing -> return Nothing
-      Just bval -> decodeValue prox bval >>= \case
-        Left _ -> return Nothing
+      Just bval -> decodeValue prox key bval >>= \case
+        Left err -> error err -- return Nothing
         Right val -> return (Just val)
   where
     prox :: Proxy db

--- a/concordium-consensus/src/Concordium/GlobalState/LMDB/Helpers.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/LMDB/Helpers.hs
@@ -348,11 +348,13 @@ transaction se readOnly tx
 withMDB_val :: ByteString -> (MDB_val -> IO a) -> IO a
 withMDB_val bs a = BS.unsafeUseAsCStringLen bs $ \(ptr, plen) -> a $ MDB_val (fromIntegral plen) (coerce ptr)
 
--- |Create a 'ByteString' from an 'MDB_val'.  This creates a copy.
+-- |Create a 'ByteString' from an 'MDB_val'. This creates a copy.
 byteStringFromMDB_val :: MDB_val -> IO ByteString
 byteStringFromMDB_val (MDB_val len ptr) = packCStringLen (coerce ptr, fromIntegral len)
 
--- |Create a 'ByteString' from an 'MDB_val'.  This does not create a copy and must be consumed in a transaction.
+-- |Create a 'ByteString' from an 'MDB_val'. This does not create a copy of the
+-- bytestring so it is imperative that the returned bytestring is fully consumed
+-- inside an LMDB transaction and no pointers to any substrings are retained.
 unsafeByteStringFromMDB_val :: MDB_val -> IO ByteString
 unsafeByteStringFromMDB_val (MDB_val len ptr) = unsafePackCStringLen (coerce ptr, fromIntegral len)
 

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockPointer.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockPointer.hs
@@ -29,7 +29,7 @@ emptyWeak = do
   return pointer
 
 -- |Creates a persistent block pointer with the provided block and metadata. Should not be called directly.
-makePersistentBlockPointer :: (IsProtocolVersion pv, Monad m)
+makePersistentBlockPointer :: (Monad m)
                            => Block pv                               -- ^Pending block
                            -> Maybe BlockHash                    -- ^Precomputed hash of this block. If not provided, it will be computed in-place.
                            -> BlockHeight                        -- ^Height of the block
@@ -68,7 +68,7 @@ makeGenesisPersistentBlockPointer :: forall pv m bs ati. (IsProtocolVersion pv, 
                                   -> m (PersistentBlockPointer pv ati bs)
 makeGenesisPersistentBlockPointer genData _bpState _bpATI = liftIO $ do
   let _bpReceiveTime = timestampToUTCTime (gdGenesisTime genData)
-      b = GenesisBlock genData
+      b = GenesisBlock (genesisConfiguration genData)
       _bpHash = genesisBlockHash genData
   _bpParent <- emptyWeak
   _bpLastFinalized <- emptyWeak
@@ -85,7 +85,7 @@ makeGenesisPersistentBlockPointer genData _bpState _bpATI = liftIO $ do
       ..}
 
 -- |Converts a Pending Block into a PersistentBlockPointer
-makePersistentBlockPointerFromPendingBlock :: forall pv m ati bs. (IsProtocolVersion pv, MonadLogger m, MonadIO m) =>
+makePersistentBlockPointerFromPendingBlock :: forall pv m ati bs. (MonadLogger m, MonadIO m) =>
                                    PendingBlock      -- ^Pending block
                                  -> PersistentBlockPointer pv ati bs  -- ^Parent block
                                  -> PersistentBlockPointer pv ati bs  -- ^Last finalized block

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/LMDB.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/LMDB.hs
@@ -617,7 +617,7 @@ writeBlock block = resizeOnFull blockSize
         storeReplaceRecord txn (dbh ^. finalizedByHeightStore) (_bpHeight b) (_bpHash b)
         storeReplaceRecord txn (dbh ^. blockStore) (_bpHash b) block
   where
-    blockSize = 1000 + fromIntegral (_bpTransactionsSize (sbInfo block))
+    blockSize = 2*digestSize + fromIntegral (LBS.length (S.runPutLazy (putStoredBlock block)))
 
 -- |Write a finalization record to the database.
 writeFinalizationRecord :: (MonadLogger m, MonadIO m, MonadState s m, HasDatabaseHandlers pv st s)

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/LMDB.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/LMDB.hs
@@ -84,6 +84,10 @@ data StoredBlock pv st = StoredBlock {
   sbState :: !st
 }
 
+-- Note: 'openReadOnlyDatabase' works on the presumption that the state is always the last part of
+-- the serialization, so we can serialize a stored block with any state type and deserialize it
+-- with the unit state type.  Any changes to the serialization used here must respect this or
+-- be accompanied by corresponding changes there.
 putStoredBlock :: forall pv st . (IsProtocolVersion pv, S.Serialize st) => S.Putter (StoredBlock pv st)
 putStoredBlock StoredBlock{..} =
       S.put sbFinalizationIndex <>

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/LMDB.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/LMDB.hs
@@ -94,7 +94,11 @@ putStoredBlock StoredBlock{..} =
 -- indexed by 'BlockHash'.
 newtype BlockStore (pv :: ProtocolVersion) st = BlockStore MDB_dbi'
 
+-- |A refinement of 'Serialize' that indicates that the size (i.e., amount of
+-- bytes used) of the serialized value is independend of the value. This must be
+-- exact, not just an upper bound.
 class S.Serialize a => FixedSizeSerialization a where
+  -- |Return the size of serialized values in bytes.
   serializedSize :: Proxy a -> Int
 
 instance FixedSizeSerialization () where
@@ -103,6 +107,7 @@ instance FixedSizeSerialization () where
 instance FixedSizeSerialization (BlobRef a) where
   serializedSize _ = 8
 
+-- This instance is needed for paired state.
 instance (FixedSizeSerialization a, FixedSizeSerialization b) => FixedSizeSerialization (a, b) where
   serializedSize _ = serializedSize (Proxy @a) + serializedSize (Proxy @b)
 

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/LMDB.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/LMDB.hs
@@ -43,6 +43,7 @@ module Concordium.GlobalState.Persistent.LMDB (
   , writeTransactionStatus
   , writeTransactionStatuses
   , writeFinalizationComposite
+  , FixedSizeSerialization
   ) where
 
 import Concordium.GlobalState.LMDB.Helpers
@@ -71,6 +72,8 @@ import System.Directory
 import qualified Data.HashMap.Strict as HM
 import Concordium.Logger
 import Concordium.Common.Version
+import Concordium.GlobalState.Persistent.BlobStore (BlobRef)
+import Data.Proxy
 
 -- |A (finalized) block as stored in the database.
 data StoredBlock pv st = StoredBlock {
@@ -80,30 +83,51 @@ data StoredBlock pv st = StoredBlock {
   sbState :: !st
 }
 
--- Note: 'openReadOnlyDatabase' works on the presumption that the state is always the last part of
--- the serialization, so we can serialize a stored block with any state type and deserialize it
--- with the unit state type.  Any changes to the serialization used here must respect this or
--- be accompanied by corresponding changes there.
-instance (IsProtocolVersion pv, S.Serialize st) => S.Serialize (StoredBlock pv st) where
-  put StoredBlock{..} = S.put sbFinalizationIndex <>
-          S.put sbInfo <>
-          putBlock (protocolVersion @pv) sbBlock <>
-          S.put sbState
-  get = do
-          sbFinalizationIndex <- S.get
-          sbInfo <- S.get
-          sbBlock <- getBlock (protocolVersion @pv) (utcTimeToTransactionTime (_bpReceiveTime sbInfo))
-          sbState <- S.get
-          return StoredBlock{..}
+putStoredBlock :: forall pv st . (IsProtocolVersion pv, S.Serialize st) => S.Putter (StoredBlock pv st)
+putStoredBlock StoredBlock{..} =
+      S.put sbFinalizationIndex <>
+      S.put sbInfo <>
+      putBlock (protocolVersion @pv) sbBlock <>
+      S.put sbState
 
 -- |A block store table. A @BlockStore pv st@ stores @StoredBlock pv st@ blocks
 -- indexed by 'BlockHash'.
 newtype BlockStore (pv :: ProtocolVersion) st = BlockStore MDB_dbi'
 
-instance (IsProtocolVersion pv, S.Serialize st) => MDBDatabase (BlockStore pv st) where
+class S.Serialize a => FixedSizeSerialization a where
+  serializedSize :: Proxy a -> Int
+
+instance FixedSizeSerialization () where
+  serializedSize _ = 0
+
+instance FixedSizeSerialization (BlobRef a) where
+  serializedSize _ = 8
+
+instance (FixedSizeSerialization a, FixedSizeSerialization b) => FixedSizeSerialization (a, b) where
+  serializedSize _ = serializedSize (Proxy @a) + serializedSize (Proxy @b)
+
+instance (IsProtocolVersion pv, FixedSizeSerialization st) => MDBDatabase (BlockStore pv st) where
   type DBKey (BlockStore pv st) = BlockHash
   type DBValue (BlockStore pv st) = StoredBlock pv st
   encodeKey _ = hashToByteString . blockHash
+  encodeValue _ sb = S.runPutLazy (putStoredBlock sb)
+  decodeValue _ blockHash mdbVal = do
+    bs <- unsafeByteStringFromMDB_val mdbVal
+    if BS.length bs < serializedSize (Proxy @st) then
+      return (Left "Unexpected block value without state.")
+    else do
+      let (body, stateValue) = BS.splitAt (BS.length bs - serializedSize (Proxy @st)) bs
+          bodyDecoder :: S.Get (FinalizationIndex, BasicBlockPointerData, Block pv)
+          bodyDecoder = do
+            sbFinalizationIndex <- S.get
+            sbInfo <- S.get
+            sbBlock <- S.label "getBlock" $ getBlock (protocolVersion @pv) (utcTimeToTransactionTime (_bpReceiveTime sbInfo), blockHash)
+            return (sbFinalizationIndex, sbInfo, sbBlock)
+      case (S.runGet bodyDecoder body, S.decode stateValue) of
+        (Right (sbFinalizationIndex, sbInfo, sbBlock), Right sbState) -> return (Right StoredBlock{..})
+        (Right _, Left err) -> return (Left $ "Cannot decode state: " ++ err)
+        (Left err, Right _) -> return (Left $ "Cannot decode block: " ++ err)
+        (Left err1, Left err2) -> return (Left $ "Cannot decode block nor state: " ++ err1 ++ ", " ++ err2)
 
 -- |A finalization record store table. A @FinalizationRecordStore@ stores
 -- 'FinalizationRecord's indexed by 'FinalizationIndex'.
@@ -160,7 +184,7 @@ instance MDBDatabase MetadataStore where
     decodeKey _ k = Right <$> byteStringFromMDB_val k
     type DBValue MetadataStore = BS.ByteString
     encodeValue _ = LBS.fromStrict
-    decodeValue _ v = Right <$> byteStringFromMDB_val v
+    decodeValue _ _ v = Right <$> byteStringFromMDB_val v
 
 -- |Key to the version information.
 -- This key should map to a serialized 'VersionMetadata' structure.
@@ -334,7 +358,7 @@ openReadOnlyDatabase treeStateDir = do
 
 
 -- |Initialize the database handlers creating the databases if needed and writing the genesis block and its finalization record into the disk
-initializeDatabase :: forall pv st ati bs. (IsProtocolVersion pv, S.Serialize st) =>
+initializeDatabase :: forall pv st ati bs. (IsProtocolVersion pv, FixedSizeSerialization st) =>
   -- |Genesis block pointer
   PersistentBlockPointer pv ati bs ->
   -- |Genesis block state
@@ -354,7 +378,7 @@ initializeDatabase gb stRef treeStateDir = do
   -- initialization would fail. Since a regenesis block can contain a serialization of the state, which may be
   -- arbitrarily large, to be safe we ensure that we have at least 1MB more than the size of the serialization
   -- of the genesis block.
-  let initSize = fromIntegral $ LBS.length (S.encodeLazy storedGenesis) + 1_048_576
+  let initSize = fromIntegral $ LBS.length (S.runPutLazy (putStoredBlock storedGenesis)) + 1_048_576
   handlers@DatabaseHandlers{..} <- makeDatabaseHandlers treeStateDir False initSize
   let gbh = getHash gb
       gbfin = FinalizationRecord 0 gbh emptyFinalizationProof 0
@@ -439,7 +463,7 @@ resizeDatabaseHandlers dbh size = do
   liftIO . withWriteStoreEnv (dbh ^. storeEnv) $ flip mdb_env_set_mapsize newMapSize
 
 -- |Read a block from the database by hash.
-readBlock :: (MonadIO m, MonadState s m, IsProtocolVersion pv, HasDatabaseHandlers pv st s, S.Serialize st)
+readBlock :: (MonadIO m, MonadState s m, IsProtocolVersion pv, HasDatabaseHandlers pv st s, FixedSizeSerialization st)
   => BlockHash
   -> m (Maybe (StoredBlock pv st))
 readBlock bh = do
@@ -469,7 +493,7 @@ readTransactionStatus txHash = do
     $ \txn -> loadRecord txn (dbh ^. transactionStatusStore) txHash
 
 -- |Get a block from the database by its height.
-getFinalizedBlockAtHeight :: (IsProtocolVersion pv, S.Serialize st)
+getFinalizedBlockAtHeight :: (IsProtocolVersion pv, FixedSizeSerialization st)
   => DatabaseHandlers pv st
   -> BlockHeight
   -> IO (Maybe (StoredBlock pv st))
@@ -479,7 +503,7 @@ getFinalizedBlockAtHeight dbh bHeight = transaction (dbh ^. storeEnv) True
         join <$> mapM (loadRecord txn (dbh ^. blockStore)) mbHash
 
 -- |Read a block from the database by its height.
-readFinalizedBlockAtHeight :: (MonadIO m, MonadState s m, IsProtocolVersion pv, HasDatabaseHandlers pv st s, S.Serialize st)
+readFinalizedBlockAtHeight :: (MonadIO m, MonadState s m, IsProtocolVersion pv, HasDatabaseHandlers pv st s, FixedSizeSerialization st)
   => BlockHeight
   -> m (Maybe (StoredBlock pv st))
 readFinalizedBlockAtHeight bHeight = do
@@ -497,7 +521,7 @@ memberTransactionTable th = do
     $ \txn -> isRecordPresent txn (dbh ^. transactionStatusStore) th
 
 -- |Build a table of a block finalization indexes for blocks.
-loadBlocksFinalizationIndexes :: (IsProtocolVersion pv, S.Serialize st) => DatabaseHandlers pv st -> IO (Either String (HM.HashMap BlockHash FinalizationIndex))
+loadBlocksFinalizationIndexes :: (IsProtocolVersion pv, FixedSizeSerialization st) => DatabaseHandlers pv st -> IO (Either String (HM.HashMap BlockHash FinalizationIndex))
 loadBlocksFinalizationIndexes dbh = transaction (dbh ^. storeEnv) True $ \txn ->
     withPrimitiveCursor txn (mdbDatabase $ dbh ^. blockStore) $ \cursor -> do
       let
@@ -515,7 +539,7 @@ loadBlocksFinalizationIndexes dbh = transaction (dbh ^. storeEnv) True $ \txn ->
       loop fstRes HM.empty
 
 -- |Get the last finalized block by block height.
-getLastBlock :: (IsProtocolVersion pv, S.Serialize st) => DatabaseHandlers pv st -> IO (Either String (FinalizationRecord, StoredBlock pv st))
+getLastBlock :: (IsProtocolVersion pv, FixedSizeSerialization st) => DatabaseHandlers pv st -> IO (Either String (FinalizationRecord, StoredBlock pv st))
 getLastBlock dbh = transaction (dbh ^. storeEnv) True $ \txn -> do
     mLastFin <- withCursor txn (dbh ^. finalizationRecordStore) $ getCursor CursorLast
     case mLastFin of
@@ -527,7 +551,7 @@ getLastBlock dbh = transaction (dbh ^. storeEnv) True $ \txn -> do
       Nothing -> return $ Left "No last finalized block found"
 
 -- |Get the first block
-getFirstBlock :: (IsProtocolVersion pv, S.Serialize st) => DatabaseHandlers pv st -> IO (Maybe (StoredBlock pv st))
+getFirstBlock :: (IsProtocolVersion pv, FixedSizeSerialization st) => DatabaseHandlers pv st -> IO (Maybe (StoredBlock pv st))
 getFirstBlock dbh = transaction (dbh ^. storeEnv) True $ \txn -> do
         mbHash <- loadRecord txn (dbh ^. finalizedByHeightStore) 0
         join <$> mapM (loadRecord txn (dbh ^. blockStore)) mbHash
@@ -561,7 +585,7 @@ resizeOnFull addSize a = do
 
 -- |Write a block to the database. Adds it both to the index by height and
 -- by block hash.
-writeBlock :: (MonadLogger m, MonadIO m, MonadState s m, HasDatabaseHandlers pv st s, IsProtocolVersion pv, S.Serialize st)
+writeBlock :: (MonadLogger m, MonadIO m, MonadState s m, HasDatabaseHandlers pv st s, IsProtocolVersion pv, FixedSizeSerialization st)
   => StoredBlock pv st -> m ()
 writeBlock block = resizeOnFull blockSize
     $ \dbh -> transaction (dbh ^. storeEnv) False
@@ -570,7 +594,7 @@ writeBlock block = resizeOnFull blockSize
         storeReplaceRecord txn (dbh ^. finalizedByHeightStore) (_bpHeight b) (_bpHash b)
         storeReplaceRecord txn (dbh ^. blockStore) (_bpHash b) block
   where
-    blockSize = 2*digestSize + fromIntegral (LBS.length (S.encodeLazy block))
+    blockSize = 1000 + fromIntegral (_bpTransactionsSize (sbInfo block))
 
 -- |Write a finalization record to the database.
 writeFinalizationRecord :: (MonadLogger m, MonadIO m, MonadState s m, HasDatabaseHandlers pv st s)
@@ -608,7 +632,7 @@ writeTransactionStatuses tss = resizeOnFull tssSize
 -- the database. This is a combination of `writeFinalizationRecord`, `writeTransactionStatuses` and
 -- an arbitrary number of `writeBlock`s in a single transaction.
 writeFinalizationComposite :: (MonadLogger m, MonadIO m, MonadState s m,
-                               HasDatabaseHandlers pv st s, IsProtocolVersion pv, S.Serialize st)
+                               HasDatabaseHandlers pv st s, IsProtocolVersion pv, FixedSizeSerialization st)
   => FinalizationRecord -> [(Maybe (StoredBlock pv st), [(TransactionHash, FinalizedTransactionStatus)])] -> m ()
 writeFinalizationComposite finRec blocktss = resizeOnFull (finRecSize + blocksSize + tssSize)
     $ \dbh -> transaction (dbh ^. storeEnv) False
@@ -619,7 +643,7 @@ writeFinalizationComposite finRec blocktss = resizeOnFull (finRecSize + blocksSi
                           storeReplaceBytes txn (dbh ^. blockStore) (_bpHash b) block
                           forM_ tss (uncurry (storeReplaceRecord txn (dbh ^. transactionStatusStore))))
   where
-    serializedBlocksTss = (((S.encodeLazy &&& sbInfo) . fromJust . fst) &&& snd) <$> filter (isJust . fst) blocktss
+    serializedBlocksTss = (((S.runPutLazy . putStoredBlock &&& sbInfo) . fromJust . fst) &&& snd) <$> filter (isJust . fst) blocktss
     finRecSize = let FinalizationProof vs _ = finalizationProof finRec in
           -- key + finIndex + finBlockPointer + finProof (list of Word32s + BlsSignature.signatureSize) + finDelay
           digestSize + 64 + digestSize + (32 * Prelude.length vs) + 48 + 64

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
@@ -302,8 +302,8 @@ loadSkovPersistentData rp _treeStateDirectory pbsc atiContext = do
           liftIO (getFirstBlock _db)
   _genesisBlockPointer <- liftIO $ makeBlockPointer genStoredBlock
   _genesisData <- case _bpBlock _genesisBlockPointer of
-     GenesisBlock gd' -> return gd'
-     _ -> logExceptionAndThrowTS (DatabaseInvariantViolation "Block at height 0 is not a genesis block.")
+    GenesisBlock gd' -> return gd'
+    _ -> logExceptionAndThrowTS (DatabaseInvariantViolation "Block at height 0 is not a genesis block.")
 
   -- Populate the block table.
   _blockTable <- liftIO (loadBlocksFinalizationIndexes _db) >>= \case
@@ -345,10 +345,10 @@ activateSkovPersistentData :: forall ati pv. (IsProtocolVersion pv, CanExtend (A
                            -> LogIO (SkovPersistentData pv ati (PBS.HashedPersistentBlockState pv))
 activateSkovPersistentData pbsc uninitState = do
   cachedLastFinalized <- liftIO (makeBlockPointerCached (_lastFinalized uninitState))
-  -- The final thing we need to establish is the transaction table invariants.
+  -- We need to establish is the transaction table invariants.
   -- This specifically means for each account we need to determine the next available nonce.
-  -- For now we simply load all accounts, but after this table is also moved to
-  -- some sort of a database we should not need to do that.
+  -- 
+  -- Before we establish the invariants we cache the block state.
   let lastState = _bpState cachedLastFinalized
   let getTransactionTable :: PBS.PersistentBlockStateMonad pv PBS.PersistentBlockStateContext (ReaderT PBS.PersistentBlockStateContext LogIO) TransactionTable
       getTransactionTable = do

--- a/concordium-consensus/src/Concordium/GlobalState/TreeState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/TreeState.hs
@@ -85,26 +85,6 @@ data AddTransactionResult =
   NotAdded !TVer.VerificationResult
   deriving(Eq, Show)
 
--- |Information about the genesis block of the chain. This is not the full
--- genesis block. It does not include the genesis state. Instead, it is the
--- minimal information needed by a running consensus.
-data GenesisConfiguration = GenesisConfiguration {
-  -- |Genesis parameters.
-  _gcCore :: !CoreGenesisParameters,
-  -- |Hash of the current genesis block. Each protocol update introduces a new
-  -- genesis block.
-  _gcCurrentHash :: !BlockHash,
-  -- |Hash of the genesis block of the chain.
-  _gcFirstGenesis :: !BlockHash
-  } deriving (Eq, Show)
-
-instance BasicGenesisData GenesisConfiguration where
-  gdGenesisTime = gdGenesisTime . _gcCore
-  gdSlotDuration = gdSlotDuration . _gcCore
-  gdMaxBlockEnergy = gdMaxBlockEnergy . _gcCore
-  gdFinalizationParameters = gdFinalizationParameters . _gcCore
-  gdEpochLength = gdEpochLength . _gcCore
-
 -- |Monad that provides operations for working with the low-level tree state.
 -- These operations are abstracted where possible to allow for a range of implementation
 -- choices.

--- a/concordium-consensus/src/Concordium/GlobalState/TreeState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/TreeState.hs
@@ -85,6 +85,26 @@ data AddTransactionResult =
   NotAdded !TVer.VerificationResult
   deriving(Eq, Show)
 
+-- |Information about the genesis block of the chain. This is not the full
+-- genesis block. It does not include the genesis state. Instead, it is the
+-- minimal information needed by a running consensus.
+data GenesisConfiguration = GenesisConfiguration {
+  -- |Genesis parameters.
+  _gcCore :: !CoreGenesisParameters,
+  -- |Hash of the current genesis block. Each protocol update introduces a new
+  -- genesis block.
+  _gcCurrentHash :: !BlockHash,
+  -- |Hash of the genesis block of the chain.
+  _gcFirstGenesis :: !BlockHash
+  } deriving (Eq, Show)
+
+instance BasicGenesisData GenesisConfiguration where
+  gdGenesisTime = gdGenesisTime . _gcCore
+  gdSlotDuration = gdSlotDuration . _gcCore
+  gdMaxBlockEnergy = gdMaxBlockEnergy . _gcCore
+  gdFinalizationParameters = gdFinalizationParameters . _gcCore
+  gdEpochLength = gdEpochLength . _gcCore
+
 -- |Monad that provides operations for working with the low-level tree state.
 -- These operations are abstracted where possible to allow for a range of implementation
 -- choices.
@@ -164,7 +184,7 @@ class (Eq (BlockPointerType m),
     -- |Get the genesis 'BlockPointer'.
     getGenesisBlockPointer :: m (BlockPointerType m)
     -- |Get the 'GenesisData'.
-    getGenesisData :: m (GenesisData (MPV m))
+    getGenesisData :: m GenesisConfiguration
     -- * Operations on the finalization list
     -- |Get the last finalized block.
     getLastFinalized :: m (BlockPointerType m, FinalizationRecord)

--- a/concordium-consensus/src/Concordium/ImportExport.hs
+++ b/concordium-consensus/src/Concordium/ImportExport.hs
@@ -198,9 +198,9 @@ exportBlocks hdl = eb 0
     eb count height =
         resizeOnResized (readFinalizedBlockAtHeight height) >>= \case
             Nothing -> return count
-            Just sb -> do
+            Just sb | NormalBlock normalBlock <- sbBlock sb -> do
                 let serializedBlock =
-                        runPut $ putVersionedBlock (protocolVersion @pv) (sbBlock sb)
+                        runPut $ putVersionedBlock (protocolVersion @pv) normalBlock
                     len = fromIntegral $ BS.length serializedBlock
                 liftIO $ do
                     BS.hPut hdl $ runPut $ putWord64be len
@@ -219,6 +219,7 @@ exportBlocks hdl = eb 0
                             dbsLastFinIndex .= finalizationIndex fr
                         _ -> return ()
                 eb (count + 1) (height + 1)
+            Just _ -> return count -- this branch should never be reachable, genesis blocks are not exported.
 
 -- |Export a series of finalization records, starting from the successor of 'dbsLastFinIndex'
 -- as recorded in the state.

--- a/concordium-consensus/src/Concordium/Kontrol/Bakers.hs
+++ b/concordium-consensus/src/Concordium/Kontrol/Bakers.hs
@@ -122,7 +122,7 @@ applyPendingChanges isEffective (bakers0, passive0) =
         pDelegators = processDelegators activeBakerDelegators
 
 -- |Compute the timestamp of the start of an epoch based on the genesis data.
-epochTimestamp :: (BasicGenesisData gd) => gd -> Epoch -> Timestamp
+epochTimestamp :: GenesisConfiguration -> Epoch -> Timestamp
 epochTimestamp gd epoch =
     addDuration
         (gdGenesisTime gd)
@@ -141,7 +141,7 @@ effectiveTest paydayEpoch = do
 
 -- |Determine whether a pending change is effective at a payday based
 -- on the epoch of the payday.
-effectiveTest' :: (BasicGenesisData gd) => gd -> Epoch -> PendingChangeEffective 'AccountV1 -> Bool
+effectiveTest' :: GenesisConfiguration -> Epoch -> PendingChangeEffective 'AccountV1 -> Bool
 effectiveTest' genData paydayEpoch = \(PendingChangeEffectiveV1 t) -> t <= paydayEpochTime
     where
         paydayEpochTime = epochTimestamp genData paydayEpoch
@@ -308,10 +308,9 @@ getSlotBakersP4 ::
     forall m.
     ( BlockStateQuery m,
       AccountVersionFor (MPV m) ~ 'AccountV1,
-      ChainParametersVersionFor (MPV m) ~ 'ChainParametersV1,
-      IsProtocolVersion (MPV m)
+      ChainParametersVersionFor (MPV m) ~ 'ChainParametersV1
     ) =>
-    GenesisData (MPV m) ->
+    GenesisConfiguration ->
     BlockState m ->
     Slot ->
     m FullBakers
@@ -386,7 +385,7 @@ getSlotBakersP4 genData bs slot = do
 getSlotBakers ::
     forall m.
     (IsProtocolVersion (MPV m), BlockStateQuery m) =>
-    GenesisData (MPV m) ->
+    GenesisConfiguration ->
     BlockState m ->
     Slot ->
     m FullBakers

--- a/concordium-consensus/src/Concordium/MultiVersion.hs
+++ b/concordium-consensus/src/Concordium/MultiVersion.hs
@@ -418,8 +418,7 @@ newGenesis (PVGenesisData (gd :: GenesisData pv)) vcGenesisHeight =
               ..
             } -> do
                 mvLog Runner LLInfo $
-                    "Starting new chain with genesis block "
-                        -- ++ show (genesisBlockHash gd)
+                    "Starting new chain"
                         ++ " at absolute height "
                         ++ show vcGenesisHeight
                 oldVersions <- readIORef mvVersions

--- a/concordium-consensus/src/Concordium/MultiVersion.hs
+++ b/concordium-consensus/src/Concordium/MultiVersion.hs
@@ -50,7 +50,7 @@ import Concordium.GlobalState.BlockPointer
 import Concordium.GlobalState.Finalization
 import Concordium.GlobalState.Paired
 import Concordium.GlobalState.Parameters
-import Concordium.GlobalState.TreeState (TreeStateMonad (getLastFinalizedHeight), GenesisConfiguration(..))
+import Concordium.GlobalState.TreeState (TreeStateMonad (getLastFinalizedHeight))
 import Concordium.ImportExport
 import Concordium.ProtocolUpdate
 import Concordium.Skov as Skov
@@ -447,8 +447,8 @@ newGenesis (PVGenesisData (gd :: GenesisData pv)) vcGenesisHeight =
                 let newEConfig :: VersionedConfiguration gsconf finconf pv
                     newEConfig = VersionedConfiguration{..}
                 writeIORef mvVersions (oldVersions `Vec.snoc` newVersion newEConfig)
-                (genesisConfiguration, _) <- runMVR (runSkovT (liftSkov getGenesisData) (mvrSkovHandlers newEConfig mvr) vcContext st) mvr
-                notifyRegenesis (Just (_gcCurrentHash genesisConfiguration))
+                (genConf, _) <- runMVR (runSkovT (liftSkov getGenesisData) (mvrSkovHandlers newEConfig mvr) vcContext st) mvr
+                notifyRegenesis (Just (_gcCurrentHash genConf))
                 -- Because this may be restoring an existing state, it is possible that a protocol
                 -- update has already happened on this chain.  Therefore, we must handle this
                 -- contingency.
@@ -628,7 +628,7 @@ startupSkov genesis@(PVGenesisData (_ :: GenesisData pvOrig)) = do
                                   ((genesisHash, lastFinalizedHeight, nextPV), _) <- runMVR (runSkovT getCurrentGenesisAndHeight (mvrSkovHandlers newEConfig mvr) vcContext st) mvr
                                   notifyRegenesis (Just genesisHash)
                                   return (Left (newVersion newEConfig, lastFinalizedHeight, nextPV))
-                                Right k -> 
+                                Right _ ->
                                   case first of
                                     Nothing -> return (Right Nothing)
                                     Just newEConfig -> return (Right (Just newEConfig))

--- a/concordium-consensus/src/Concordium/MultiVersion.hs
+++ b/concordium-consensus/src/Concordium/MultiVersion.hs
@@ -128,7 +128,7 @@ data MultiVersionConfiguration gsconf finconf = MultiVersionConfiguration
 -- genesis.
 class
     (GlobalStateConfig gsconf) =>
-    MultiVersionStateConfig (gsconf :: ProtocolVersion -> Type)
+    MultiVersionStateConfig (gsconf :: Type)
     where
     -- |Type of state configuration data.
     type StateConfig gsconf
@@ -138,14 +138,13 @@ class
 
     -- |Create a global state configuration for a specific genesis.
     globalStateConfig ::
-        IsProtocolVersion pv =>
         StateConfig gsconf ->
         TXLogConfig gsconf ->
         RuntimeParameters ->
         GenesisIndex ->
         -- |Absolute height of the genesis block.
         AbsoluteBlockHeight ->
-        gsconf pv
+        gsconf
 
 instance MultiVersionStateConfig MemoryTreeMemoryBlockConfig where
     type StateConfig MemoryTreeMemoryBlockConfig = ()

--- a/concordium-consensus/src/Concordium/ProtocolUpdate.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate.hs
@@ -48,6 +48,17 @@ updateRegenesis (UpdateP1 u) = P1.updateRegenesis u
 updateRegenesis (UpdateP2 u) = P2.updateRegenesis u
 updateRegenesis (UpdateP3 u) = P3.updateRegenesis u
 
+-- |Determine the next protocol version for the given update. Although the same
+-- information can be retrieved from 'updateRegenesis', this is more efficient
+-- than 'updateRegenesis' if only the next protocol version is needed.
+updateNextProtocolVersion ::
+    Update pv ->
+    SomeProtocolVersion
+updateNextProtocolVersion (UpdateP1 u) = P1.updateNextProtocolVersion u
+updateNextProtocolVersion (UpdateP2 u) = P2.updateNextProtocolVersion u
+updateNextProtocolVersion (UpdateP3 u) = P3.updateNextProtocolVersion u
+
+
 -- |If a protocol update has taken effect, return the genesis data for the new chain.
 getUpdateGenesisData ::
     (BlockStateStorage m, SkovQueryMonad m) =>
@@ -58,3 +69,12 @@ getUpdateGenesisData =
             Left _ -> return Nothing
             Right u -> Just <$> updateRegenesis u
         PendingProtocolUpdates _ -> return Nothing
+
+getNextProtocolVersion :: forall m .(BlockStateStorage m, SkovQueryMonad m) => m (Maybe SomeProtocolVersion)
+getNextProtocolVersion =
+    getProtocolUpdateStatus >>= \case
+        ProtocolUpdated pu -> case checkUpdate @(MPV m) pu of
+            Left _ -> return Nothing
+            Right u -> return . Just . updateNextProtocolVersion $ u
+        PendingProtocolUpdates _ -> return Nothing
+

--- a/concordium-consensus/src/Concordium/ProtocolUpdate.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate.hs
@@ -70,6 +70,8 @@ getUpdateGenesisData =
             Right u -> Just <$> updateRegenesis u
         PendingProtocolUpdates _ -> return Nothing
 
+-- |If a protocol update has taken effect, return its protocol version.
+-- Otherwise return 'Nothing'.
 getNextProtocolVersion :: forall m .(BlockStateStorage m, SkovQueryMonad m) => m (Maybe SomeProtocolVersion)
 getNextProtocolVersion =
     getProtocolUpdateStatus >>= \case

--- a/concordium-consensus/src/Concordium/ProtocolUpdate/P1.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/P1.hs
@@ -5,6 +5,7 @@ module Concordium.ProtocolUpdate.P1 (
     Update (..),
     checkUpdate,
     updateRegenesis,
+    updateNextProtocolVersion,
 ) where
 
 import qualified Data.HashMap.Strict as HM
@@ -16,7 +17,6 @@ import Concordium.Types
 import Concordium.Types.Updates
 
 import Concordium.GlobalState.BlockState
-import Concordium.GlobalState.Types (MPV)
 import Concordium.Kontrol
 import qualified Concordium.ProtocolUpdate.P1.ProtocolP2 as ProtocolP2
 import qualified Concordium.ProtocolUpdate.P1.Reboot as Reboot
@@ -41,6 +41,13 @@ checkUpdate ProtocolUpdate{..} = case HM.lookup puSpecificationHash updates of
 -- It is assumed that the last finalized block is the terminal block of the old chain:
 -- i.e. it is the first (and only) explicitly-finalized block with timestamp after the
 -- update takes effect.
-updateRegenesis :: (BlockStateStorage m, SkovQueryMonad m, MPV m ~ 'P1) => Update -> m PVGenesisData
+updateRegenesis :: (BlockStateStorage m, SkovQueryMonad m) => Update -> m PVGenesisData
 updateRegenesis (Reboot upd) = Reboot.updateRegenesis upd
 updateRegenesis ProtocolP2 = ProtocolP2.updateRegenesis
+
+-- |Determine the protocol version the update will update to.
+updateNextProtocolVersion ::
+    Update ->
+    SomeProtocolVersion
+updateNextProtocolVersion (Reboot _) = SomeProtocolVersion SP1
+updateNextProtocolVersion ProtocolP2 = SomeProtocolVersion SP2

--- a/concordium-consensus/src/Concordium/ProtocolUpdate/P1/ProtocolP2.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/P1/ProtocolP2.hs
@@ -65,7 +65,6 @@ import Concordium.GlobalState.BlockMonads
 import Concordium.GlobalState.BlockPointer
 import Concordium.GlobalState.BlockState
 import Concordium.Kontrol
-import Concordium.GlobalState.TreeState (GenesisConfiguration(..))
 
 -- |The hash that identifies a update from P1 to P2 protocol.
 -- This is the hash of the published specification document.

--- a/concordium-consensus/src/Concordium/ProtocolUpdate/P1/ProtocolP2.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/P1/ProtocolP2.hs
@@ -57,17 +57,15 @@ import Data.Serialize
 import qualified Concordium.Crypto.SHA256 as SHA256
 import Concordium.Genesis.Data
 import qualified Concordium.Genesis.Data as GenesisData
-import qualified Concordium.Genesis.Data.P1 as P1
 import qualified Concordium.Genesis.Data.P2 as P2
-import Concordium.Types
 import Concordium.Types.SeedState
 
 import Concordium.GlobalState.Block
 import Concordium.GlobalState.BlockMonads
 import Concordium.GlobalState.BlockPointer
 import Concordium.GlobalState.BlockState
-import Concordium.GlobalState.Types (MPV)
 import Concordium.Kontrol
+import Concordium.GlobalState.TreeState (GenesisConfiguration(..))
 
 -- |The hash that identifies a update from P1 to P2 protocol.
 -- This is the hash of the published specification document.
@@ -78,7 +76,7 @@ updateHash = read "9b1f206bbe230fef248c9312805460b4f1b05c1ef3964946981a8d4abb58b
 -- It is assumed that the last finalized block is the terminal block of the old chain:
 -- i.e. it is the first (and only) explicitly-finalized block with timestamp after the
 -- update takes effect.
-updateRegenesis :: (BlockPointerMonad m, BlockStateStorage m, SkovQueryMonad m, MPV m ~ 'P1) => m PVGenesisData
+updateRegenesis :: (BlockPointerMonad m, BlockStateStorage m, SkovQueryMonad m) => m PVGenesisData
 updateRegenesis = do
     lfb <- lastFinalizedBlock
     -- Genesis time is the timestamp of the terminal block
@@ -86,13 +84,11 @@ updateRegenesis = do
     -- Core parameters are derived from the old genesis, apart from genesis time which is set for
     -- the time of the last finalized block.
     gd <- getGenesisData
-    let core = (P1._core $ unGDP1 gd){GenesisData.genesisTime = regenesisTime}
+    let core = (_gcCore gd){GenesisData.genesisTime = regenesisTime}
     -- genesisFirstGenesis is the block hash of the previous genesis, if it is initial,
     -- or the genesisFirstGenesis of the previous genesis otherwise.
-    let genesisFirstGenesis = case gd of
-            GDP1 P1.GDP1Initial{} -> genesisBlockHash gd
-            GDP1 P1.GDP1Regenesis{genesisRegenesis = GenesisData.RegenesisData{genesisFirstGenesis = firstGen}} -> firstGen
-    let genesisPreviousGenesis = genesisBlockHash gd
+    let genesisFirstGenesis = _gcFirstGenesis gd
+    let genesisPreviousGenesis = _gcCurrentHash gd
     let genesisTerminalBlock = bpHash lfb
     -- Determine the new state by updating the terminal state.
     s0 <- thawBlockState =<< blockState lfb

--- a/concordium-consensus/src/Concordium/ProtocolUpdate/P1/Reboot.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/P1/Reboot.hs
@@ -70,7 +70,6 @@ import Concordium.GlobalState.BlockMonads
 import Concordium.GlobalState.BlockPointer
 import Concordium.GlobalState.BlockState
 import Concordium.Kontrol
-import Concordium.GlobalState.TreeState (GenesisConfiguration(..))
 
 -- |The data required to perform a P1.Reboot update.
 data UpdateData = UpdateData

--- a/concordium-consensus/src/Concordium/ProtocolUpdate/P2.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/P2.hs
@@ -5,6 +5,7 @@ module Concordium.ProtocolUpdate.P2 (
     Update (..),
     checkUpdate,
     updateRegenesis,
+    updateNextProtocolVersion,
 ) where
 
 import qualified Data.HashMap.Strict as HM
@@ -16,7 +17,6 @@ import Concordium.Types
 import Concordium.Types.Updates
 
 import Concordium.GlobalState.BlockState
-import Concordium.GlobalState.Types (MPV)
 import Concordium.Kontrol
 import qualified Concordium.ProtocolUpdate.P2.ProtocolP3 as ProtocolP3
 
@@ -40,5 +40,11 @@ checkUpdate ProtocolUpdate{..} = case HM.lookup puSpecificationHash updates of
 -- It is assumed that the last finalized block is the terminal block of the old chain:
 -- i.e. it is the first (and only) explicitly-finalized block with timestamp after the
 -- update takes effect.
-updateRegenesis :: (BlockStateStorage m, SkovQueryMonad m, MPV m ~ 'P2) => Update -> m PVGenesisData
+updateRegenesis :: (BlockStateStorage m, SkovQueryMonad m) => Update -> m PVGenesisData
 updateRegenesis ProtocolP3 = ProtocolP3.updateRegenesis
+
+-- |Determine the protocol version the update will update to.
+updateNextProtocolVersion ::
+    Update ->
+    SomeProtocolVersion
+updateNextProtocolVersion ProtocolP3 = SomeProtocolVersion SP3

--- a/concordium-consensus/src/Concordium/ProtocolUpdate/P2/ProtocolP3.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/P2/ProtocolP3.hs
@@ -65,7 +65,6 @@ import Concordium.GlobalState.BlockMonads
 import Concordium.GlobalState.BlockPointer
 import Concordium.GlobalState.BlockState
 import Concordium.Kontrol
-import Concordium.GlobalState.TreeState (GenesisConfiguration(..))
 
 -- |The hash that identifies a update from P2 to P3 protocol.
 -- This is the hash of the published specification document.

--- a/concordium-consensus/src/Concordium/ProtocolUpdate/P3.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/P3.hs
@@ -5,6 +5,7 @@ module Concordium.ProtocolUpdate.P3 (
     Update (..),
     checkUpdate,
     updateRegenesis,
+    updateNextProtocolVersion
 ) where
 
 import qualified Data.HashMap.Strict as HM
@@ -17,7 +18,6 @@ import qualified Concordium.Genesis.Data.P4 as P4
 import Concordium.Types.Updates
 
 import Concordium.GlobalState.BlockState
-import Concordium.GlobalState.Types (MPV)
 import Concordium.Kontrol
 import qualified Concordium.ProtocolUpdate.P3.ProtocolP4 as ProtocolP4
 
@@ -41,5 +41,11 @@ checkUpdate ProtocolUpdate{..} = case HM.lookup puSpecificationHash updates of
 -- It is assumed that the last finalized block is the terminal block of the old chain:
 -- i.e. it is the first (and only) explicitly-finalized block with timestamp after the
 -- update takes effect.
-updateRegenesis :: (BlockStateStorage m, SkovQueryMonad m, MPV m ~ 'P3) => Update -> m PVGenesisData
+updateRegenesis :: (BlockStateStorage m, SkovQueryMonad m) => Update -> m PVGenesisData
 updateRegenesis (ProtocolP4 updateData) = ProtocolP4.updateRegenesis updateData
+
+-- |Determine the protocol version the update will update to.
+updateNextProtocolVersion ::
+    Update ->
+    SomeProtocolVersion
+updateNextProtocolVersion (ProtocolP4 _) = SomeProtocolVersion SP4

--- a/concordium-consensus/src/Concordium/ProtocolUpdate/P3/ProtocolP4.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/P3/ProtocolP4.hs
@@ -70,7 +70,6 @@ import Concordium.GlobalState.BlockMonads
 import Concordium.GlobalState.BlockPointer
 import Concordium.GlobalState.BlockState
 import Concordium.Kontrol
-import Concordium.GlobalState.TreeState (GenesisConfiguration(..))
 
 -- |The hash that identifies a update from P3 to P4 protocol.
 -- This is the hash of the published specification document.

--- a/concordium-consensus/src/Concordium/Skov/Monad.hs
+++ b/concordium-consensus/src/Concordium/Skov/Monad.hs
@@ -109,7 +109,7 @@ data UpdateResult
     -- ^The importing of blocks has been stopped.
     deriving (Eq, Show)
 
-class (Monad m, Eq (BlockPointerType m), HashableTo BlockHash (BlockPointerType m), BlockPointerData (BlockPointerType m), BlockPointerMonad m, EncodeBlock (MPV m) (BlockPointerType m), BlockStateQuery m, MonadProtocolVersion m)
+class (Monad m, Eq (BlockPointerType m), HashableTo BlockHash (BlockPointerType m), BlockPointerData (BlockPointerType m), BlockPointerMonad m, BlockStateQuery m, MonadProtocolVersion m)
         => SkovQueryMonad m where
     -- |Look up a block in the table given its hash
     resolveBlock :: BlockHash -> m (Maybe (BlockPointerType m))
@@ -127,7 +127,7 @@ class (Monad m, Eq (BlockPointerType m), HashableTo BlockHash (BlockPointerType 
     -- |Determine the next index for finalization.
     nextFinalizationIndex :: m FinalizationIndex
     -- |Get the genesis configuration.
-    getGenesisData :: m TS.GenesisConfiguration
+    getGenesisData :: m GenesisConfiguration
     -- |Get the genesis block pointer.
     genesisBlock :: m (BlockPointerType m)
     -- |Get the height of the highest blocks in the tree.

--- a/concordium-consensus/src/Concordium/Skov/Monad.hs
+++ b/concordium-consensus/src/Concordium/Skov/Monad.hs
@@ -126,8 +126,8 @@ class (Monad m, Eq (BlockPointerType m), HashableTo BlockHash (BlockPointerType 
     recordAtFinIndex :: FinalizationIndex -> m (Maybe FinalizationRecord)
     -- |Determine the next index for finalization.
     nextFinalizationIndex :: m FinalizationIndex
-    -- |Get the genesis data.
-    getGenesisData :: m (GenesisData (MPV m))
+    -- |Get the genesis configuration.
+    getGenesisData :: m TS.GenesisConfiguration
     -- |Get the genesis block pointer.
     genesisBlock :: m (BlockPointerType m)
     -- |Get the height of the highest blocks in the tree.

--- a/concordium-consensus/src/Concordium/Skov/MonadImplementations.hs
+++ b/concordium-consensus/src/Concordium/Skov/MonadImplementations.hs
@@ -183,7 +183,7 @@ instance (SkovFinalizationHandlers h m, Monad m, TimeMonad m, MonadLogger m, Sko
 -- * @finconfig@: the finalization configuration. Currently supported types are @NoFinalization t@,
 --   @ActiveFinalization t@ and @BufferedFinalization t@, where @t@ is the type of timers in the supporting monad.
 -- * @handlerconfig@ is the type of event handlers. Currently supported types are @NoHandlers@ and @LogUpdateHandlers@.
-data SkovConfig (pv :: ProtocolVersion) gsconfig finconfig handlerconfig = SkovConfig !(gsconfig pv) !finconfig !handlerconfig
+data SkovConfig (pv :: ProtocolVersion) gsconfig finconfig handlerconfig = SkovConfig !gsconfig !finconfig !handlerconfig
 
 -- |The type of contexts (i.e. read only data) for the skov configuration type.
 data family SkovContext c
@@ -298,7 +298,7 @@ instance
         SkovState (SkovConfig pv gsconfig finconfig handlerconfig) ->
         LogIO (SkovState (SkovConfig pv gsconfig finconfig handlerconfig))
     activateSkovState skovContext skovState = do
-        activatedState <- activateGlobalState (Proxy @(gsconfig pv)) (scGSContext skovContext) (ssGSState skovState)
+        activatedState <- activateGlobalState (Proxy @gsconfig) (Proxy @pv) (scGSContext skovContext) (ssGSState skovState)
         return skovState { ssGSState = activatedState }
     shutdownSkov :: forall pv. IsProtocolVersion pv => SkovContext (SkovConfig pv gsconfig finconfig handlerconfig) -> SkovState (SkovConfig pv gsconfig finconfig handlerconfig) -> LogIO ()
     shutdownSkov (SkovContext c _ _) (SkovState s _ _ logCtx) = liftIO $ shutdownGlobalState (protocolVersion @pv) (Proxy :: Proxy gsconfig) c s logCtx

--- a/concordium-consensus/src/Concordium/Skov/MonadImplementations.hs
+++ b/concordium-consensus/src/Concordium/Skov/MonadImplementations.hs
@@ -337,14 +337,6 @@ data SkovHandlers pv t c m = SkovHandlers {
     shPendingLive :: m ()
 }
 
-emptySkovHandlers :: forall m pv t c . Monad m => SkovHandlers pv t c m
-emptySkovHandlers = SkovHandlers {
-  shBroadcastFinalizationMessage = \_ -> return (),
-  shOnTimeout = \_ _ -> return undefined,
-  shCancelTimer = \ _ -> return (),
-  shPendingLive = return ()
-  }
-
 instance SkovFinalizationHandlers (SkovHandlers pv t c m) m where
     handleBroadcastFinalizationMessage SkovHandlers{..} = shBroadcastFinalizationMessage
 

--- a/concordium-consensus/test-runners/app/Main.hs
+++ b/concordium-consensus/test-runners/app/Main.hs
@@ -371,7 +371,7 @@ main = do
                             hPutStrLn logFile $ "[" ++ show timestamp ++ "] " ++ show lvl ++ " - " ++ show src ++ ": " ++ msg
                             hFlush logFile
                     let cbks = callbacks (bakerId bid) peersRef monitorChan
-                    mvr <- makeMultiVersionRunner bconfig cbks (Just bid) blogger (PVGenesisData genesisData)
+                    mvr <- makeMultiVersionRunner bconfig cbks (Just bid) blogger (Right (PVGenesisData genesisData))
                     (bakerId bid,) <$> makePeer (bakerId bid) mvr
                 )
 

--- a/concordium-consensus/test-runners/catchup/Main.hs
+++ b/concordium-consensus/test-runners/catchup/Main.hs
@@ -395,7 +395,7 @@ main = do
                             hPutStrLn logFile $ "[" ++ show timestamp ++ "] " ++ show lvl ++ " - " ++ show src ++ ": " ++ msg
                             hFlush logFile
                     let cbks = callbacks (bakerId bid) peersRef monitorChan
-                    mvr <- makeMultiVersionRunner bconfig cbks (Just bid) blogger (PVGenesisData genesisData)
+                    mvr <- makeMultiVersionRunner bconfig cbks (Just bid) blogger (Right (PVGenesisData genesisData))
                     (bakerId bid,) <$> makePeer (bakerId bid) mvr
                 )
 

--- a/concordium-consensus/test-runners/deterministic/Main.hs
+++ b/concordium-consensus/test-runners/deterministic/Main.hs
@@ -285,7 +285,7 @@ initialState = do
                 finconfig = BufferedFinalization (FinalizationInstance (bakerSignKey _bsIdentity) (bakerElectionKey _bsIdentity) (bakerAggregationKey _bsIdentity))
                 hconfig = NoHandler
                 config = SkovConfig gsconfig finconfig hconfig
-            (_bsContext, _bsState) <- runLoggerT (initialiseSkovWithGenesis genData config) (logFor (fromIntegral bakerId))
+            (_bsContext, _bsState) <- runLoggerT (initialiseSkov genData config) (logFor (fromIntegral bakerId))
             return BakerState{..}
         _ssEvents = makeEvents $ (PEvent 0 (TransactionEvent (transactions (mkStdGen 1)))) : [PEvent 0 (BakerEvent i (EBake 0)) | i <- allBakers]
         _ssNextTimer = 0

--- a/concordium-consensus/test-runners/deterministic/Main.hs
+++ b/concordium-consensus/test-runners/deterministic/Main.hs
@@ -65,8 +65,8 @@ type TreeConfig = DiskTreeDiskBlockConfig
 
 -- |Construct the global state configuration.
 -- Can be customised if changing the configuration.
-makeGlobalStateConfig :: RuntimeParameters -> FilePath -> FilePath -> GenesisData PV -> IO (TreeConfig PV)
-makeGlobalStateConfig rt treeStateDir blockStateFile genData = return $ DTDBConfig rt treeStateDir blockStateFile genData
+makeGlobalStateConfig :: RuntimeParameters -> FilePath -> FilePath -> IO (TreeConfig PV)
+makeGlobalStateConfig rt treeStateDir blockStateFile = return $ DTDBConfig rt treeStateDir blockStateFile
 
 {-
 type TreeConfig = PairGSConfig MemoryTreeMemoryBlockConfig DiskTreeDiskBlockConfig
@@ -281,12 +281,11 @@ initialState = do
                             defaultRuntimeParameters 
                             ("data/treestate-" ++ show now ++ "-" ++ show bakerId)
                             ("data/blockstate-" ++ show now ++ "-" ++ show bakerId ++ ".dat")
-                            genData
             let
                 finconfig = BufferedFinalization (FinalizationInstance (bakerSignKey _bsIdentity) (bakerElectionKey _bsIdentity) (bakerAggregationKey _bsIdentity))
                 hconfig = NoHandler
                 config = SkovConfig gsconfig finconfig hconfig
-            (_bsContext, _bsState) <- runLoggerT (initialiseSkov config) (logFor (fromIntegral bakerId))
+            (_bsContext, _bsState) <- runLoggerT (initialiseSkovWithGenesis genData config) (logFor (fromIntegral bakerId))
             return BakerState{..}
         _ssEvents = makeEvents $ (PEvent 0 (TransactionEvent (transactions (mkStdGen 1)))) : [PEvent 0 (BakerEvent i (EBake 0)) | i <- allBakers]
         _ssNextTimer = 0

--- a/concordium-consensus/test-runners/deterministic/Main.hs
+++ b/concordium-consensus/test-runners/deterministic/Main.hs
@@ -65,7 +65,7 @@ type TreeConfig = DiskTreeDiskBlockConfig
 
 -- |Construct the global state configuration.
 -- Can be customised if changing the configuration.
-makeGlobalStateConfig :: RuntimeParameters -> FilePath -> FilePath -> IO (TreeConfig PV)
+makeGlobalStateConfig :: RuntimeParameters -> FilePath -> FilePath -> IO TreeConfig
 makeGlobalStateConfig rt treeStateDir blockStateFile = return $ DTDBConfig rt treeStateDir blockStateFile
 
 {-

--- a/concordium-consensus/test-runners/execute-chain/Main.hs
+++ b/concordium-consensus/test-runners/execute-chain/Main.hs
@@ -61,6 +61,6 @@ main = do
                   notifyRegenesis = \_ -> return ()
                 }
 
-    mvr <- makeMultiVersionRunner config callbacks Nothing logM genesisData
+    mvr <- makeMultiVersionRunner config callbacks Nothing logM (Right genesisData)
     result <- runMVR (importBlocks blocks) mvr
     print result

--- a/concordium-consensus/tests/consensus/ConcordiumTests/CatchUp.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/CatchUp.hs
@@ -31,14 +31,14 @@ import Concordium.GlobalState
 import Concordium.GlobalState.Finalization
 import Concordium.Types.HashableTo
 import Concordium.GlobalState.DummyData (dummyChainParameters, dummyKeyCollection)
-import Concordium.Genesis.Data.P1
+import qualified Concordium.Genesis.Data.P1 as GP1
 
 import Concordium.Logger
 import Concordium.Skov.Monad
 import Concordium.Skov.MonadImplementations
 import Concordium.Afgjort.Finalize
 import Concordium.Birk.Bake
-import Concordium.Types (Energy(..), AccountAddress, protocolVersion)
+import Concordium.Types (BlockHash, Energy(..), AccountAddress, protocolVersion)
 import Concordium.Startup (defaultFinalizationParameters, makeBakersByStake)
 
 import ConcordiumTests.Konsensus hiding (tests)
@@ -90,13 +90,13 @@ runKonsensus steps g states es
                         continue fs' es'
 
 -- |Create initial states where the first baker is a dictator with respect to finalization.
-initialiseStatesDictator :: Int -> PropertyM IO States
+initialiseStatesDictator :: Int -> PropertyM IO (States, BlockHash)
 initialiseStatesDictator n = do
         let bakerAmt = 1000000
             stakes = (2*bakerAmt) : replicate (n-1) bakerAmt
             bis = makeBakersByStake stakes
             bakerAccounts = map (\(_, _, acc, _) -> acc) bis
-            gen = GDP1 GDP1Initial {
+            gen = GDP1 GP1.GDP1Initial {
                     genesisCore = CoreGenesisParameters {
                         genesisTime = 0,
                         genesisSlotDuration = 1,
@@ -123,11 +123,11 @@ initialiseStatesDictator n = do
                                 (initCtx, initState) <- liftIO $ runSilentLogger (initialiseSkovWithGenesis gen config)
                                 return (bid, binfo, (kp, gaAddress acct), initCtx, initState)
                              ) bis
-        return $ Vec.fromList res
+        return $ (Vec.fromList res, genesisBlockHash gen)
 
-simpleCatchUpCheck :: States -> Property
-simpleCatchUpCheck ss =
-        conjoin [monadicIO $ catchUpCheck s1 s2 | s1 <- toList ss, s2 <- toList ss ]
+simpleCatchUpCheck :: BlockHash -> States -> Property
+simpleCatchUpCheck genHash ss =
+        conjoin [monadicIO $ catchUpCheck genHash s1 s2 | s1 <- toList ss, s2 <- toList ss ]
 
 type TrivialHandlers = SkovHandlers PV DummyTimer (Config DummyTimer) LogIO
 
@@ -145,8 +145,8 @@ trivialEvalSkovT a ctx st = liftIO $ flip runLoggerT doLog $ evalSkovT a trivial
         doLog src LLError msg = error $ show src ++ ": " ++ msg
         doLog _ _ _ = return ()
 
-catchUpCheck :: (BakerIdentity, FullBakerInfo, (SigScheme.KeyPair, AccountAddress), SkovContext (Config DummyTimer), SkovState (Config DummyTimer)) -> (BakerIdentity, FullBakerInfo, (SigScheme.KeyPair, AccountAddress), SkovContext (Config DummyTimer), SkovState (Config DummyTimer)) -> PropertyM IO Bool
-catchUpCheck (_, _, _, c1, s1) (_, _, _, c2, s2) = do
+catchUpCheck :: BlockHash -> (BakerIdentity, FullBakerInfo, (SigScheme.KeyPair, AccountAddress), SkovContext (Config DummyTimer), SkovState (Config DummyTimer)) -> (BakerIdentity, FullBakerInfo, (SigScheme.KeyPair, AccountAddress), SkovContext (Config DummyTimer), SkovState (Config DummyTimer)) -> PropertyM IO Bool
+catchUpCheck genHash (_, _, _, c1, s1) (_, _, _, c2, s2) = do
         request <- myLoggedEvalSkovT (getCatchUpStatus True) c1 s1
         (response, result) <- trivialEvalSkovT (handleCatchUpStatus request 2000) c2 s2
         let
@@ -180,7 +180,7 @@ catchUpCheck (_, _, _, c1, s1) (_, _, _, c2, s2) = do
                     checkBinary Set.isSubsetOf (Set.fromList $ cusLeaves request) respLive "is a subset of" "resquestor leaves" "respondent nodes, given no counter-request"
                 unless (lfh2 < lfh1) $ do
                     -- If the respondent should be able to send us something meaningful, then make sure they do
-                    let recBHs = [getHash (bp :: Block PV) | (MessageBlock, runGet (B.getVersionedBlock (protocolVersion @PV) 0) -> Right bp) <- l]
+                    let recBHs = [getHash (bp :: Block PV) | (MessageBlock, runGet (B.getVersionedBlock (protocolVersion @PV) (0, genHash)) -> Right bp) <- l]
                     let recBlocks = Set.fromList recBHs
                     -- Check that the requestor's live blocks + received blocks include all live blocks for respondent
                     checkBinary Set.isSubsetOf respLive (reqLive `Set.union` recBlocks) "is a subset of" "respondent live blocks" "requestor live blocks + received blocks"
@@ -219,10 +219,10 @@ catchUpCheck (_, _, _, c1, s1) (_, _, _, c2, s2) = do
 
 doCatchUpCheck :: Int -> Int -> Property
 doCatchUpCheck n steps = monadicIO $ do
-        s0 <- initialiseStatesDictator n
+        (s0, genHash) <- initialiseStatesDictator n
         gen <- pick $ mkStdGen <$> arbitrary
         s1 <- liftIO $ runKonsensus steps gen s0 (makeExecState $ initialEvents s0)
-        return $ simpleCatchUpCheck s1
+        return $ simpleCatchUpCheck genHash s1
 
 tests :: Word -> Spec
 tests lvl = parallel $ describe "Concordium.CatchUp" $ do

--- a/concordium-consensus/tests/consensus/ConcordiumTests/CatchUp.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/CatchUp.hs
@@ -120,7 +120,7 @@ initialiseStatesDictator n = do
                                         (MTMBConfig defaultRuntimeParameters{rpEarlyBlockThreshold=maxBound})
                                         (ActiveFinalization fininst)
                                         NoHandler
-                                (initCtx, initState) <- liftIO $ runSilentLogger (initialiseSkovWithGenesis gen config)
+                                (initCtx, initState) <- liftIO $ runSilentLogger (initialiseSkov gen config)
                                 return (bid, binfo, (kp, gaAddress acct), initCtx, initState)
                              ) bis
         return $ (Vec.fromList res)

--- a/concordium-consensus/tests/consensus/ConcordiumTests/CatchUp.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/CatchUp.hs
@@ -117,10 +117,10 @@ initialiseStatesDictator n = do
         res <- liftIO $ mapM (\(bid, binfo, acct, kp) -> do
                                 let fininst = FinalizationInstance (bakerSignKey bid) (bakerElectionKey bid) (bakerAggregationKey bid)
                                 let config = SkovConfig
-                                        (MTMBConfig defaultRuntimeParameters{rpEarlyBlockThreshold=maxBound} gen)
+                                        (MTMBConfig defaultRuntimeParameters{rpEarlyBlockThreshold=maxBound})
                                         (ActiveFinalization fininst)
                                         NoHandler
-                                (initCtx, initState) <- liftIO $ runSilentLogger (initialiseSkov config)
+                                (initCtx, initState) <- liftIO $ runSilentLogger (initialiseSkovWithGenesis gen config)
                                 return (bid, binfo, (kp, gaAddress acct), initCtx, initState)
                              ) bis
         return $ Vec.fromList res

--- a/concordium-consensus/tests/consensus/ConcordiumTests/FinalizationRecover.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/FinalizationRecover.hs
@@ -69,13 +69,13 @@ setup nBakers = do
   let initialState inst =
         initialFinalizationState
         inst
-        (getHash (GenesisBlock genData))
+        (getHash (GenesisBlock (genesisConfiguration genData)))
         (gdFinalizationParameters genData)
         fullBakers
         genTotal
   let initialPassiveState =
         initialPassiveFinalizationState
-        (getHash (GenesisBlock genData))
+        (getHash (GenesisBlock (genesisConfiguration genData)))
         (gdFinalizationParameters genData)
         fullBakers
         genTotal

--- a/concordium-consensus/tests/consensus/ConcordiumTests/FinalizationRecover.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/FinalizationRecover.hs
@@ -80,7 +80,7 @@ setup nBakers = do
         fullBakers
         genTotal
   let finInstances = map (makeFinalizationInstance . fst) bakers
-  (gsc, gss, _) <- runSilentLogger( initialiseGlobalStateWithGenesis genData =<< (liftIO $ makeGlobalStateConfig defaultRuntimeParameters))
+  (gsc, gss, _) <- runSilentLogger( initialiseGlobalState genData =<< (liftIO $ makeGlobalStateConfig defaultRuntimeParameters))
   active <- forM finInstances (\inst -> (initialState inst,) <$> runSilentLogger (getFinalizationState (Proxy :: Proxy PV) (Proxy :: Proxy TreeConfig) (gsc, gss) (Just inst)))
   passive <- (initialPassiveState,) <$> runSilentLogger (getFinalizationState (Proxy :: Proxy PV) (Proxy :: Proxy TreeConfig) (gsc, gss) Nothing)
   return $ passive:active

--- a/concordium-consensus/tests/consensus/ConcordiumTests/FinalizationRecover.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/FinalizationRecover.hs
@@ -37,8 +37,8 @@ dummyArs = emptyAnonymityRevokers
 
 -- type TreeConfig = DiskTreeDiskBlockConfig
 type TreeConfig = MemoryTreeMemoryBlockConfig
-makeGlobalStateConfig :: RuntimeParameters -> GenesisData PV -> IO (TreeConfig PV)
-makeGlobalStateConfig rt genData = return $ MTMBConfig rt genData
+makeGlobalStateConfig :: RuntimeParameters -> IO (TreeConfig PV)
+makeGlobalStateConfig rt = return $ MTMBConfig rt
 
 genesis :: Word -> (GenesisData PV, [(BakerIdentity, FullBakerInfo)], Amount)
 genesis nBakers =
@@ -80,7 +80,7 @@ setup nBakers = do
         fullBakers
         genTotal
   let finInstances = map (makeFinalizationInstance . fst) bakers
-  (gsc, gss, _) <- runSilentLogger( initialiseGlobalState =<< (liftIO $ makeGlobalStateConfig defaultRuntimeParameters genData))
+  (gsc, gss, _) <- runSilentLogger( initialiseGlobalStateWithGenesis genData =<< (liftIO $ makeGlobalStateConfig defaultRuntimeParameters))
   active <- forM finInstances (\inst -> (initialState inst,) <$> runSilentLogger (getFinalizationState (Proxy :: Proxy PV) (Proxy :: Proxy TreeConfig) (gsc, gss) (Just inst)))
   passive <- (initialPassiveState,) <$> runSilentLogger (getFinalizationState (Proxy :: Proxy PV) (Proxy :: Proxy TreeConfig) (gsc, gss) Nothing)
   return $ passive:active

--- a/concordium-consensus/tests/consensus/ConcordiumTests/FinalizationRecover.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/FinalizationRecover.hs
@@ -37,7 +37,7 @@ dummyArs = emptyAnonymityRevokers
 
 -- type TreeConfig = DiskTreeDiskBlockConfig
 type TreeConfig = MemoryTreeMemoryBlockConfig
-makeGlobalStateConfig :: RuntimeParameters -> IO (TreeConfig PV)
+makeGlobalStateConfig :: RuntimeParameters -> IO TreeConfig
 makeGlobalStateConfig rt = return $ MTMBConfig rt
 
 genesis :: Word -> (GenesisData PV, [(BakerIdentity, FullBakerInfo)], Amount)

--- a/concordium-consensus/tests/consensus/ConcordiumTests/Konsensus.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/Konsensus.hs
@@ -562,7 +562,7 @@ createInitStates bis extraAccounts maxFinComSize = Vec.fromList <$> liftIO (mapM
                     (MTMBConfig defaultRuntimeParameters)
                     (ActiveFinalization fininst)
                     NoHandler
-            (initCtx, initState) <- runSilentLogger (initialiseSkovWithGenesis gen config)
+            (initCtx, initState) <- runSilentLogger (initialiseSkov gen config)
             return (bid, binfo, (kp, gaAddress acct), initCtx, initState)
 
 instance Show BakerIdentity where

--- a/concordium-consensus/tests/consensus/ConcordiumTests/Konsensus.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/Konsensus.hs
@@ -559,10 +559,10 @@ createInitStates bis extraAccounts maxFinComSize = Vec.fromList <$> liftIO (mapM
         createState (bid, binfo, acct, kp) = do
             let fininst = FinalizationInstance (bakerSignKey bid) (bakerElectionKey bid) (bakerAggregationKey bid)
                 config = SkovConfig
-                    (MTMBConfig defaultRuntimeParameters gen)
+                    (MTMBConfig defaultRuntimeParameters)
                     (ActiveFinalization fininst)
                     NoHandler
-            (initCtx, initState) <- runSilentLogger (initialiseSkov config)
+            (initCtx, initState) <- runSilentLogger (initialiseSkovWithGenesis gen config)
             return (bid, binfo, (kp, gaAddress acct), initCtx, initState)
 
 instance Show BakerIdentity where

--- a/concordium-consensus/tests/consensus/ConcordiumTests/PassiveFinalization.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/PassiveFinalization.hs
@@ -305,10 +305,10 @@ createInitStates additionalFinMembers = do
         createState = liftIO . (\(bid, _, _, _) -> do
                                    let fininst = FinalizationInstance (bakerSignKey bid) (bakerElectionKey bid) (bakerAggregationKey bid)
                                        config = SkovConfig
-                                           (MTMBConfig defaultRuntimeParameters gen)
+                                           (MTMBConfig defaultRuntimeParameters)
                                            (ActiveFinalization fininst)
                                            NoHandler
-                                   (initCtx, initState) <- runSilentLogger (initialiseSkov config)
+                                   (initCtx, initState) <- runSilentLogger (initialiseSkovWithGenesis gen config)
                                    return (bid, initCtx, initState))
     b1 <- createState baker1
     b2 <- createState baker2

--- a/concordium-consensus/tests/consensus/ConcordiumTests/PassiveFinalization.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/PassiveFinalization.hs
@@ -308,7 +308,7 @@ createInitStates additionalFinMembers = do
                                            (MTMBConfig defaultRuntimeParameters)
                                            (ActiveFinalization fininst)
                                            NoHandler
-                                   (initCtx, initState) <- runSilentLogger (initialiseSkovWithGenesis gen config)
+                                   (initCtx, initState) <- runSilentLogger (initialiseSkov gen config)
                                    return (bid, initCtx, initState))
     b1 <- createState baker1
     b2 <- createState baker2

--- a/concordium-consensus/tests/consensus/ConcordiumTests/Update.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/Update.hs
@@ -123,10 +123,10 @@ createInitStates = do
         createState = liftIO . (\(bid, _, _, _) -> do
                                    let fininst = FinalizationInstance (bakerSignKey bid) (bakerElectionKey bid) (bakerAggregationKey bid)
                                        config = SkovConfig
-                                           (MTMBConfig defaultRuntimeParameters gen)
+                                           (MTMBConfig defaultRuntimeParameters)
                                            (ActiveFinalization fininst)
                                            NoHandler
-                                   (initCtx, initState) <- runSilentLogger (initialiseSkov config)
+                                   (initCtx, initState) <- runSilentLogger (initialiseSkovWithGenesis gen config)
                                    return (bid, initCtx, initState))
     b1 <- createState baker1
     b2 <- createState baker2

--- a/concordium-consensus/tests/consensus/ConcordiumTests/Update.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/Update.hs
@@ -126,7 +126,7 @@ createInitStates = do
                                            (MTMBConfig defaultRuntimeParameters)
                                            (ActiveFinalization fininst)
                                            NoHandler
-                                   (initCtx, initState) <- runSilentLogger (initialiseSkovWithGenesis gen config)
+                                   (initCtx, initState) <- runSilentLogger (initialiseSkov gen config)
                                    return (bid, initCtx, initState))
     b1 <- createState baker1
     b2 <- createState baker2

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/AccountReleaseScheduleTest.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/AccountReleaseScheduleTest.hs
@@ -103,8 +103,8 @@ createGS dbDir = do
     n = 3
     genesis = makeTestingGenesisDataP1 now n 1 1 dummyFinalizationCommitteeMaxSize dummyCryptographicParameters emptyIdentityProviders emptyAnonymityRevokers maxBound dummyKeyCollection dummyChainParameters
     rp = defaultRuntimeParameters
-    config = PairGSConfig (MTMBConfig rp genesis, DTDBConfig rp dbDir (dbDir </> "blockstate" <.> "dat") genesis)
-  (x, y, (NoLogContext, NoLogContext)) <- runSilentLogger $ initialiseGlobalState config
+    config = PairGSConfig (MTMBConfig rp, DTDBConfig rp dbDir (dbDir </> "blockstate" <.> "dat"))
+  (x, y, (NoLogContext, NoLogContext)) <- runSilentLogger $ initialiseGlobalStateWithGenesis genesis config
   return (Identity x, Identity y)
 
 destroyGS :: (Identity PairedGSContext, Identity PairedGState) -> IO ()

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/AccountReleaseScheduleTest.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/AccountReleaseScheduleTest.hs
@@ -104,7 +104,7 @@ createGS dbDir = do
     genesis = makeTestingGenesisDataP1 now n 1 1 dummyFinalizationCommitteeMaxSize dummyCryptographicParameters emptyIdentityProviders emptyAnonymityRevokers maxBound dummyKeyCollection dummyChainParameters
     rp = defaultRuntimeParameters
     config = PairGSConfig (MTMBConfig rp, DTDBConfig rp dbDir (dbDir </> "blockstate" <.> "dat"))
-  (x, y, (NoLogContext, NoLogContext)) <- runSilentLogger $ initialiseGlobalStateWithGenesis genesis config
+  (x, y, (NoLogContext, NoLogContext)) <- runSilentLogger $ initialiseGlobalState genesis config
   return (Identity x, Identity y)
 
 destroyGS :: (Identity PairedGSContext, Identity PairedGState) -> IO ()

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/PersistentTreeState.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/PersistentTreeState.hs
@@ -66,7 +66,7 @@ createGlobalState dbDir = do
     n = 3
     genesis = makeTestingGenesisDataP1 now n 1 1 dummyFinalizationCommitteeMaxSize dummyCryptographicParameters emptyIdentityProviders emptyAnonymityRevokers maxBound dummyKeyCollection dummyChainParameters
     config = DTDBConfig defaultRuntimeParameters dbDir (dbDir </> "blockstate" <.> "dat")
-  (x, y, NoLogContext) <- runSilentLogger $ initialiseGlobalStateWithGenesis genesis config
+  (x, y, NoLogContext) <- runSilentLogger $ initialiseGlobalState genesis config
   return (x, y)
 
 destroyGlobalState :: (PBS.PersistentBlockStateContext, SkovPersistentData PV () (PBS.HashedPersistentBlockState PV)) -> IO ()

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/PersistentTreeState.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/PersistentTreeState.hs
@@ -65,8 +65,8 @@ createGlobalState dbDir = do
   let
     n = 3
     genesis = makeTestingGenesisDataP1 now n 1 1 dummyFinalizationCommitteeMaxSize dummyCryptographicParameters emptyIdentityProviders emptyAnonymityRevokers maxBound dummyKeyCollection dummyChainParameters
-    config = DTDBConfig defaultRuntimeParameters dbDir (dbDir </> "blockstate" <.> "dat") genesis
-  (x, y, NoLogContext) <- runSilentLogger $ initialiseGlobalState config
+    config = DTDBConfig defaultRuntimeParameters dbDir (dbDir </> "blockstate" <.> "dat")
+  (x, y, NoLogContext) <- runSilentLogger $ initialiseGlobalStateWithGenesis genesis config
   return (x, y)
 
 destroyGlobalState :: (PBS.PersistentBlockStateContext, SkovPersistentData PV () (PBS.HashedPersistentBlockState PV)) -> IO ()

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/Updates.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/Updates.hs
@@ -104,8 +104,8 @@ createGS dbDir = do
                                      dummyKeyCollection
                                      dummyChainParameters
     rp = defaultRuntimeParameters
-    config = PairGSConfig (MTMBConfig rp genesis, DTDBConfig rp dbDir (dbDir </> "blockstate" <.> "dat") genesis)
-  (x, y, (NoLogContext, NoLogContext)) <- runSilentLogger $ initialiseGlobalState config
+    config = PairGSConfig (MTMBConfig rp, DTDBConfig rp dbDir (dbDir </> "blockstate" <.> "dat"))
+  (x, y, (NoLogContext, NoLogContext)) <- runSilentLogger $ initialiseGlobalStateWithGenesis genesis config
   return (Identity x, Identity y)
 
 destroyGS :: (Identity PairedGSContext, Identity PairedGState) -> IO ()

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/Updates.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/Updates.hs
@@ -105,7 +105,7 @@ createGS dbDir = do
                                      dummyChainParameters
     rp = defaultRuntimeParameters
     config = PairGSConfig (MTMBConfig rp, DTDBConfig rp dbDir (dbDir </> "blockstate" <.> "dat"))
-  (x, y, (NoLogContext, NoLogContext)) <- runSilentLogger $ initialiseGlobalStateWithGenesis genesis config
+  (x, y, (NoLogContext, NoLogContext)) <- runSilentLogger $ initialiseGlobalState genesis config
   return (Identity x, Identity y)
 
 destroyGS :: (Identity PairedGSContext, Identity PairedGState) -> IO ()

--- a/concordium-consensus/tests/scheduler/SchedulerTests/Payday.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/Payday.hs
@@ -255,8 +255,8 @@ createGlobalState :: (IsProtocolVersion pv) => FilePath -> IO (PersistentBlockSt
 createGlobalState dbDir = do
   let
     n = 5
-    config = DTDBConfig defaultRuntimeParameters dbDir (dbDir </> "blockstate" <.> "dat") (genesis n ^. _1)
-  (x, y, NoLogContext) <- runSilentLogger $ initialiseGlobalState config
+    config = DTDBConfig defaultRuntimeParameters dbDir (dbDir </> "blockstate" <.> "dat")
+  (x, y, NoLogContext) <- runSilentLogger $ initialiseGlobalState (genesis n ^. _1) config
   return (x, y)
 
 destroyGlobalState :: (IsProtocolVersion pv) => (PersistentBlockStateContext, MyPersistentTreeState pv) -> IO ()

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/AllNewHostFunctions.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/AllNewHostFunctions.hs
@@ -8,16 +8,13 @@
 module SchedulerTests.SmartContracts.V1.AllNewHostFunctions (tests) where
 
 import Test.Hspec
-import Test.HUnit(assertFailure, assertEqual, Assertion)
+import Test.HUnit(assertFailure, Assertion)
 
 import qualified Data.ByteString as BS
-import qualified Data.Set as Set
-import qualified Data.Map.Strict as Map
 
 import Concordium.Wasm
 import qualified Concordium.GlobalState.Wasm as GSWasm
 import qualified Concordium.Scheduler.WasmIntegration.V1 as WasmV1
-import qualified Concordium.Scheduler.WasmIntegration as WasmV0
 
 -- |A V1 module with extra exports.
 testModule1 :: Assertion

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_node"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "anyhow",
  "app_dirs2",

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_node"
-version = "4.0.11"
+version = "4.1.0"
 dependencies = [
  "anyhow",
  "app_dirs2",

--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium_node"
-version = "4.0.11" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
+version = "4.1.0" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
 description = "Concordium Node"
 authors = ["Concordium <developers@concordium.com>"]
 exclude = [".gitignore", ".gitlab-ci.yml", "test/**/*","**/**/.gitignore","**/**/.gitlab-ci.yml"]

--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium_node"
-version = "4.1.0" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
+version = "4.2.0" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
 description = "Concordium Node"
 authors = ["Concordium <developers@concordium.com>"]
 exclude = [".gitignore", ".gitlab-ci.yml", "test/**/*","**/**/.gitignore","**/**/.gitlab-ci.yml"]

--- a/scripts/genesis/genesis-p1.json
+++ b/scripts/genesis/genesis-p1.json
@@ -1,7 +1,7 @@
 {
   "v": 2,
   "value": {
-    "genesisTime": 1637307534000,
+    "genesisTime": 1652531203000,
     "slotDuration": 250,
     "leadershipElectionNonce": "5bb78b5f359007c9532e17e474ff188c30bbd999147f6721d870f7ab2004e438",
     "epochLength": 3600,


### PR DESCRIPTION
## Purpose

Improve node startup time by avoiding to load data that is not needed.

Closes #340

## Changes

- [x] Avoid processing protocol updates that have already been processed by the node and whose results are already stored in the state.
- [x] To achieve the above it was necessary to avoid storing genesis data as well. Genesis data was stored for each genesis index in two places, in the genesisData field of SkovPersistentData, as well as behind the genesisBlockPointer field. Both of those now store `GenesisConfiguration` only which has a small, fixed size. The effect of this should be considerably reduced memory use in case of multiple protocol updates with large number of accounts or contracts.
- [x] In order to avoid loading genesis some changes in LMDB were needed. The new node will no longer store the full genesis block in the tree state. Instead only genesis configuration is stored. The new node is compatible with existing state. It will manage to load GenesisConfiguration from the stored genesis block. However the opposite is not true. The state produced by node version 4.1 cannot be used by node versions < 4.1.
- [x] The effect of the changes is that the node will no longer check whether the genesis data it was given is compatible with the state that it has.

## Depends on 
- [x] https://github.com/Concordium/concordium-base/pull/152

### Startup time of mainnet node
- After the changes around 1min 50s
```
2022-05-23T06:55:17.228017214Z: INFO: Starting up concordium_node version 4.1.0!
...
2022-05-23T06:57:04.318102248Z: INFO: Starting RPC server
```

Memory use around 2.5GB after startup.

- Before the changes around 3min 40s
```
May 23 09:03:10 capybara concordium-mainnet-node-4.0.11[2258237]: [INFO  concordium_node::utils] Starting up concordium_node version 4.0.11!
May 23 09:06:51 capybara concordium-mainnet-node-4.0.11[2258237]: [INFO  concordium_node] Starting RPC server
```

Memory use around 4GB (unshared) after startup.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG
