### PR TITLE
Fix consensus tests with corrected transaction costs.

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/TransactionTable.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/TransactionTable.hs
@@ -120,7 +120,7 @@ emptyANFTWithNonce = AccountNonFinalizedTransactions Map.empty
 data NonFinalizedChainUpdates = NonFinalizedChainUpdates {
     _nfcuMap :: Map.Map UpdateSequenceNumber (Map.Map (WithMetadata UpdateInstruction) TVer.VerificationResult),
     _nfcuNextSequenceNumber :: UpdateSequenceNumber
-} deriving (Eq)
+} deriving (Eq, Show)
 makeLenses ''NonFinalizedChainUpdates
 
 emptyNFCU :: NonFinalizedChainUpdates


### PR DESCRIPTION
## Purpose

The cost of dummy transfer transactions was previously incorrect. This is fixed in https://github.com/Concordium/concordium-base/pull/184. The change causes some consensus tests to fail, which this rectifies.

## Changes

- When checking the invariant for the transaction table, the account (and chain-update) non-finalized transactions should record the same transaction verification result as present in the transaction table hash map.

## Checklist

- [x] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
