### PR TITLE
gRPC API v2 Getters for info about election, IP, AR and nonfinal tx

### DIFF
--- a/concordium-consensus/lib.def
+++ b/concordium-consensus/lib.def
@@ -70,3 +70,4 @@ EXPORTS
  getPassiveDelegatorsRewardPeriodV2
  getBranchesV2
  getElectionInfoV2
+ getIdentityProvidersV2

--- a/concordium-consensus/lib.def
+++ b/concordium-consensus/lib.def
@@ -69,3 +69,4 @@ EXPORTS
  getPassiveDelegatorsV2
  getPassiveDelegatorsRewardPeriodV2
  getBranchesV2
+ getElectionInfoV2

--- a/concordium-consensus/lib.def
+++ b/concordium-consensus/lib.def
@@ -71,3 +71,4 @@ EXPORTS
  getBranchesV2
  getElectionInfoV2
  getIdentityProvidersV2
+ getAnonymityRevokersV2

--- a/concordium-consensus/lib.def
+++ b/concordium-consensus/lib.def
@@ -72,3 +72,4 @@ EXPORTS
  getElectionInfoV2
  getIdentityProvidersV2
  getAnonymityRevokersV2
+ getAccountNonFinalizedTransactionsV2

--- a/concordium-consensus/src/Concordium/External.hs
+++ b/concordium-consensus/src/Concordium/External.hs
@@ -1070,7 +1070,7 @@ getAllAnonymityRevokers :: StablePtr ConsensusRunner -> CString -> IO CString
 getAllAnonymityRevokers cptr blockcstr =
     decodeBlockHash blockcstr >>= \case
         Nothing -> jsonCString AE.Null
