### PR TITLE
Added the ability to download the catch-up file from configured URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
   versions <= 4.1. The other direction works.
 - Increase precision of block arrive and block receive times in the
   `GetBlockInfo` query.
+- Added the ability to download the catch-up file
+  ('CONCORDIUM_NODE_CONSENSUS_IMPORT_BLOCKS_FROM' now accepts both local paths and URLs)
 
 ## 4.1.1
 - The `SendTransaction` function exposed via the gRPC interface now provides the caller with detailed error messages if the 

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -2604,7 +2604,6 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "serde 1.0.126",
- "serde_json 1.0.64",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -512,6 +512,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "twox-hash",
+ "url",
  "uuid",
  "walkdir",
 ]

--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -12,7 +12,7 @@ default-run = "concordium-node"
 license-file = "../LICENSE"
 
 [features]
-default = []
+default = [ "reqwest" ]
 test_utils = [ "tempfile" ]
 instrumentation = ["serde_derive", "gotham", "mime", "gotham_derive", "prometheus", "hyper", "num_cpus", "reqwest", "http" ]
 network_dump = []
@@ -63,6 +63,7 @@ rpassword = "5.0"
 anyhow = "1.0"
 thiserror = "1.0"
 futures = { version = "0.3" }
+url = "2.2.2"
 
 # gRPC dependencies
 tonic = "0.4.1"

--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -64,7 +64,7 @@ anyhow = "1.0"
 thiserror = "1.0"
 futures = { version = "0.3" }
 url = "2.2.2"
-reqwest = { version = "0.11" }
+reqwest = { version = "0.11", features = ["stream"] }
 
 # gRPC dependencies
 tonic = "0.4.1"

--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -12,9 +12,9 @@ default-run = "concordium-node"
 license-file = "../LICENSE"
 
 [features]
-default = [ "reqwest" ]
+default = []
 test_utils = [ "tempfile" ]
-instrumentation = ["serde_derive", "gotham", "mime", "gotham_derive", "prometheus", "hyper", "num_cpus", "reqwest", "http" ]
+instrumentation = ["serde_derive", "gotham", "mime", "gotham_derive", "prometheus", "hyper", "num_cpus", "http" ]
 network_dump = []
 static = [ ]
 profiling = [ "static" ]
@@ -64,6 +64,7 @@ anyhow = "1.0"
 thiserror = "1.0"
 futures = { version = "0.3" }
 url = "2.2.2"
+reqwest = { version = "0.11" }
 
 # gRPC dependencies
 tonic = "0.4.1"
@@ -75,7 +76,6 @@ gotham = { version = "0.6", optional = true }
 gotham_derive = { version = "0.6", optional = true }
 http = { version = "0.2", optional = true }
 hyper = { version = "0.14", optional = true }
-reqwest = { version = "0.11", default-features = false, optional = true, features = ["default-tls", "stream", "json"] }
 mime = { version = "0.3", optional = true }
 serde_derive = { version = "1.0", optional = true }
 rmp-serde = { version = "0.15", optional = true }

