### PR TITLE
Correct absolute height

### DIFF
--- a/concordium-consensus/src/Concordium/MultiVersion.hs
+++ b/concordium-consensus/src/Concordium/MultiVersion.hs
@@ -652,12 +652,12 @@ startupSkov genesis = do
                                       newEConfig = VersionedConfiguration{..}
                                   oldVersions <- readIORef mvVersions
                                   writeIORef mvVersions (oldVersions `Vec.snoc` newVersion newEConfig)
-                                  let getCurrentGenesisAndHeight :: VersionedSkovM gsconf finconf pv (BlockHash, BlockHeight, Maybe SomeProtocolVersion)
+                                  let getCurrentGenesisAndHeight :: VersionedSkovM gsconf finconf pv (BlockHash, AbsoluteBlockHeight, Maybe SomeProtocolVersion)
                                       getCurrentGenesisAndHeight = liftSkov $ do
                                         currentGenesis <- getGenesisData
                                         lfHeight <- getLastFinalizedHeight
                                         nextPV <- getNextProtocolVersion
-                                        return (_gcCurrentHash currentGenesis, lfHeight, nextPV)
+                                        return (_gcCurrentHash currentGenesis, localToAbsoluteBlockHeight vcGenesisHeight lfHeight, nextPV)
                                   ((genesisHash, lastFinalizedHeight, nextPV), _) <- runMVR (runSkovT getCurrentGenesisAndHeight (mvrSkovHandlers newEConfig mvr) vcContext st) mvr
                                   notifyRegenesis (Just genesisHash)
                                   return (Left (newVersion newEConfig, lastFinalizedHeight, nextPV))

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_node"
-version = "4.2.0"
+version = "4.2.1"
 dependencies = [
  "anyhow",
  "app_dirs2",

--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium_node"
-version = "4.2.0" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
+version = "4.2.1" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
 description = "Concordium Node"
 authors = ["Concordium <developers@concordium.com>"]
 exclude = [".gitignore", ".gitlab-ci.yml", "test/**/*","**/**/.gitignore","**/**/.gitlab-ci.yml"]

--- a/service/windows/installer/Node.wxs
+++ b/service/windows/installer/Node.wxs
@@ -2,9 +2,9 @@
 <!-- When updating the product version, the Product Id should be refreshed, otherwise it will not be
     possible to upgrade an existing installation.
 -->
-<?define VersionNumber="4.2.0" ?>
+<?define VersionNumber="4.2.1" ?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:Util="http://schemas.microsoft.com/wix/UtilExtension">
-    <Product Name="Concordium Node" Manufacturer="Concordium Software" Id="b4b12449-67e7-40fb-a057-f545cf8d663e" UpgradeCode="297295b4-c716-4d33-8170-0f6136663bfd" Language="1033" Codepage="1252" Version="$(var.VersionNumber)">
+    <Product Name="Concordium Node" Manufacturer="Concordium Software" Id="3659d520-44f1-4bee-be49-156bef0c8330" UpgradeCode="297295b4-c716-4d33-8170-0f6136663bfd" Language="1033" Codepage="1252" Version="$(var.VersionNumber)">
         <Package Id="*" Keywords="Concordium Installer" Description="Concordium Node $(var.VersionNumber) Installer" Manufacturer="Concordium Software" InstallerVersion="500" Languages="1033" Compressed="yes" InstallScope="perMachine" />
         <MajorUpgrade Schedule="afterInstallValidate" DowngradeErrorMessage="The currently-installed version of [ProductName] is newer than the version you are trying to install. The installation cannot continue. If you wish to install this version, please remove the newer version first." />
         <Media Id="1" Cabinet="Node.cab" EmbedCab="yes" />


### PR DESCRIPTION
## Purpose

Fixes #393 

## Changes

After each protocol version we record the absolute height of the last finalized
block before the new genesis. This is so we can have a single set of heights.

During startup we did not record this height correctly.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.