### PR TITLE
Added support for importing catchup chunk files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - `database-exporter` now produces a collection of export files, instead of a single file. The new
   `--chunksize` option specifies the size of export files in blocks.
+- The `--download-blocks-from` option now takes the URL to the catchup _index file_, permitting to
+  only download and import catchup files containing blocks not already present in the database.
 
 ## 4.3.0
 

--- a/concordium-consensus/lib.def
+++ b/concordium-consensus/lib.def
@@ -34,7 +34,7 @@ EXPORTS
  getBlockSummary
  getNextAccountNonce
  getBlocksAtHeight
- getBestBlockHeight
+ getLastFinalizedBlockHeight
  getAllIdentityProviders
  getAllAnonymityRevokers
  getCryptographicParameters

--- a/concordium-consensus/lib.def
+++ b/concordium-consensus/lib.def
@@ -34,6 +34,7 @@ EXPORTS
  getBlockSummary
  getNextAccountNonce
  getBlocksAtHeight
+ getBestBlockHeight
  getAllIdentityProviders
  getAllAnonymityRevokers
  getCryptographicParameters

--- a/concordium-consensus/src/Concordium/External.hs
+++ b/concordium-consensus/src/Concordium/External.hs
@@ -903,6 +903,8 @@ getBlocksAtHeight cptr height genIndex restrict =
             (GenesisIndex genIndex)
             (restrict /= 0)
 
+-- | Retrieve the last finalized block height relative to the most recent genesis index. Used for
+-- resuming out-of-band catchup.
 getLastFinalizedBlockHeight ::
     StablePtr ConsensusRunner ->
     IO Word64

--- a/concordium-consensus/src/Concordium/External.hs
+++ b/concordium-consensus/src/Concordium/External.hs
@@ -24,7 +24,6 @@ import qualified Concordium.Crypto.SHA256 as SHA256
 import Concordium.ID.Types
 import Concordium.Logger
 import Concordium.Types
-import Concordium.Types.Block (theAbsoluteBlockHeight)
 import qualified Data.FixedByteString as FBS
 
 import Concordium.Afgjort.Finalize.Types (FinalizationInstance (FinalizationInstance))
@@ -909,7 +908,7 @@ getLastFinalizedBlockHeight ::
     IO Word64
 getLastFinalizedBlockHeight cptr = do
   (ConsensusRunner mvr) <- deRefStablePtr cptr
-  theAbsoluteBlockHeight <$> runMVR Q.getLastFinalizedBlockHeight mvr
+  theBlockHeight <$> runMVR Q.getLastFinalizedBlockHeight mvr
 
 -- ** Block-indexed queries
 

--- a/concordium-consensus/src/Concordium/External.hs
+++ b/concordium-consensus/src/Concordium/External.hs
@@ -13,7 +13,6 @@ import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Unsafe as BS
 import Data.Int
 import qualified Data.Serialize as S
-import Data.Functor ( (<&>) )
 import Data.Word
 import Foreign
 import Foreign.C
@@ -905,12 +904,12 @@ getBlocksAtHeight cptr height genIndex restrict =
             (GenesisIndex genIndex)
             (restrict /= 0)
 
-getBestBlockHeight ::
+getLastFinalizedBlockHeight ::
     StablePtr ConsensusRunner ->
     IO Word64
-getBestBlockHeight cptr = do
+getLastFinalizedBlockHeight cptr = do
   (ConsensusRunner mvr) <- deRefStablePtr cptr
-  runMVR Q.getBestBlockHeight mvr <&> theAbsoluteBlockHeight
+  theAbsoluteBlockHeight <$> runMVR Q.getLastFinalizedBlockHeight mvr
 
 -- ** Block-indexed queries
 
@@ -1350,7 +1349,7 @@ foreign export ccall getAccountNonFinalizedTransactions :: StablePtr ConsensusRu
 foreign export ccall getBlockSummary :: StablePtr ConsensusRunner -> CString -> IO CString
 foreign export ccall getNextAccountNonce :: StablePtr ConsensusRunner -> CString -> IO CString
 foreign export ccall getBlocksAtHeight :: StablePtr ConsensusRunner -> Word64 -> Word32 -> Word8 -> IO CString
