### PR TITLE
Remove unused runtime parameter from the node.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unrelease changes
 
+- Remove obsolete and unused option `--max-expiry-duration`
+
 ## 4.2.4
 
 - Reduce startup time and memory use further by reducing the amount of block

--- a/concordium-consensus/src/Concordium/External.hs
+++ b/concordium-consensus/src/Concordium/External.hs
@@ -305,8 +305,6 @@ startConsensus ::
     Word64 ->
     -- |Block construction timeout in milliseconds
     Word64 ->
-    -- |The amount of time in the future a transaction's expiry can be. In seconds.
-    Word64 ->
     -- |Insertions before purging of transactions
     Word64 ->
     -- |Time in seconds during which a transaction can't be purged
@@ -343,7 +341,6 @@ startConsensus ::
 startConsensus
     maxBlock
     blockConstructionTimeout
-    maxTimeToExpiry
     insertionsBeforePurge
     transactionsKeepAlive
     transactionsPurgingDelay
@@ -418,8 +415,7 @@ startConsensus
                   rpMaxBakingDelay = defaultMaxBakingDelay,
                   rpInsertionsBeforeTransactionPurge = fromIntegral insertionsBeforePurge,
                   rpTransactionsKeepAliveTime = TransactionTime transactionsKeepAlive,
-                  rpTransactionsPurgingDelay = fromIntegral transactionsPurgingDelay,
-                  rpMaxTimeToExpiry = fromIntegral maxTimeToExpiry
+                  rpTransactionsPurgingDelay = fromIntegral transactionsPurgingDelay
                 }
 
 -- |Start up an instance of Skov without starting the baker thread.
@@ -429,8 +425,6 @@ startConsensusPassive ::
     -- |Maximum block size.
     Word64 ->
     -- |Block construction timeout in milliseconds
-    Word64 ->
-    -- |The amount of time in the future a transaction's expiry can be. In seconds.
     Word64 ->
     -- |Insertions before purging of transactions
     Word64 ->
@@ -463,7 +457,6 @@ startConsensusPassive ::
 startConsensusPassive
     maxBlock
     blockConstructionTimeout
-    maxTimeToExpiry
     insertionsBeforePurge
     transactionsKeepAlive
     transactionsPurgingDelay
@@ -520,8 +513,7 @@ startConsensusPassive
                   rpMaxBakingDelay = defaultMaxBakingDelay,
                   rpInsertionsBeforeTransactionPurge = fromIntegral insertionsBeforePurge,
                   rpTransactionsKeepAliveTime = TransactionTime transactionsKeepAlive,
-                  rpTransactionsPurgingDelay = fromIntegral transactionsPurgingDelay,
-                  rpMaxTimeToExpiry = fromIntegral maxTimeToExpiry
+                  rpTransactionsPurgingDelay = fromIntegral transactionsPurgingDelay
                 }
 
 -- |Shut down consensus, stopping any baker thread if necessary.
@@ -1222,8 +1214,6 @@ foreign export ccall
         Word64 ->
         -- |Block construction timeout in milliseconds
         Word64 ->
-        -- |The amount of time in the future a transaction's expiry can be. In seconds.
-        Word64 ->
         -- |Insertions before purging of transactions
         Word64 ->
         -- |Time in seconds during which a transaction can't be purged
@@ -1262,8 +1252,6 @@ foreign export ccall
         -- |Maximum block size.
         Word64 ->
         -- |Block construction timeout in milliseconds
-        Word64 ->
-        -- |The amount of time in the future a transaction's expiry can be. In seconds.
         Word64 ->
         -- |Insertions before purging of transactions
         Word64 ->

--- a/concordium-consensus/src/Concordium/GlobalState/Parameters.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Parameters.hs
@@ -102,9 +102,7 @@ data RuntimeParameters = RuntimeParameters {
   -- transaction table if a purge is executed.
   rpTransactionsKeepAliveTime :: !TransactionTime,
   -- |Number of seconds between automatic transaction table purging  runs.
-  rpTransactionsPurgingDelay :: !Int,
-  -- |The maximum allowed time difference between slot time and a transaction's expiry time.
-  rpMaxTimeToExpiry :: !TransactionTime
+  rpTransactionsPurgingDelay :: !Int
   }
 
 -- |Default runtime parameters, block size = 10MB.
@@ -116,8 +114,7 @@ defaultRuntimeParameters = RuntimeParameters {
   rpMaxBakingDelay = 10000, -- 10 seconds
   rpInsertionsBeforeTransactionPurge = 1000,
   rpTransactionsKeepAliveTime = 5 * 60, -- 5 min
-  rpTransactionsPurgingDelay = 3 * 60, -- 3 min
-  rpMaxTimeToExpiry = 60 * 60 * 2 -- 2 hours
+  rpTransactionsPurgingDelay = 3 * 60 -- 3 min
   }
 
 instance FromJSON RuntimeParameters where
