### PR TITLE
Bump version to 4.2.2 for stagenet deployment.

### DIFF
--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_node"
-version = "4.2.1"
+version = "4.2.2"
 dependencies = [
  "anyhow",
  "app_dirs2",

--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium_node"
-version = "4.2.1" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
+version = "4.2.2" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
 description = "Concordium Node"
 authors = ["Concordium <developers@concordium.com>"]
 exclude = [".gitignore", ".gitlab-ci.yml", "test/**/*","**/**/.gitignore","**/**/.gitlab-ci.yml"]


### PR DESCRIPTION
## Purpose

Make the version distinguishable from previous ones for today's stagenet deployment.