-        Just bh -> jsonQuery cptr (Q.getAllAnonymityRevokers bh)
+        Just bh -> jsonQuery cptr (snd <$> Q.getAllAnonymityRevokers (BHIGiven bh))
 
 -- |Given a null-terminated string that represents a block hash (base 16), and a number of blocks,
 -- returns a null-terminated string containing a JSON list of the ancestors of the node (up to the

--- a/concordium-consensus/src/Concordium/External.hs
+++ b/concordium-consensus/src/Concordium/External.hs
@@ -1060,7 +1060,7 @@ getAllIdentityProviders :: StablePtr ConsensusRunner -> CString -> IO CString
 getAllIdentityProviders cptr blockcstr =
     decodeBlockHash blockcstr >>= \case
         Nothing -> jsonCString AE.Null
-        Just bh -> jsonQuery cptr (Q.getAllIdentityProviders bh)
+        Just bh -> jsonQuery cptr (snd <$> Q.getAllIdentityProviders (BHIGiven bh))
 
 -- |Get all of the identity providers registered in the system as of a given block.
 -- The block must be given as a null-terminated base16 encoding of the block hash.

--- a/concordium-consensus/src/Concordium/External.hs
+++ b/concordium-consensus/src/Concordium/External.hs
@@ -1040,7 +1040,7 @@ getBirkParameters :: StablePtr ConsensusRunner -> CString -> IO CString
 getBirkParameters cptr blockcstr =
     decodeBlockHash blockcstr >>= \case
         Nothing -> jsonCString AE.Null
-        Just bh -> jsonQuery cptr (Q.getBlockBirkParameters bh)
+        Just bh -> jsonQuery cptr (snd <$> Q.getBlockBirkParameters (BHIGiven bh))
 
 -- |Get the cryptographic parameters in a given block. The block must be given as a
 -- null-terminated base16 encoding of the block hash.

--- a/concordium-consensus/src/Concordium/GRPC2.hs
+++ b/concordium-consensus/src/Concordium/GRPC2.hs
@@ -1450,6 +1450,24 @@ instance ToProto QueryTypes.Branch where
       ProtoFields.blockHash .= toProto branchBlockHash
       ProtoFields.children .= fmap toProto branchChildren
 
+instance ToProto QueryTypes.BlockBirkParameters where
+    type Output QueryTypes.BlockBirkParameters = Maybe Proto.ElectionInfo
+    toProto QueryTypes.BlockBirkParameters {..} = do
+      bakerElectionInfo <- mapM toProto (Vec.toList bbpBakers)
+      Just $ Proto.make $ do
+        ProtoFields.electionDifficulty .= toProto bbpElectionDifficulty
+        ProtoFields.electionNonce .= mkSerialize bbpElectionNonce
+        ProtoFields.bakerElectionInfo .= bakerElectionInfo
+
+instance ToProto QueryTypes.BakerSummary where
+    type Output QueryTypes.BakerSummary = Maybe Proto.ElectionInfo'Baker
+    toProto QueryTypes.BakerSummary {..} = do
+      bakerAccount <- bsBakerAccount
+      Just $ Proto.make $ do
+        ProtoFields.baker .= toProto bsBakerId
+        ProtoFields.account .= toProto bakerAccount
+        ProtoFields.lotteryPower .= bsBakerLotteryPower
+
 -- |NB: Assumes the data is at least 32 bytes
 decodeBlockHashInput :: Word8 -> Ptr Word8 -> IO Q.BlockHashInput
 decodeBlockHashInput 0 _ = return Q.BHIBest
@@ -2116,6 +2134,32 @@ getBranchesV2 cptr outVec copierCbk = do
     result <- runMVR Q.getBranches mvr
     returnMessage (copier outVec) $ Just result
 
+getElectionInfoV2 ::
+    StablePtr Ext.ConsensusRunner ->
+    -- |Block type.
+    Word8 ->
+    -- |Block hash.
+    Ptr Word8 ->
+    -- |Out pointer for writing the block hash that was used.
+    Ptr Word8 ->
+    Ptr ReceiverVec ->
+    -- |Callback to output data.
+    FunPtr CopyToVecCallback ->
+    IO Int64
+getElectionInfoV2 cptr blockType blockHashPtr outHash outVec copierCbk = do
+    Ext.ConsensusRunner mvr <- deRefStablePtr cptr
+    let copier = callCopyToVecCallback copierCbk
+    bhi <- decodeBlockHashInput blockType blockHashPtr
+    (bh, maybeInfo) <- runMVR (Q.getBlockBirkParameters bhi) mvr
+    copyHashTo outHash bh
+    case maybeInfo of
+        Nothing -> return $ queryResultCode QRNotFound
+        Just info -> case toProto info of
+                       Nothing -> return $ queryResultCode QRInternalError
+                       Just proto -> do
+                         let encoded = Proto.encodeMessage proto
+                         BS.unsafeUseAsCStringLen encoded (\(ptr, len) -> copier outVec (castPtr ptr) (fromIntegral len))
+                         return $ queryResultCode QRSuccess
 
 {- |Write the hash to the provided pointer, and if the message is given encode and
    write it using the provided callback.
@@ -2517,6 +2561,19 @@ foreign export ccall
 foreign export ccall
     getBranchesV2 ::
         StablePtr Ext.ConsensusRunner ->
+        Ptr ReceiverVec ->
+        FunPtr CopyToVecCallback ->
+        IO Int64
+
+foreign export ccall
+    getElectionInfoV2 ::
+        StablePtr Ext.ConsensusRunner ->
+        -- |Block type.
+        Word8 ->
+        -- |Block hash.
+        Ptr Word8 ->
+        -- |Out pointer for writing the block hash that was used.
+        Ptr Word8 ->
         Ptr ReceiverVec ->
         FunPtr CopyToVecCallback ->
         IO Int64

--- a/concordium-consensus/src/Concordium/GRPC2.hs
+++ b/concordium-consensus/src/Concordium/GRPC2.hs
@@ -2184,6 +2184,30 @@ getIdentityProvidersV2 cptr channel blockType blockHashPtr outHash cbk = do
             _ <- enqueueMessages (sender channel) ipInfos
             return (queryResultCode QRSuccess)
 
+getAnonymityRevokersV2 ::
+    StablePtr Ext.ConsensusRunner ->
+    Ptr SenderChannel ->
+    -- |Block type.
+    Word8 ->
+    -- |Block hash.
+    Ptr Word8 ->
+    -- |Out pointer for writing the block hash that was used.
+    Ptr Word8 ->
+    FunPtr ChannelSendCallback ->
+    IO Int64
+getAnonymityRevokersV2 cptr channel blockType blockHashPtr outHash cbk = do
+    Ext.ConsensusRunner mvr <- deRefStablePtr cptr
+    let sender = callChannelSendCallback cbk
+    bhi <- decodeBlockHashInput blockType blockHashPtr
+    (bh, maybeAnonymityRevokers) <- runMVR (Q.getAllAnonymityRevokers bhi) mvr
+    case maybeAnonymityRevokers of
+        Nothing -> return (queryResultCode QRNotFound)
+        Just arInfos -> do
+            copyHashTo outHash bh
+            _ <- enqueueMessages (sender channel) arInfos
+            return (queryResultCode QRSuccess)
+
+
 {- |Write the hash to the provided pointer, and if the message is given encode and
    write it using the provided callback.
 -}
@@ -2614,3 +2638,15 @@ foreign export ccall
         FunPtr ChannelSendCallback ->
         IO Int64
 
+foreign export ccall
+    getAnonymityRevokersV2 ::
+        StablePtr Ext.ConsensusRunner ->
+        Ptr SenderChannel ->
+        -- |Block type.
+        Word8 ->
+        -- |Block hash.
+        Ptr Word8 ->
+        -- |Out pointer for writing the block hash that was used.
+        Ptr Word8 ->
+        FunPtr ChannelSendCallback ->
+        IO Int64

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -516,8 +516,8 @@ getCryptographicParameters = liftSkovQueryBHI $ \bp -> do
     BS.getCryptographicParameters bs
 
 -- |Get all of the identity providers registered in the system as of a given block.
-getAllIdentityProviders :: BlockHash -> MVR gsconf finconf (Maybe [IpInfo])
-getAllIdentityProviders = liftSkovQueryBlock $ BS.getAllIdentityProviders <=< blockState
+getAllIdentityProviders :: BlockHashInput -> MVR gsconf finconf (BlockHash, Maybe [IpInfo])
+getAllIdentityProviders = liftSkovQueryBHI $ BS.getAllIdentityProviders <=< blockState
 
 -- |Get all of the anonymity revokers registered in the system as of a given block.
 getAllAnonymityRevokers :: BlockHash -> MVR gsconf finconf (Maybe [ArInfo])

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -493,8 +493,8 @@ getRewardStatus = liftSkovQueryBHI $ \bp -> do
     return $ epochToUTC <$> reward
 
 -- |Get the birk parameters that applied when a given block was baked.
-getBlockBirkParameters :: BlockHash -> MVR gsconf finconf (Maybe BlockBirkParameters)
-getBlockBirkParameters = liftSkovQueryBlock $ \bp -> do
+getBlockBirkParameters :: BlockHashInput -> MVR gsconf finconf (BlockHash, Maybe BlockBirkParameters)
+getBlockBirkParameters = liftSkovQueryBHI $ \bp -> do
     bs <- blockState bp
     bbpElectionDifficulty <- BS.getCurrentElectionDifficulty bs
     bbpElectionNonce <- currentLeadershipElectionNonce <$> BS.getSeedState bs

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -520,8 +520,8 @@ getAllIdentityProviders :: BlockHashInput -> MVR gsconf finconf (BlockHash, Mayb
 getAllIdentityProviders = liftSkovQueryBHI $ BS.getAllIdentityProviders <=< blockState
 
 -- |Get all of the anonymity revokers registered in the system as of a given block.
-getAllAnonymityRevokers :: BlockHash -> MVR gsconf finconf (Maybe [ArInfo])
-getAllAnonymityRevokers = liftSkovQueryBlock $ BS.getAllAnonymityRevokers <=< blockState
+getAllAnonymityRevokers :: BlockHashInput -> MVR gsconf finconf (BlockHash, Maybe [ArInfo])
+getAllAnonymityRevokers = liftSkovQueryBHI $ BS.getAllAnonymityRevokers <=< blockState
 
 -- |Get the ancestors of a block (including itself) up to a maximum
 -- length.

--- a/concordium-node/build.rs
+++ b/concordium-node/build.rs
@@ -435,6 +435,16 @@ fn build_grpc2(proto_root_input: &str) -> std::io::Result<()> {
                 .server_streaming()
                 .build(),
         )
+        .method(
+            tonic_build::manual::Method::builder()
+                .name("get_anonymity_revokers")
+                .route_name("GetAnonymityRevokers")
+                .input_type("crate::grpc2::types::BlockHashInput")
+                .output_type("Vec<u8>")
+                .codec_path("crate::grpc2::RawCodec")
+                .server_streaming()
+                .build(),
+        )
         .build();
     // Due to the slightly hacky nature of the RawCodec (i.e., it does not support
     // deserialization) we cannot build the client. But we also don't need it in the

--- a/concordium-node/build.rs
+++ b/concordium-node/build.rs
@@ -445,6 +445,16 @@ fn build_grpc2(proto_root_input: &str) -> std::io::Result<()> {
                 .server_streaming()
                 .build(),
         )
+        .method(
+            tonic_build::manual::Method::builder()
+                .name("get_account_non_finalized_transactions")
+                .route_name("GetAccountNonFinalizedTransactions")
+                .input_type("crate::grpc2::types::AccountAddress")
+                .output_type("Vec<u8>")
+                .codec_path("crate::grpc2::RawCodec")
+                .server_streaming()
+                .build(),
+        )
         .build();
     // Due to the slightly hacky nature of the RawCodec (i.e., it does not support
     // deserialization) we cannot build the client. But we also don't need it in the

--- a/concordium-node/build.rs
+++ b/concordium-node/build.rs
@@ -416,6 +416,15 @@ fn build_grpc2(proto_root_input: &str) -> std::io::Result<()> {
                 .codec_path("crate::grpc2::RawCodec")
                 .build(),
         )
+        .method(
+            tonic_build::manual::Method::builder()
+                .name("get_election_info")
+                .route_name("GetElectionInfo")
+                .input_type("crate::grpc2::types::BlockHashInput")
+                .output_type("Vec<u8>")
+                .codec_path("crate::grpc2::RawCodec")
+                .build(),
+        )
         .build();
     // Due to the slightly hacky nature of the RawCodec (i.e., it does not support
     // deserialization) we cannot build the client. But we also don't need it in the

--- a/concordium-node/build.rs
+++ b/concordium-node/build.rs
@@ -425,6 +425,16 @@ fn build_grpc2(proto_root_input: &str) -> std::io::Result<()> {
                 .codec_path("crate::grpc2::RawCodec")
                 .build(),
         )
+        .method(
+            tonic_build::manual::Method::builder()
+                .name("get_identity_providers")
+                .route_name("GetIdentityProviders")
+                .input_type("crate::grpc2::types::BlockHashInput")
+                .output_type("Vec<u8>")
+                .codec_path("crate::grpc2::RawCodec")
+                .server_streaming()
+                .build(),
+        )
         .build();
     // Due to the slightly hacky nature of the RawCodec (i.e., it does not support
     // deserialization) we cannot build the client. But we also don't need it in the

--- a/concordium-node/src/consensus_ffi/ffi.rs
+++ b/concordium-node/src/consensus_ffi/ffi.rs
@@ -1070,6 +1070,29 @@ extern "C" {
         copier: CopyToVecCallback,
     ) -> i64;
 
+    /// Get the identity providers registered as of the end of a given block.
+    /// The stream will end when all the identity providers have been returned.
+    ///
+    /// * `consensus` - Pointer to the current consensus.
+    /// * `stream` - Pointer to the response stream.
+    /// * `block_id_type` - Type of block identifier.
+    /// * `block_id` - Location with the block identifier. Length must match the
+    ///   corresponding type of block identifier.
+    /// * `out_hash` - Location to write the block hash used in the query.
+    /// * `callback` - Callback for writing to the response stream.
+    pub fn getIdentityProvidersV2(
+        consensus: *mut consensus_runner,
+        stream: *mut futures::channel::mpsc::Sender<Result<Vec<u8>, tonic::Status>>,
+        block_id_type: u8,
+        block_id: *const u8,
+        out_hash: *mut u8,
+        callback: extern "C" fn(
+            *mut futures::channel::mpsc::Sender<Result<Vec<u8>, tonic::Status>>,
+            *const u8,
+            i64,
+        ) -> i32,
+    ) -> i64;
+
 }
 
 /// This is the callback invoked by consensus on newly arrived, and newly
@@ -2318,6 +2341,34 @@ impl ConsensusContainer {
         .try_into()?;
         response.ensure_ok("block")?;
         Ok((out_hash, out_data))
+    }
+
+    /// Get the identity providers registered as of the end of a given block.
+    /// The stream will end when all the identity providers have been returned.
+    pub fn get_identity_providers_v2(
+        &self,
+        request: &crate::grpc2::types::BlockHashInput,
+        sender: futures::channel::mpsc::Sender<Result<Vec<u8>, tonic::Status>>,
+    ) -> Result<[u8; 32], tonic::Status> {
+        use crate::grpc2::Require;
+        let sender = Box::new(sender);
+        let consensus = self.consensus.load(Ordering::SeqCst);
+        let mut buf = [0u8; 32];
+        let (block_id_type, block_hash) =
+            crate::grpc2::types::block_hash_input_to_ffi(request).require()?;
+        let response: ConsensusQueryResponse = unsafe {
+            getIdentityProvidersV2(
+                consensus,
+                Box::into_raw(sender),
+                block_id_type,
+                block_hash,
+                buf.as_mut_ptr(),
+                enqueue_bytearray_callback,
+            )
+        }
+        .try_into()?;
+        response.ensure_ok("block")?;
+        Ok(buf)
     }
 }
 

--- a/concordium-node/src/consensus_ffi/ffi.rs
+++ b/concordium-node/src/consensus_ffi/ffi.rs
@@ -1115,6 +1115,26 @@ extern "C" {
             i64,
         ) -> i32,
     ) -> i64;
