### PR TITLE
Do not reset the stop flag on import start.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Fix a bug in Ctrl-C signal handling where a node would fail to stop if
+  interrupted early on in the startup if out-of-band catchup was enabled.
 - `database-exporter` now produces a collection of export files, instead of a single file. The new
   `--chunksize` option specifies the size of export files in blocks.
 

--- a/concordium-consensus/src/Concordium/MultiVersion.hs
+++ b/concordium-consensus/src/Concordium/MultiVersion.hs
@@ -1076,9 +1076,6 @@ receiveTransaction transactionBS = do
 importBlocks :: FilePath -> MVR gsconf finconf UpdateResult
 importBlocks importFile = do
     vvec <- liftIO . readIORef =<< asks mvVersions
-    -- reset the stop flag to False, in case it was set to True
-    shouldStop <- asks mvShouldStopImportingBlocks
-    liftIO $ writeIORef shouldStop False
     case Vec.last vvec of
         EVersionedConfiguration vc -> do
             -- Import starting from the genesis index of the latest consensus


### PR DESCRIPTION
## Purpose

Fixes part 1 of #469

## Changes

- Do not reset the shutdown signal flag on startup.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.