### PR TITLE
Info log when blocks are received.

### DIFF
--- a/concordium-consensus/src/Concordium/Skov/Update.hs
+++ b/concordium-consensus/src/Concordium/Skov/Update.hs
@@ -488,7 +488,7 @@ doStoreBlock pb@GB.PendingBlock{..} = unlessShutDown $ do
                 -- Check that the claimed key matches the signature/blockhash
                 checkClaimedSignature pb $ do
                 -- The block is new, so we have some work to do.
-                logEvent Skov LLDebug $ "Received block " ++ show pb
+                logEvent Skov LLInfo $ "Received block " ++ show pb
                 -- Get the `BlockState` of which the transactions should be verified within.
                 bs <- getContextBlockState (blockPointer bbFields)
                 txListWithVerRes <- sequence <$> forM (blockTransactions pb)


### PR DESCRIPTION
## Purpose

Info log whenever blocks are received in contrast to today when it is only logged when running with debug log level. 


Today we already info log when blocks 'arrive' into the state. 
Info logging the receive time as well could potentially be useful when inspecting logs and understanding the network. 

Info logging the block received event will not pollute the log and as such it would be ok to do. 


## Changes

Changed log level from debug to info for when blocks are received. 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
