### PR TITLE
Fix typo in environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Fix typo in environment variable `CONCORDIUM_NODE_PROMETHEUS_LISTEN_ADDRESSS` (remove trailing `S`).
+
 ## 4.4.2
 
 - Speed up and reduce memory overhead during protocol updates.

--- a/concordium-node/src/configuration.rs
+++ b/concordium-node/src/configuration.rs
@@ -92,7 +92,7 @@ pub struct PrometheusConfig {
         long = "prometheus-listen-addr",
         help = "IP to listen for prometheus requests on",
         default_value = "127.0.0.1",
-        env = "CONCORDIUM_NODE_PROMETHEUS_LISTEN_ADDRESSS"
+        env = "CONCORDIUM_NODE_PROMETHEUS_LISTEN_ADDRESS"
     )]
     pub prometheus_listen_addr:   String,
     #[structopt(


### PR DESCRIPTION
## Purpose

Spell cewrectly.

## Changes

Fix typo in environment variable `CONCORDIUM_NODE_PROMETHEUS_LISTEN_ADDRESSS` (remove trailing `S`).

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.