### PR TITLE
Fix regression in start-up time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `database-exporter` now produces a collection of export files, instead of a single file. The new
   `--chunksize` option specifies the size of export files in blocks.
+- Improvements to start-up time that fix regressions introduced by the account caching.
 
 ## 4.3.0
 

--- a/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState.hs
@@ -2090,8 +2090,9 @@ genesisState gd = case protocolVersion @pv of
                             StateMigrationParametersP3ToP4{} -> False
                         genesisTT = getInitialTransactionTable hbs
 
--- |Construct a transaction table that is empty but records the next nonces/sequence numbers
--- for all accounts and chain updates.
+-- |Construct a transaction table that is empty but reflects the next nonces/sequence numbers
+-- for all accounts and chain updates. That is, if the next nonce/sequence number is not the minimal
+    -- one, it is recorded in the transaction table.
 getInitialTransactionTable ::
     ( HasBlockState s pv,
       IsChainParametersVersion (ChainParametersVersionFor pv)

--- a/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState.hs
@@ -835,27 +835,6 @@ instance (IsProtocolVersion pv, Monad m) => BS.BlockStateQuery (PureBlockStateMo
             ..
         }
 
-    getInitialTransactionTable bs = return tt2
-      where
-        tt1 = Accounts.foldAccounts accInTT TransactionTable.emptyTransactionTable (bs ^. blockAccounts)
-        tt2 = foldl' updInTT tt1 [minBound..]
-        accInTT tt acct =
-            let nonce = acct ^. accountNonce
-                addr = acct ^. accountAddress
-            in if nonce /= minNonce
-                then
-                    tt & TransactionTable.ttNonFinalizedTransactions . at' (accountAddressEmbed addr)
-                        ?~ TransactionTable.emptyANFTWithNonce nonce
-                else tt
-        updInTT tt uty =
-            let sn = lookupNextUpdateSequenceNumber (bs ^. blockUpdates) uty
-            in if sn /= minUpdateSequenceNumber
-                then
-                    tt & TransactionTable.ttNonFinalizedChainUpdates . at' uty
-                        ?~ TransactionTable.emptyNFCUWithSequenceNumber sn
-                else
-                    tt
-
 instance (Monad m, IsProtocolVersion pv) => BS.AccountOperations (PureBlockStateMonad pv m) where
 
   getAccountCanonicalAddress acc = return $ acc ^. accountAddress
@@ -1870,9 +1849,6 @@ instance (IsProtocolVersion pv, MonadIO m) => BS.BlockStateStorage (PureBlockSta
     {-# INLINE loadBlockState #-}
     loadBlockState _ _ = error "Cannot load memory-based block state"
 
-    {-# INLINE cacheBlockState #-}
-    cacheBlockState = return
-
     {-# INLINE serializeBlockState #-}
     serializeBlockState = return . runPut . putBlockState . _unhashedBlockState
 
@@ -2112,4 +2088,32 @@ genesisState gd = case protocolVersion @pv of
                         hashShouldMatch = case migration of
                             StateMigrationParametersTrivial{} -> True
                             StateMigrationParametersP3ToP4{} -> False
-                        genesisTT = runIdentity $ runPureBlockStateMonad $ BS.getInitialTransactionTable hbs
+                        genesisTT = getInitialTransactionTable hbs
+
+-- |Construct a transaction table that is empty but records the next nonces/sequence numbers
+-- for all accounts and chain updates.
+getInitialTransactionTable ::
+    ( HasBlockState s pv,
+      IsChainParametersVersion (ChainParametersVersionFor pv)
+    ) =>
+    s ->
+    TransactionTable.TransactionTable
+getInitialTransactionTable bs = tt2
+  where
+    tt1 = Accounts.foldAccounts accInTT TransactionTable.emptyTransactionTable (bs ^. blockAccounts)
+    tt2 = foldl' updInTT tt1 [minBound ..]
+    accInTT tt acct =
+        let nonce = acct ^. accountNonce
+            addr = acct ^. accountAddress
+         in if nonce /= minNonce
+                then
+                    tt & TransactionTable.ttNonFinalizedTransactions . at' (accountAddressEmbed addr)
+                        ?~ TransactionTable.emptyANFTWithNonce nonce
+                else tt
+    updInTT tt uty =
+        let sn = lookupNextUpdateSequenceNumber (bs ^. blockUpdates) uty
+         in if sn /= minUpdateSequenceNumber
+                then
+                    tt & TransactionTable.ttNonFinalizedChainUpdates . at' uty
+                        ?~ TransactionTable.emptyNFCUWithSequenceNumber sn
+                else tt

--- a/concordium-consensus/src/Concordium/GlobalState/Paired.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Paired.hs
@@ -458,10 +458,6 @@ instance
         ps1 <- coerceBSML (getPoolStatus bps1 mbid)
         ps2 <- coerceBSMR (getPoolStatus bps2 mbid)
         assertEq ps1 ps2 $ return ps1
-    getInitialTransactionTable (bps1, bps2) = do
-        tt1 <- coerceBSML (getInitialTransactionTable bps1)
-        tt2 <- coerceBSMR (getInitialTransactionTable bps2)
-        assertEq tt1 tt2 $ return tt1
 
 instance (Monad m, C.HasGlobalStateContext (PairGSContext lc rc) r) => ContractStateOperations (BlockStateM pv (PairGSContext lc rc) r (PairGState ls rs) s m) where
   thawContractState (InstanceStateV0 st) = return st
@@ -955,10 +951,6 @@ instance (MonadLogger m,
         bs1 <- coerceBSML $ loadBlockState h p1
         bs2 <- coerceBSMR $ loadBlockState h p2
         return (bs1, bs2)
-    cacheBlockState (bs1, bs2) = do
-        bs1' <- coerceBSML $ cacheBlockState bs1
-        bs2' <- coerceBSMR $ cacheBlockState bs2
-        return (bs1', bs2')
     serializeBlockState (bps1, bps2) = do
         s1 <- coerceBSML (serializeBlockState bps1)
         s2 <- coerceBSMR (serializeBlockState bps2)

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Accounts.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Accounts.hs
@@ -155,16 +155,6 @@ instance (SupportsPersistentAccount pv m) => BlobStorable m (Accounts pv) where
             accountRegIdHistory <- mrRIH
             return $ Accounts {accountRegIds = Null,..}
 
-instance SupportsPersistentAccount pv m => Cacheable m (Accounts pv) where
-    cache accts0 = do
-        (_, accts@Accounts{..}) <- loadRegIds accts0
-        acctMap <- cache accountMap
-        acctTable <- cache accountTable
-        return accts{
-            accountMap = acctMap,
-            accountTable = acctTable
-        }
-
 instance (SupportsPersistentAccount pv m, av ~ AccountVersionFor pv) => Cacheable1 m (Accounts pv) (PersistentAccount av) where
     liftCache cch accts0 = do
         (_, accts@Accounts{..}) <- loadRegIds accts0

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
@@ -1174,8 +1174,11 @@ instance (Applicative m) => Cacheable m BakerCapital
 instance (Applicative m) => Cacheable m CapitalDistribution
 
 -- |Typeclass for caching a container type, given a function for caching the
--- contained type.
+-- contained type. The caching operation should not affect the value up to an equivalence
+-- appropriate to the type in question.
 class Cacheable1 m c a where
+    -- |Lift a caching operation on the contained type to a caching operation on the container
+    -- type.
     liftCache :: (a -> m a) -> c -> m c
 
 instance BlobStorable m a => Cacheable1 m (BufferedRef a) a where

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
@@ -1130,7 +1130,7 @@ instance (MHashableTo m h a, BlobStorable m a, Cacheable m a) => Cacheable m (Ha
     ref' <- cache ref
     currentHash <- liftIO (readIORef hshRef)
     when (isNull currentHash) $ do
-        h <- getHashM ref
+        h <- getHashM ref'
         liftIO $ writeIORef hshRef $! Some h
     return (HashedBufferedRef ref' hshRef)
 

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
@@ -1172,3 +1172,28 @@ instance (Applicative m) => Cacheable m BakerPoolRewardDetails
 instance (Applicative m) => Cacheable m DelegatorCapital
 instance (Applicative m) => Cacheable m BakerCapital
 instance (Applicative m) => Cacheable m CapitalDistribution
+
+-- |Typeclass for caching a container type, given a function for caching the
+-- contained type.
+class Cacheable1 m c a where
+    liftCache :: (a -> m a) -> c -> m c
+
+instance BlobStorable m a => Cacheable1 m (BufferedRef a) a where
+    liftCache cch BRBlobbed{..} = do
+        brValue <- cch =<< loadRef brRef
+        return BRBoth{..}
+    liftCache cch br@BRMemory{..} = do
+        cachedVal <- cch brValue
+        return $! br{brValue = cachedVal}
+    liftCache cch br@BRBoth{..} = do
+        cachedVal <- cch brValue
+        return $! br{brValue = cachedVal}
+
+instance (MHashableTo m h a, BlobStorable m a) => Cacheable1 m (HashedBufferedRef' h a) a where
+    liftCache cch (HashedBufferedRef ref hshRef) = do
+        ref' <- liftCache cch ref
+        currentHash <- liftIO (readIORef hshRef)
+        when (isNull currentHash) $ do
+            h <- getHashM ref'
+            liftIO $ writeIORef hshRef $! Some h
+        return (HashedBufferedRef ref' hshRef)

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/LFMBTree.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/LFMBTree.hs
@@ -237,6 +237,16 @@ instance (Applicative m, Cacheable m (T ref v)) => Cacheable m (LFMBTree' k ref 
   cache t@Empty = pure t
   cache (NonEmpty s t) = NonEmpty s <$> cache t
 
+instance (Applicative m, Cacheable1 m (r (T r v)) (T r v)) => Cacheable1 m (T r v) v where
+    liftCache cch = lc
+        where
+            lc (Node h l r) = Node h <$> liftCache lc l <*> liftCache lc r
+            lc (Leaf a) = Leaf <$> cch a
+
+instance (Applicative m, Cacheable1 m (r (T r v)) (T r v)) => Cacheable1 m (LFMBTree' k r v) v where
+    liftCache _ t@Empty = pure t
+    liftCache cch (NonEmpty s t) = NonEmpty s <$> liftCache cch t
+
 {-
 -------------------------------------------------------------------------------
                                   Interface

--- a/concordium-consensus/tests/scheduler/GlobalStateMock.hs
+++ b/concordium-consensus/tests/scheduler/GlobalStateMock.hs
@@ -30,7 +30,6 @@ import Concordium.GlobalState.BakerInfo
 import Concordium.GlobalState.Basic.BlockState.AccountReleaseSchedule
 import Concordium.GlobalState.BlockState
 import Concordium.GlobalState.CapitalDistribution
-import Concordium.GlobalState.TransactionTable (TransactionTable)
 import Concordium.GlobalState.Types
 import qualified Concordium.GlobalState.Wasm as GSWasm
 import qualified Concordium.ID.Types as ID
@@ -140,7 +139,6 @@ data BlockStateQueryAction (pv :: ProtocolVersion) a where
     GetEnergyRate :: MockBlockState -> BlockStateQueryAction pv EnergyRate
     GetPaydayEpoch :: (AccountVersionFor pv ~ 'AccountV1) => MockBlockState -> BlockStateQueryAction pv Epoch
     GetPoolStatus :: (AccountVersionFor pv ~ 'AccountV1, ChainParametersVersionFor pv ~ 'ChainParametersV1) => MockBlockState -> Maybe BakerId -> BlockStateQueryAction pv (Maybe PoolStatus)
-    GetInitialTransactionTable :: MockBlockState -> BlockStateQueryAction pv TransactionTable
 
 deriving instance Eq (BlockStateQueryAction pv a)
 deriving instance Show (BlockStateQueryAction pv a)


### PR DESCRIPTION
## Purpose

Addresses #464.

The account caching changes introduced a performance regression in the node start-up time with an existing database. This rectifies that. The most serious issue was that in the `Cacheable` instance for `HashedBufferedRef'`, the hash was computed on the uncached data, which lead to the data being loaded multiple times. A secondary issue was that many accounts were loaded twice because the accounts were traversed to construct the transaction table.

Anecdotally, start-up time is reduced to around 18 seconds for mainnet, compared with around 28 seconds for 4.2.3 and around 57 seconds for the previous 4.3.0.

## Changes

- Introduced a `Cacheable1` class that allows lifting a cache operation on an inner type to a cache operation on a container type.
- Implemented `Cacheable1` instances for reference types (`BufferedRef`, `HashedBufferedRef`, `HashedCachedRef`), for `LFMBTree'` and for `Accounts`.
- Introduced `cacheStateAndGetTransactionTable` for the persistent block state that amalgamates and replaces the previous functionality of `cacheBlockState` and `getInitialTransactionTable`. This makes use of the `Cacheable1` instance for `Accounts` to initialise the transaction table while the accounts are cached, avoiding a second pass over the transaction table, which would result in re-loading the accounts.
- Removed `cacheBlockState` and `getInitialTransactionTable` from the `BlockStateStorage` and `BlockStateQuery` interfaces respectively. As `getInitialTransactionTable` was still used in the basic (in-memory) block state for re-genesis, that version was retained in a modified form.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
