### PR TITLE
Fix incorrect rpc response for when user have insufficient funds.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Decrease memory usage by not storing genesis blocks. This has the effect that
   the database produced by node versions >= 4.2.* cannot be used by node
   versions <= 4.1. The other direction works.
+- Fix issue #375 which resulted in a wrong rpc response when the sender of a 
+  transaction did not have enough funds to cover the costs.
 
 ## 4.0.11
 - The `SendTransaction` function exposed via the gRPC interface now provides the caller with detailed error messages if the 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Decrease memory usage by not storing genesis blocks. This has the effect that
   the database produced by node versions >= 4.2.* cannot be used by node
   versions <= 4.1. The other direction works.
-- Fix issue #375 which resulted in a wrong rpc response when the sender of a 
+- Fix an issue which resulted in a wrong rpc response when the sender of a
   transaction did not have enough funds to cover the costs.
 
 ## 4.0.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Decrease memory usage by not storing genesis blocks. This has the effect that
   the database produced by node versions >= 4.2.* cannot be used by node
   versions <= 4.1. The other direction works.
-- The gRPC API reports correctly when the sender of a transaction did 
+- The gRPC API now reports correctly when the sender of a transaction did 
   not have enough funds to cover the transaction costs.
 
 ## 4.0.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 - Decrease memory usage by not storing genesis blocks. This has the effect that
   the database produced by node versions >= 4.2.* cannot be used by node
   versions <= 4.1. The other direction works.
-- Fix an issue which resulted in a wrong rpc response when the sender of a
-  transaction did not have enough funds to cover the costs.
+- The gRPC API reports correctly when the sender of a transaction did 
+  not have enough funds to cover the transaction costs.
 
 ## 4.0.11
 - The `SendTransaction` function exposed via the gRPC interface now provides the caller with detailed error messages if the 

--- a/concordium-consensus/src/Concordium/External.hs
+++ b/concordium-consensus/src/Concordium/External.hs
@@ -651,9 +651,7 @@ stopBaker cptr = mask_ $ do
 -- +-------+---------------------------------------------+-----------------------------------------------------------------------------------------------+----------+
 -- |    29 | ResultEnergyExceeded                        | The stated energy of the transaction exceeds the maximum allowed                              | No       |
 -- +-------+---------------------------------------------+-----------------------------------------------------------------------------------------------+----------+
--- |    30 | ResultImportStopped                         | The importing of the blocks has been stopped.                                                 | No       |
--- +-------+---------------------------------------------+-----------------------------------------------------------------------------------------------+----------+
--- |    31 | ResultInsufficientFunds                     | The sender did not have enough funds to cover the costs.                                      | No       |
+-- |    30 | ResultInsufficientFunds                     | The sender did not have enough funds to cover the costs.                                      | No       |
 -- +-------+---------------------------------------------+-----------------------------------------------------------------------------------------------+----------+
 
 type ReceiveResult = Int64
@@ -690,8 +688,7 @@ toReceiveResult ResultChainUpdateInvalidEffectiveTime = 26
 toReceiveResult ResultChainUpdateSequenceNumberTooOld = 27
 toReceiveResult ResultChainUpdateInvalidSignatures = 28
 toReceiveResult ResultEnergyExceeded = 29
-toReceiveResult ResultImportStopped = 30
-toReceiveResult ResultInsufficientFunds = 31
+toReceiveResult ResultInsufficientFunds = 30
 
 -- |Handle receipt of a block.
 -- The possible return codes are @ResultSuccess@, @ResultSerializationFail@, @ResultInvalid@,

--- a/concordium-consensus/src/Concordium/External.hs
+++ b/concordium-consensus/src/Concordium/External.hs
@@ -653,6 +653,8 @@ stopBaker cptr = mask_ $ do
 -- +-------+---------------------------------------------+-----------------------------------------------------------------------------------------------+----------+
 -- |    30 | ResultImportStopped                         | The importing of the blocks has been stopped.                                                 | No       |
 -- +-------+---------------------------------------------+-----------------------------------------------------------------------------------------------+----------+
