### PR TITLE
Hardcode genesis paths for Ubuntu distribution

### DIFF
--- a/jenkinsfiles/ubuntu.Jenkinsfile
+++ b/jenkinsfiles/ubuntu.Jenkinsfile
@@ -19,6 +19,12 @@ Map listen_port = [
     stagenet: "9500"
 ]
 
+Map genesis_path = [
+    mainnet: "mainnet/2021-06-09",
+    testnet: "testnet/2022-06-13/genesis_data",
+    stagenet: "stagenet/2022-06-24/genesis_data"
+]
+
 pipeline {
     // Use jenkins-worker, as it has the keys for pushing to AWS.
     agent { label 'jenkins-worker' }
@@ -33,11 +39,16 @@ pipeline {
                 returnStdout: true,
                 script: "[[ -z '${VERSION}' ]] && echo '${CODE_VERSION}' || echo '${VERSION}'"
             )}""".trim()
+        // Ude default genesis path for each environment, if the GENESIS_PATH param has not been set.
+        GENESIS_FULL_PATH = """${sh(
+                returnStdout: true,
+                script: "[[ -z '${GENESIS_PATH}' ]] && echo 'genesis/${genesis_path[ENVIRONMENT]}' || echo 'genesis/${GENESIS_PATH}'"
+            )}""".trim()
         DOMAIN = concordiumDomain(ENVIRONMENT)
         BUILD_FILE = "concordium-${ENVIRONMENT}-node_${CODE_VERSION}_amd64.deb"
         OUTFILE = "s3://distribution.${DOMAIN}/deb/concordium-${ENVIRONMENT}-node_${OUT_VERSION}_amd64.deb"
-        GENESIS_HASH_PATH = "genesis/${GENESIS_PATH}/genesis_hash"
-        GENESIS_DAT_FILE = "genesis/${GENESIS_PATH}/genesis.dat"
+        GENESIS_HASH_PATH = "${GENESIS_FULL_PATH}/genesis_hash"
+        GENESIS_DAT_FILE = "${GENESIS_FULL_PATH}/genesis.dat"
         ENVIRONMENT_CAP = environment.capitalize()
         DATA_DIR = "./scripts/distribution/ubuntu-packages/template/data/"
         RPC_PORT = "${rpc_port[environment]}"

--- a/scripts/distribution/ubuntu-packages/build-mainnet-deb.sh
+++ b/scripts/distribution/ubuntu-packages/build-mainnet-deb.sh
@@ -11,7 +11,7 @@ set -euxo pipefail
 # Set STATIC_BINARIES_IMAGE_TAG to latest if not already set
 export STATIC_BINARIES_IMAGE_TAG="${STATIC_BINARIES_IMAGE_TAG:-latest}"
 
-if ! docker inspect --type=image static-node-binaries > /dev/null 2> /dev/null ; then
+if ! docker inspect --type=image static-node-binaries:$STATIC_BINARIES_IMAGE_TAG > /dev/null 2> /dev/null ; then
     # build static binaries
     export STATIC_LIBRARIES_IMAGE_TAG="${STATIC_LIBRARIES_IMAGE_TAG:-latest}"
     export GHC_VERSION="${GHC_VERSION:-9.0.2}"

--- a/scripts/distribution/ubuntu-packages/build-testnet-deb.sh
+++ b/scripts/distribution/ubuntu-packages/build-testnet-deb.sh
@@ -13,7 +13,7 @@ export STATIC_BINARIES_IMAGE_TAG="${STATIC_BINARIES_IMAGE_TAG:-latest}"
 
 # If the static-node-binaries image exists we use the binaries therein.
 # Otherwise we build it first.
-if ! docker inspect --type=image static-node-binaries > /dev/null 2> /dev/null ; then
+if ! docker inspect --type=image static-node-binaries:$STATIC_BINARIES_IMAGE_TAG > /dev/null 2> /dev/null ; then
     # build static binaries
     export STATIC_LIBRARIES_IMAGE_TAG="${STATIC_LIBRARIES_IMAGE_TAG:-latest}"
     export GHC_VERSION="${GHC_VERSION:-9.0.2}"


### PR DESCRIPTION
## Purpose

Make it easier and less error prone to build the Ubuntu distribution from Jenkins, by adding environment specific defaults for genesis path.

## Changes

Added a map from environment to default genesis path.
Fixed a small bug in the manual ubuntu distribution build script, where the conditional build of the binaries docker image did not consider the supplied `STATIC_BINARIES_IMAGE_TAG`.

## Checklist

- [ ] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
