### PR TITLE
Docker release pipeline

### DIFF
--- a/jenkinsfiles/activate-distribution-image.Jenkinsfile
+++ b/jenkinsfiles/activate-distribution-image.Jenkinsfile
@@ -24,14 +24,13 @@ node {
     
     
     def docker_repo = "concordium/${docker_images_base}"
-    def current_image_name = "${docker_repo}:${source_image_tag}"
-    def future_image_name = "${docker_repo}:${destination_image_tag}"
+    def source_image_name = "${docker_repo}:${source_image_tag}"
+    def destination_image_name = "${docker_repo}:${destination_image_tag}"
     def latest_image_name = "${docker_repo}:latest"
 
-    if (set_latest) {
-        def latest_image_command = "--tag ${docker_repo}:latest"
-    } else {
-        def latest_image_command = ""
+    def latest_image_command = ""
+    if (params.set_latest) {
+        latest_image_command = "--tag ${docker_repo}:latest"
     }
 
     stage('verify') {
@@ -55,7 +54,7 @@ node {
         }
     }
     stage('update') {
-        sh "docker buildx imagetools create ${source_image_tag} --tag ${destination_image_tag} ${latest_image_command}"
+        sh "docker buildx imagetools create ${source_image_name} --tag ${destination_image_tag} ${latest_image_command}"
     }
     stage('cleanup') {
         when {

--- a/jenkinsfiles/activate-distribution-image.Jenkinsfile
+++ b/jenkinsfiles/activate-distribution-image.Jenkinsfile
@@ -10,7 +10,7 @@ node {
         stagenet: 'stagenet-node',
         testnet: 'testnet-node',
         mainnet: 'mainnet-node',
-    ]
+    ][environment]
     
     if (!environment?.trim()) {
         error "No value for 'environment' provided."
@@ -22,7 +22,8 @@ node {
         error "No value for 'destination_image_tag' found."
     }
     
-    def docker_repo = "concordium/${docker_images_base[environment]}"
+    
+    def docker_repo = "concordium/${docker_images_base}"
     def current_image_name = "${docker_repo}:${source_image_tag}"
     def future_image_name = "${docker_repo}:${destination_image_tag}"
     def latest_image_name = "${docker_repo}:latest"
@@ -36,24 +37,21 @@ node {
     stage('verify') {
         // Verify existens of source image
         try {
-            sh "curl --silent https://hub.docker.com/v2/namespaces/concordium/repositories/${docker_images_base}/tags/${source_image_tag} | jq -re '.digest'"
+            sh "curl --silent https://hub.docker.com/v2/namespaces/concordium/repositories/${docker_repo}/tags/${source_image_tag} | jq -re '.digest'"
         } catch (e) {
             error "Image with tag '${source_image_tag}' does not exist in repo '${docker_repo}'."
         }
 
         // Verify tags to add don't already exist
         try {
-            sh "! curl --silent https://hub.docker.com/v2/namespaces/concordium/repositories/${docker_images_base}/tags/${destination_image_tag} | jq -re '.digest'"
+            sh "! curl --silent https://hub.docker.com/v2/namespaces/concordium/repositories/${docker_repos}/tags/${destination_image_tag} | jq -re '.digest'"
         } catch (e) {
             error "Image with tag '${destination_image_tag}' already exists in repo '${docker_repo}'."
         }
     }
     stage('dockerhub-login') {
-        environment {
-            CRED = credentials('jenkins-dockerhub')
-        }
-        steps {
-            sh 'echo $CRED_PSW | docker login --username $CRED_USR --password-stdin'
+        withCredentials([usernamePassword(credentialsId: 'jenkins-dockerhub', passwordVariable: 'CRED_PSW', usernameVariable: 'CRED_USR')]) {
+            sh 'docker login --username $CRED_USR --password $CRED_PSW'
         }
     }
     stage('update') {
@@ -64,10 +62,7 @@ node {
             beforeAgent true
             environment name: 'delete_source', value: 'true'
         }
-        environment {
-            CRED = credentials('jenkins-dockerhub')
-        }
-        steps {
+        withCredentials([usernamePassword(credentialsId: 'jenkins-dockerhub', passwordVariable: 'CRED_PSW', usernameVariable: 'CRED_USR')]) {
             //https://devopsheaven.com/docker/dockerhub/2018/04/09/delete-docker-image-tag-dockerhub.html
             sh '''\
             login_data() {

--- a/jenkinsfiles/activate-distribution-image.Jenkinsfile
+++ b/jenkinsfiles/activate-distribution-image.Jenkinsfile
@@ -64,8 +64,8 @@ node {
                 login_data() {
                 cat <<EOF
                 {
-                "username": "\$CRED_USR",
-                "password": "\$CRED_PSW"
+                "username": "${CRED_USR}",
+                "password": "${CRED_PSW}"
                 }
                 EOF
                 }

--- a/jenkinsfiles/activate-distribution-image.Jenkinsfile
+++ b/jenkinsfiles/activate-distribution-image.Jenkinsfile
@@ -37,14 +37,14 @@ node {
     stage('verify') {
         // Verify existens of source image
         try {
-            sh "curl --silent https://hub.docker.com/v2/namespaces/concordium/repositories/${docker_repo}/tags/${source_image_tag} | jq -re '.digest'"
+            sh "curl --silent https://hub.docker.com/v2/namespaces/concordium/repositories/${docker_images_base}/tags/${source_image_tag} | jq -re '.digest'"
         } catch (e) {
             error "Image with tag '${source_image_tag}' does not exist in repo '${docker_repo}'."
         }
 
         // Verify tags to add don't already exist
         try {
-            sh "! curl --silent https://hub.docker.com/v2/namespaces/concordium/repositories/${docker_repos}/tags/${destination_image_tag} | jq -re '.digest'"
+            sh "! curl --silent https://hub.docker.com/v2/namespaces/concordium/repositories/${docker_images_base}/tags/${destination_image_tag} | jq -re '.digest'"
         } catch (e) {
             error "Image with tag '${destination_image_tag}' already exists in repo '${docker_repo}'."
         }

--- a/jenkinsfiles/activate-distribution-image.Jenkinsfile
+++ b/jenkinsfiles/activate-distribution-image.Jenkinsfile
@@ -5,7 +5,7 @@
 // - set_latest
 // - delete_source
 @Library('concordium-pipelines') _
-node('any') {
+node {
     def docker_images_base = [
         stagenet: 'stagenet-node',
         testnet: 'testnet-node',

--- a/jenkinsfiles/activate-distribution-image.Jenkinsfile
+++ b/jenkinsfiles/activate-distribution-image.Jenkinsfile
@@ -15,16 +15,16 @@ node {
     if (!environment?.trim()) {
         error "No value for 'environment' provided."
     }
-    if (!current_image_tag) {
-        error "No value for 'current_image_tag' found."
+    if (!source_image_tag) {
+        error "No value for 'source_image_tag' found."
     }
-    if (!future_image_tag) {
-        error "No value for 'future_image_tag' found."
+    if (!destination_image_tag) {
+        error "No value for 'destination_image_tag' found."
     }
     
     def docker_repo = "concordium/${docker_images_base[environment]}"
-    def current_image_name = "${docker_repo}:${current_image_tag}"
-    def future_image_name = "${docker_repo}:${future_image_tag}"
+    def current_image_name = "${docker_repo}:${source_image_tag}"
+    def future_image_name = "${docker_repo}:${destination_image_tag}"
     def latest_image_name = "${docker_repo}:latest"
 
     if (set_latest) {

--- a/jenkinsfiles/activate-distribution-image.Jenkinsfile
+++ b/jenkinsfiles/activate-distribution-image.Jenkinsfile
@@ -1,56 +1,90 @@
 // Parameters:
 // - environment
-// - image_tag
+// - source_image_tag
+// - destination_image_tag
+// - set_latest
+// - delete_source
 @Library('concordium-pipelines') _
-node('master-node') {
-    def DISTRIBUTION_IDS = [
-        stagenet: 'E2Z6VZ10YEWPDX',
-        testnet: 'E3OE3P6NHHWU0I',
-        mainnet: 'E1F07594M64NU0',
+node('any') {
+    def docker_images_base = [
+        stagenet: 'stagenet-node',
+        testnet: 'testnet-node',
+        mainnet: 'mainnet-node',
     ]
     
     if (!environment?.trim()) {
         error "No value for 'environment' provided."
     }
+    if (!current_image_tag) {
+        error "No value for 'current_image_tag' found."
+    }
+    if (!future_image_tag) {
+        error "No value for 'future_image_tag' found."
+    }
     
-    def image_name = "${environment}-node"
-    def file_name = "${image_name}-${image_tag}.tar.gz"
-    def s3_bucket = "s3://distribution.${concordiumDomain(environment)}"
-    def s3_version_path = 'image/version.json'
-    def s3_image_path = "image/${file_name}"
-    def cf_distribution_id = DISTRIBUTION_IDS[environment]
-    if (!cf_distribution_id) {
-        error "No value for 'cf_distribution_id' found."
+    def docker_repo = "concordium/${docker_images_base[environment]}"
+    def current_image_name = "${docker_repo}:${current_image_tag}"
+    def future_image_name = "${docker_repo}:${future_image_tag}"
+    def latest_image_name = "${docker_repo}:latest"
+
+    if (set_latest) {
+        def latest_image_command = "--tag ${docker_repo}:latest"
+    } else {
+        def latest_image_command = ""
     }
 
     stage('verify') {
+        // Verify existens of source image
         try {
-            sh (script: """\
-                aws s3 ls "${s3_bucket}/${s3_image_path}"
-            """.stripIndent())
+            sh "curl --silent https://hub.docker.com/v2/namespaces/concordium/repositories/${docker_images_base}/tags/${source_image_tag} | jq -re '.digest'"
         } catch (e) {
-            error "Image with tag '${image_tag}' does not exist in bucket '${s3_bucket}' on path '${s3_image_path}'."
+            error "Image with tag '${source_image_tag}' does not exist in repo '${docker_repo}'."
+        }
+
+        // Verify tags to add don't already exist
+        try {
+            sh "! curl --silent https://hub.docker.com/v2/namespaces/concordium/repositories/${docker_images_base}/tags/${destination_image_tag} | jq -re '.digest'"
+        } catch (e) {
+            error "Image with tag '${destination_image_tag}' already exists in repo '${docker_repo}'."
+        }
+    }
+    stage('dockerhub-login') {
+        environment {
+            CRED = credentials('jenkins-dockerhub')
+        }
+        steps {
+            sh 'echo $CRED_PSW | docker login --username $CRED_USR --password-stdin'
         }
     }
     stage('update') {
-        sh(script: """\
-            aws s3 cp - "${s3_bucket}/${s3_version_path}" --grants=read=uri=http://acs.amazonaws.com/groups/global/AllUsers <<EOF
+        sh "docker buildx imagetools create ${source_image_tag} --tag ${destination_image_tag} ${latest_image_command}"
+    }
+    stage('cleanup') {
+        when {
+            beforeAgent true
+            environment name: 'delete_source', value: 'true'
+        }
+        environment {
+            CRED = credentials('jenkins-dockerhub')
+        }
+        steps {
+            //https://devopsheaven.com/docker/dockerhub/2018/04/09/delete-docker-image-tag-dockerhub.html
+            sh '''\
+            login_data() {
+            cat <<EOF
             {
-                "image_tag": "${image_tag}",
-                "file": "${file_name}",
-                "image_name": "${image_name}"
+            "username": "$CRED_USR",
+            "password": "$CRED_PSW"
             }
             EOF
-        """.stripIndent())
-    }
-    stage('invalidate') {
-        invalidation_result = sh(script: """\
-            aws cloudfront create-invalidation --distribution-id="${cf_distribution_id}" --paths="/${s3_version_path}"
-        """, returnStdout: true)
-        // Wait for invalidation to complete.
-        invalidation = readJSON(text: invalidation_result)
-        sh(script: """\
-            aws cloudfront wait invalidation-completed --distribution-id="${cf_distribution_id}" --id="${invalidation.Invalidation.Id}"
-        """.stripIndent())
+            }
+
+            TOKEN=`curl -s -H "Content-Type: application/json" -X POST -d "$(login_data)" "https://hub.docker.com/v2/users/login/" | jq -r .token`
+
+            curl "https://hub.docker.com/v2/repositories/${ORGANIZATION}/${IMAGE}/tags/${TAG}/" \
+            -X DELETE \
+            -H "Authorization: JWT ${TOKEN}"
+            '''..stripIndent()
+        }
     }
 }

--- a/jenkinsfiles/activate-distribution-image.Jenkinsfile
+++ b/jenkinsfiles/activate-distribution-image.Jenkinsfile
@@ -64,8 +64,8 @@ node {
                 login_data() {
                 cat <<EOF
                 {
-                "username": "${CRED_USR}",
-                "password": "${CRED_PSW}"
+                "username": "\${CRED_USR}",
+                "password": "\${CRED_PSW}"
                 }
                 EOF
                 }
@@ -74,7 +74,7 @@ node {
 
                 curl "https://hub.docker.com/v2/repositories/concordium/${docker_images_base}/tags/${source_image_tag}/" \
                 -X DELETE \
-                -H "Authorization: JWT ${TOKEN}"
+                -H "Authorization: JWT \${TOKEN}"
                 """.stripIndent()
             }
         }

--- a/jenkinsfiles/activate-distribution-image.Jenkinsfile
+++ b/jenkinsfiles/activate-distribution-image.Jenkinsfile
@@ -70,7 +70,7 @@ node {
                 EOF
                 }
 
-                TOKEN=`curl -s -H "Content-Type: application/json" -X POST -d "$(login_data)" "https://hub.docker.com/v2/users/login/" | jq -r .token`
+                TOKEN=`curl -s -H "Content-Type: application/json" -X POST -d "\$(login_data)" "https://hub.docker.com/v2/users/login/" | jq -r .token`
 
                 curl "https://hub.docker.com/v2/repositories/concordium/${docker_images_base}/tags/${source_image_tag}/" \
                 -X DELETE \

--- a/jenkinsfiles/activate-distribution-image.Jenkinsfile
+++ b/jenkinsfiles/activate-distribution-image.Jenkinsfile
@@ -60,22 +60,22 @@ node {
         stage('cleanup') {
             withCredentials([usernamePassword(credentialsId: 'jenkins-dockerhub', passwordVariable: 'CRED_PSW', usernameVariable: 'CRED_USR')]) {
                 //https://devopsheaven.com/docker/dockerhub/2018/04/09/delete-docker-image-tag-dockerhub.html
-                sh '''\
+                sh """\
                 login_data() {
                 cat <<EOF
                 {
-                "username": "$CRED_USR",
-                "password": "$CRED_PSW"
+                "username": "\$CRED_USR",
+                "password": "\$CRED_PSW"
                 }
                 EOF
                 }
 
                 TOKEN=`curl -s -H "Content-Type: application/json" -X POST -d "$(login_data)" "https://hub.docker.com/v2/users/login/" | jq -r .token`
 
-                curl "https://hub.docker.com/v2/repositories/${ORGANIZATION}/${IMAGE}/tags/${TAG}/" \
+                curl "https://hub.docker.com/v2/repositories/concordium/${docker_images_base}/tags/${source_image_tag}/" \
                 -X DELETE \
                 -H "Authorization: JWT ${TOKEN}"
-                '''.stripIndent()
+                """.stripIndent()
             }
         }
     }

--- a/jenkinsfiles/activate-distribution-image.Jenkinsfile
+++ b/jenkinsfiles/activate-distribution-image.Jenkinsfile
@@ -33,14 +33,14 @@ node {
     }
 
     stage('verify') {
-        // Verify existens of source image
+        // Verify existence of source image
         try {
             sh "curl -s https://hub.docker.com/v2/namespaces/concordium/repositories/${docker_images_base}/tags/${source_image_tag} | jq -re '.digest'"
         } catch (e) {
             error "Image with tag '${source_image_tag}' does not exist in repo '${docker_repo}'."
         }
 
-        // Verify source tag doesen't already exist
+        // Verify target tag doesen't already exist
         try {
             sh "! curl -s https://hub.docker.com/v2/namespaces/concordium/repositories/${docker_images_base}/tags/${destination_image_tag} | jq -re '.digest'"
         } catch (e) {

--- a/jenkinsfiles/activate-distribution-image.Jenkinsfile
+++ b/jenkinsfiles/activate-distribution-image.Jenkinsfile
@@ -75,7 +75,7 @@ node {
                 curl "https://hub.docker.com/v2/repositories/${ORGANIZATION}/${IMAGE}/tags/${TAG}/" \
                 -X DELETE \
                 -H "Authorization: JWT ${TOKEN}"
-                '''..stripIndent()
+                '''.stripIndent()
             }
         }
     }


### PR DESCRIPTION
## Purpose

Change the activation pipeline to the new clean docker setup. The pipeline allows for promoting a release candidate docker image to release, by retagging the RC image.

## Changes

The entire pipeline was changed from creating a file in s3 and triggering a CloudFront invalidation, to now retagging docker images on Docker Hub.

## Checklist

- [ ] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