--- a/concordium-node/src/bin/cli.rs
+++ b/concordium-node/src/bin/cli.rs
@@ -459,8 +459,7 @@ fn start_consensus_message_threads(
 
 fn handle_queue_stop<F>(msg: QueueMsg<ConsensusMessage>, dir: &'static str, f: F) -> bool
 where
-    F: FnOnce(ConsensusMessage) -> anyhow::Result<()>,
-{
+    F: FnOnce(ConsensusMessage) -> anyhow::Result<()>, {
     match msg {
         QueueMsg::Relay(msg) => {
             if let Err(e) = f(msg) {

--- a/concordium-node/src/bin/cli.rs
+++ b/concordium-node/src/bin/cli.rs
@@ -37,7 +37,7 @@ use concordium_node::{
 use mio::{net::TcpListener, Poll};
 use parking_lot::Mutex as ParkingMutex;
 use rand::Rng;
-use std::{sync::Arc, thread::JoinHandle};
+use std::{path::Path, sync::Arc, thread::JoinHandle};
 #[cfg(unix)]
 use tokio::signal::unix as unix_signal;
 #[cfg(windows)]
@@ -142,42 +142,16 @@ async fn main() -> anyhow::Result<()> {
 
     // Out-of-band catch-up
     if let Some(ref import_blocks_from) = conf.cli.baker.import_blocks_from {
-        let from: anyhow::Result<String> = if let Ok(import_url) = Url::parse(import_blocks_from) {
-            let default_filename = format!(
-                "{}_{}{}",
-                config::CATCHUP_FILE_BASENAME,
-                Utc::now().timestamp(),
-                config::CATCHUP_FILE_EXT
-            );
-            let filename = import_url
-                .path_segments()
-                .and_then(|x| x.last())
-                .map(|x| x.to_string())
-                .unwrap_or(default_filename);
-            let import_path = data_dir_path.to_path_buf().join(&filename);
-
-            info!(
-                "Downloading the catch-up file from {} to {}",
-                import_url,
-                import_path.display().to_string()
-            );
-            let file = std::fs::File::create(&import_path)?;
-            let mut buffer = std::io::BufWriter::new(file);
-            let mut stream = reqwest::get(import_url).await?.bytes_stream();
-            while let Some(Ok(bytes)) = stream.next().await {
-                buffer.write_all(&bytes)?;
-            }
-            buffer.flush()?;
-
-            Ok(import_path.display().to_string())
-        } else {
-            Ok(import_blocks_from.to_string())
-        };
+        let from: anyhow::Result<String> =
+            download_catchup_files(import_blocks_from, data_dir_path).await;
         match from {
             Ok(from) => {
                 info!("Starting out of band catch-up");
                 consensus.import_blocks(from.as_bytes());
                 info!("Completed out of band catch-up");
+                if let Err(e) = std::fs::remove_file(from) {
+                    error!("Cleaning up downloaded out of band catch-up files failed: {}", e);
+                };
             }
             Err(e) => {
                 error!("Downloading catch-up files failed: {}", e);
@@ -488,4 +462,37 @@ where
         }
     }
     true
+}
+
+async fn download_catchup_files(
+    import_blocks_from: &str,
+    data_dir_path: &Path,
+) -> anyhow::Result<String> {
+    if let Ok(import_url) = Url::parse(import_blocks_from) {
+        let default_filename = format!(
+            "{}_{}{}",
+            config::CATCHUP_FILE_BASENAME,
+            Utc::now().timestamp(),
+            config::CATCHUP_FILE_EXT
+        );
+        let filename = import_url
+            .path_segments()
+            .and_then(|x| x.last())
+            .map(|x| x.to_string())
+            .unwrap_or(default_filename);
+        let import_path = data_dir_path.to_path_buf().join(&filename);
+
+        info!("Downloading the catch-up file from {} to {}", import_url, import_path.display());
+        let file = std::fs::File::create(&import_path)?;
+        let mut buffer = std::io::BufWriter::new(file);
+        let mut stream = reqwest::get(import_url).await?.bytes_stream();
+        while let Some(Ok(bytes)) = stream.next().await {
+            buffer.write_all(&bytes)?;
+        }
+        buffer.flush()?;
+
+        return Ok(import_path.display().to_string());
+    } else {
+        return Ok(import_blocks_from.to_string());
+    };
 }

--- a/concordium-node/src/bin/cli.rs
+++ b/concordium-node/src/bin/cli.rs
@@ -149,8 +149,10 @@ async fn main() -> anyhow::Result<()> {
                 info!("Starting out of band catch-up");
                 consensus.import_blocks(from.as_bytes());
                 info!("Completed out of band catch-up");
-                if let Err(e) = std::fs::remove_file(from) {
-                    error!("Cleaning up downloaded out of band catch-up files failed: {}", e);
+                if from != *import_blocks_from {
+                    if let Err(e) = std::fs::remove_file(from) {
+                        error!("Cleaning up downloaded out of band catch-up files failed: {}", e);
+                    };
                 };
             }
             Err(e) => {
@@ -491,8 +493,8 @@ async fn download_catchup_files(
         }
         buffer.flush()?;
 
-        return Ok(import_path.display().to_string());
+        Ok(import_path.display().to_string())
     } else {
-        return Ok(import_blocks_from.to_string());
-    };
+        Ok(import_blocks_from.to_string())
+    }
 }

--- a/concordium-node/src/configuration.rs
+++ b/concordium-node/src/configuration.rs
@@ -76,8 +76,10 @@ pub const SOFT_BAN_DURATION_SECS: u64 = 300;
 pub const MAX_PEER_NETWORKS: usize = 20;
 /// Database subdirectory name
 pub const DATABASE_SUB_DIRECTORY_NAME: &str = "database-v4";
-/// Default out-of-band catch-up file name
-pub const CATCHUP_FILE: &str = "blocks_to_import.mdb";
+/// Default out-of-band catch-up file name (excluding the extension)
+pub const CATCHUP_FILE_BASENAME: &str = "blocks_to_import";
+/// Default out-of-band catch-up file extension
+pub const CATCHUP_FILE_EXT: &str = ".mdb";
 
 // In order to avoid premature connection drops, it is estimated that the
 // KEEP_ALIVE_FACTOR should be kept above 3.
@@ -248,8 +250,7 @@ pub struct BakerConfig {
     pub transactions_purging_delay: u32,
     #[structopt(
         long = "import-blocks-from",
-        help = "Where to find a file exported by the database exporter. Can be a local path or a \
-                URL.",
+        help = "Local path or URL pointing at a file exported by the database exporter",
         env = "CONCORDIUM_NODE_CONSENSUS_IMPORT_BLOCKS_FROM"
     )]
     pub import_blocks_from: Option<String>,

--- a/concordium-node/src/configuration.rs
+++ b/concordium-node/src/configuration.rs
@@ -18,7 +18,7 @@ use structopt::{clap::AppSettings, StructOpt};
 
 /// Client's details for local directory setup purposes.
 pub const APP_INFO: AppInfo = AppInfo {
-    name: "concordium",
+    name:   "concordium",
     author: "concordium",
 };
 
@@ -96,33 +96,33 @@ pub struct PrometheusConfig {
         default_value = "127.0.0.1",
         env = "CONCORDIUM_NODE_PROMETHEUS_LISTEN_ADDRESSS"
     )]
-    pub prometheus_listen_addr: String,
+    pub prometheus_listen_addr:   String,
     #[structopt(
         long = "prometheus-listen-port",
         help = "Port for prometheus to listen on",
         default_value = "9090",
         env = "CONCORDIUM_NODE_PROMETHEUS_LISTEN_PORT"
     )]
-    pub prometheus_listen_port: u16,
+    pub prometheus_listen_port:   u16,
     #[structopt(
         long = "prometheus-server",
         help = "Enable prometheus server for metrics",
         env = "CONCORDIUM_NODE_PROMETHEUS_SERVER"
     )]
-    pub prometheus_server: bool,
+    pub prometheus_server:        bool,
     #[structopt(
         long = "prometheus-push-gateway",
         help = "Enable prometheus via push gateway",
         env = "CONCORDIUM_NODE_PROMETHEUS_PUSH_GATEWAY"
     )]