+-- |    31 | ResultInsufficientFunds                     | The sender did not have enough funds to cover the costs.                                      | No       |
+-- +-------+---------------------------------------------+-----------------------------------------------------------------------------------------------+----------+
 
 type ReceiveResult = Int64
 
@@ -689,6 +691,7 @@ toReceiveResult ResultChainUpdateSequenceNumberTooOld = 27
 toReceiveResult ResultChainUpdateInvalidSignatures = 28
 toReceiveResult ResultEnergyExceeded = 29
 toReceiveResult ResultImportStopped = 30
+toReceiveResult ResultInsufficientFunds = 31
 
 -- |Handle receipt of a block.
 -- The possible return codes are @ResultSuccess@, @ResultSerializationFail@, @ResultInvalid@,

--- a/concordium-consensus/src/Concordium/MultiVersion.hs
+++ b/concordium-consensus/src/Concordium/MultiVersion.hs
@@ -1116,7 +1116,7 @@ importBlocks importFile = do
         -- Check if the import should be stopped.
         shouldStop <- liftIO . readIORef =<< asks mvShouldStopImportingBlocks
         if shouldStop
-            then return $ Left (ImportOtherError ResultImportStopped)
+            then return $ fixResult ResultConsensusShutDown
             else fixResult <$> receiveBlock gi bs
 
     doImport (ImportFinalizationRecord _ gi bs) = fixResult <$> receiveFinalizationRecord gi bs

--- a/concordium-consensus/src/Concordium/Skov/Monad.hs
+++ b/concordium-consensus/src/Concordium/Skov/Monad.hs
@@ -107,6 +107,8 @@ data UpdateResult
     -- ^The stated energy of the 'Transaction' exceeds the maximum allowed.
     | ResultImportStopped
     -- ^The importing of blocks has been stopped.
+    | ResultInsufficientFunds
+    -- ^The sender did not have enough funds to cover the costs.
     deriving (Eq, Show)
 
 class (Monad m, Eq (BlockPointerType m), HashableTo BlockHash (BlockPointerType m), BlockPointerData (BlockPointerType m), BlockPointerMonad m, BlockStateQuery m, MonadProtocolVersion m)

--- a/concordium-consensus/src/Concordium/Skov/Monad.hs
+++ b/concordium-consensus/src/Concordium/Skov/Monad.hs
@@ -105,8 +105,6 @@ data UpdateResult
     -- ^The 'ChainUpdate' contained invalid signatures.
     | ResultEnergyExceeded
     -- ^The stated energy of the 'Transaction' exceeds the maximum allowed.
-    | ResultImportStopped
-    -- ^The importing of blocks has been stopped.
     | ResultInsufficientFunds
     -- ^The sender did not have enough funds to cover the costs.
     deriving (Eq, Show)