+
+    /// Get a list of non-finalized transaction hashes for a given account.
+    /// The stream will end when all the non-finalized transaction hashes have
+    /// been returned.
+    ///
+    /// * `consensus` - Pointer to the current consensus.
+    /// * `stream` - Pointer to the response stream.
+    /// * `account_address_ptr` - Pointer to account address. Must contain 32
+    ///   bytes.
+    /// * `callback` - Callback for writing to the response stream.
+    pub fn getAccountNonFinalizedTransactionsV2(
+        consensus: *mut consensus_runner,
+        stream: *mut futures::channel::mpsc::Sender<Result<Vec<u8>, tonic::Status>>,
+        account_address_ptr: *const u8,
+        callback: extern "C" fn(
+            *mut futures::channel::mpsc::Sender<Result<Vec<u8>, tonic::Status>>,
+            *const u8,
+            i64,
+        ) -> i32,
+    ) -> i64;
 }
 
 /// This is the callback invoked by consensus on newly arrived, and newly
@@ -2419,6 +2439,31 @@ impl ConsensusContainer {
         .try_into()?;
         response.ensure_ok("block")?;
         Ok(buf)
+    }
+
+    /// Get a list of non-finalized transaction hashes for a given account.
+    /// The stream will end when all the non-finalized transaction hashes have
+    /// been returned.
+    pub fn get_account_non_finalized_transactions_v2(
+        &self,
+        request: &crate::grpc2::types::AccountAddress,
+        sender: futures::channel::mpsc::Sender<Result<Vec<u8>, tonic::Status>>,
+    ) -> Result<(), tonic::Status> {
+        use crate::grpc2::Require;
+        let sender = Box::new(sender);
+        let consensus = self.consensus.load(Ordering::SeqCst);
+        let account_address_ptr = crate::grpc2::types::account_address_to_ffi(request).require()?;
+        let response: ConsensusQueryResponse = unsafe {
+            getAccountNonFinalizedTransactionsV2(
+                consensus,
+                Box::into_raw(sender),
+                account_address_ptr,
+                enqueue_bytearray_callback,
+            )
+        }
+        .try_into()?;
+        response.ensure_ok("account address")?;
+        Ok(())
     }
 }
 

