### PR TITLE
Install package 'ca-certificates' to make node collector work over HTTPS

### DIFF
--- a/scripts/docker/node-collector.Dockerfile
+++ b/scripts/docker/node-collector.Dockerfile
@@ -3,7 +3,7 @@ FROM ${universal_image_name} AS build
 
 FROM ubuntu:20.04
 RUN apt-get update && \
-    apt-get install -y libpq-dev && \
+    apt-get install -y ca-certificates libpq-dev && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=build /build/concordium-node/target/release/node-collector /node-collector
 ENTRYPOINT ["/node-collector"]


### PR DESCRIPTION
## Purpose

Ensure that the containers started from the Node Collector image is able to push over HTTPS.

## Changes

Install package 'ca-certificates' into the image.