--- a/concordium-consensus/src/Concordium/Skov/Update.hs
+++ b/concordium-consensus/src/Concordium/Skov/Update.hs
@@ -685,7 +685,7 @@ transactionVerificationResultToUpdateResult (TV.NotOk TV.CredentialDeploymentInv
 transactionVerificationResultToUpdateResult (TV.NotOk (TV.ChainUpdateSequenceNumberTooOld _)) = ResultChainUpdateSequenceNumberTooOld
 transactionVerificationResultToUpdateResult (TV.NotOk TV.ChainUpdateEffectiveTimeBeforeTimeout) = ResultChainUpdateInvalidEffectiveTime
 transactionVerificationResultToUpdateResult (TV.NotOk TV.CredentialDeploymentExpired) = ResultCredentialDeploymentExpired
-transactionVerificationResultToUpdateResult (TV.NotOk TV.NormalTransactionDepositInsufficient) = ResultInsufficientFunds
+transactionVerificationResultToUpdateResult (TV.NotOk TV.NormalTransactionDepositInsufficient) = ResultTooLowEnergy
 transactionVerificationResultToUpdateResult (TV.NotOk TV.NormalTransactionEnergyExceeded) = ResultEnergyExceeded
 transactionVerificationResultToUpdateResult (TV.NotOk (TV.NormalTransactionDuplicateNonce _)) = ResultDuplicateNonce
 transactionVerificationResultToUpdateResult (TV.NotOk TV.Expired) = ResultStale

--- a/concordium-consensus/src/Concordium/Skov/Update.hs
+++ b/concordium-consensus/src/Concordium/Skov/Update.hs
@@ -675,7 +675,7 @@ transactionVerificationResultToUpdateResult (TV.MaybeOk (TV.CredentialDeployment
 transactionVerificationResultToUpdateResult (TV.MaybeOk TV.CredentialDeploymentInvalidAnonymityRevokers) = ResultCredentialDeploymentInvalidAR
 transactionVerificationResultToUpdateResult (TV.MaybeOk (TV.ChainUpdateInvalidNonce _)) = ResultNonceTooLarge
 transactionVerificationResultToUpdateResult (TV.MaybeOk TV.ChainUpdateInvalidSignatures) = ResultChainUpdateInvalidSignatures
-transactionVerificationResultToUpdateResult (TV.MaybeOk TV.NormalTransactionInsufficientFunds) = ResultTooLowEnergy
+transactionVerificationResultToUpdateResult (TV.MaybeOk TV.NormalTransactionInsufficientFunds) = ResultInsufficientFunds
 transactionVerificationResultToUpdateResult (TV.MaybeOk (TV.NormalTransactionInvalidSender _)) = ResultNonexistingSenderAccount
 transactionVerificationResultToUpdateResult (TV.MaybeOk TV.NormalTransactionInvalidSignatures) = ResultVerificationFailed
 transactionVerificationResultToUpdateResult (TV.MaybeOk (TV.NormalTransactionInvalidNonce _)) = ResultNonceTooLarge
@@ -685,7 +685,7 @@ transactionVerificationResultToUpdateResult (TV.NotOk TV.CredentialDeploymentInv
 transactionVerificationResultToUpdateResult (TV.NotOk (TV.ChainUpdateSequenceNumberTooOld _)) = ResultChainUpdateSequenceNumberTooOld
 transactionVerificationResultToUpdateResult (TV.NotOk TV.ChainUpdateEffectiveTimeBeforeTimeout) = ResultChainUpdateInvalidEffectiveTime
 transactionVerificationResultToUpdateResult (TV.NotOk TV.CredentialDeploymentExpired) = ResultCredentialDeploymentExpired
-transactionVerificationResultToUpdateResult (TV.NotOk TV.NormalTransactionDepositInsufficient) = ResultTooLowEnergy
+transactionVerificationResultToUpdateResult (TV.NotOk TV.NormalTransactionDepositInsufficient) = ResultInsufficientFunds
 transactionVerificationResultToUpdateResult (TV.NotOk TV.NormalTransactionEnergyExceeded) = ResultEnergyExceeded
 transactionVerificationResultToUpdateResult (TV.NotOk (TV.NormalTransactionDuplicateNonce _)) = ResultDuplicateNonce
 transactionVerificationResultToUpdateResult (TV.NotOk TV.Expired) = ResultStale

--- a/concordium-node/src/consensus_ffi/ffi.rs
+++ b/concordium-node/src/consensus_ffi/ffi.rs
@@ -454,7 +454,7 @@ extern "C" {
         consensus: *mut consensus_runner,
         import_file_path: *const u8,
         import_file_path_len: i64,
-    ) -> u8;
+    ) -> u64;
     pub fn stopImportingBlocks(consensus: *mut consensus_runner);
 }
 
@@ -871,7 +871,7 @@ impl ConsensusContainer {
         )))
     }
 
