### PR TITLE
grpc2 peersinfo

### DIFF
--- a/concordium-node/build.rs
+++ b/concordium-node/build.rs
@@ -455,6 +455,15 @@ fn build_grpc2(proto_root_input: &str) -> std::io::Result<()> {
                 .server_streaming()
                 .build(),
         )
+        .method(
+            tonic_build::manual::Method::builder()
+                .name("get_peers_info")
+                .route_name("GetPeersInfo")
+                .input_type("crate::grpc2::types::Empty")
+                .output_type("crate::grpc2::types::PeersInfo")
+                .codec_path("tonic::codec::ProstCodec")
+                .build(),
+        )
         .build();
     // Due to the slightly hacky nature of the RawCodec (i.e., it does not support
     // deserialization) we cannot build the client. But we also don't need it in the


### PR DESCRIPTION
## Purpose

Support the new grpc2 version of `PeersInfo`

## Changes

Introduced a rpc endpoint `GetPeersInfo` which exposes this new `PeersInfo` type.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
