### PR TITLE
Revise how the initial transaction table is generated

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState.hs
@@ -382,8 +382,8 @@ class GlobalStateConfig (c :: Type) where
     initialiseExistingGlobalState :: forall pv . IsProtocolVersion pv => SProtocolVersion pv -> c -> LogIO (Maybe (GSContext c pv, GSState c pv))
 
     -- |Initialise new global state with the given genesis. If the state already
-    -- exists this will raise an exception. The same considerations as for
-    -- 'initialiseExistingGlobalState' apply about state activation.
+    -- exists this will raise an exception. It is not necessary to call 'activateGlobalState'
+    -- on the generated state, as this will establish the necessary invariants.
     initialiseNewGlobalState :: IsProtocolVersion pv => GenesisData pv -> c -> LogIO (GSContext c pv, GSState c pv)
 
     -- |Either initialise an existing state, or if it does not exist, initialise a new one with the given genesis.

--- a/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState.hs
@@ -59,6 +59,7 @@ import Concordium.GlobalState.CapitalDistribution
 
 import qualified Concordium.GlobalState.AccountMap as AccountMap
 import qualified Concordium.GlobalState.Rewards as Rewards
+import qualified Concordium.GlobalState.TransactionTable as TransactionTable
 import qualified Concordium.Types.IdentityProviders as IPS
 import qualified Concordium.Types.AnonymityRevokers as ARS
 import Concordium.Types.Queries (PoolStatus(..),CurrentPaydayBakerPoolStatus(..),makePoolPendingChange, RewardStatus'(..))
@@ -833,6 +834,27 @@ instance (IsProtocolVersion pv, Monad m) => BS.BlockStateQuery (PureBlockStateMo
             psAllPoolTotalCapital = totalCapital bs,
             ..
         }
+
+    getInitialTransactionTable bs = return tt2
+      where
+        tt1 = Accounts.foldAccounts accInTT TransactionTable.emptyTransactionTable (bs ^. blockAccounts)
+        tt2 = foldl' updInTT tt1 [minBound..]
+        accInTT tt acct =
+            let nonce = acct ^. accountNonce
+                addr = acct ^. accountAddress
+            in if nonce /= minNonce
+                then
+                    tt & TransactionTable.ttNonFinalizedTransactions . at' (accountAddressEmbed addr)
+                        ?~ TransactionTable.emptyANFTWithNonce nonce
+                else tt
+        updInTT tt uty =
+            let sn = lookupNextUpdateSequenceNumber (bs ^. blockUpdates) uty
+            in if sn /= minUpdateSequenceNumber
+                then
+                    tt & TransactionTable.ttNonFinalizedChainUpdates . at' uty
+                        ?~ TransactionTable.emptyNFCUWithSequenceNumber sn
+                else
+                    tt
 
 instance (Monad m, IsProtocolVersion pv) => BS.AccountOperations (PureBlockStateMonad pv m) where
 
@@ -2023,7 +2045,8 @@ genesisBakerInfo spv cp GenesisBaker{..} = AccountBaker{..}
     _bakerPendingChange = NoChange
 
 -- |Initial block state based on 'GenesisData', for a given protocol version.
-genesisState :: forall pv . IsProtocolVersion pv => GenesisData pv -> Either String (BlockState pv)
+-- This also returns the transaction table.
+genesisState :: forall pv . IsProtocolVersion pv => GenesisData pv -> Either String (BlockState pv, TransactionTable.TransactionTable)
 genesisState gd = case protocolVersion @pv of
                     SP1 -> case gd of
                       GDP1 P1.GDP1Initial{..} -> mkGenesisStateInitial genesisCore genesisInitialState
@@ -2039,7 +2062,7 @@ genesisState gd = case protocolVersion @pv of
                       GDP4 P4.GDP4Regenesis{..} -> mkGenesisStateRegenesis StateMigrationParametersTrivial genesisRegenesis
                       GDP4 P4.GDP4MigrateFromP3{..} -> mkGenesisStateRegenesis (StateMigrationParametersP3ToP4 genesisMigration) genesisRegenesis
     where
-        mkGenesisStateInitial :: CoreGenesisParameters -> GenesisState pv -> Either String (BlockState pv)
+        mkGenesisStateInitial :: CoreGenesisParameters -> GenesisState pv -> Either String (BlockState pv, TransactionTable.TransactionTable)
         mkGenesisStateInitial GenesisData.CoreGenesisParameters{..} GenesisData.GenesisState{..} = do
             accounts <- mapM mkAccount (zip [0..] (toList genesisAccounts))
             let
@@ -2048,7 +2071,9 @@ genesisState gd = case protocolVersion @pv of
                 -- initial amount in the central bank is the amount on all genesis accounts combined
                 initialAmount = List.foldl' (\c acc -> c + acc ^. accountAmount) 0 accounts
                 _blockBank = makeHashed $ Rewards.makeGenesisBankStatus initialAmount
-            return BlockState {..}
+                -- In initial genesis, all accounts and updates have no prior transactions
+                initialTT = TransactionTable.emptyTransactionTable
+            return (BlockState {..}, initialTT)
               where
                   mkAccount :: (BakerId, GenesisAccount) -> Either String (Account (AccountVersionFor pv))
                   mkAccount (bid, GenesisAccount{..}) =
@@ -2076,9 +2101,10 @@ genesisState gd = case protocolVersion @pv of
                 Right bs
                     | hashShouldMatch && hbs ^. blockStateHash /= genesisStateHash -> Left "Could not deserialize genesis state: state hash is incorrect"
                     | epochLength (bs ^. blockBirkParameters . birkSeedState) /= GenesisData.genesisEpochLength genesisCore -> Left "Could not deserialize genesis state: epoch length mismatch"
-                    | otherwise -> Right bs
+                    | otherwise -> Right $!! (bs, genesisTT)
                     where
                         hbs = hashBlockState bs
                         hashShouldMatch = case migration of
                             StateMigrationParametersTrivial{} -> True
                             StateMigrationParametersP3ToP4{} -> False
+                        genesisTT = runIdentity $ runPureBlockStateMonad $ BS.getInitialTransactionTable hbs

--- a/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/AccountTable.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/AccountTable.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -111,3 +112,14 @@ toList (Tree t) = toL 0 t
     where
         toL o (Leaf _ a) = [(o, a)]
         toL o (Branch lvl _ _ t1 t2) = toL o t1 ++ toL (setBit o (fromIntegral lvl)) t2
+
+-- |Strict fold over the account table in increasing order of account index.
+foldl' :: (a -> Account av -> a) -> a ->  AccountTable av -> a
+foldl' _ a Empty = a
+foldl' f !a0 (Tree t) = ft a0 t
+    where
+        ft a (Leaf _ acct) = f a acct
+        ft a (Branch _ _ _ l r) =
+            let !a1 = ft a l
+                !a2 = ft a1 r
+            in a2

--- a/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/Accounts.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/Accounts.hs
@@ -194,6 +194,10 @@ instance IsProtocolVersion pv => Ixed (Accounts pv) where
 accountList :: Accounts pv -> [Account (AccountVersionFor pv)]
 accountList = fmap snd . AT.toList . accountTable
 
+-- |Fold over the account table in ascending order of account index.
+foldAccounts :: (a -> Account (AccountVersionFor pv) -> a) -> a -> Accounts pv -> a
+foldAccounts f a = AT.foldl' f a. accountTable
+
 -- |Serialize 'Accounts' in V0 format.
 serializeAccounts :: IsProtocolVersion pv => GlobalContext -> Putter (Accounts pv)
 serializeAccounts cryptoParams Accounts{..} = do

--- a/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
@@ -89,6 +89,7 @@ import Concordium.Crypto.EncryptedTransfers
 import Concordium.GlobalState.ContractStateFFIHelpers (LoadCallback)
 import qualified Concordium.GlobalState.ContractStateV1 as StateV1
 import Concordium.GlobalState.Persistent.LMDB (FixedSizeSerialization)
+import Concordium.GlobalState.TransactionTable (TransactionTable)
 
 -- |Hash associated with birk parameters.
 newtype BirkParametersHash (pv :: ProtocolVersion) = BirkParametersHash {birkParamHash :: H.Hash}
@@ -475,6 +476,10 @@ class (ContractStateOperations m, AccountOperations m) => BlockStateQuery m wher
     -- if the 'BakerId' is not currently a baker.
     getPoolStatus :: (AccountVersionFor (MPV m) ~ 'AccountV1, ChainParametersVersionFor (MPV m) ~ 'ChainParametersV1)
         => BlockState m -> Maybe BakerId -> m (Maybe PoolStatus)
+
+    -- |Construct a transaction table that is empty but records the next nonces/sequence numbers
+    -- for all accounts and chain updates.
+    getInitialTransactionTable :: BlockState m -> m TransactionTable
 
 -- |Distribution of newly-minted GTU.
 data MintAmounts = MintAmounts {
@@ -1237,6 +1242,7 @@ instance (Monad (t m), MonadTrans t, BlockStateQuery m) => BlockStateQuery (MGST
   getEnergyRate s = lift $ getEnergyRate s
   getPaydayEpoch = lift . getPaydayEpoch
   getPoolStatus s = lift . getPoolStatus s
+  getInitialTransactionTable = lift . getInitialTransactionTable
   {-# INLINE getModule #-}
   {-# INLINE getAccount #-}
   {-# INLINE accountExists #-}
@@ -1267,6 +1273,7 @@ instance (Monad (t m), MonadTrans t, BlockStateQuery m) => BlockStateQuery (MGST
   {-# INLINE getAnonymityRevokers #-}
   {-# INLINE getUpdateKeysCollection #-}
   {-# INLINE getEnergyRate #-}
+  {-# INLINE getInitialTransactionTable #-}
 
 instance (Monad (t m), MonadTrans t, AccountOperations m) => AccountOperations (MGSTrans t m) where
   getAccountCanonicalAddress = lift . getAccountCanonicalAddress

--- a/concordium-consensus/src/Concordium/GlobalState/Paired.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Paired.hs
@@ -438,6 +438,10 @@ instance (Monad m, C.HasGlobalStateContext (PairGSContext lc rc) r, BlockStateQu
         ps1 <- coerceBSML (getPoolStatus bps1 mbid)
         ps2 <- coerceBSMR (getPoolStatus bps2 mbid)
         assertEq ps1 ps2 $ return ps1
+    getInitialTransactionTable (bps1, bps2) = do
+        tt1 <- coerceBSML (getInitialTransactionTable bps1)
+        tt2 <- coerceBSMR (getInitialTransactionTable bps2)
+        assertEq tt1 tt2 $ return tt1
 
 instance (Monad m, C.HasGlobalStateContext (PairGSContext lc rc) r) => ContractStateOperations (BlockStateM pv (PairGSContext lc rc) r (PairGState ls rs) s m) where
   thawContractState (InstanceStateV0 st) = return st

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Accounts.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Accounts.hs
@@ -281,3 +281,11 @@ serializeAccounts :: (MonadBlobStore m, MonadPut m, IsProtocolVersion pv) => Glo
 serializeAccounts cryptoParams accts = do
         liftPut $ putWord64be $ L.size (accountTable accts)
         L.mmap_ (serializeAccount cryptoParams) (accountTable accts)
+
+-- |Fold over the account table in ascending order of account index.
+foldAccounts :: (MonadBlobStore m, IsProtocolVersion pv) => (a -> PersistentAccount (AccountVersionFor pv) -> m a) -> a -> Accounts pv -> m a
+foldAccounts f a accts = L.mfold f a (accountTable accts)
+
+-- |Fold over the account table in ascending order of account index.
+foldAccountsDesc :: (MonadBlobStore m, IsProtocolVersion pv) => (a -> PersistentAccount (AccountVersionFor pv) -> m a) -> a -> Accounts pv -> m a
+foldAccountsDesc f a accts = L.mfoldDesc f a (accountTable accts)

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
@@ -21,7 +21,6 @@ import qualified Concordium.GlobalState.Persistent.BlockState as PBS
 import Concordium.GlobalState.BlockState
 import Concordium.GlobalState.Finalization
 import Concordium.GlobalState.Parameters
-import Concordium.GlobalState.Persistent.Account
 import Concordium.GlobalState.Persistent.BlockPointer as PB
 import Concordium.GlobalState.Persistent.LMDB
 import Concordium.GlobalState.Statistics
@@ -238,9 +237,13 @@ initialSkovPersistentDataDefault
     -> GenesisData pv
     -> bs
     -> TS.BlockStatePointer bs -- ^How to serialize the block state reference for inclusion in the table.
+    -> TransactionTable
     -> m (SkovPersistentData pv bs)
 initialSkovPersistentDataDefault = initialSkovPersistentData defaultRuntimeParameters
 
+-- |Create an initial 'SkovPersistentData'.
+-- The state does not need to be activated if the supplied 'TransactionTable' is correctly
+-- initialised with the nonces and sequence numbers of the accounts and update types.
 initialSkovPersistentData
     :: (IsProtocolVersion pv, FixedSizeSerialization (TS.BlockStatePointer bs), BlockStateQuery m, bs ~ BlockState m, MonadIO m)
     => RuntimeParameters
@@ -253,25 +256,14 @@ initialSkovPersistentData
     -- ^Genesis state
     -> TS.BlockStatePointer bs
     -- ^Genesis block state
+    -> TransactionTable
+    -- ^Genesis transaction table
     -> m (SkovPersistentData pv bs)
-initialSkovPersistentData rp treeStateDir gd genState serState = do
+initialSkovPersistentData rp treeStateDir gd genState serState genTT = do
   gb <- makeGenesisPersistentBlockPointer gd genState
   let gbh = bpHash gb
       gbfin = FinalizationRecord 0 gbh emptyFinalizationProof 0
   initialDb <- liftIO $ initializeDatabase gb serState treeStateDir
-  -- When the state contains accounts, we must ensure that the transaction
-  -- table correctly reflects the account nonces, and similarly for
-  -- updates.
-  acctAddrs <- getAccountList genState
-  acctNonces <- foldM (\nnces addr ->
-      getAccount genState addr >>= \case
-          Nothing -> error "Invariant violation: listed account does not exist"
-          Just (_, acct) -> do
-              nonce <- getAccountNonce acct
-              return $! (addr, nonce):nnces) [] acctAddrs
-  updSeqNums <- foldM (\m uty -> do
-      sn <- getNextUpdateSequenceNumber genState uty
-      return $! Map.insert uty sn m) Map.empty [minBound..]
   return SkovPersistentData {
             _blockTable = emptyBlockTable,
             _possiblyPendingTable = HM.empty,
@@ -283,7 +275,7 @@ initialSkovPersistentData rp treeStateDir gd genState serState = do
             _genesisBlockPointer = gb,
             _focusBlock = gb,
             _pendingTransactions = emptyPendingTransactionTable,
-            _transactionTable = emptyTransactionTableWithSequenceNumbers acctNonces updSeqNums,
+            _transactionTable = genTT,
             _transactionTablePurgeCounter = 0,
             _statistics = initialConsensusStatistics,
             _runtimeParameters = rp,
@@ -425,26 +417,17 @@ activateSkovPersistentData :: forall pv. (IsProtocolVersion pv)
                            -> SkovPersistentData pv (PBS.HashedPersistentBlockState pv)
                            -> LogIO (SkovPersistentData pv (PBS.HashedPersistentBlockState pv))
 activateSkovPersistentData pbsc uninitState = do
+  -- Before we establish the invariants we cache the block state.
+  logEvent GlobalState LLTrace "Caching last finalized block"
   cachedLastFinalized <- liftIO (makeBlockPointerCached (_lastFinalized uninitState))
+  let lastState = _bpState cachedLastFinalized
   -- We need to establish is the transaction table invariants.
   -- This specifically means for each account we need to determine the next available nonce.
-  -- 
-  -- Before we establish the invariants we cache the block state.
-  let lastState = _bpState cachedLastFinalized
-  let getTransactionTable :: PBS.PersistentBlockStateMonad pv PBS.PersistentBlockStateContext (ReaderT PBS.PersistentBlockStateContext LogIO) TransactionTable
-      getTransactionTable = do
-        accs <- getAccountList lastState
-        tt0 <- foldM (\table addr ->
-                 getAccount lastState addr >>= \case
-                  Nothing -> logExceptionAndThrowTS (DatabaseInvariantViolation $ "Account " ++ show addr ++ " which is in the account list cannot be loaded.")
-                  Just (_, acc) -> return (table & ttNonFinalizedTransactions . at (accountAddressEmbed addr) ?~ emptyANFTWithNonce (acc ^. accountNonce)))
-            emptyTransactionTable
-            accs
-        foldM (\table uty -> do
-            sn <- getNextUpdateSequenceNumber lastState uty
-            return $ table & ttNonFinalizedChainUpdates . at uty ?~ emptyNFCUWithSequenceNumber sn
-          ) tt0 [minBound..]
-  tt <- runReaderT (PBS.runPersistentBlockStateMonad getTransactionTable) pbsc
+  -- This is handled by the 'BlockStateQuery' monad operation 'getInitialTransactionTable'
+  -- to ensure that the account table is traversed as efficiently as possible.
+  logEvent GlobalState LLTrace "Initialising transaction table"
+  tt <- runReaderT (PBS.runPersistentBlockStateMonad (getInitialTransactionTable lastState)) pbsc
+  logEvent GlobalState LLTrace "Done initialising transaction table"
   return (uninitState{_transactionTable = tt, _lastFinalized = cachedLastFinalized})
   where 
     makeBlockPointerCached :: PersistentBlockPointer pv (PBS.HashedPersistentBlockState pv) -> IO (PersistentBlockPointer pv (PBS.HashedPersistentBlockState pv))

--- a/concordium-consensus/src/Concordium/GlobalState/TransactionTable.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/TransactionTable.hs
@@ -99,10 +99,10 @@ getTransactionIndex bh = \case
 -- |The non-finalized transactions for a particular account.
 data AccountNonFinalizedTransactions = AccountNonFinalizedTransactions {
     -- |Non-finalized transactions (for an account) and their verification results indexed by nonce.
-    _anftMap :: Map.Map Nonce (Map.Map Transaction TVer.VerificationResult),
+    _anftMap :: !(Map.Map Nonce (Map.Map Transaction TVer.VerificationResult)),
     -- |The next available nonce at the last finalized block.
     -- 'anftMap' should only contain nonces that are at least 'anftNextNonce'.
-    _anftNextNonce :: Nonce
+    _anftNextNonce :: !Nonce
 } deriving (Eq, Show)
 makeLenses ''AccountNonFinalizedTransactions
 
@@ -118,9 +118,9 @@ emptyANFTWithNonce = AccountNonFinalizedTransactions Map.empty
 
 -- |The non-finalized chain updates of a particular type.
 data NonFinalizedChainUpdates = NonFinalizedChainUpdates {
-    _nfcuMap :: Map.Map UpdateSequenceNumber (Map.Map (WithMetadata UpdateInstruction) TVer.VerificationResult),
-    _nfcuNextSequenceNumber :: UpdateSequenceNumber
-} deriving (Eq)
+    _nfcuMap :: !(Map.Map UpdateSequenceNumber (Map.Map (WithMetadata UpdateInstruction) TVer.VerificationResult)),
+    _nfcuNextSequenceNumber :: !UpdateSequenceNumber
+} deriving (Eq, Show)
 makeLenses ''NonFinalizedChainUpdates
 
 emptyNFCU :: NonFinalizedChainUpdates
@@ -182,7 +182,7 @@ data TransactionTable = TransactionTable {
     -- |For each update types, the non-finalized update instructions, grouped by
     -- sequence number.
     _ttNonFinalizedChainUpdates :: !(Map.Map UpdateType NonFinalizedChainUpdates)
-}
+} deriving (Eq, Show)
 makeLenses ''TransactionTable
 
 -- |Get the verification result for a non finalized transaction given by its hash.

--- a/concordium-consensus/src/Concordium/MultiVersion.hs
+++ b/concordium-consensus/src/Concordium/MultiVersion.hs
@@ -471,7 +471,7 @@ checkForProtocolUpdate = liftSkov body
                     oldTransactions <- terminateSkov
                     -- Transfer the non-finalized transactions to the new version.
                     lift $ do
-                        lastV <- fmap Vec.last . liftIO . readIORef =<< asks mvVersions
+                        lastV <- liftIO . fmap Vec.last . readIORef =<< asks mvVersions
                         case lastV of
                             (EVersionedConfiguration vc) ->
                                 liftSkovUpdate vc $ mapM_ Skov.receiveTransaction oldTransactions

--- a/concordium-consensus/src/Concordium/Skov/MonadImplementations.hs
+++ b/concordium-consensus/src/Concordium/Skov/MonadImplementations.hs
@@ -222,6 +222,8 @@ class SkovConfiguration gsconfig finconfig handlerconfig where
 
     -- |Create an initial context and state from a given configuration assuming
     -- no state exists. If the state exists then an IO exception will be thrown.
+    --
+    -- It is not necessary to call 'activateSkovState' on the resulting state.
     initialiseNewSkov :: IsProtocolVersion pv
                       => GenesisData pv
                       -> SkovConfig pv gsconfig finconfig handlerconfig

--- a/concordium-consensus/src/Concordium/Skov/MonadImplementations.hs
+++ b/concordium-consensus/src/Concordium/Skov/MonadImplementations.hs
@@ -278,13 +278,15 @@ instance
         SkovConfig pv gsconfig finconfig handlerconfig ->
         LogIO (Maybe (SkovContext (SkovConfig pv gsconfig finconfig handlerconfig), SkovState (SkovConfig pv gsconfig finconfig handlerconfig)))
     initialiseExistingSkov (SkovConfig gsc finconf hconf) = do
-        logEvent Baker LLDebug "Attempting to use existing global state."
+        logEvent Skov LLDebug "Attempting to use existing global state."
         initialiseExistingGlobalState (protocolVersion @pv) gsc >>= \case
-          Nothing -> return Nothing
+          Nothing -> do
+            logEvent Skov LLDebug "No existing global state."
+            return Nothing
           Just (c, s) -> do
             (finctx, finst) <- evalGlobalState @_ @pv (Proxy @gsconfig) (initialiseFinalization finconf) c s
-            logEvent Baker LLDebug $ "Initializing finalization with context = " ++ show finctx
-            logEvent Baker LLDebug $ "Initializing finalization with initial state = " ++ show finst
+            logEvent Skov LLDebug $ "Initializing finalization with context = " ++ show finctx
+            logEvent Skov LLDebug $ "Initializing finalization with initial state = " ++ show finst
             let (hctx, hst) = initialiseHandler hconf
             return (Just (SkovContext c finctx hctx, SkovState s finst hst))
 
@@ -295,11 +297,11 @@ instance
         SkovConfig pv gsconfig finconfig handlerconfig ->
         LogIO (SkovContext (SkovConfig pv gsconfig finconfig handlerconfig), SkovState (SkovConfig pv gsconfig finconfig handlerconfig))
     initialiseNewSkov genData (SkovConfig gsc finconf hconf) = do
-        logEvent Baker LLDebug "Creating new global state."
+        logEvent Skov LLDebug "Creating new global state."
         (c, s) <- initialiseNewGlobalState genData gsc
         (finctx, finst) <- evalGlobalState @_ @pv (Proxy @gsconfig) (initialiseFinalization finconf) c s
-        logEvent Baker LLDebug $ "Initializing finalization with context = " ++ show finctx
-        logEvent Baker LLDebug $ "Initializing finalization with initial state = " ++ show finst
+        logEvent Skov LLDebug $ "Initializing finalization with context = " ++ show finctx
+        logEvent Skov LLDebug $ "Initializing finalization with initial state = " ++ show finst
         let (hctx, hst) = initialiseHandler hconf
         return (SkovContext c finctx hctx, SkovState s finst hst)
 

--- a/concordium-consensus/tests/consensus/ConcordiumTests/ReceiveTransactionsTest.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/ReceiveTransactionsTest.hs
@@ -220,9 +220,9 @@ runMyMonad act time initialState = runReaderT (runDeterministic (runStateT (runP
 
 -- |Run the given computation in a state consisting of only the genesis block and the state determined by it.
 runMyMonad' :: MyMonad a -> UTCTime -> GenesisData PV -> IO (a, MyState)
-runMyMonad' act time gd = runPureBlockStateMonad (initialSkovDataDefault gd (hashBlockState $ mock bs)) >>= runMyMonad act time
+runMyMonad' act time gd = runPureBlockStateMonad (initialSkovDataDefault gd (hashBlockState $ mock bs) genTT) >>= runMyMonad act time
   where
-    bs = case genesisState gd of
+    (bs, genTT) = case genesisState gd of
                Left err -> error $ "Invalid genesis state: " ++ err
                Right x -> x
     mock = mockChainUpdate . mockAccount

--- a/concordium-consensus/tests/scheduler/GlobalStateMock.hs
+++ b/concordium-consensus/tests/scheduler/GlobalStateMock.hs
@@ -30,6 +30,7 @@ import Concordium.GlobalState.BakerInfo
 import Concordium.GlobalState.Basic.BlockState.AccountReleaseSchedule
 import Concordium.GlobalState.BlockState
 import Concordium.GlobalState.CapitalDistribution
+import Concordium.GlobalState.TransactionTable (TransactionTable)
 import Concordium.GlobalState.Types
 import qualified Concordium.GlobalState.Wasm as GSWasm
 import qualified Concordium.ID.Types as ID
@@ -138,6 +139,7 @@ data BlockStateQueryAction (pv :: ProtocolVersion) a where
     GetEnergyRate :: MockBlockState -> BlockStateQueryAction pv EnergyRate
     GetPaydayEpoch :: (AccountVersionFor pv ~ 'AccountV1) => MockBlockState -> BlockStateQueryAction pv Epoch
     GetPoolStatus :: (AccountVersionFor pv ~ 'AccountV1, ChainParametersVersionFor pv ~ 'ChainParametersV1) => MockBlockState -> Maybe BakerId -> BlockStateQueryAction pv (Maybe PoolStatus)
+    GetInitialTransactionTable :: MockBlockState -> BlockStateQueryAction pv TransactionTable
 
 deriving instance Eq (BlockStateQueryAction pv a)
 deriving instance Show (BlockStateQueryAction pv a)

--- a/concordium-consensus/tests/scheduler/SchedulerTests/Payday.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/Payday.hs
@@ -14,7 +14,6 @@ import Control.Monad.Trans.State
 
 import qualified Data.Vector as Vec
 import Data.Ratio
-import Data.Either ( fromRight )
 import Data.List ( maximumBy, sortBy )
 import Data.Map ( (!) )
 import Data.Proxy

--- a/concordium-consensus/tests/scheduler/SchedulerTests/Payday.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/Payday.hs
@@ -50,6 +50,7 @@ import Concordium.GlobalState.Persistent.BlobStore
 import Concordium.GlobalState.Persistent.BlockState
 import Concordium.GlobalState.Persistent.BlockPointer
 import Concordium.GlobalState.Persistent.TreeState
+import Concordium.GlobalState.TransactionTable (TransactionTable, emptyTransactionTable)
 import Concordium.ID.Types
 import SchedulerTests.TestUtils ()
 import Concordium.GlobalState.BlockPointer (BlockPointer (_bpState))
@@ -235,8 +236,8 @@ type MyPureMonad pv = PureTreeStateMonad (MyPureBlockState pv) (PureBlockStateMo
 runMyPureMonad :: (IsProtocolVersion pv) => MyPureTreeState pv -> MyPureMonad pv a -> IO (a, MyPureTreeState pv)
 runMyPureMonad is = (`runStateT` is) . runPureBlockStateMonad . runPureTreeStateMonad
 
-runMyPureMonad' :: (IsProtocolVersion pv) => GenesisData pv -> MyPureMonad pv a -> IO (a, MyPureTreeState pv)
-runMyPureMonad' gd = runPureBlockStateMonad (initialSkovDataDefault gd initialPureBlockState) >>= runMyPureMonad
+runMyPureMonad' :: (IsProtocolVersion pv) => GenesisData pv -> TransactionTable -> MyPureMonad pv a -> IO (a, MyPureTreeState pv)
+runMyPureMonad' gd genTT = runPureBlockStateMonad (initialSkovDataDefault gd initialPureBlockState genTT) >>= runMyPureMonad
 
 type MyPersistentBlockState pv = HashedPersistentBlockState pv
 type MyPersistentTreeState pv = SkovPersistentData pv (MyPersistentBlockState pv)
@@ -276,7 +277,7 @@ testRewardDistribution = do
   it "splits the minted amount three ways" $ withMaxSuccess 10000 $ property propMintAmountsEqNewMint
   it "chooses the most recent mint distribution before payday" $ withMaxSuccess 10000 $ property propMintDistributionMostRecent
   it "does not change after mint distribution (in-memory)" $ do
-    (resultPure, _) <- runMyPureMonad' gd (propMintDistributionImmediate ibs blockParentPure slot bid epoch mfinInfo newSeedState transFees freeCounts updates)
+    (resultPure, _) <- runMyPureMonad' gd genTT (propMintDistributionImmediate ibs blockParentPure slot bid epoch mfinInfo newSeedState transFees freeCounts updates)
     assertBool "in-memory" resultPure
   it "does not change after mint distribution (persistent)" $ do
     ipbs :: MyPersistentBlockState 'P4 <- runBlobStoreTemp "." initialPersistentBlockState
@@ -284,13 +285,15 @@ testRewardDistribution = do
     (resultPersistent, _) <- withPersistentState' (\x -> propMintDistributionImmediate (hpbsPointers x) blockParentPersistent slot bid epoch mfinInfo newSeedState transFees freeCounts updates)
     assertBool "persistent" resultPersistent
   it "does not change after block reward distribution (in-memory)" $ do
-    (resultPure, _) <- runMyPureMonad' gd (propTransactionFeesDistributionP4 transFees freeCounts bid ibs)
+    (resultPure, _) <- runMyPureMonad' gd genTT (propTransactionFeesDistributionP4 transFees freeCounts bid ibs)
     assertBool "in-memory" resultPure
   it "does not change after block reward distribution (persistent)" $ do
     (resultPersistent, _ :: MyPersistentTreeState 'P4) <- withPersistentState' (propTransactionFeesDistributionP4 transFees freeCounts bid . hpbsPointers)
     assertBool "persistent" resultPersistent
       where gd = genesis 5 ^._1 :: GenesisData 'P4
-            ibs = fromRight (_unhashedBlockState initialPureBlockState :: Concordium.GlobalState.Basic.BlockState.BlockState 'P4) (genesisState gd)
+            (ibs, genTT) = case genesisState gd of
+              Right x -> x
+              Left _ -> (_unhashedBlockState initialPureBlockState :: Concordium.GlobalState.Basic.BlockState.BlockState 'P4, emptyTransactionTable)
             blockParentPure = makeGenesisBasicBlockPointer gd initialPureBlockState
             slot = 400
             bid = BakerId 1


### PR DESCRIPTION
## Purpose

Revise how the transaction table is generated when initialising the Skov.

## Changes

- It is no longer necessary to call `activateSkovState`/`activateGlobalState` after `initialiseNewSkov`/`initialiseNewGlobalState` in order to use it for consensus (though it is after `initialiseExistingSkov`). This is because these functions now generate the transaction table based on the (re)genesis data. (And the only block is already cached.) This avoids potentially expensive additional traversals of the account table.
- The `genesisState` function returns an initial transaction table as well as the (in-memory) block state.
- Generating a transaction table from a block state is handled by a new `BlockStateQuery` function `getInitialTransactionTable`.
- The generated transaction tables omit entries for accounts with next nonce 1 (where they are not required).

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
