### PR TITLE
Treestate is recreated if not readable but blockstate exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix a bug in database recovery where corruption was not always correctly detected.
 - Fix typo in environment variable `CONCORDIUM_NODE_PROMETHEUS_LISTEN_ADDRESSS` (remove trailing `S`).
+- The node is now able to recover after crashes which leave only treestate or only blockstate usable.
 
 ## 4.4.2
 

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
@@ -46,8 +46,6 @@ import qualified Data.Sequence as Seq
 import Lens.Micro.Platform
 import Concordium.Utils
 import System.Mem.Weak
-import System.Directory
-import System.IO.Error
 import Concordium.Logger
 import Control.Monad.Except
 import qualified Concordium.TransactionVerification as TVer
@@ -93,18 +91,6 @@ logExceptionAndThrowTS = logExceptionAndThrow TreeState
 
 logErrorAndThrowTS :: (MonadLogger m, MonadIO m) => String -> m a
 logErrorAndThrowTS = logErrorAndThrow TreeState
-
-  -- Check whether a path is a normal file that is readable and writable
-checkRWFile :: forall m. (MonadLogger m, MonadIO m) => FilePath -> InitException -> m ()
-checkRWFile path exc = do
-  fileEx <- liftIO $ doesFileExist path
-  unless fileEx $ logExceptionAndThrowTS BlockStatePathDir
-  mperms <- liftIO $ catchJust (guard . isPermissionError)
-    (Just <$> getPermissions path) (const $ return Nothing)
-  case mperms of
-    Nothing -> logExceptionAndThrowTS exc
-    Just perms ->
-      unless (readable perms && writable perms) $ logExceptionAndThrowTS exc
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Purpose

Closes #493.

## Changes

`initialiseExistingGlobalState` will now not throw an exception if the treestate cannot be read but will attempt to create a new one using the genesis state for the latest protocol update.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
