### PR TITLE
Block removal until the last with a valid blockstate

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
@@ -215,6 +215,24 @@ runBlobStoreTemp dir a = bracket openf closef usef
             freeCallbacks bscLoadCallback bscStoreCallback
             return res
 
+-- | Truncate the blob store after the blob stored at the given offset. The blob should not be
+-- corrupted (i.e., its size header should be readable, and its size should match the size header).
+truncateBlobStore :: BlobStoreAccess -> BlobRef a -> IO ()
+truncateBlobStore BlobStoreAccess{..} (BlobRef offset) = mask $ \restore -> do
+  bh@BlobHandle{..} <- takeMVar blobStoreFile
+  eres <- try $ restore $ do
+    hSeek bhHandle AbsoluteSeek (fromIntegral offset)
+    esize <- decode <$> BS.hGet bhHandle 8
+    case esize :: Either String Word64 of
+      Left e -> error e
+      Right size -> do
+        let newSize = offset + 8 + size
+        hSetFileSize bhHandle $ fromIntegral newSize
+        putMVar blobStoreFile bh{bhSize = fromIntegral newSize, bhAtEnd=False}
+  case eres :: Either SomeException () of
+    Left e -> throwIO e
+    Right () -> return ()
+
 -- | Read a bytestring from the blob store at the given offset using the file handle.
 readBlobBSFromHandle :: BlobStoreAccess -> BlobRef a -> IO BS.ByteString
 readBlobBSFromHandle BlobStoreAccess{..} (BlobRef offset) = mask $ \restore -> do

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
@@ -224,11 +224,11 @@ truncateBlobStore BlobStoreAccess{..} (BlobRef offset) = mask $ \restore -> do
     hSeek bhHandle AbsoluteSeek (fromIntegral offset)
     esize <- decode <$> BS.hGet bhHandle 8
     case esize :: Either String Word64 of
-      Left e -> error e
       Right size -> do
         let newSize = offset + 8 + size
         hSetFileSize bhHandle $ fromIntegral newSize
         putMVar blobStoreFile bh{bhSize = fromIntegral newSize, bhAtEnd=False}
+      _ -> throwIO $ userError "Cannot truncate the blob store: cannot obtain the last blob size"
   case eres :: Either SomeException () of
     Left e -> throwIO e
     Right () -> return ()

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
@@ -381,7 +381,7 @@ loadSkovPersistentData rp _treeStateDirectory pbsc = do
 
   -- Unroll the treestate if the last finalized blockstate is corrupted. If the last finalized
   -- blockstate is not corrupted, the treestate is unchanged.
-  unrollTreeStateWhile _db isBlockStateCorrupted >>= \case
+  unrollTreeStateWhile _db (liftIO . isBlockStateCorrupted) >>= \case
     Left e -> logExceptionAndThrowTS . DatabaseInvariantViolation $
               "The block state database is corrupt. Recovery attempt failed: " <> e
     Right (_lastFinalizationRecord, lfStoredBlock) -> do

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
@@ -381,25 +381,10 @@ loadSkovPersistentData rp _treeStateDirectory pbsc = do
 
   -- Unroll the treestate if the last finalized blockstate is corrupted. If the last finalized
   -- blockstate is not corrupted, the treestate is unchanged.
-  deleteFinalizedBlocksWhile _db isBlockStateCorrupted >>= \case
-    Left e -> logExceptionAndThrowTS . DatabaseInvariantViolation $ "Database recovery failed: " <> e
-    Right bh -> logEvent GlobalState LLInfo $ "Local treestate and blockstate unrolled. Last finalized block hash is now " <> show bh
-
-  -- Get the last finalized block.
-  (_lastFinalizationRecord, lfStoredBlock) <- liftIO (getLastBlock _db) >>= \case
-      Left s -> logExceptionAndThrowTS $ DatabaseInvariantViolation s
-      Right r -> return r
-
-  -- Check that the block state for the last finalized block is not corrupt. The check works because
-  -- the `BlobRef` to the block state is stored in LMDB only after the block state is stored in the
-  -- blob store. If the reference points to a blob that cannot be read, the blob store can be
-  -- assumed to be corrupted.
-  elfBlob <- liftIO . try $
-    readBlobBSFromHandle (bscBlobStore . PBS.pbscBlobStore $ pbsc) (sbState lfStoredBlock)
-  case elfBlob :: Either IOError BS.ByteString of
-    Left _ -> logExceptionAndThrowTS $
-        DatabaseInvariantViolation "Last finalized block cannot be read. Blockstate database recovery required."
-    Right _ -> do
+  unrollTreeStateWhile _db isBlockStateCorrupted >>= \case
+    Left e -> logExceptionAndThrowTS . DatabaseInvariantViolation $
+              "The block state database is corrupt. Recovery attempt failed: " <> e
+    Right (_lastFinalizationRecord, lfStoredBlock) -> do
       -- Truncate the blobstore beyond the last finalized blockstate. If no corruption was found
       -- earlier, the blobstore size does not change.
       liftIO $ truncateBlobStore (bscBlobStore . PBS.pbscBlobStore $ pbsc) (sbState lfStoredBlock)


### PR DESCRIPTION
## Purpose

Closes #480. 

## Changes

Adds `deleteFinalizedBlocksWhile` which traverses blocks in the treestate, starting with the last finalized block, while they match a predicate and deletes them. When used with the predicate checking for validity of the corresponding blockstate, it acts as a tree state rollback mechanism in case of the blob store corruption.
Adds `truncateBlobStore` which removes all content of the blob store following a blob specified by a reference. When given a reference to the last blob that can be successfully read, it performs the blob store cleanup after its corruption.

`loadSkovPersistentData` now attempts a rollback after the last finalized block is read from LMDB. If a rollback isn't needed, it doesn't happen.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
