### PR TITLE
Deferred credential registration id deserialization until use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
   - increased smart contract module size limit, 512kB
   - a number of cryptographic primitives
 - Node can now be stopped during out of band catchup by using signals, SIGINT and SIGTERM.
+- Decreased node startup time but deferring credential registration id deserialization until use.
 
 ## concordium-node 3.0.1
 

--- a/concordium-consensus/src/Concordium/GlobalState/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Account.hs
@@ -32,11 +32,11 @@ import Concordium.GlobalState.Basic.BlockState.AccountReleaseSchedule
 -- |A list of credential IDs that have been removed from an account.
 data RemovedCredentials
     = EmptyRemovedCredentials
-    | RemovedCredential !CredentialRegistrationID !RemovedCredentials
+    | RemovedCredential !RawCredentialRegistrationID !RemovedCredentials
     deriving (Eq)
 
 -- |Convert a 'RemovedCredentials' to a list of 'CredentialRegistrationID's.
-removedCredentialsToList :: RemovedCredentials -> [CredentialRegistrationID]
+removedCredentialsToList :: RemovedCredentials -> [RawCredentialRegistrationID]
 removedCredentialsToList EmptyRemovedCredentials = []
 removedCredentialsToList (RemovedCredential cred rest) = cred : removedCredentialsToList rest
 