-    pub fn import_blocks(&self, import_file_path: &[u8]) -> u8 {
+    pub fn import_blocks(&self, import_file_path: &[u8]) -> u64 {
         let consensus = self.consensus.load(Ordering::SeqCst);
         let len = import_file_path.len();
 

--- a/concordium-node/src/consensus_ffi/helpers.rs
+++ b/concordium-node/src/consensus_ffi/helpers.rs
@@ -357,8 +357,8 @@ impl TryFrom<i64> for ConsensusFfiResponse {
             27 => Ok(ChainUpdateSequenceNumberTooOld),
             28 => Ok(ChainUpdateInvalidSignatures),
             29 => Ok(MaxBlockEnergyExceeded),
-            // 30 is reserved for`ResultImportStopped` which origins from a `SIGINT` or `SIGTERM`
-            // signal send to the node.
+            // 30 is used for`ResultImportStopped` which origins from a `SIGINT` or `SIGTERM`
+            // signal send to the node while catching up out of band.
             31 => Ok(InsufficientFunds),
             _ => Err(anyhow!("Unsupported FFI return code ({})", value)),
         }

--- a/concordium-node/src/consensus_ffi/helpers.rs
+++ b/concordium-node/src/consensus_ffi/helpers.rs
@@ -357,9 +357,7 @@ impl TryFrom<i64> for ConsensusFfiResponse {
             27 => Ok(ChainUpdateSequenceNumberTooOld),
             28 => Ok(ChainUpdateInvalidSignatures),
             29 => Ok(MaxBlockEnergyExceeded),
-            // 30 is used for`ResultImportStopped` which origins from a `SIGINT` or `SIGTERM`
-            // signal send to the node while catching up out of band.
-            31 => Ok(InsufficientFunds),
+            30 => Ok(InsufficientFunds),
             _ => Err(anyhow!("Unsupported FFI return code ({})", value)),
         }
     }

--- a/concordium-node/src/consensus_ffi/helpers.rs
+++ b/concordium-node/src/consensus_ffi/helpers.rs
@@ -245,6 +245,8 @@ pub enum ConsensusFfiResponse {
     ChainUpdateInvalidSignatures,
     #[error("The stated energy of the transaction exceeds the maximum allowed")]
     MaxBlockEnergyExceeded,
+    #[error("The sender did not have enough funds to cover the costs.")]
+    InsufficientFunds,
 }
 
 impl ConsensusFfiResponse {
@@ -278,6 +280,7 @@ impl ConsensusFfiResponse {
                 | TooLowEnergy
                 | ConsensusShutDown
                 | InvalidGenesisIndex
+                | InsufficientFunds
         )
     }
 
@@ -310,6 +313,7 @@ impl ConsensusFfiResponse {
                 | ChainUpdateSequenceNumberTooOld
                 | ChainUpdateInvalidSignatures
                 | MaxBlockEnergyExceeded
+                | InsufficientFunds
         )
     }
 }
@@ -353,6 +357,9 @@ impl TryFrom<i64> for ConsensusFfiResponse {
             27 => Ok(ChainUpdateSequenceNumberTooOld),
             28 => Ok(ChainUpdateInvalidSignatures),
             29 => Ok(MaxBlockEnergyExceeded),
+            // 30 is reserved for`ResultImportStopped` which origins from a `SIGINT` or `SIGTERM`
+            // signal send to the node.
+            31 => Ok(InsufficientFunds),
             _ => Err(anyhow!("Unsupported FFI return code ({})", value)),
         }
     }

--- a/concordium-node/src/consensus_ffi/helpers.rs
+++ b/concordium-node/src/consensus_ffi/helpers.rs
@@ -245,7 +245,7 @@ pub enum ConsensusFfiResponse {
     ChainUpdateInvalidSignatures,
     #[error("The stated energy of the transaction exceeds the maximum allowed")]
     MaxBlockEnergyExceeded,
-    #[error("The sender did not have enough funds to cover the costs.")]
+    #[error("The sender did not have enough funds to cover the costs")]
     InsufficientFunds,
 }
 


### PR DESCRIPTION
## Purpose

Fixes https://github.com/Concordium/concordium-node/issues/375 by introducing a new `ResultInsufficientFunds` error when the user do not have enough funds to cover the costs of its transaction.

## Changes

Introduced a new FFI result `ResultInsufficientFunds` and vice versa a new rpc error which will result in a rpc `InvalidArgument` error that will yield the message: "The sender did not have enough funds to cover the costs".


## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