--- a/concordium-node/src/consensus_ffi/ffi.rs
+++ b/concordium-node/src/consensus_ffi/ffi.rs
@@ -1051,6 +1051,25 @@ extern "C" {
         out: *mut Vec<u8>,
         copier: CopyToVecCallback,
     ) -> i64;
+
+    /// Get information related to the baker election for a particular block.
+    ///
+    /// * `consensus` - Pointer to the current consensus.
+    /// * `block_id_type` - Type of block identifier.
+    /// * `block_id` - Location with the block identifier. Length must match the
+    ///   corresponding type of block identifier.
+    /// * `out_hash` - Location to write the block hash used in the query.
+    /// * `out` - Location to write the output of the query.
+    /// * `copier` - Callback for writting the output.
+    pub fn getElectionInfoV2(
+        consensus: *mut consensus_runner,
+        block_id_type: u8,
+        block_id: *const u8,
+        out_hash: *mut u8,
+        out: *mut Vec<u8>,
+        copier: CopyToVecCallback,
+    ) -> i64;
+
 }
 
 /// This is the callback invoked by consensus on newly arrived, and newly
@@ -2272,6 +2291,33 @@ impl ConsensusContainer {
         let _response: ConsensusQueryResponse =
             unsafe { getBranchesV2(consensus, &mut out_data, copy_to_vec_callback) }.try_into()?;
         Ok(out_data)
+    }
+
+    /// Get information related to the baker election for a particular block.
+    pub fn get_election_info_v2(
+        &self,
+        request: &crate::grpc2::types::BlockHashInput,
+    ) -> Result<([u8; 32], Vec<u8>), tonic::Status> {
+        use crate::grpc2::Require;
+        let consensus = self.consensus.load(Ordering::SeqCst);
+        let mut out_data: Vec<u8> = Vec::new();
+        let mut out_hash = [0u8; 32];
+        let (block_id_type, block_id) =
+            crate::grpc2::types::block_hash_input_to_ffi(request).require()?;
+
+        let response: ConsensusQueryResponse = unsafe {
+            getElectionInfoV2(
+                consensus,
+                block_id_type,
+                block_id,
+                out_hash.as_mut_ptr(),
+                &mut out_data,
+                copy_to_vec_callback,
+            )
+        }
+        .try_into()?;
+        response.ensure_ok("block")?;
+        Ok((out_hash, out_data))
     }
 }
 

