### PR TITLE
Fix space leak in nonce computation.

### DIFF
--- a/concordium-consensus/src/Concordium/Kontrol/UpdateLeaderElectionParameters.hs
+++ b/concordium-consensus/src/Concordium/Kontrol/UpdateLeaderElectionParameters.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE BangPatterns #-}
 -- |Functionality for updating and computing leadership election nonces.
 module Concordium.Kontrol.UpdateLeaderElectionParameters (
     updateSeedState,
@@ -25,7 +26,7 @@ updateWithEpoch
     -> H.Hash
     -- ^Running updated leadership election nonce
     -> H.Hash
-updateWithEpoch e n = hash $ runPut $ put n <> put e
+updateWithEpoch e !n = hash $ runPut $ put n <> put e
 
 -- |Update the seed state. The slot must not belong to a prior epoch.
 updateSeedState :: Slot -> BlockNonce -> SeedState -> SeedState


### PR DESCRIPTION
## Purpose

Previously starting the chain with a year old genesis would lead to 1.7GB of memory use that did not go away for a long time. Now the memory is <100MB with the same genesis.

Most of the memory that is leakedin that example is actually retained in foreign code, in modules and in contract state.

This also reduces execution time on the specific example from ~900s to ~600s. It must be that GC time is less, or that there are fewer finalizers for foreign objects that need to be maintained that causes this improvement.

## Changes

Update with epoch is strict now.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