-foreign export ccall getBestBlockHeight :: StablePtr ConsensusRunner -> IO Word64
+foreign export ccall getLastFinalizedBlockHeight :: StablePtr ConsensusRunner -> IO Word64
 foreign export ccall getAllIdentityProviders :: StablePtr ConsensusRunner -> CString -> IO CString
 foreign export ccall getAllAnonymityRevokers :: StablePtr ConsensusRunner -> CString -> IO CString
 foreign export ccall getCryptographicParameters :: StablePtr ConsensusRunner -> CString -> IO CString

--- a/concordium-consensus/src/Concordium/External.hs
+++ b/concordium-consensus/src/Concordium/External.hs
@@ -13,6 +13,7 @@ import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Unsafe as BS
 import Data.Int
 import qualified Data.Serialize as S
+import Data.Functor ( (<&>) )
 import Data.Word
 import Foreign
 import Foreign.C
@@ -909,7 +910,7 @@ getBestBlockHeight ::
     IO Word64
 getBestBlockHeight cptr = do
   (ConsensusRunner mvr) <- deRefStablePtr cptr
-  runMVR Q.getBestBlockHeight mvr >>= return . theAbsoluteBlockHeight
+  runMVR Q.getBestBlockHeight mvr <&> theAbsoluteBlockHeight
 
 -- ** Block-indexed queries
 

--- a/concordium-consensus/src/Concordium/External.hs
+++ b/concordium-consensus/src/Concordium/External.hs
@@ -24,6 +24,7 @@ import qualified Concordium.Crypto.SHA256 as SHA256
 import Concordium.ID.Types
 import Concordium.Logger
 import Concordium.Types
+import Concordium.Types.Block (theAbsoluteBlockHeight)
 import qualified Data.FixedByteString as FBS
 
 import Concordium.Afgjort.Finalize.Types (FinalizationInstance (FinalizationInstance))
@@ -903,6 +904,13 @@ getBlocksAtHeight cptr height genIndex restrict =
             (GenesisIndex genIndex)
             (restrict /= 0)
 
+getBestBlockHeight ::
+    StablePtr ConsensusRunner ->
+    IO Word64
+getBestBlockHeight cptr = do
+  (ConsensusRunner mvr) <- deRefStablePtr cptr
+  runMVR Q.getBestBlockHeight mvr >>= return . theAbsoluteBlockHeight
+
 -- ** Block-indexed queries
 
 -- |Given a null-terminated string that represents a block hash (base 16), returns a null-terminated
@@ -1341,6 +1349,7 @@ foreign export ccall getAccountNonFinalizedTransactions :: StablePtr ConsensusRu
 foreign export ccall getBlockSummary :: StablePtr ConsensusRunner -> CString -> IO CString
 foreign export ccall getNextAccountNonce :: StablePtr ConsensusRunner -> CString -> IO CString
 foreign export ccall getBlocksAtHeight :: StablePtr ConsensusRunner -> Word64 -> Word32 -> Word8 -> IO CString
+foreign export ccall getBestBlockHeight :: StablePtr ConsensusRunner -> IO Word64
 foreign export ccall getAllIdentityProviders :: StablePtr ConsensusRunner -> CString -> IO CString
 foreign export ccall getAllAnonymityRevokers :: StablePtr ConsensusRunner -> CString -> IO CString
 foreign export ccall getCryptographicParameters :: StablePtr ConsensusRunner -> CString -> IO CString

--- a/concordium-consensus/src/Concordium/ImportExport.hs
+++ b/concordium-consensus/src/Concordium/ImportExport.hs
@@ -164,6 +164,7 @@ exportDatabaseV3 dbDir outDir chunkSize = do
       return (lastChunkGenesisIndex, lastChunkFirstBlock)
     else do
       createDirectoryIfMissing True outDir
+      writeFile indexFile "filename,genesis_index,first_block_height,last_block_height\n"
       -- we export blocks starting from height 1 because genesis blocks need not be exported
       return (0, 1)
   bracket (openFile indexFile AppendMode) hClose