--- a/concordium-node/src/grpc2.rs
+++ b/concordium-node/src/grpc2.rs
@@ -492,6 +492,9 @@ pub mod server {
         /// Return type for the 'GetAccountList' method.
         type GetAccountListStream =
             futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
+        /// Return type for the 'GetAccountNonFinalizedTransactions' method.
+        type GetAccountNonFinalizedTransactionsStream =
+            futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
         /// Return type for the 'GetAncestors' method.
         type GetAncestorsStream = futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
         /// Return type for the 'GetAnonymityRevokers' method.
@@ -969,6 +972,17 @@ pub mod server {
             let hash = self.consensus.get_anonymity_revokers_v2(request.get_ref(), sender)?;
             let mut response = tonic::Response::new(receiver);
             add_hash(&mut response, hash)?;
+            Ok(response)
+        }
+
+        async fn get_account_non_finalized_transactions(
+            &self,
+            request: tonic::Request<crate::grpc2::types::AccountAddress>,
+        ) -> Result<tonic::Response<Self::GetAccountNonFinalizedTransactionsStream>, tonic::Status>
+        {
+            let (sender, receiver) = futures::channel::mpsc::channel(10);
+            self.consensus.get_account_non_finalized_transactions_v2(request.get_ref(), sender)?;
+            let response = tonic::Response::new(receiver);
             Ok(response)
         }
     }