-    pub prometheus_push_gateway: Option<String>,
+    pub prometheus_push_gateway:  Option<String>,
     #[structopt(
         long = "prometheus-job-name",
         help = "Job name to send to push gateway",
         default_value = "p2p_node_push",
         env = "CONCORDIUM_NODE_PROMETHEUS_JOB_NAME"
     )]
-    pub prometheus_job_name: String,
+    pub prometheus_job_name:      String,
     #[structopt(
         long = "prometheus-instance-name",
         help = "If not present node_id will be used",
@@ -248,8 +248,8 @@ pub struct BakerConfig {
     pub transactions_purging_delay: u32,
     #[structopt(
         long = "import-blocks-from",
-        help = "Where to find a file exported by the database exporter. \
-		Can be a local path or a URL.",
+        help = "Where to find a file exported by the database exporter. Can be a local path or a \
+                URL.",
         env = "CONCORDIUM_NODE_CONSENSUS_IMPORT_BLOCKS_FROM"
     )]
     pub import_blocks_from: Option<String>,
@@ -293,21 +293,21 @@ pub struct RpcCliConfig {
         help = "Disable the built-in RPC server",
         env = "CONCORDIUM_NODE_DISABLE_RPC_SERVER"
     )]
-    pub no_rpc_server: bool,
+    pub no_rpc_server:    bool,
     #[structopt(
         long = "rpc-server-port",
         help = "RPC server port",
         default_value = "10000",
         env = "CONCORDIUM_NODE_RPC_SERVER_PORT"
     )]