@@ -59,7 +59,7 @@ emptyRemovedCredentialsHash = Hash.hash "E"
 {-# NOINLINE emptyRemovedCredentialsHash #-}
 
 -- |Function for determining the hash of a 'RemovedCredential'.
-removedCredentialHash :: CredentialRegistrationID -> Hash.Hash -> Hash.Hash
+removedCredentialHash :: RawCredentialRegistrationID -> Hash.Hash -> Hash.Hash
 removedCredentialHash cred hrest = Hash.hash $ "R" <> encode cred <> Hash.hashToByteString hrest
 
 instance HashableTo Hash.Hash RemovedCredentials where
@@ -67,7 +67,7 @@ instance HashableTo Hash.Hash RemovedCredentials where
   getHash (RemovedCredential cred rest) = removedCredentialHash cred (getHash rest)
 
 -- |Update hashed remove credentials with a new removed credentials.
-addRemovedCredential :: CredentialRegistrationID -> Hashed RemovedCredentials -> Hashed RemovedCredentials
+addRemovedCredential :: RawCredentialRegistrationID -> Hashed RemovedCredentials -> Hashed RemovedCredentials
 addRemovedCredential cred hrc = Hashed (RemovedCredential cred (hrc ^. unhashed)) (removedCredentialHash cred (getHash hrc))
 
 -- |Hashed 'EmptyRemovedCredentials'.
@@ -278,7 +278,7 @@ updateCredentials cuRemove cuAdd cuAccountThreshold d =
                & (accountVerificationKeys %~ updateAccountInformation cuAccountThreshold cuAdd cuRemove)
                & (accountRemovedCredentials %~ flip (foldl' (flip (addRemovedCredential . removedCredentialId))) cuRemove)
   where removeKeys = flip (foldl' (flip Map.delete)) cuRemove
-        removedCredentialId cix = credId $ Map.findWithDefault (error "Removed credential key not found") cix (d ^. accountCredentials)
+        removedCredentialId cix = toRawCredRegId . credId $ Map.findWithDefault (error "Removed credential key not found") cix (d ^. accountCredentials)
         
 
 -- |Update the keys of the given account credential.

--- a/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState.hs
@@ -29,6 +29,7 @@ import qualified Control.Monad.State.Strict as MTL
 import qualified Control.Monad.Except as MTL
 import qualified Control.Monad.Writer.Strict as MTL
 
+import qualified Concordium.ID.Types as ID
 import Concordium.Types
 import Concordium.Types.Accounts
 import Concordium.Types.Updates
@@ -639,7 +640,7 @@ instance (IsProtocolVersion pv, Monad m) => BS.BlockStateQuery (PureBlockStateMo
 
     {-# INLINE getAccountByCredId #-}
     getAccountByCredId bs cid =
-      let mai = bs ^? blockAccounts . to Accounts.accountRegIds . ix (encode cid)
+      let mai = bs ^? blockAccounts . to Accounts.accountRegIds . ix (ID.toRawCredRegId cid)
       in case mai of
            Nothing -> return Nothing
            Just ai -> return $ (ai, ) <$> bs ^? blockAccounts . Accounts.indexedAccount ai

--- a/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState.hs
@@ -639,7 +639,7 @@ instance (IsProtocolVersion pv, Monad m) => BS.BlockStateQuery (PureBlockStateMo
 
     {-# INLINE getAccountByCredId #-}
     getAccountByCredId bs cid =
-      let mai = bs ^? blockAccounts . to Accounts.accountRegIds . ix cid
+      let mai = bs ^? blockAccounts . to Accounts.accountRegIds . ix (encode cid)
       in case mai of
            Nothing -> return Nothing
            Just ai -> return $ (ai, ) <$> bs ^? blockAccounts . Accounts.indexedAccount ai

--- a/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState.hs
@@ -29,7 +29,6 @@ import qualified Control.Monad.State.Strict as MTL
 import qualified Control.Monad.Except as MTL
 import qualified Control.Monad.Writer.Strict as MTL
 
-import qualified Concordium.ID.Types as ID
 import Concordium.Types
 import Concordium.Types.Accounts
 import Concordium.Types.Updates
@@ -640,7 +639,7 @@ instance (IsProtocolVersion pv, Monad m) => BS.BlockStateQuery (PureBlockStateMo
 
     {-# INLINE getAccountByCredId #-}
     getAccountByCredId bs cid =
-      let mai = bs ^? blockAccounts . to Accounts.accountRegIds . ix (ID.toRawCredRegId cid)
+      let mai = bs ^? blockAccounts . to Accounts.accountRegIds . ix cid
       in case mai of
            Nothing -> return Nothing
            Just ai -> return $ (ai, ) <$> bs ^? blockAccounts . Accounts.indexedAccount ai

--- a/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/Accounts.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/Accounts.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE TypeFamilies #-}
 module Concordium.GlobalState.Basic.BlockState.Accounts where
 
+import qualified Data.ByteString as BS
 import Data.Serialize
 import qualified Data.Map.Strict as Map
 import GHC.Stack (HasCallStack)
@@ -46,7 +47,7 @@ data Accounts (pv :: ProtocolVersion) = Accounts {
     -- |Hashed Merkle-tree of the accounts.
     accountTable :: !(AT.AccountTable (AccountVersionFor pv)),
     -- |A mapping of 'ID.CredentialRegistrationID's to accounts on which they are used.
-    accountRegIds :: !(Map.Map ID.CredentialRegistrationID AccountIndex)
+    accountRegIds :: !(Map.Map BS.ByteString AccountIndex)
 }
 
 instance IsProtocolVersion pv => Show (Accounts pv) where
@@ -166,16 +167,16 @@ addressWouldClash addr Accounts{..} = AccountMap.addressWouldClashPure addr acco
 -- is the account index of the account is or was associated with, and @Nothing@
 -- otherwise.
 regIdExists :: ID.CredentialRegistrationID -> Accounts pv -> Maybe AccountIndex
-regIdExists rid Accounts{..} = rid `Map.lookup` accountRegIds
+regIdExists rid Accounts{..} = encode rid `Map.lookup` accountRegIds
 
 -- |Record an account registration ID as used on the account.
 recordRegId :: ID.CredentialRegistrationID -> AccountIndex -> Accounts pv -> Accounts pv
-recordRegId rid idx accs = accs { accountRegIds = Map.insert rid idx (accountRegIds accs) }
+recordRegId rid idx accs = accs { accountRegIds = Map.insert (encode rid) idx (accountRegIds accs) }
 
 -- |Record multiple registration ids as used. This implementation is marginally
 -- more efficient than repeatedly calling `recordRegId`.
 recordRegIds :: [(ID.CredentialRegistrationID, AccountIndex)] -> Accounts pv -> Accounts pv
-recordRegIds rids accs = accs { accountRegIds = Map.union (accountRegIds accs) (Map.fromAscList rids) }
+recordRegIds rids accs = accs { accountRegIds = Map.union (accountRegIds accs) (Map.fromAscList ((_1 %~ encode) <$> rids)) }
     -- since credentials can only be used on one account the union is well-defined, the maps should be disjoint.
 
 instance HashableTo H.Hash (Accounts pv) where
@@ -223,8 +224,8 @@ deserializeAccounts migration cryptoParams = do
                   | cred `Map.member` regids = fail "Duplicate credential"
                   | otherwise = return $ Map.insert cred acctId regids
             newRegIds <- foldM addRegId accountRegIds $
-                (ID.credId <$> Map.elems (acct ^. accountCredentials))
-                ++ removedCredentialsToList (acct ^. accountRemovedCredentials . unhashed)
+                (encode . ID.credId <$> Map.elems (acct ^. accountCredentials))
+                ++ (encode <$> removedCredentialsToList (acct ^. accountRemovedCredentials . unhashed))
             loop (i+1)
               Accounts {
                 accountMap = AccountMap.insertPure (acct ^. accountAddress) acctId accountMap,

--- a/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/Accounts.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/Accounts.hs
@@ -224,7 +224,7 @@ deserializeAccounts migration cryptoParams = do
                   | otherwise = return $ Map.insert cred acctId regids
             newRegIds <- foldM addRegId accountRegIds $
                 (ID.toRawCredRegId . ID.credId <$> Map.elems (acct ^. accountCredentials))
-                ++ (ID.toRawCredRegId <$> removedCredentialsToList (acct ^. accountRemovedCredentials . unhashed))
+                ++ removedCredentialsToList (acct ^. accountRemovedCredentials . unhashed)
             loop (i+1)
               Accounts {
                 accountMap = AccountMap.insertPure (acct ^. accountAddress) acctId accountMap,

--- a/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/Invariants.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/Invariants.hs
@@ -4,6 +4,7 @@
 -- auditing.
 module Concordium.GlobalState.Basic.BlockState.Invariants where
 
+import Data.Serialize
 import qualified Data.Set as Set
 import qualified Data.Map.Strict as Map
 import qualified Data.Vector as Vec
@@ -74,7 +75,7 @@ invariantBlockState bs extraBalance = do
                         unless (Set.member (binfo ^. bakerAggregationVerifyKey) bakerKeys) $ Left "Baker aggregation key is missing from active bakers"
                         return (Map.delete (BakerId i) bakerIds, Set.delete (binfo ^. bakerAggregationVerifyKey) bakerKeys)
             return (creds', Map.insert addr i amp, bal + (acct ^. accountAmount), bakerIds', bakerKeys')
-        checkCred i creds (ID.credId -> cred)
+        checkCred i creds (encode . ID.credId -> cred)
             | cred `Map.member` creds = Left $ "Duplicate credential: " ++ show cred
             | otherwise = return $ Map.insert cred i creds
         checkEpochBakers EpochBakers{..} = do

--- a/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/Invariants.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/Invariants.hs
@@ -4,7 +4,6 @@
 -- auditing.
 module Concordium.GlobalState.Basic.BlockState.Invariants where
 
-import Data.Serialize
 import qualified Data.Set as Set
 import qualified Data.Map.Strict as Map
 import qualified Data.Vector as Vec
@@ -75,7 +74,7 @@ invariantBlockState bs extraBalance = do
                         unless (Set.member (binfo ^. bakerAggregationVerifyKey) bakerKeys) $ Left "Baker aggregation key is missing from active bakers"
                         return (Map.delete (BakerId i) bakerIds, Set.delete (binfo ^. bakerAggregationVerifyKey) bakerKeys)
             return (creds', Map.insert addr i amp, bal + (acct ^. accountAmount), bakerIds', bakerKeys')
-        checkCred i creds (encode . ID.credId -> cred)
+        checkCred i creds (ID.toRawCredRegId . ID.credId -> cred)
             | cred `Map.member` creds = Left $ "Duplicate credential: " ++ show cred
             | otherwise = return $ Map.insert cred i creds
         checkEpochBakers EpochBakers{..} = do

--- a/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
@@ -84,7 +84,7 @@ import Concordium.Types.Transactions hiding (BareBlockItem(..))
 
 import qualified Concordium.ID.Types as ID
 import Concordium.ID.Parameters(GlobalContext)
-import Concordium.ID.Types (AccountCredential, CredentialRegistrationID)
+import Concordium.ID.Types (AccountCredential)
 import Concordium.Crypto.EncryptedTransfers
 import Concordium.GlobalState.ContractStateFFIHelpers (LoadCallback)
 import qualified Concordium.GlobalState.ContractStateV1 as StateV1
@@ -371,7 +371,7 @@ class (ContractStateOperations m, AccountOperations m) => BlockStateQuery m wher
     getActiveBakersAndDelegators :: (AccountVersionFor (MPV m) ~ 'AccountV1) => BlockState m -> m ([ActiveBakerInfo m], [ActiveDelegatorInfo])
 
     -- |Query an account by the id of the credential that belonged to it.
-    getAccountByCredId :: BlockState m -> CredentialRegistrationID -> m (Maybe (AccountIndex, Account m))
+    getAccountByCredId :: BlockState m -> ID.RawCredentialRegistrationID -> m (Maybe (AccountIndex, Account m))
 
     -- |Query an account by the account index that belonged to it.
     getAccountByIndex :: BlockState m -> AccountIndex -> m (Maybe (AccountIndex, Account m))

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Accounts.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Accounts.hs
@@ -33,6 +33,7 @@ import qualified Concordium.GlobalState.Persistent.LFMBTree as L
 import Concordium.Types.HashableTo
 import Data.Foldable (foldrM, foldl', foldlM)
 import Concordium.ID.Parameters
+import qualified Data.ByteString as BS
 
 -- |Representation of the set of accounts on the chain.
 -- Each account has an 'AccountIndex' which is the order
@@ -61,9 +62,9 @@ data Accounts (pv :: ProtocolVersion) = Accounts {
     -- |Hashed Merkle-tree of the accounts
     accountTable :: !(LFMBTree AccountIndex HashedBufferedRef (PersistentAccount (AccountVersionFor pv))),
     -- |Optional cached set of used 'ID.CredentialRegistrationID's
-    accountRegIds :: !(Nullable (Map.Map ID.CredentialRegistrationID AccountIndex)),
+    accountRegIds :: !(Nullable (Map.Map BS.ByteString AccountIndex)),
     -- |Persisted representation of the map from registration ids to account indices.
-    accountRegIdHistory :: !(Trie.TrieN (BufferedBlobbed BlobRef) ID.CredentialRegistrationID AccountIndex)
+    accountRegIdHistory :: !(Trie.TrieN (BufferedBlobbed BlobRef) BS.ByteString AccountIndex)
 }
 
 -- |Convert a (non-persistent) 'Transient.Accounts' to a (persistent) 'Accounts'.
@@ -95,7 +96,7 @@ instance MonadBlobStore m => BlobStorable m RegIdHistory
 -- |Load the registration ids.  If 'accountRegIds' is @Null@, then 'accountRegIdHistory'
 -- is used (reading from disk as necessary) to determine it, in which case 'accountRegIds'
 -- is updated with the determined value.
-loadRegIds :: forall m pv. MonadBlobStore m => Accounts pv -> m (Map.Map ID.CredentialRegistrationID AccountIndex, Accounts pv)
+loadRegIds :: forall m pv. MonadBlobStore m => Accounts pv -> m (Map.Map BS.ByteString AccountIndex, Accounts pv)
 loadRegIds a@Accounts{accountRegIds = Some regids} = return (regids, a)
 loadRegIds a@Accounts{accountRegIds = Null, ..} = do
         regids <- Trie.toMap accountRegIdHistory
@@ -168,11 +169,11 @@ getAccount addr Accounts{..} = AccountMap.lookup addr accountMap >>= \case
 -- |Retrieve an account associated with the given credential registration ID.
 -- Returns @Nothing@ if no such account exists.
 getAccountByCredId :: (MonadBlobStore m, IsProtocolVersion pv) => ID.CredentialRegistrationID -> Accounts pv -> m (Maybe (AccountIndex, PersistentAccount (AccountVersionFor pv)))
-getAccountByCredId cid accs@Accounts{accountRegIds = Null,..} = Trie.lookup cid accountRegIdHistory  >>= \case
+getAccountByCredId cid accs@Accounts{accountRegIds = Null,..} = Trie.lookup (encode cid) accountRegIdHistory  >>= \case
         Nothing -> return Nothing
         Just ai -> fmap (ai, ) <$> indexedAccount ai accs
 getAccountByCredId cid accs@Accounts{accountRegIds = Some cachedIds} =
-    case Map.lookup cid cachedIds of
+    case Map.lookup (encode cid) cachedIds of
         Nothing -> return Nothing
         Just ai -> fmap (ai, ) <$> indexedAccount ai accs
 
@@ -210,14 +211,14 @@ addressWouldClash addr Accounts{..} = AccountMap.addressWouldClash addr accountM
 regIdExists :: MonadBlobStore m => ID.CredentialRegistrationID -> Accounts pv -> m (Maybe AccountIndex, Accounts pv)
 regIdExists rid accts0 = do
         (regids, accts) <- loadRegIds accts0
-        return (rid `Map.lookup` regids, accts)
+        return (encode rid `Map.lookup` regids, accts)
 
 -- |Record an account registration ID as used.
 recordRegId :: MonadBlobStore m => ID.CredentialRegistrationID -> AccountIndex -> Accounts pv -> m (Accounts pv)
 recordRegId rid idx accts0 = do
-        accountRegIdHistory' <- Trie.insert rid idx (accountRegIdHistory accts0)
+        accountRegIdHistory' <- Trie.insert (encode rid) idx (accountRegIdHistory accts0)
         return $! accts0 {
-                accountRegIds = Map.insert rid idx <$> accountRegIds accts0,
+                accountRegIds = Map.insert (encode rid) idx <$> accountRegIds accts0,
                 accountRegIdHistory = accountRegIdHistory'
                 }
 

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Accounts.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Accounts.hs
@@ -33,7 +33,6 @@ import qualified Concordium.GlobalState.Persistent.LFMBTree as L
 import Concordium.Types.HashableTo
 import Data.Foldable (foldrM, foldl', foldlM)
 import Concordium.ID.Parameters
-import qualified Data.ByteString as BS
 
 -- |Representation of the set of accounts on the chain.
 -- Each account has an 'AccountIndex' which is the order
@@ -62,9 +61,9 @@ data Accounts (pv :: ProtocolVersion) = Accounts {
     -- |Hashed Merkle-tree of the accounts
     accountTable :: !(LFMBTree AccountIndex HashedBufferedRef (PersistentAccount (AccountVersionFor pv))),
     -- |Optional cached set of used 'ID.CredentialRegistrationID's
-    accountRegIds :: !(Nullable (Map.Map BS.ByteString AccountIndex)),
+    accountRegIds :: !(Nullable (Map.Map ID.RawCredentialRegistrationID AccountIndex)),
     -- |Persisted representation of the map from registration ids to account indices.
-    accountRegIdHistory :: !(Trie.TrieN (BufferedBlobbed BlobRef) BS.ByteString AccountIndex)
+    accountRegIdHistory :: !(Trie.TrieN (BufferedBlobbed BlobRef) ID.RawCredentialRegistrationID AccountIndex)
 }
 
 -- |Convert a (non-persistent) 'Transient.Accounts' to a (persistent) 'Accounts'.
@@ -96,7 +95,7 @@ instance MonadBlobStore m => BlobStorable m RegIdHistory
 -- |Load the registration ids.  If 'accountRegIds' is @Null@, then 'accountRegIdHistory'
 -- is used (reading from disk as necessary) to determine it, in which case 'accountRegIds'
 -- is updated with the determined value.
-loadRegIds :: forall m pv. MonadBlobStore m => Accounts pv -> m (Map.Map BS.ByteString AccountIndex, Accounts pv)
+loadRegIds :: forall m pv. MonadBlobStore m => Accounts pv -> m (Map.Map ID.RawCredentialRegistrationID AccountIndex, Accounts pv)
 loadRegIds a@Accounts{accountRegIds = Some regids} = return (regids, a)
 loadRegIds a@Accounts{accountRegIds = Null, ..} = do
         regids <- Trie.toMap accountRegIdHistory
@@ -169,11 +168,11 @@ getAccount addr Accounts{..} = AccountMap.lookup addr accountMap >>= \case
 -- |Retrieve an account associated with the given credential registration ID.
 -- Returns @Nothing@ if no such account exists.
 getAccountByCredId :: (MonadBlobStore m, IsProtocolVersion pv) => ID.CredentialRegistrationID -> Accounts pv -> m (Maybe (AccountIndex, PersistentAccount (AccountVersionFor pv)))
-getAccountByCredId cid accs@Accounts{accountRegIds = Null,..} = Trie.lookup (encode cid) accountRegIdHistory  >>= \case
+getAccountByCredId cid accs@Accounts{accountRegIds = Null,..} = Trie.lookup (ID.toRawCredRegId cid) accountRegIdHistory  >>= \case
         Nothing -> return Nothing
         Just ai -> fmap (ai, ) <$> indexedAccount ai accs
 getAccountByCredId cid accs@Accounts{accountRegIds = Some cachedIds} =
-    case Map.lookup (encode cid) cachedIds of
+    case Map.lookup (ID.toRawCredRegId cid) cachedIds of
         Nothing -> return Nothing
         Just ai -> fmap (ai, ) <$> indexedAccount ai accs
 
@@ -211,14 +210,14 @@ addressWouldClash addr Accounts{..} = AccountMap.addressWouldClash addr accountM
 regIdExists :: MonadBlobStore m => ID.CredentialRegistrationID -> Accounts pv -> m (Maybe AccountIndex, Accounts pv)
 regIdExists rid accts0 = do
         (regids, accts) <- loadRegIds accts0
-        return (encode rid `Map.lookup` regids, accts)
+        return (ID.toRawCredRegId rid `Map.lookup` regids, accts)
 
 -- |Record an account registration ID as used.
 recordRegId :: MonadBlobStore m => ID.CredentialRegistrationID -> AccountIndex -> Accounts pv -> m (Accounts pv)
 recordRegId rid idx accts0 = do
-        accountRegIdHistory' <- Trie.insert (encode rid) idx (accountRegIdHistory accts0)
+        accountRegIdHistory' <- Trie.insert (ID.toRawCredRegId rid) idx (accountRegIdHistory accts0)
         return $! accts0 {
-                accountRegIds = Map.insert (encode rid) idx <$> accountRegIds accts0,
+                accountRegIds = Map.insert (ID.toRawCredRegId rid) idx <$> accountRegIds accts0,
                 accountRegIdHistory = accountRegIdHistory'
                 }
 

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Accounts.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Accounts.hs
@@ -167,12 +167,12 @@ getAccount addr Accounts{..} = AccountMap.lookup addr accountMap >>= \case
 
 -- |Retrieve an account associated with the given credential registration ID.
 -- Returns @Nothing@ if no such account exists.
-getAccountByCredId :: (MonadBlobStore m, IsProtocolVersion pv) => ID.CredentialRegistrationID -> Accounts pv -> m (Maybe (AccountIndex, PersistentAccount (AccountVersionFor pv)))
-getAccountByCredId cid accs@Accounts{accountRegIds = Null,..} = Trie.lookup (ID.toRawCredRegId cid) accountRegIdHistory  >>= \case
+getAccountByCredId :: (MonadBlobStore m, IsProtocolVersion pv) => ID.RawCredentialRegistrationID -> Accounts pv -> m (Maybe (AccountIndex, PersistentAccount (AccountVersionFor pv)))
+getAccountByCredId cid accs@Accounts{accountRegIds = Null,..} = Trie.lookup cid accountRegIdHistory  >>= \case
         Nothing -> return Nothing
         Just ai -> fmap (ai, ) <$> indexedAccount ai accs
 getAccountByCredId cid accs@Accounts{accountRegIds = Some cachedIds} =
-    case Map.lookup (ID.toRawCredRegId cid) cachedIds of
+    case Map.lookup cid cachedIds of
         Nothing -> return Nothing
         Just ai -> fmap (ai, ) <$> indexedAccount ai accs
 

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -1664,7 +1664,7 @@ doGetActiveBakers pbs = do
     ab <- refLoad $ bspBirkParameters bsp ^. birkActiveBakers
     Trie.keysAsc (ab ^. activeBakers)
 
-doGetAccountByCredId :: (IsProtocolVersion pv, MonadBlobStore m) => PersistentBlockState pv -> ID.CredentialRegistrationID -> m (Maybe (AccountIndex, PersistentAccount (AccountVersionFor pv)))
+doGetAccountByCredId :: (IsProtocolVersion pv, MonadBlobStore m) => PersistentBlockState pv -> ID.RawCredentialRegistrationID -> m (Maybe (AccountIndex, PersistentAccount (AccountVersionFor pv)))
 doGetAccountByCredId pbs cid = do
         bsp <- loadPBS pbs
         Accounts.getAccountByCredId cid (bspAccounts bsp)

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Trie.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Trie.hs
@@ -64,6 +64,10 @@ deriving via Word64 instance FixedTrieKey DelegatorId
 instance FixedTrieKey Bls.PublicKey -- FIXME: This is a bad instance. Serialization of these is expensive.
 instance FixedTrieKey IDTypes.CredentialRegistrationID -- FIXME: this is not the best instance, serialization is expensive.
 
+instance FixedTrieKey BS.ByteString where
+  unpackKey = BS.unpack
+  packKey = BS.pack
+
 -- |Class for Trie keys that respect the 'Ord' instance.
 -- That is, @a `compare` b == unpackKey a `compare` unpackKey b@.
 class (Ord a, FixedTrieKey a) => OrdFixedTrieKey a

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Trie.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Trie.hs
@@ -25,6 +25,7 @@ import Data.Serialize
 import qualified Data.ByteString as BS
 import Data.Either
 import qualified Data.Map.Strict as Map
+import qualified Data.FixedByteString as FBS
 
 import Concordium.Types (AccountAddress, BakerId(..), DelegatorId(..), AccountIndex(..), ModuleRef(..))
 import Concordium.Utils
@@ -64,9 +65,9 @@ deriving via Word64 instance FixedTrieKey DelegatorId
 instance FixedTrieKey Bls.PublicKey -- FIXME: This is a bad instance. Serialization of these is expensive.
 instance FixedTrieKey IDTypes.CredentialRegistrationID -- FIXME: this is not the best instance, serialization is expensive.
 
-instance FixedTrieKey BS.ByteString where
-  unpackKey = BS.unpack
-  packKey = BS.pack
+instance FixedTrieKey (IDTypes.RawCredentialRegistrationID) where
+  unpackKey (IDTypes.RawCredRegId x) = FBS.unpack x
+  packKey = IDTypes.RawCredRegId . FBS.pack
 
 -- |Class for Trie keys that respect the 'Ord' instance.
 -- That is, @a `compare` b == unpackKey a `compare` unpackKey b@.

--- a/concordium-consensus/src/Concordium/GlobalState/TreeState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/TreeState.hs
@@ -39,6 +39,7 @@ import Concordium.Types.HashableTo
 import Concordium.Types
 import Concordium.Types.Updates hiding (getUpdateKeysCollection)
 import Concordium.GlobalState.AccountTransactionIndex
+import qualified Concordium.ID.Types as ID
 
 import Data.ByteString
 import Concordium.Logger
@@ -577,7 +578,7 @@ instance (Monad m,
   {-# INLINE registrationIdExists #-}
   registrationIdExists regId = do
     ctx <- ask
-    lift $ isJust <$> getAccountByCredId (ctx ^. ctxBs) regId
+    lift $ isJust <$> getAccountByCredId (ctx ^. ctxBs) (ID.toRawCredRegId regId)
   {-# INLINE getAccount #-}
   getAccount aaddr = do
     ctx <- ask

--- a/concordium-consensus/tests/scheduler/GlobalStateMock.hs
+++ b/concordium-consensus/tests/scheduler/GlobalStateMock.hs
@@ -106,7 +106,7 @@ data BlockStateQueryAction (pv :: ProtocolVersion) a where
     AccountExists :: MockBlockState -> AccountAddress -> BlockStateQueryAction pv Bool
     GetActiveBakers :: MockBlockState -> BlockStateQueryAction pv [BakerId]
     GetActiveBakersAndDelegators :: (AccountVersionFor pv ~ 'AccountV1) => MockBlockState -> BlockStateQueryAction pv ([ActiveBakerInfo' MockBakerInfoRef], [ActiveDelegatorInfo])
-    GetAccountByCredId :: MockBlockState -> ID.CredentialRegistrationID -> BlockStateQueryAction pv (Maybe (AccountIndex, MockAccount))
+    GetAccountByCredId :: MockBlockState -> ID.RawCredentialRegistrationID -> BlockStateQueryAction pv (Maybe (AccountIndex, MockAccount))
     GetContractInstance :: MockBlockState -> ContractAddress -> BlockStateQueryAction pv (Maybe (InstanceInfoType MockContractState))
     GetModuleList :: MockBlockState -> BlockStateQueryAction pv [ModuleRef]
     GetAccountList :: MockBlockState -> BlockStateQueryAction pv [AccountAddress]


### PR DESCRIPTION
## Purpose

Deserialization of credential registration ids takes too much time during node startup. This PR defers it until credential registration ids are used. 

Closes #342 

## Changes

In `Accounts`, the maps from credential registration ids to account index are now keyed by byte representations of credential registration ids. Every function taking a `CredentialRegistrationID` as an argument was updated to serialize it before looking it up in the account map.

Starting the consensus layer used to take 294 s before these changes, it takes 256 s after.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [X] I accept the above linked CLA.
