### PR TITLE
Fix default GHC versions for build scripts and documentation.

### DIFF
--- a/concordium-consensus/README.md
+++ b/concordium-consensus/README.md
@@ -48,7 +48,7 @@ rustup default stable-x86_64-pc-windows-gnu
 ```
 
 ### `user specified .o/.so/.DLL could not be loaded (addDLL: pthread or dependencies not loaded. (Win32 error 5)) whilst trying to load:  (dynamic) pthread`
-Copy `%APPDATA%\Local\Programs\stack\x86_64-windows\ghc-8.10.4\mingw\bin\libwinpthread-1.dll` to `%APPDATA%\Local\Programs\stack\x86_64-windows\ghc-8.10.4\mingw\bin\pthread.dll`.
+Copy `%APPDATA%\Local\Programs\stack\x86_64-windows\ghc-9.0.2\mingw\bin\libwinpthread-1.dll` to `%APPDATA%\Local\Programs\stack\x86_64-windows\ghc-9.0.2\mingw\bin\pthread.dll`.
 
 # The library and dependencies
 

--- a/concordium-node/README.md
+++ b/concordium-node/README.md
@@ -47,7 +47,7 @@ The package supports the following features related to linking with the Haskell 
   mkdir out
   docker run -v $(pwd)/out:/out concordium/static-libraries
   mkdir -p concordium-node/deps/static-libs/linux
-  tar -xf out/static-consensus-8.10.4.tar.gz --strip-components=1 -C concordium-node/deps/static-libs/linux
+  tar -xf out/static-consensus-9.0.2.tar.gz --strip-components=1 -C concordium-node/deps/static-libs/linux
   ```
 
   (this is assuming a GNU version of tar)

--- a/jenkinsfiles/distribution-image.Jenkinsfile
+++ b/jenkinsfiles/distribution-image.Jenkinsfile
@@ -3,7 +3,7 @@
 // - image_tag (default: "latest")
 // - base_image_tag (default: "latest")
 // - static_libraries_image_tag (default: "latest")
-// - ghc_version (default: "8.10.4")
+// - ghc_version (default: "9.0.2")
 // - genesis_ref (default: "master")
 // - genesis_path
 

--- a/scripts/distribution/ubuntu-packages/README.md
+++ b/scripts/distribution/ubuntu-packages/README.md
@@ -82,7 +82,7 @@ The general strategy for building the package is as follows.
 
    For example use the [../../static-binaries/build-static-binaries.sh](../../static-binaries/build-static-binaries.sh).
    ```console
-   $ UBUNTU_VERSION=20.04 STATIC_LIBRARIES_IMAGE_TAG=0.21 GHC_VERSION=8.10.4 EXTRA_FEATURES=collector ./scripts/static-binaries/build-static-binaries.sh
+   $ UBUNTU_VERSION=20.04 STATIC_LIBRARIES_IMAGE_TAG=ghc-9.0.2 GHC_VERSION=9.0.2 EXTRA_FEATURES=collector ./scripts/static-binaries/build-static-binaries.sh
    ```
 
    If not then just comment out the relevant lines and manually copy the

--- a/scripts/distribution/ubuntu-packages/build-mainnet-deb.sh
+++ b/scripts/distribution/ubuntu-packages/build-mainnet-deb.sh
@@ -5,12 +5,12 @@ set -euxo pipefail
 # Used environment variables.
 # - UBUNTU_VERSION (mandatory)
 # - STATIC_LIBRARIES_IMAGE_TAG (defaults to 'latest' if not given)
-# - GHC_VERSION (defaults to '8.10.4' if not given)
+# - GHC_VERSION (defaults to '9.0.2' if not given)
 
 if ! docker inspect --type=image static-node-binaries > /dev/null 2> /dev/null ; then
     # build static binaries
     export STATIC_LIBRARIES_IMAGE_TAG="${STATIC_LIBRARIES_IMAGE_TAG:-latest}"
-    export GHC_VERSION="${GHC_VERSION:-8.10.4}"
+    export GHC_VERSION="${GHC_VERSION:-9.0.2}"
     export EXTRA_FEATURES="collector"
     (cd ../../../; ./scripts/static-binaries/build-static-binaries.sh)
 fi

--- a/scripts/distribution/ubuntu-packages/build-testnet-deb.sh
+++ b/scripts/distribution/ubuntu-packages/build-testnet-deb.sh
@@ -5,14 +5,14 @@ set -euxo pipefail
 # Used environment variables.
 # - UBUNTU_VERSION (mandatory)
 # - STATIC_LIBRARIES_IMAGE_TAG (defaults to 'latest' if not given)
-# - GHC_VERSION (defaults to '8.10.4' if not given)
+# - GHC_VERSION (defaults to '9.0.2' if not given)
 
 # If the static-node-binaries image exists we use the binaries therein.
 # Otherwise we build it first.
 if ! docker inspect --type=image static-node-binaries > /dev/null 2> /dev/null ; then
     # build static binaries
     export STATIC_LIBRARIES_IMAGE_TAG="${STATIC_LIBRARIES_IMAGE_TAG:-latest}"
-    export GHC_VERSION="${GHC_VERSION:-8.10.4}"
+    export GHC_VERSION="${GHC_VERSION:-9.0.2}"
     export EXTRA_FEATURES="collector"
     (cd ../../../; ./scripts/static-binaries/build-static-binaries.sh)
 fi


### PR DESCRIPTION
## Purpose

This is a leftover from the stack resolver update and just brings the versions up to date.

## Changes

Change defaults in build scripts, as well as in documentation. No node changes.