-    pub rpc_server_port: u16,
+    pub rpc_server_port:  u16,
     #[structopt(
         long = "rpc-server-addr",
         help = "RPC server listen address",
         default_value = "127.0.0.1",
         env = "CONCORDIUM_NODE_RPC_SERVER_ADDR"
     )]
-    pub rpc_server_addr: String,
+    pub rpc_server_addr:  String,
     #[structopt(
         long = "rpc-server-token",
         help = "RPC server access token",
@@ -707,19 +707,19 @@ pub struct MacOsConfig {
 #[structopt(about = "Concordium P2P node.")]
 pub struct Config {
     #[structopt(flatten)]
-    pub common: CommonConfig,
+    pub common:       CommonConfig,
     #[cfg(feature = "instrumentation")]
     #[structopt(flatten)]
-    pub prometheus: PrometheusConfig,
+    pub prometheus:   PrometheusConfig,
     #[structopt(flatten)]
-    pub connection: ConnectionConfig,
+    pub connection:   ConnectionConfig,
     #[structopt(flatten)]
-    pub cli: CliConfig,
+    pub cli:          CliConfig,
     #[structopt(flatten)]
     pub bootstrapper: BootstrapperConfig,
     #[cfg(target_os = "macos")]
     #[structopt(flatten)]
-    pub macos: MacOsConfig,
+    pub macos:        MacOsConfig,
 }
 
 impl Config {
@@ -823,8 +823,8 @@ pub fn parse_config() -> anyhow::Result<Config> {
 /// Handles the configuration data.
 #[derive(Debug)]
 pub struct AppPreferences {
-    preferences_map: PreferencesMap<String>,
-    override_data_dir: PathBuf,
+    preferences_map:     PreferencesMap<String>,
+    override_data_dir:   PathBuf,
     override_config_dir: PathBuf,
 }
 
@@ -843,8 +843,8 @@ impl AppPreferences {
             let prefs = load_result.unwrap_or_else(|_| PreferencesMap::<String>::new());
 
             AppPreferences {
-                preferences_map: prefs,
-                override_data_dir: override_data,
+                preferences_map:     prefs,
+                override_data_dir:   override_data,
                 override_config_dir: override_conf,
             }
         } else {
@@ -856,8 +856,8 @@ impl AppPreferences {
             let prefs = PreferencesMap::<String>::new();
 
             AppPreferences {
-                preferences_map: prefs,
-                override_data_dir: override_data,
+                preferences_map:     prefs,
+                override_data_dir:   override_data,
                 override_config_dir: override_conf,
             }
         };
@@ -916,12 +916,8 @@ impl AppPreferences {
     }
 
     /// Returns the path to the application directory.
-    pub fn get_data_dir(&self) -> &Path {
-        &self.override_data_dir
-    }
+    pub fn get_data_dir(&self) -> &Path { &self.override_data_dir }
 
     /// Returns the path to the config directory.
-    pub fn get_config_dir(&self) -> &Path {
-        &self.override_config_dir
-    }
+    pub fn get_config_dir(&self) -> &Path { &self.override_config_dir }
 }

--- a/concordium-node/src/configuration.rs
+++ b/concordium-node/src/configuration.rs
@@ -79,7 +79,7 @@ pub const DATABASE_SUB_DIRECTORY_NAME: &str = "database-v4";
 /// Default out-of-band catch-up file name (excluding the extension)
 pub const CATCHUP_FILE_BASENAME: &str = "blocks_to_import";
 /// Default out-of-band catch-up file extension
-pub const CATCHUP_FILE_EXT: &str = ".mdb";
+pub const CATCHUP_FILE_EXT: &str = ".dat";
 
 // In order to avoid premature connection drops, it is estimated that the
 // KEEP_ALIVE_FACTOR should be kept above 3.


### PR DESCRIPTION
## Purpose

Adds the ability to download catch-up files during node startup from URLs given to `--import-blocks-from`.

Closes #381 

## Changes

The `--import-blocks-from` configuration option now accepts URLs as arguments, in addition to local file paths. If the argument can be parsed as a URL, the node will attempt to download the file from that URL during startup and use it to perform out-of-band catch-up.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
