### PR TITLE
Throw an exception on reading beyond blob store end

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
@@ -223,7 +223,9 @@ readBlobBSFromHandle BlobStoreAccess{..} (BlobRef offset) = mask $ \restore -> d
             hSeek bhHandle AbsoluteSeek (fromIntegral offset)
             esize <- decode <$> BS.hGet bhHandle 8
             case esize :: Either String Word64 of
-                Right size | offset + size <= fromIntegral bhSize ->
+                -- there should be at least `size` bytes left to read after `offset + 8`, where 8 is
+                -- the size of the blob size header
+                Right size | offset + 8 + size <= fromIntegral bhSize ->
                              BS.hGet bhHandle (fromIntegral size)
                 _ ->  throwIO $ userError "Attempted to read beyond the blob store end"
         putMVar blobStoreFile bh{bhAtEnd=False}

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
@@ -223,8 +223,9 @@ readBlobBSFromHandle BlobStoreAccess{..} (BlobRef offset) = mask $ \restore -> d
             hSeek bhHandle AbsoluteSeek (fromIntegral offset)
             esize <- decode <$> BS.hGet bhHandle 8
             case esize :: Either String Word64 of
-                Left e -> error e
-                Right size -> BS.hGet bhHandle (fromIntegral size)
+                Right size | offset + size <= fromIntegral bhSize ->
+                             BS.hGet bhHandle (fromIntegral size)
+                _ ->  throwIO $ userError "Attempted to read beyond the blob store end"
         putMVar blobStoreFile bh{bhAtEnd=False}
         case eres :: Either SomeException BS.ByteString of
             Left e -> throwIO e

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
@@ -382,6 +382,10 @@ loadSkovPersistentData rp _treeStateDirectory pbsc = do
   (_lastFinalizationRecord, lfStoredBlock) <- liftIO (getLastBlock _db) >>= \case
       Left s -> logExceptionAndThrowTS $ DatabaseInvariantViolation s
       Right r -> return r
+  -- Check that the block state for the last finalized block is not corrupt. The check works because
+  -- the `BlobRef` to the block state is stored in LMDB only after the block state is stored in the
+  -- blob store. If the reference points to a blob that cannot be read, the blob store can be
+  -- assumed to be corrupted.
   elfBlob <- liftIO . try $
     readBlobBSFromHandle (bscBlobStore . PBS.pbscBlobStore $ pbsc) (sbState lfStoredBlock)
   case elfBlob :: Either IOError BS.ByteString of

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
@@ -389,7 +389,8 @@ loadSkovPersistentData rp _treeStateDirectory pbsc = do
   elfBlob <- liftIO . try $
     readBlobBSFromHandle (bscBlobStore . PBS.pbscBlobStore $ pbsc) (sbState lfStoredBlock)
   case elfBlob :: Either IOError BS.ByteString of
-    Left _ -> liftIO . throwIO $ userError "Last finalized block cannot be read. Blockstate database recovery required."
+    Left _ -> logExceptionAndThrowTS $
+      DatabaseInvariantViolation "Last finalized block cannot be read. Blockstate database recovery required."
     Right _ -> do
       _lastFinalized <- liftIO (makeBlockPointer lfStoredBlock)
       return SkovPersistentData {


### PR DESCRIPTION
## Purpose

Closes #476.

## Changes

`readBlobBSFromHandle` will now not crash but throw an exception if either of the two conditions doesn't hold:

1) the size of a blob can't be read at the given `BlobRef` offset in the blob store
2) the blob store size is smaller than the `BlobRef` offset + blob size

This change alone gives more meaningful error messages if the blob store is corrupted. For example, it permits `startConsensus` to return a meaningful error code over FFI and let the node shutdown gracefully instead of crashing.

Further, we can now use `readBlobBSFromHandle` to check if there is a valid blockstate stored for the last finalized block and attempt to recover the blob store if there isn't one. Actual recovery is going to be implemented in #480.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
