### PR TITLE
Upgrade Rust to 1.62 and resolve the new clippy complaints.

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         plan:
-        - rust: 1.53
+        - rust: 1.62
 
     steps:
     - name: Checkout

--- a/.github/workflows/rustfmt.yaml
+++ b/.github/workflows/rustfmt.yaml
@@ -35,8 +35,7 @@ jobs:
     strategy:
       matrix:
         plan:
-          # from concordium/rustfmt:0.17
-        - rust: "nightly-2021-06-09-x86_64-unknown-linux-gnu"
+        - rust: "nightly-2022-06-09-x86_64-unknown-linux-gnu"
 
     steps:
     - name: Checkout

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ already exists.
 
 ## Rust workflow
 
-We use **stable version** of rust, 1.53, to compile the code.
+We use **stable version** of rust, 1.62, to compile the code.
 
 The CI is configured to check two things
 - the [clippy](https://github.com/rust-lang/rust-clippy) tool is run to check

--- a/collector-backend/src/bin/node-collector-backend.rs
+++ b/collector-backend/src/bin/node-collector-backend.rs
@@ -77,6 +77,7 @@ struct ConfigCli {
     #[structopt(long = "trace", help = "Trace mode", env = "COLLECTOR_BACKEND_LOG_LEVEL_TRACE")]
     pub trace:                  bool,
     #[structopt(long = "info", help = "Info mode", env = "COLLECTOR_BACKEND_LOG_LEVEL_INFO")]
+    #[allow(dead_code)] // for backwards compatibility
     pub info:                   bool,
     #[structopt(
         long = "no-log-timestamp",
@@ -358,7 +359,7 @@ async fn nodes_post_handler(state: &mut State) -> gotham::anyhow::Result<Respons
         nodes_info.peersCount <= validation_conf.valid_node_peers_count,
         "peersCount is too high to be considered valid"
     );
-    let state_data = CollectorStateData::borrow_from(&state);
+    let state_data = CollectorStateData::borrow_from(state);
     ensure!(!state_data.banned_versions.contains(&nodes_info.client), "node version is banned");
     ensure!(
         !state_data.banned_node_names.contains(&nodes_info.nodeName.trim().to_string()),
@@ -405,7 +406,7 @@ async fn nodes_post_handler(state: &mut State) -> gotham::anyhow::Result<Respons
         .expect("RWLock poisoned")
         .insert(nodes_info.nodeId.clone(), nodes_info);
 
-    Ok(create_empty_response(&state, StatusCode::OK))
+    Ok(create_empty_response(state, StatusCode::OK))
 }
 
 pub fn router(

--- a/collector-backend/src/lib.rs
+++ b/collector-backend/src/lib.rs
@@ -262,9 +262,9 @@ pub fn setup_logger(trace: bool, debug: bool, no_log_timestamp: bool) {
             writeln!(buf, "{}: {}: {}", buf.timestamp_nanos(), record.level(), record.args())
         });
     }
-    log_builder.filter(Some(&"tokio_reactor"), LevelFilter::Warn);
-    log_builder.filter(Some(&"hyper"), LevelFilter::Warn);
-    log_builder.filter(Some(&"gotham"), LevelFilter::Warn);
-    log_builder.filter(Some(&"h2"), LevelFilter::Warn);
+    log_builder.filter(Some("tokio_reactor"), LevelFilter::Warn);
+    log_builder.filter(Some("hyper"), LevelFilter::Warn);
+    log_builder.filter(Some("gotham"), LevelFilter::Warn);
+    log_builder.filter(Some("h2"), LevelFilter::Warn);
     log_builder.init();
 }

--- a/concordium-node/README.md
+++ b/concordium-node/README.md
@@ -2,7 +2,7 @@
 
 ## Dependencies to build the project
 
-- Rust (stable 1.53 for using static libraries)
+- Rust (stable 1.62 for using static libraries)
 - binutils >= 2.22
   - For macOS one should use the binutils provided by Xcode.
 - cmake >= 3.8.0
