### PR TITLE
Only return AccountInfo and not the hash in the old query.

### DIFF
--- a/concordium-consensus/src/Concordium/External.hs
+++ b/concordium-consensus/src/Concordium/External.hs
@@ -1116,7 +1116,7 @@ getAccountInfo cptr blockcstr acctcstr = do
     acctbs <- BS.packCString acctcstr
     let account = decodeAccountIdentifier acctbs
     case (mblock, account) of
-        (Just bh, Just acct) -> jsonQuery cptr (Q.getAccountInfo (Q.BHIGiven bh) acct)
+        (Just bh, Just acct) -> jsonQuery cptr (snd <$> Q.getAccountInfo (Q.BHIGiven bh) acct)
         _ -> jsonCString AE.Null
 
 -- |Get instance information the given block and instance. The block must be


### PR DESCRIPTION
## Purpose

Revert a change in response introduced by #475 . The existing API should stay as is.

## Changes

Only return account info, not the hash.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.