@@ -220,7 +221,8 @@ exportSections dbDir outDir indexHdl chunkSize genIndex startHeight = do
 -- chunk (i.e. the one containing the block with the greatest height in the section) also contains
 -- finalization records finalizing all blocks after the last block containing a finalization
 -- record. The exported chunks will be accompanied by an index file mapping chunk filenames to the
--- block ranges stored in them. Each line in index file has format FILENAME,GENESISINDEX,FIRSTBLOCK,LASTBLOCK\n
+-- block ranges stored in them. Each line in index file has format
+-- 'filename,genesis_index,first_block_height,last_block_height\n'.
 writeChunks ::
     (IsProtocolVersion pv, MonadIO m, MonadState (DBState pv) m, MonadCatch m) =>
     -- |Genesis index

--- a/concordium-consensus/src/Concordium/ImportExport.hs
+++ b/concordium-consensus/src/Concordium/ImportExport.hs
@@ -164,7 +164,6 @@ exportDatabaseV3 dbDir outDir chunkSize = do
       return (lastChunkGenesisIndex, lastChunkFirstBlock)
     else do
       createDirectoryIfMissing True outDir
-      writeFile indexFile "filename,genesis_index,first_block_height,last_block_height\n"
       -- we export blocks starting from height 1 because genesis blocks need not be exported
       return (0, 1)
   bracket (openFile indexFile AppendMode) hClose

--- a/concordium-consensus/src/Concordium/ImportExport.hs
+++ b/concordium-consensus/src/Concordium/ImportExport.hs
@@ -221,7 +221,7 @@ exportSections dbDir outDir indexHdl chunkSize genIndex startHeight = do
 -- finalization records finalizing all blocks after the last block containing a finalization
 -- record. The exported chunks will be accompanied by an index file mapping chunk filenames to the
 -- block ranges stored in them. Each line in index file has format
--- 'filename,genesis_index,first_block_height,last_block_height\n'.
+-- @filename,genesis_index,first_block_height,last_block_height\n@.
 writeChunks ::
     (IsProtocolVersion pv, MonadIO m, MonadState (DBState pv) m, MonadCatch m) =>
     -- |Genesis index

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -292,8 +292,8 @@ getBlocksAtHeight height baseGI True = MVR $ \mvr -> do
         Nothing -> return []
         Just evc -> liftSkovQuery mvr evc (map getHash <$> Skov.getBlocksAtHeight height)
 
--- | Retrieve the last finalized block (relative) height (useful to know where to resume out-of-band
--- catchup).
+-- | Retrieve the last finalized block height relative to the most recent genesis index. Used for
+-- resuming out-of-band catchup.
 getLastFinalizedBlockHeight :: MVR gsconf finconf BlockHeight
 getLastFinalizedBlockHeight = liftSkovQueryLatest $ bpHeight <$> lastFinalizedBlock
 

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -292,15 +292,15 @@ getBlocksAtHeight height baseGI True = MVR $ \mvr -> do
         Nothing -> return []
         Just evc -> liftSkovQuery mvr evc (map getHash <$> Skov.getBlocksAtHeight height)
 
--- | Retrieve the best block height (useful to know where to resume out-of-band catchup)
-getBestBlockHeight :: MVR gsconf finconf AbsoluteBlockHeight
-getBestBlockHeight = MVR $ \mvr -> do
+-- | Retrieve the last finalized block height (useful to know where to resume out-of-band catchup)
+getLastFinalizedBlockHeight :: MVR gsconf finconf AbsoluteBlockHeight
+getLastFinalizedBlockHeight = MVR $ \mvr -> do
     versions <- readIORef (mvVersions mvr)
     case Vec.last versions of
         evc@(EVersionedConfiguration (vc :: VersionedConfiguration gsconf finconf pv)) -> do
           liftSkovQuery mvr evc $ do
             let absoluteHeight = localToAbsoluteBlockHeight (vcGenesisHeight vc) . bpHeight            
-            bb <- bestBlock
+            bb <- lastFinalizedBlock
             return . absoluteHeight $ bb
 
 -- ** Accounts