@@ -149,8 +149,8 @@ Before building the node, you should install the following dependencies:
 
 - Haskell [stack](https://docs.haskellstack.org/en/stable/install_and_upgrade/)
 - [Rust](https://www.rust-lang.org/tools/install)
-  - For building the node, the toolchain `1.53.0-x86_64-pc-windows-gnu` is required, which can be installed with the command: `rustup toolchain install 1.53.0-x86_64-pc-windows-gnu`.
-  - For building the node runner service (optional), the toolchain `1.53.0-x86_64-pc-windows-msvc`  is required, which can be installed with the command: `rustup toolchain install 1.53.0-x86_64-pc-windows-msvc`.
+  - For building the node, the toolchain `1.62.0-x86_64-pc-windows-gnu` is required, which can be installed with the command: `rustup toolchain install 1.62.0-x86_64-pc-windows-gnu`.
+  - For building the node runner service (optional), the toolchain `1.62.0-x86_64-pc-windows-msvc`  is required, which can be installed with the command: `rustup toolchain install 1.62.0-x86_64-pc-windows-msvc`.
 - [flatc](https://github.com/google/flatbuffers/releases/tag/v2.0.0) 2.0.0 (should be in the path)
 - [protoc](https://github.com/protocolbuffers/protobuf/releases) >= 3.7.1
 - LMDB should be installed under `stack`'s `msys2` installation, which can be done with the following commands:

--- a/concordium-node/src/bin/cli.rs
+++ b/concordium-node/src/bin/cli.rs
@@ -308,7 +308,7 @@ fn instantiate_node(
         error!("Failed to persist own node id.");
     };
 
-    P2PNode::new(Some(node_id), &conf, PeerType::Node, stats_export_service, regenesis_arc)
+    P2PNode::new(Some(node_id), conf, PeerType::Node, stats_export_service, regenesis_arc)
 }
 
 fn establish_connections(conf: &config::Config, node: &Arc<P2PNode>) -> anyhow::Result<()> {

--- a/concordium-node/src/bin/collector.rs
+++ b/concordium-node/src/bin/collector.rs
@@ -80,6 +80,7 @@ struct ConfigCli {
     #[structopt(long = "trace", help = "Trace mode", env = "CONCORDIUM_NODE_COLLECTOR_TRACE")]
     pub trace:                  bool,
     #[structopt(long = "info", help = "Info mode", env = "CONCORDIUM_NODE_COLLECTOR_INFO")]
+    #[allow(dead_code)] // allow for backwards compatibility.
     pub info:                   bool,
     #[structopt(
         long = "no-log-timestamp",

--- a/concordium-node/src/connection/mod.rs
+++ b/concordium-node/src/connection/mod.rs
@@ -109,14 +109,14 @@ impl DeduplicationQueueXxHash64 {
         use std::hash::Hasher;
         use twox_hash::XxHash64;
         let mut hasher = XxHash64::with_seed(self.seed);
-        hasher.write(&input);
+        hasher.write(input);
         hasher.finish()
     }
 }
 
 impl DeduplicationQueue for DeduplicationQueueXxHash64 {
     fn check_and_insert(&mut self, input: &[u8]) -> anyhow::Result<bool> {
-        let num = self.hash(&input);
+        let num = self.hash(input);
         if !self.queue.iter().any(|n| n == &num) {
             trace!("Message XxHash64 {:x} is unique, adding to dedup queue", num);
             self.queue.push(num);
@@ -128,7 +128,7 @@ impl DeduplicationQueue for DeduplicationQueueXxHash64 {
     }
 
     fn invalidate_if_exists(&mut self, input: &[u8]) {
-        let num = self.hash(&input);
+        let num = self.hash(input);
         if let Some(old_val) = self.queue.iter_mut().find(|val| **val == num) {
             // flip all bits in the old hash; we can't just remove the value from the queue
             *old_val = !*old_val;
@@ -159,7 +159,7 @@ impl DeduplicationQueueSha256 {
 
 impl DeduplicationQueue for DeduplicationQueueSha256 {
     fn check_and_insert(&mut self, input: &[u8]) -> anyhow::Result<bool> {
-        let hash = self.hash(&input);
+        let hash = self.hash(input);
         if !self.queue.iter().any(|n| *n == hash) {
             trace!("Message SHA256 {:X?} is unique, adding to dedup queue", &hash[..]);
             self.queue.push(hash);
@@ -171,7 +171,7 @@ impl DeduplicationQueue for DeduplicationQueueSha256 {
     }
 
     fn invalidate_if_exists(&mut self, input: &[u8]) {
-        let hash = self.hash(&input);
+        let hash = self.hash(input);
         if let Some(old_val) = self.queue.iter_mut().find(|val| **val == hash) {
             // zero out all bits in the old hash; we can't just remove the value from the
             // queue

--- a/concordium-node/src/consensus_ffi/consensus.rs
+++ b/concordium-node/src/consensus_ffi/consensus.rs
@@ -90,18 +90,10 @@ impl Default for ConsensusOutboundQueues {
     }
 }
 
+#[derive(Default)]
 pub struct ConsensusQueues {
     pub inbound:  ConsensusInboundQueues,
     pub outbound: ConsensusOutboundQueues,
-}
-
-impl Default for ConsensusQueues {
-    fn default() -> Self {
-        Self {
-            inbound:  Default::default(),
-            outbound: Default::default(),
-        }
-    }
 }
 
 impl ConsensusQueues {

--- a/concordium-node/src/consensus_ffi/ffi.rs
+++ b/concordium-node/src/consensus_ffi/ffi.rs
@@ -908,7 +908,7 @@ pub extern "C" fn on_finalization_message_catchup_out(
         let mut full_payload = Vec::with_capacity(1 + payload.len());
         (msg_variant as u8).serial(&mut full_payload);
 
-        full_payload.write_all(&payload).unwrap(); // infallible
+        full_payload.write_all(payload).unwrap(); // infallible
         let full_payload = Arc::from(full_payload);
 
         let msg = ConsensusMessage::new(
@@ -1045,7 +1045,7 @@ pub unsafe extern "C" fn regenesis_callback(ptr: *const Regenesis, block_hash: *
 
     // The pointer must remain valid, so we use into_raw to prevent the reference
     // count from being decremented.
-    Arc::into_raw(arc);
+    let _ = Arc::into_raw(arc);
 }
 
 /// A callback to free the regenesis Arc.

--- a/concordium-node/src/consensus_ffi/helpers.rs
+++ b/concordium-node/src/consensus_ffi/helpers.rs
@@ -84,7 +84,7 @@ impl Deref for HashBytes {
 }
 
 impl AsRef<[u8]> for HashBytes {
-    fn as_ref(&self) -> &[u8] { &self }
+    fn as_ref(&self) -> &[u8] { self }
 }
 
 impl FromStr for HashBytes {

--- a/concordium-node/src/network/mod.rs
+++ b/concordium-node/src/network/mod.rs
@@ -64,10 +64,10 @@ pub struct NetworkMessage {
 #[macro_export]
 macro_rules! netmsg {
     ($payload_type:ident, $payload:expr) => {{
-        crate::network::NetworkMessage {
+        $crate::network::NetworkMessage {
             created:  get_current_stamp(),
             received: None,
-            payload:  crate::network::NetworkPayload::$payload_type($payload),
+            payload:  $crate::network::NetworkPayload::$payload_type($payload),
         }
     }};
 }

--- a/concordium-node/src/network/serialization/fbs.rs
+++ b/concordium-node/src/network/serialization/fbs.rs
@@ -195,7 +195,7 @@ fn deserialize_request(root: &network::NetworkMessage) -> anyhow::Result<Network
                         .iter()
                         .map(|wv| {
                             wv.genesis_block()
-                                .map_or_else(|| bail!("Missing block hash"), |w| BlockHash::new(w))
+                                .map_or_else(|| bail!("Missing block hash"), BlockHash::new)
                         })
                         .collect::<anyhow::Result<Vec<BlockHash>>>()?
                 } else {

--- a/concordium-node/src/network/serialization/tests.rs
+++ b/concordium-node/src/network/serialization/tests.rs
@@ -88,7 +88,7 @@ fn s11n_packet() {
     let mut buffer = Cursor::new(Vec::new());
 
     msg.serialize(&mut buffer).unwrap();
-    let deserialized = NetworkMessage::deserialize(&buffer.get_ref()).unwrap();
+    let deserialized = NetworkMessage::deserialize(buffer.get_ref()).unwrap();
     assert_eq!(deserialized.payload, msg.payload);
 }
 

--- a/concordium-node/src/p2p/connectivity.rs
+++ b/concordium-node/src/p2p/connectivity.rs
@@ -166,9 +166,9 @@ impl P2PNode {
         let mut removed_peers = false;
         let mut removed_candidates = false;
         for token in tokens {
-            if conn_candidates.remove(&token).is_some() {
+            if conn_candidates.remove(token).is_some() {
                 removed_candidates = true;
-            } else if connections.remove(&token).is_some() {
+            } else if connections.remove(token).is_some() {
                 removed_peers = true;
             }
         }
@@ -192,7 +192,7 @@ impl P2PNode {
                     use rand::seq::SliceRandom;
                     let mut rng = rand::thread_rng();
                     let mut peers = self.get_node_peer_tokens();
-                    peers.retain(|token| !dont_relay_to.contains(&token));
+                    peers.retain(|token| !dont_relay_to.contains(token));
                     let peers_to_take = f64::floor(
                         f64::from(peers.len() as u32) * self.config.relay_broadcast_percentage,
                     );
@@ -560,13 +560,13 @@ pub fn connection_housekeeping(node: &Arc<P2PNode>) -> bool {
     };
 
     // remove connections without handshakes
-    lock_or_die!(node.conn_candidates()).retain(|_, conn| !is_conn_without_handshake(&conn));
+    lock_or_die!(node.conn_candidates()).retain(|_, conn| !is_conn_without_handshake(conn));
 
     // remove faulty and inactive connections
     {
         let mut faulty_removed = false;
         write_or_die!(node.connections()).retain(|_, conn| {
-            if is_conn_faulty(&conn) || is_conn_inactive(&conn) {
+            if is_conn_faulty(conn) || is_conn_inactive(conn) {
                 faulty_removed = true;
                 false
             } else {

--- a/concordium-node/src/p2p/peers.rs
+++ b/concordium-node/src/p2p/peers.rs
@@ -121,7 +121,7 @@ pub fn check_peers(node: &Arc<P2PNode>, peer_stats: &[PeerStats], attempted_boot
     debug!("I currently have {}/{} peers", peer_stats.len(), node.config.max_allowed_nodes);
 
     if node.config.print_peers {
-        node.print_stats(&peer_stats);
+        node.print_stats(peer_stats);
     }
 
     if node.self_peer.peer_type == PeerType::Node {

--- a/concordium-node/src/plugins/consensus.rs
+++ b/concordium-node/src/plugins/consensus.rs
@@ -254,7 +254,7 @@ pub fn handle_consensus_inbound_msg(
             && request.variant.is_rebroadcastable()
         {
             send_consensus_msg_to_net(
-                &node,
+                node,
                 request.dont_relay_to(),
                 None,
                 (request.payload.clone(), request.variant),
@@ -286,7 +286,7 @@ pub fn handle_consensus_inbound_msg(
             && consensus_result.is_rebroadcastable()
         {
             send_consensus_msg_to_net(
-                &node,
+                node,
                 request.dont_relay_to(),
                 None,
                 (request.payload, request.variant),
@@ -375,8 +375,8 @@ pub fn update_peer_list(node: &P2PNode) {
 
     let mut peers = write_or_die!(node.peers);
     // remove global state peers whose connections were dropped
-    peers.peer_states.retain(|id, _| peer_ids.contains(&id));
-    peers.pending_queue.retain(|id| peer_ids.contains(&id));
+    peers.peer_states.retain(|id, _| peer_ids.contains(id));
+    peers.pending_queue.retain(|id| peer_ids.contains(id));
     if let Some(in_progress) = peers.catch_up_peer {
         if !peers.peer_states.contains_key(&in_progress) {
             peers.catch_up_peer = None;

--- a/concordium-node/src/rpc.rs
+++ b/concordium-node/src/rpc.rs
@@ -254,7 +254,7 @@ impl P2p for RpcServerImpl {
             let result = if consensus_result == Success {
                 let mut payload = Vec::with_capacity(1 + transaction.len());
                 payload.write_u8(PacketType::Transaction as u8)?;
-                payload.write_all(&transaction)?;
+                payload.write_all(transaction)?;
 
                 CALLBACK_QUEUE.send_out_message(ConsensusMessage::new(
                     MessageType::Outbound(None),
@@ -493,14 +493,14 @@ impl P2p for RpcServerImpl {
         let req = req.get_ref();
         let banned_node = match (&req.node_id, &req.ip) {
             (Some(node_id), None) => {
-                if let Ok(id) = RemotePeerId::from_str(&node_id.to_string()) {
+                if let Ok(id) = RemotePeerId::from_str(node_id) {
                     Ok(self.node.drop_by_id(id))
                 } else {
                     return Err(Status::new(Code::InvalidArgument, "Malformed node ID."));
                 }
             }
             (None, Some(ip)) => {
-                if let Ok(ip) = IpAddr::from_str(&ip.to_string()) {
+                if let Ok(ip) = IpAddr::from_str(ip) {
                     self.node.drop_by_ip_and_ban(ip)
                 } else {
                     return Err(Status::new(Code::InvalidArgument, "Malformed IP address."));
@@ -535,7 +535,7 @@ impl P2p for RpcServerImpl {
         authenticate!(req, self.access_token);
         let req = req.get_ref();
         let banned_node = match req.ip {
-            Some(ref ip) => IpAddr::from_str(&ip.to_string()).ok().map(PersistedBanId::Ip),
+            Some(ref ip) => IpAddr::from_str(ip).ok().map(PersistedBanId::Ip),
             _ => None,
         };
 

--- a/concordium-node/src/utils.rs
+++ b/concordium-node/src/utils.rs
@@ -36,11 +36,11 @@ pub fn setup_logger(trace: bool, debug: bool, no_log_timestamp: bool) {
             writeln!(buf, "{}: {}: {}", buf.timestamp_nanos(), record.level(), record.args())
         });
     }
-    log_builder.filter(Some(&"tokio_reactor"), LevelFilter::Error);
-    log_builder.filter(Some(&"hyper"), LevelFilter::Error);
-    log_builder.filter(Some(&"reqwest"), LevelFilter::Error);
-    log_builder.filter(Some(&"gotham"), LevelFilter::Error);
-    log_builder.filter(Some(&"h2"), LevelFilter::Error);
+    log_builder.filter(Some("tokio_reactor"), LevelFilter::Error);
+    log_builder.filter(Some("hyper"), LevelFilter::Error);
+    log_builder.filter(Some("reqwest"), LevelFilter::Error);
+    log_builder.filter(Some("gotham"), LevelFilter::Error);
+    log_builder.filter(Some("h2"), LevelFilter::Error);
     log_builder.init();
 }
 

--- a/scripts/distribution/windows/build-all.ps1
+++ b/scripts/distribution/windows/build-all.ps1
@@ -1,4 +1,4 @@
-param ([string] $rustVersion = "1.53.0")
+param ([string] $rustVersion = "1.62.1")
 
 Write-Output "stack version: $(stack --version)"
 Write-Output "cargo version: $(cargo --version)"

--- a/scripts/static-binaries/build-on-ubuntu.sh
+++ b/scripts/static-binaries/build-on-ubuntu.sh
@@ -14,7 +14,7 @@ set -euxo pipefail
 extra_features=${EXTRA_FEATURES:-""}
 
 flatbuffers_version=v2.0.0
-rust_toolchain_version=1.53
+rust_toolchain_version=1.62
 
 # Install dependencies.
 

--- a/service/windows/README.md
+++ b/service/windows/README.md
@@ -24,16 +24,16 @@ Full details of the configuration options available are to be found in [Configur
 Building the Node Runner Service currently requires the `msvc` rust toolchain.
 (Note, this is different to the node itself, which requires the `gnu` rust toolchain.)
 Building is only supported on Windows.
-Currently, we support rust version 1.53.
+Currently, we support rust version 1.62.
 
 The service can be built with the following command:
 ```
-cargo +1.53.0-msvc build
+cargo +1.62.1-msvc build
 ```
 
 If the toolchain is not already installed, it can be done with the following command:
 ```
-rustup toolchain install 1.53.0-x86_64-pc-windows-msvc
+rustup toolchain install 1.62.1-x86_64-pc-windows-msvc
 ```
 
 ## Installer


### PR DESCRIPTION
## Purpose

Upgrade rust to 1.62. This is necessary since we need to upgrade tonic in the node to version 0.8 (for the upcoming grpc changes) which needs rust at least 1.56.

## Changes

Address new clippy suggestions. They do not change semantics or performance of the code.

Update versions in the build jobs.

## Depends on
- [x] https://github.com/Concordium/concordium-wasm-smart-contracts/pull/57
- [x] https://github.com/Concordium/concordium-base/pull/187

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.