### PR TITLE
Dead block cache test failure

### DIFF
--- a/concordium-consensus/tests/globalstate/GlobalStateTests/PersistentTreeState.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/PersistentTreeState.hs
@@ -230,7 +230,7 @@ constructCache = List.foldl' (flip insertDeadCache) emptyDeadCache
 -- - the size of the cache is bounded by 1000
 testDeadCache :: Property
 testDeadCache =
-    withMaxSuccess 100000 $
+    withMaxSuccess 1000 $
         property $
             forAll genBlockHashes $ \bhs ->
                 let dc = constructCache bhs
@@ -244,7 +244,7 @@ testDeadCache =
 -- - the size of the cache is bounded by 1000
 testDeadCacheDistinct :: Property
 testDeadCacheDistinct =
-    withMaxSuccess 100000 $
+    withMaxSuccess 1000 $
         property $
             forAll genDistinctBlockHashes $ \bhs ->
                 let dc = constructCache bhs


### PR DESCRIPTION
## Purpose

A test on the dead block cache can fail because the assumption that the last-inserted 1000 blocks are in the cache is only guaranteed if none of them were already in the cache.

## Changes

- Remove the 1000 block check from the existing test.
- Add a test with the check where the generator guarantees distinctness of block hashes.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
