### PR TITLE
Update installer versions, and use -I0 in mac and ubuntu distributions.

### DIFF
--- a/scripts/distribution/macOS-package/template/payload/tmp/Concordium Node/LaunchDaemons/software.concordium.mainnet.node.plist
+++ b/scripts/distribution/macOS-package/template/payload/tmp/Concordium Node/LaunchDaemons/software.concordium.mainnet.node.plist
@@ -71,7 +71,7 @@
 
         <!-- Haskell RTS flags to pass to consensus. -->
         <key>CONCORDIUM_NODE_RUNTIME_HASKELL_RTS_FLAGS</key>
-        <string>-N2</string>
+        <string>-N2,-I0</string>
 
     </dict>
 

--- a/scripts/distribution/macOS-package/template/payload/tmp/Concordium Node/LaunchDaemons/software.concordium.testnet.node.plist
+++ b/scripts/distribution/macOS-package/template/payload/tmp/Concordium Node/LaunchDaemons/software.concordium.testnet.node.plist
@@ -71,7 +71,7 @@
 
         <!-- Haskell RTS flags to pass to consensus. -->
         <key>CONCORDIUM_NODE_RUNTIME_HASKELL_RTS_FLAGS</key>
-        <string>-N2</string>
+        <string>-N2,-I0</string>
 
     </dict>
 

--- a/scripts/distribution/ubuntu-packages/template/debian/concordium-node.service
+++ b/scripts/distribution/ubuntu-packages/template/debian/concordium-node.service
@@ -60,7 +60,7 @@ Environment=CONCORDIUM_NODE_NO_LOG_TIMESTAMP=true
 # The bootstrapping interval in seconds.
 Environment=CONCORDIUM_NODE_CONNECTION_BOOTSTRAPPING_INTERVAL=1800
 # Haskell RTS flags to pass to consensus.
-Environment=CONCORDIUM_NODE_RUNTIME_HASKELL_RTS_FLAGS=-N2
+Environment=CONCORDIUM_NODE_RUNTIME_HASKELL_RTS_FLAGS=-N2,-I0
     
 [Install]
 # start the service when reaching multi-user target

--- a/service/windows/installer/Node.wxs
+++ b/service/windows/installer/Node.wxs
@@ -2,9 +2,9 @@
 <!-- When updating the product version, the Product Id should be refreshed, otherwise it will not be
     possible to upgrade an existing installation.
 -->
-<?define VersionNumber="4.1.1" ?>
+<?define VersionNumber="4.2.0" ?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:Util="http://schemas.microsoft.com/wix/UtilExtension">
-    <Product Name="Concordium Node" Manufacturer="Concordium Software" Id="47060dd1-07a9-4e87-ad7d-f37f20f3ae4e" UpgradeCode="297295b4-c716-4d33-8170-0f6136663bfd" Language="1033" Codepage="1252" Version="$(var.VersionNumber)">
+    <Product Name="Concordium Node" Manufacturer="Concordium Software" Id="b4b12449-67e7-40fb-a057-f545cf8d663e" UpgradeCode="297295b4-c716-4d33-8170-0f6136663bfd" Language="1033" Codepage="1252" Version="$(var.VersionNumber)">
         <Package Id="*" Keywords="Concordium Installer" Description="Concordium Node $(var.VersionNumber) Installer" Manufacturer="Concordium Software" InstallerVersion="500" Languages="1033" Compressed="yes" InstallScope="perMachine" />
         <MajorUpgrade Schedule="afterInstallValidate" DowngradeErrorMessage="The currently-installed version of [ProductName] is newer than the version you are trying to install. The installation cannot continue. If you wish to install this version, please remove the newer version first." />
         <Media Id="1" Cabinet="Node.cab" EmbedCab="yes" />

--- a/service/windows/installer/resources/nodes.toml
+++ b/service/windows/installer/resources/nodes.toml
@@ -41,6 +41,10 @@ log.roll.count = 2
 collector.url = 'https://dashboard.mainnet.concordium.software/nodes/post'
 # Controls whether data is submitted to the network dashboard for this node.
 collector.enabled = false
+# Disable the idle major garbage collection. This is especially useful for
+# non-baker nodes. It significantly reduces CPU use when the node's database is
+# large and seems to have little downside.
+node.env.CONCORDIUM_NODE_RUNTIME_HASKELL_RTS_FLAGS = '-I0'
 
 [node.testnet]
 # Controls whether the node is enabled
@@ -77,3 +81,7 @@ log.roll.count = 2
 collector.url = 'https://dashboard.testnet.concordium.com/nodes/post'
 # Controls whether data is submitted to the network dashboard for this node.
 collector.enabled = false
+# Disable the idle major garbage collection. This is especially useful for
+# non-baker nodes. It significantly reduces CPU use when the node's database is
+# large and seems to have little downside.
+node.env.CONCORDIUM_NODE_RUNTIME_HASKELL_RTS_FLAGS = '-I0'


### PR DESCRIPTION
## Purpose

Bump installer versions.

Address #385 

## Changes

- [x] Change version and GUID of the windows installer.
- [x] Use `-I0` in ubuntu and mac distributions. This disables the idle garbage collector and only affects non-baking nodes (at least with slot duration set for testnet/mainnet).

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.