--- a/concordium-node/src/grpc2.rs
+++ b/concordium-node/src/grpc2.rs
@@ -494,6 +494,9 @@ pub mod server {
             futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
         /// Return type for the 'GetAncestors' method.
         type GetAncestorsStream = futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
+        /// Return type for the 'GetAnonymityRevokers' method.
+        type GetAnonymityRevokersStream =
+            futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
         /// Return type for the 'GetBakerList' method.
         type GetBakerListStream = futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
         /// Return type for the 'Blocks' method.
@@ -953,6 +956,17 @@ pub mod server {
         ) -> Result<tonic::Response<Self::GetIdentityProvidersStream>, tonic::Status> {
             let (sender, receiver) = futures::channel::mpsc::channel(10);
             let hash = self.consensus.get_identity_providers_v2(request.get_ref(), sender)?;
+            let mut response = tonic::Response::new(receiver);
+            add_hash(&mut response, hash)?;
+            Ok(response)
+        }
+
+        async fn get_anonymity_revokers(
+            &self,
+            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+        ) -> Result<tonic::Response<Self::GetAnonymityRevokersStream>, tonic::Status> {
+            let (sender, receiver) = futures::channel::mpsc::channel(10);
+            let hash = self.consensus.get_anonymity_revokers_v2(request.get_ref(), sender)?;
             let mut response = tonic::Response::new(receiver);
             add_hash(&mut response, hash)?;
             Ok(response)

--- a/concordium-node/src/grpc2.rs
+++ b/concordium-node/src/grpc2.rs
@@ -933,6 +933,16 @@ pub mod server {
         ) -> Result<tonic::Response<Vec<u8>>, tonic::Status> {
             Ok(tonic::Response::new(self.consensus.get_branches_v2()?))
         }
+
+        async fn get_election_info(
+            &self,
+            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+        ) -> Result<tonic::Response<Vec<u8>>, tonic::Status> {
+            let (hash, response) = self.consensus.get_election_info_v2(request.get_ref())?;
+            let mut response = tonic::Response::new(response);
+            add_hash(&mut response, hash)?;
+            Ok(response)
+        }
     }
 }
 


### PR DESCRIPTION
## Purpose

Implement more of the new gRPC API v2.
Related issue https://github.com/Concordium/concordium-node/issues/433.
Depends on https://github.com/Concordium/concordium-grpc-api/pull/19.

## Changes

- `GetElectionInfo`, `GetIdentityProvidersV2`, `GetAnonymityRevokers` and `GetAccountNonFinalizedTransactions`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.