### PR TITLE
Unmap before truncating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased changes
 
-- Fix a bug in database recovery where truncating the block state database would hang on Windows.
+- Fix a bug in database recovery where the node would hang when truncating the block state database
+  on Windows.
 
 ## 4.4.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Fix a bug in database recovery where truncating the block state database would hang on Windows.
+
 ## 4.4.3
 
 - Fix a bug in database recovery where corruption was not always correctly detected.

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
@@ -284,8 +284,8 @@ runBlobStoreTemp dir a = bracket openf closef usef
 -- | Truncate the blob store after the blob stored at the given offset. The blob should not be
 -- corrupted (i.e., its size header should be readable, and its size should match the size header).
 --
--- **Note**: This function must not be made after any writes to the blob store. It assumes that the
--- current 'blobStoreMMap' is the only mapping of the file (which can be relied on if no writes
+-- **Note**: This function must not be called after any writes to the blob store. It assumes that
+-- the current 'blobStoreMMap' is the only mapping of the file (which can be relied on if no writes
 -- have occurred). Since the existing memory map is invalidated, any other references to it will
 -- also be invalidated, such as 'BS.ByteString's returned by 'loadBlobPtr'.
 truncateBlobStore :: BlobStoreAccess -> BlobRef a -> IO ()

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
@@ -390,23 +390,22 @@ loadSkovPersistentData rp _treeStateDirectory pbsc = do
   liftIO (checkDatabaseVersion _db) >>=
       either (logExceptionAndThrowTS . IncorrectDatabaseVersion) return
 
-  -- Get the genesis block and check that its data matches the supplied genesis data.
-  genStoredBlock <- maybe (logExceptionAndThrowTS GenesisBlockNotInDataBaseError) return =<<
-          liftIO (getFirstBlock _db)
-  _genesisBlockPointer <- liftIO $ makeBlockPointer genStoredBlock
-  _genesisData <- case _bpBlock _genesisBlockPointer of
-    GenesisBlock gd' -> return gd'
-    _ -> logExceptionAndThrowTS (DatabaseInvariantViolation "Block at height 0 is not a genesis block.")
-
   -- Unroll the treestate if the last finalized blockstate is corrupted. If the last finalized
   -- blockstate is not corrupted, the treestate is unchanged.
   unrollTreeStateWhile _db (liftIO . isBlockStateCorrupted) >>= \case
     Left e -> logExceptionAndThrowTS . DatabaseInvariantViolation $
               "The block state database is corrupt. Recovery attempt failed: " <> e
     Right (_lastFinalizationRecord, lfStoredBlock) -> do
-      -- Truncate the blobstore beyond the last finalized blockstate. If no corruption was found
-      -- earlier, the blobstore size does not change.
+      -- Truncate the blobstore beyond the last finalized blockstate.
       liftIO $ truncateBlobStore (bscBlobStore . PBS.pbscBlobStore $ pbsc) (sbState lfStoredBlock)
+      -- Get the genesis block.
+      genStoredBlock <- maybe (logExceptionAndThrowTS GenesisBlockNotInDataBaseError) return =<<
+              liftIO (getFirstBlock _db)
+      _genesisBlockPointer <- liftIO $ makeBlockPointer genStoredBlock
+      _genesisData <- case _bpBlock _genesisBlockPointer of
+        GenesisBlock gd' -> return gd'
+        _ -> logExceptionAndThrowTS (DatabaseInvariantViolation "Block at height 0 is not a genesis block.")
+      -- Get the last finalized block.
       _lastFinalized <- liftIO (makeBlockPointer lfStoredBlock)
       return SkovPersistentData {
             _possiblyPendingTable = HM.empty,


### PR DESCRIPTION
## Purpose

Addresses #515.

This unmaps the blob store memory map before truncating the blob store, as truncating the file while it is memory mapped will fail on Windows.

## Changes

- Unmap the memory map in `truncateBlobStore`.
- Load the genesis block after truncation, to reduce the risk of any residual bad pointers. (It is unlikely that loading the genesis block earlier would actually retain bad pointers, but this mitigates the risk from future changes to block storage.)

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.