### PR TITLE
Fix docker distribution build , and update documentation for static-binaries

### DIFF
--- a/jenkinsfiles/distribution-image.Jenkinsfile
+++ b/jenkinsfiles/distribution-image.Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     
     environment {
         image_name = "${environment}-node"
-        STATIC_BINARIES_IMAGE_TAG = "${BUILD_TAG}"
+        static_binaries_image_tag = "${BUILD_TAG}"
     }
 
     stages {

--- a/scripts/distribution/docker/build-distribution-image.sh
+++ b/scripts/distribution/docker/build-distribution-image.sh
@@ -13,6 +13,7 @@
 
 # This builder script expects the following environment variables to be set
 # - static_libraries_image_tag (image with dependencies for building Haskell libraries that are linked statically)
+# - static_binaries_image_tag (image tag for the static libraries docker build, defaults to latest)
 # - ghc_version (version of the GHC compiler used to build static binaries)
 # - genesis_path (root of the genesis directory from which the genesis block is taken)
 # - genesis_ref (branch or commit of the genesis_data repository where the genesis data is located)
@@ -23,13 +24,14 @@
 set -euxo pipefail
 
 # Build the image and tag it as static-node-binaries
-GHC_VERSION="${ghc_version}" UBUNTU_VERSION=20.04 STATIC_LIBRARIES_IMAGE_TAG="${static_libraries_image_tag}" EXTRA_FEATURES="collector" ./scripts/static-binaries/build-static-binaries.sh
+GHC_VERSION="${ghc_version}" UBUNTU_VERSION=20.04 STATIC_LIBRARIES_IMAGE_TAG="${static_libraries_image_tag}" STATIC_BINARIES_IMAGE_TAG="${static_binaries_image_tag:-latest}" EXTRA_FEATURES="collector" ./scripts/static-binaries/build-static-binaries.sh
 
 # Then pack it all together with genesis
 DOCKER_BUILDKIT=1 docker build\
                   --build-arg environment="${environment}"\
                   --build-arg genesis_ref="${genesis_ref}"\
                   --build-arg genesis_path="${genesis_path}"\
+                  --build-arg static_binaries_image_tag="${static_binaries_image_tag:-latest}"\
                   -t "concordium/${image_name}:${image_tag}"\
                   --ssh default\
                   -f scripts/distribution/docker/builder.Dockerfile\

--- a/scripts/distribution/docker/builder.Dockerfile
+++ b/scripts/distribution/docker/builder.Dockerfile
@@ -17,7 +17,8 @@
 # The build of the image will clone the genesis data repository so needs
 # credentials to access it.
 
-FROM static-node-binaries:latest as binaries
+ARG static_binaries_image_tag
+FROM static-node-binaries:${static_binaries_image_tag} as binaries
 
 # Fetch genesis-data.
 FROM alpine/git:latest as genesis-data

--- a/scripts/distribution/ubuntu-packages/README.md
+++ b/scripts/distribution/ubuntu-packages/README.md
@@ -82,7 +82,8 @@ The general strategy for building the package is as follows.
 
    For example use the [../../static-binaries/build-static-binaries.sh](../../static-binaries/build-static-binaries.sh).
    ```console
-   $ UBUNTU_VERSION=20.04 STATIC_LIBRARIES_IMAGE_TAG=ghc-9.0.2 GHC_VERSION=9.0.2 EXTRA_FEATURES=collector ./scripts/static-binaries/build-static-binaries.sh
+   $ UBUNTU_VERSION=20.04 STATIC_LIBRARIES_IMAGE_TAG=ghc-9.0.2 
+        STATIC_BINARIES_IMAGE_TAG=latest GHC_VERSION=9.0.2 EXTRA_FEATURES=collector ./scripts/static-binaries/build-static-binaries.sh
    ```
 
    If not then just comment out the relevant lines and manually copy the

--- a/scripts/static-binaries/README.md
+++ b/scripts/static-binaries/README.md
@@ -14,6 +14,8 @@ specific package manager for installing dependencies (and possibly renaming depe
     - `STATIC_LIBRARIES_IMAGE_TAG`, tag of the docker image used to build static
       libraries. `latest` should work, but otherwise see which tags are
       available on dockerhub.
+    - `STATIC_BINARIES_IMAGE_TAG`, tag of the docker image produced by the script,
+      e.g. `latest`.
     - `GHC_VERSION` which Haskell compiler version to use. Generally this should
       match whatever the version is specified by the resolver in [stack.yaml](../../concordium-consensus/stack.yaml).
     - `EXTRA_FEATURES` (optional) extra features that will be used when building


### PR DESCRIPTION
## Purpose

When creating the Ubuntu pipeline a parameter was added to `build-static-binaries.sh`, but was not added to the docker pipeline.

## Changes

The `static_binaries_image_tag` param was added to the pipeline and the manual build script for the docker distribution.
And the `static_binaries_image_tag` param was documented in the README's that mention `build-static-binaries.sh`.

## Checklist

- [ ] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