--- a/concordium-consensus/tools/database-exporter/README.md
+++ b/concordium-consensus/tools/database-exporter/README.md
@@ -29,8 +29,21 @@ imported, the state will remain as-is and the node will have to catch-up using P
 
 A version of `database-exporter` shipped with `concordium-node` <=4.3.0 did not implement the
 `--chunksize` option in its `export` command. It exported the node database as a single file. If you
-would like still to export the node database as a single file, run `database-exporter` with a very
-large `--chunksize` argument, for example, 1000000000000.
+would like still to export the node database as a single file, run `database-exporter` shipped with
+`concordium-node` <= 4.3.0.
+
+It is possible to export each database section as a single file using `database-exporter` shipped
+with `concordium-node` >4.3.0 by setting `--chunksize` to a large number, for
+example, 1000000000. It will still be possible to import each exported database section into
+`concordium-node` <4.3.0 using the `--import-blocks-from` option by concatenating all exported
+database sections stripped of the 4-byte database version header:
+
+```
+#!/bin/sh
+for b in blocks-*.dat; do
+  dd skip=4 if=$b of=blocks_to_import.dat
+done
+```
 
 After upgrading to `database-exporter` shipped with `concordium-node` >4.3.0, use the `--chunksize`
 option to every invocation of `database-exporter export`, as it is required. A good first choice of

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -522,6 +522,7 @@ dependencies = [
  "criterion",
  "crossbeam-channel",
  "crypto_common",
+ "csv-async",
  "digest 0.9.0",
  "ed25519-dalek",
  "env_logger",
@@ -770,6 +771,21 @@ dependencies = [
  "bstr",
  "csv-core",
  "itoa 0.4.8",
+ "ryu",
+ "serde 1.0.142",
+]
+
+[[package]]
+name = "csv-async"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c19b33b32fd48f83388821bd8f534b59e1b1ffd5c6c83771d1b23abd3dac2685"
+dependencies = [
+ "bstr",
+ "cfg-if",
+ "csv-core",
+ "futures",
+ "itoa 1.0.3",
  "ryu",
  "serde 1.0.142",
 ]

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -566,6 +566,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tonic",
  "tonic-build",
  "twox-hash",

--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -66,11 +66,12 @@ futures = { version = "0.3" }
 url = "2.2.2"
 reqwest = { version = "0.11", features = ["stream"] }
 csv-async = "1.2.4"
+tokio-util = { version = "0.7.3", features = ["io"] }
 
 # gRPC dependencies
 tonic = "0.8"
 prost = "0.11"
-tokio = { version = "1.20", features = ["macros", "rt-multi-thread", "signal"] }
+tokio = { version = "1.20", features = ["macros", "rt-multi-thread", "signal", "io-util"] }
 
 # Feature-gated dependencies
 gotham = { version = "0.6", optional = true }

--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -65,6 +65,7 @@ thiserror = "1.0"
 futures = { version = "0.3" }
 url = "2.2.2"
 reqwest = { version = "0.11", features = ["stream"] }
+csv-async = "1.2.4"
 
 # gRPC dependencies
 tonic = "0.8"

--- a/concordium-node/src/bin/cli.rs
+++ b/concordium-node/src/bin/cli.rs
@@ -543,7 +543,8 @@ async fn import_missing_blocks(
         .strip_prefix("# genesis hash ")
         .context(
             "The catchup index file does not begin with a line containing the genesis block hash. \
-             Please contact the catchup service administrator.",
+             Please verify that you specified a correct catchup service URL. If the specified URL \
+             is correct, contact the catchup service administrator.",
         )?
         .trim();
     let genesis_hash = genesis_block_hashes[0].to_string();

--- a/concordium-node/src/bin/cli.rs
+++ b/concordium-node/src/bin/cli.rs
@@ -525,7 +525,7 @@ async fn import_missing_blocks(
     index_url: &url::Url,
     data_dir_path: &Path,
 ) -> anyhow::Result<()> {
-    let best_block_height = consensus.get_best_block_height();
+    let last_finalized_block_height = consensus.get_last_finalized_block_height();
     let current_genesis_index = genesis_block_hashes.len() - 1;
     let current_genesis_block_hash = genesis_block_hashes[current_genesis_index].to_string();
     let json_genesis_block_value: serde_json::Value =
@@ -534,7 +534,7 @@ async fn import_missing_blocks(
 
     info!("Current genesis index: {}", current_genesis_index);
     info!("Current genesis block height: {}", current_genesis_block_height);
-    info!("Local best block height: {}", best_block_height);
+    info!("Local last finalized block height: {}", last_finalized_block_height);
 
     let comments_stream = reqwest::get(index_url.clone())
         .await?
@@ -573,9 +573,9 @@ async fn import_missing_blocks(
         // no need to reimport blocks that are present in the database
         if block_chunk_data.genesis_index < current_genesis_index
             || current_genesis_block_height + block_chunk_data.last_block_height
-                <= best_block_height
+                <= last_finalized_block_height
         {
-	    info!("Skipping chunk {}: no blocks above best block height", block_chunk_data.filename);
+	    info!("Skipping chunk {}: no blocks above last finalized block height", block_chunk_data.filename);
             continue;
         }
         let block_chunk_url = index_url.join(&block_chunk_data.filename)?;

--- a/concordium-node/src/bin/cli.rs
+++ b/concordium-node/src/bin/cli.rs
@@ -567,7 +567,7 @@ async fn import_missing_blocks(
         if block_chunk_data.genesis_index < current_genesis_index
             || block_chunk_data.last_block_height <= last_finalized_block_height
         {
-            info!(
+            debug!(
                 "Skipping chunk {}: no blocks above last finalized block height",
                 block_chunk_data.filename
             );

--- a/concordium-node/src/consensus_ffi/ffi.rs
+++ b/concordium-node/src/consensus_ffi/ffi.rs
@@ -421,7 +421,7 @@ extern "C" {
         genesis_index: u32,
         restrict: u8,
     ) -> *const c_char;
-    pub fn getBestBlockHeight(consensus: *mut consensus_runner) -> u64;
+    pub fn getLastFinalizedBlockHeight(consensus: *mut consensus_runner) -> u64;
     pub fn getTransactionStatus(
         consensus: *mut consensus_runner,
         transaction_hash: *const c_char,
@@ -592,9 +592,9 @@ impl ConsensusContainer {
         ))
     }
 
-    pub fn get_best_block_height(&self) -> u64 {
+    pub fn get_last_finalized_block_height(&self) -> u64 {
         let consensus = self.consensus.load(Ordering::SeqCst);
-        unsafe { getBestBlockHeight(consensus) }
+        unsafe { getLastFinalizedBlockHeight(consensus) }
     }
 
     pub fn get_ancestors(&self, block_hash: &str, amount: u64) -> anyhow::Result<String> {

--- a/concordium-node/src/consensus_ffi/ffi.rs
+++ b/concordium-node/src/consensus_ffi/ffi.rs
@@ -421,6 +421,7 @@ extern "C" {
         genesis_index: u32,
         restrict: u8,
     ) -> *const c_char;
+    pub fn getBestBlockHeight(consensus: *mut consensus_runner) -> u64;
     pub fn getTransactionStatus(
         consensus: *mut consensus_runner,
         transaction_hash: *const c_char,
@@ -589,6 +590,11 @@ impl ConsensusContainer {
             genesis_index,
             restrict as u8
         ))
+    }
+
+    pub fn get_best_block_height(&self) -> u64 {
+        let consensus = self.consensus.load(Ordering::SeqCst);
+        unsafe { getBestBlockHeight(consensus) }
     }
 
     pub fn get_ancestors(&self, block_hash: &str, amount: u64) -> anyhow::Result<String> {


### PR DESCRIPTION
## Purpose

Closes #437. `--download-blocks-from` now takes a URL to the index file that lists block chunks to download and import. Only chunks containing blocks with a height greater than the best block height are downloaded.

## Changes

The implementation is contained in the `import_missing_blocks` function which streams the index file, parses it and uses the extracted chunk records to decide whether to download and import chunks.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