@@ -129,7 +126,6 @@ instance FromJSON RuntimeParameters where
     rpInsertionsBeforeTransactionPurge <- v .: "insertionsBeforeTransactionPurge"
     rpTransactionsKeepAliveTime <- (fromIntegral :: Int -> TransactionTime) <$> v .: "transactionsKeepAliveTime"
     rpTransactionsPurgingDelay <- v .: "transactionsPurgingDelay"
-    rpMaxTimeToExpiry <- v .: "maxTimeToExpiry"
     when (rpBlockSize <= 0) $
       fail "Block size must be a positive integer."
     when (rpEarlyBlockThreshold <= 0) $

--- a/concordium-node/src/configuration.rs
+++ b/concordium-node/src/configuration.rs
@@ -255,14 +255,6 @@ pub struct BakerConfig {
     )]
     pub import_blocks_from: Option<String>,
     #[structopt(
-        long = "max-expiry-duration",
-        help = "Maximum allowed time difference between now and a transaction's expiry time in \
-                seconds",
-        default_value = "7200",
-        env = "CONCORDIUM_NODE_CONSENSUS_MAX_EXPIRY_DURATION"
-    )]
-    pub max_time_to_expiry: u64,
-    #[structopt(
         long = "genesis-data-file",
         help = "Path to the data that constitutes the genesis block. If the path is relative it \
                 is interpreted relative to the supplied data directory.",

--- a/concordium-node/src/consensus_ffi/consensus.rs
+++ b/concordium-node/src/consensus_ffi/consensus.rs
@@ -201,7 +201,6 @@ impl std::fmt::Display for ConsensusType {
 pub struct ConsensusContainer {
     pub max_block_size:             u64,
     pub block_construction_timeout: u64,
-    pub max_time_to_expiry:         u64,
     pub insertions_before_purging:  u64,
     pub transaction_keep_alive:     u64,
     pub is_baking:                  Arc<AtomicBool>,
@@ -216,7 +215,6 @@ impl ConsensusContainer {
     pub fn new(
         max_block_size: u64,
         block_construction_timeout: u64,
-        max_time_to_expiry: u64,
         insertions_before_purging: u64,
         transaction_keep_alive: u64,
         transactions_purging_delay: u64,
@@ -237,7 +235,6 @@ impl ConsensusContainer {
         match get_consensus_ptr(
             max_block_size,
             block_construction_timeout,
-            max_time_to_expiry,
             insertions_before_purging,
             transaction_keep_alive,
             transactions_purging_delay,
@@ -250,7 +247,6 @@ impl ConsensusContainer {
             Ok(consensus_ptr) => Ok(Self {
                 max_block_size,
                 block_construction_timeout,
-                max_time_to_expiry,
                 insertions_before_purging,
                 transaction_keep_alive,
                 is_baking: Arc::new(AtomicBool::new(false)),

--- a/concordium-node/src/consensus_ffi/ffi.rs
+++ b/concordium-node/src/consensus_ffi/ffi.rs
@@ -258,7 +258,6 @@ extern "C" {
     pub fn startConsensus(
         max_block_size: u64,
         block_construction_timeout: u64,
-        max_time_to_expiry: u64,
         insertions_before_purging: u64,
         transaction_keep_alive: u64,
         transactions_purging_delay: u64,
@@ -280,7 +279,6 @@ extern "C" {
     pub fn startConsensusPassive(
         max_block_size: u64,
         block_construction_timeout: u64,
-        max_time_to_expiry: u64,
         insertions_before_purging: u64,
         transaction_keep_alive: u64,
         transactions_purging_delay: u64,
@@ -459,7 +457,6 @@ extern "C" {
 pub fn get_consensus_ptr(
     max_block_size: u64,
     block_construction_timeout: u64,
-    max_time_to_expiry: u64,
     insertions_before_purging: u64,
     transaction_keep_alive: u64,
     transactions_purging_delay: u64,
@@ -481,7 +478,6 @@ pub fn get_consensus_ptr(
                 startConsensus(
                     max_block_size,
                     block_construction_timeout,
-                    max_time_to_expiry,
                     insertions_before_purging,
                     transaction_keep_alive,
                     transactions_purging_delay,
@@ -509,7 +505,6 @@ pub fn get_consensus_ptr(
                     startConsensusPassive(
                         max_block_size,
                         block_construction_timeout,
-                        max_time_to_expiry,
                         insertions_before_purging,
                         transaction_keep_alive,
                         transactions_purging_delay,

--- a/concordium-node/src/plugins/consensus.rs
+++ b/concordium-node/src/plugins/consensus.rs
@@ -60,7 +60,6 @@ pub fn start_consensus_layer(
     ConsensusContainer::new(
         u64::from(conf.maximum_block_size),
         u64::from(conf.block_construction_timeout),
-        conf.max_time_to_expiry,
         u64::from(conf.transaction_insertions_before_purge),
         u64::from(conf.transaction_keep_alive),
         u64::from(conf.transactions_purging_delay),


### PR DESCRIPTION
## Purpose

The max expiry time used to be an option we had to limit damage from bad transactions. It is no longer used since we have introduced more transaction validation in #120 , but the command-line option remained.

## Changes

Remove unused option.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.