### PR TITLE
Fix for block state truncation issue on Windows.

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Cache.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Cache.hs
@@ -17,7 +17,12 @@ import qualified Data.Vector.Primitive.Mutable as Vec
 
 import Concordium.Utils.Serialization.Put (PutT)
 
-import Concordium.GlobalState.Persistent.BlobStore (BlobRef (..), BlobStoreT, HasNull (..))
+import Concordium.GlobalState.Persistent.BlobStore (
+    BlobRef (..),
+    BlobStoreT,
+    HasNull (..),
+    ProvisionalBlobStoreT,
+ )
 
 -- |The 'HasCache' class supports projecting a cache of a particular type.
 -- This is used to access a cache given a context.
@@ -48,6 +53,10 @@ instance (MonadCache c m) => MonadCache c (ExceptT e m) where
     {-# INLINE getCache #-}
 
 instance (HasCache c r, MonadIO m) => MonadCache c (BlobStoreT r m) where
+    getCache = asks projectCache
+    {-# INLINE getCache #-}
+
+instance (HasCache c r, MonadIO m) => MonadCache c (ProvisionalBlobStoreT r m) where
     getCache = asks projectCache
     {-# INLINE getCache #-}
 


### PR DESCRIPTION
## Purpose

Addresses #515

This fixes a problem with block state truncation failing on Windows.  This issue is caused by attempting to truncate a file that is currently memory mapped.  As releasing the memory maps is dependent on the garbage collector, this revises the process so that truncation is performed before the file is ever memory mapped.

## Changes

- Introduce a `ProvisionalBlobStore` that supports loading, but not storing, and does not make use of the memory map.
- Use the `ProvisionalBlobStore` while testing block states for validity.
- Redefine truncation only on `ProvisionalBlobStore`.
- Allow upgrading a `ProvisionalBlobStore` to a regular `BlobStore` once the truncation is completed.


## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
