### PR TITLE
Loosen the sandboxing and allow writable and executable regions.

### DIFF
--- a/scripts/distribution/ubuntu-packages/template/debian/concordium-node.service
+++ b/scripts/distribution/ubuntu-packages/template/debian/concordium-node.service
@@ -26,7 +26,10 @@ ProtectKernelTunables=yes
 CapabilityBoundingSet=
 LockPersonality=yes
 RestrictRealtime=yes
-MemoryDenyWriteExecute=yes
+# The current node version generates some code at runtime to bridge the FFI
+# between Haskell and rust related to smart contracts. Hence we have to allow
+# mappings that are writable and then turned into executable.
+MemoryDenyWriteExecute=no
 DynamicUser=yes
 # state directory is relative to /var/lib/, see systemd man pages Sandboxing section.
 # This sets the STATE_DIRECTORY environment variable that is used as part of the ExecStart command.


### PR DESCRIPTION
## Purpose

Fixes #388 

It is unclear to me why this is not a problem when compiling with 8.10.4, but it is a problem when compiling with GHC 9.0.2, but something about dynamic code generation must have changed in between the two versions.

## Changes

Remove the `MemoryDenyWriteExecute` restriction in the debian package.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
