### PR TITLE
Remove memory credential map

### DIFF
--- a/concordium-consensus/benchmarks/credential-lookup/CredentialLookup.hs
+++ b/concordium-consensus/benchmarks/credential-lookup/CredentialLookup.hs
@@ -50,7 +50,9 @@ genRegID :: Int -> RawCredentialRegistrationID
 genRegID seed = RawCredentialRegistrationID $! FBS.pack (randoms (mkStdGen seed))
 
 -- |Create a benchmark environment by populating the map and tries with the given number of
--- generated credentials.
+-- generated credentials. The trie is written out after each insertion. This decreases the locality
+-- of the trie in the blob store and gives a more realistic scenario than if the trie is only
+-- written a single time.
 setup :: Int -> IO Setup
 setup size = do
     tempBlobStoreFile <- emptySystemTempFile "blb.dat"

--- a/concordium-consensus/benchmarks/credential-lookup/CredentialLookup.hs
+++ b/concordium-consensus/benchmarks/credential-lookup/CredentialLookup.hs
@@ -1,0 +1,138 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- |A benchmark for credential lookup. This compares three approaches:
+--
+-- 1. A map stored in memory.
+--
+-- 2. A trie that is cached in the memory.
+--
+-- 3. A trie that is not cached in the memory and always accessed from the disk.
+module Main where
+
+import Control.DeepSeq
+import Control.Monad
+import Criterion
+import Criterion.Main
+import qualified Data.Map.Strict as Map
+import Data.Maybe
+import System.IO.Temp
+import System.Random
+
+import Concordium.ID.Types
+import Concordium.Types
+import qualified Data.FixedByteString as FBS
+
+import Concordium.GlobalState.Persistent.BlobStore
+import qualified Concordium.GlobalState.Persistent.Trie as Trie
+
+-- |The starting state from which the benchmarks are run.
+-- This consists of the blob store, and indexes in the three forms required for testing.
+data Setup = Setup
+    { setupBlobStore :: !BlobStore,
+      setupMemMap :: !(Map.Map RawCredentialRegistrationID AccountIndex),
+      setupBufferedTrie :: !(Trie.TrieN BufferedFix RawCredentialRegistrationID AccountIndex),
+      setupUnbufferedTrie :: !(Trie.TrieN UnbufferedFix RawCredentialRegistrationID AccountIndex)
+    }
+
+instance NFData Setup where
+    rnf Setup{..} = rnf setupMemMap
+
+instance NFData RawCredentialRegistrationID where
+    rnf a = a `seq` ()
+
+instance NFData AccountIndex where
+    rnf (AccountIndex x) = rnf x
+
+-- |Generate a pseudo-randoming registration ID given a seed.
+genRegID :: Int -> RawCredentialRegistrationID
+genRegID seed = RawCredentialRegistrationID $! FBS.pack (randoms (mkStdGen seed))
+
+-- |Create a benchmark environment by populating the map and tries with the given number of
+-- generated credentials.
+setup :: Int -> IO Setup
+setup size = do
+    tempBlobStoreFile <- emptySystemTempFile "blb.dat"
+    setupBlobStore <- loadBlobStore tempBlobStoreFile
+    flip runBlobStoreM setupBlobStore $ do
+        (setupMemMap, bt) <- foldM add (Map.empty, Trie.empty) toInsert
+        setupBufferedTrie <- snd <$> storeUpdate bt
+        setupUnbufferedTrie <- case setupBufferedTrie of
+            Trie.EmptyTrieN -> return Trie.EmptyTrieN
+            Trie.TrieN sz (BufferedFix br) -> do
+                (_, blobRef) <- refFlush br
+                return $! Trie.TrieN sz (UnbufferedFix (blobRefToUnbufferedRef (BlobRef (theBlobRef blobRef))))
+        return $! Setup{..}
+  where
+    toInsert = [(genRegID x, fromIntegral x) | x <- [1 .. size]]
+    add (m, t) (regid, acctix) = do
+        (_, t') <- storeUpdate =<< Trie.insert regid acctix t
+        return (Map.insert regid acctix m, t')
+
+cleanup :: Setup -> IO ()
+cleanup = destroyBlobStore . setupBlobStore
+
+-- |Benchmark looking up specific registration IDs.
+benches :: Int -> Benchmark
+benches size = envWithCleanup (setup size) cleanup $ \cnf ->
+    let testRegID x = env (pure (genRegID x)) $ \regid ->
+            bgroup
+                ("Cred" ++ show x)
+                [ bench "map" $
+                    whnf
+                        (\(c, r) -> Map.lookup r (setupMemMap c) == xres)
+                        (cnf, regid),
+                  bench "mem-trie" $
+                    whnfIO
+                        ( do
+                            res <- runBlobStoreM (Trie.lookup regid (setupBufferedTrie cnf)) (setupBlobStore cnf)
+                            return (res == xres)
+                        ),
+                  bench "disk-trie" $
+                    whnfIO
+                        ( do
+                            res <- runBlobStoreM (Trie.lookup regid (setupUnbufferedTrie cnf)) (setupBlobStore cnf)
+                            return (res == xres)
+                        )
+                ]
+          where
+            !xres = if 1 <= x && x <= size then Just $! fromIntegral x else Nothing
+     in bgroup
+            ("Map size " ++ show size)
+            [ testRegID 1,
+              testRegID size,
+              testRegID (-1)
+            ]
+
+-- |Benchmark looking up random registration IDs. There should be a 50% chance of each occurring
+-- in the map.
+benchesRandom :: Int -> Benchmark
+benchesRandom size = envWithCleanup (setup size) cleanup $ \cnf ->
+    bgroup
+        ("Map size " ++ show size)
+        [ bench "map" $
+            perRunEnv
+                (genRegID <$> randomRIO (1, 2 * size))
+                ( \regid -> do
+                    let res = Map.lookup regid (setupMemMap cnf)
+                    return $ isJust res
+                ),
+          bench "mem-trie" $
+            perRunEnv
+                (genRegID <$> randomRIO (1, 2 * size))
+                ( \regid -> do
+                    res <- runBlobStoreM (Trie.lookup regid (setupBufferedTrie cnf)) (setupBlobStore cnf)
+                    return $ isJust res
+                ),
+          bench "disk-trie" $
+            perRunEnv
+                (genRegID <$> randomRIO (1, 2 * size))
+                ( \regid -> do
+                    res <- runBlobStoreM (Trie.lookup regid (setupUnbufferedTrie cnf)) (setupBlobStore cnf)
+                    return $ isJust res
+                )
+        ]
+
+main :: IO ()
+main = defaultMain [benchesRandom 100000, benchesRandom 1000000]

--- a/concordium-consensus/package.yaml
+++ b/concordium-consensus/package.yaml
@@ -366,3 +366,32 @@ benchmarks:
     - temporary >= 1.3
     - criterion
     - deepseq
+
+  credential-lookup:
+    main:                CredentialLookup.hs
+    source-dirs:         benchmarks/credential-lookup
+    ghc-options:
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N1
+    - -Wall
+    - -Wcompat
+    - -fno-ignore-asserts
+    - -Wno-deprecations
+    when:
+      - condition: os(windows)
+        then:
+          ghc-options: -static
+        else:
+          when:
+            - condition: flag(dynamic)
+              then:
+                ghc-options: -dynamic
+              else:
+                ghc-options: -static
+    dependencies:
+    - concordium-consensus
+    - containers
+    - temporary >= 1.3
+    - criterion
+    - deepseq

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
@@ -91,6 +91,7 @@ module Concordium.GlobalState.Persistent.BlobStore(
     UnbufferedRef,
     makeUnbufferedRef,
     makeFlushedUnbufferedRef,
+    blobRefToUnbufferedRef,
     -- * Fixpoint references
     BufferedFix(..),
     UnbufferedFix(..),
@@ -1099,6 +1100,10 @@ makeFlushedUnbufferedRef :: DirectBlobStorable m a => a -> m (UnbufferedRef a)
 makeFlushedUnbufferedRef val = do
     (r, _) <- storeUpdateDirect val
     return $! URBlobbed r
+
+-- |Create an 'UnbufferedRef' from a 'BlobRef'.
+blobRefToUnbufferedRef :: BlobRef a -> UnbufferedRef a
+blobRefToUnbufferedRef = URBlobbed
 
 instance DirectBlobStorable m a => Reference m UnbufferedRef a where
     refMake = makeUnbufferedRef

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -1840,7 +1840,7 @@ doRegIdExists :: (SupportsPersistentState pv m) => PersistentBlockState pv -> ID
 
 doRegIdExists pbs regid = do
         bsp <- loadPBS pbs
-        isJust . fst <$> Accounts.regIdExists regid (bspAccounts bsp)
+        isJust <$> Accounts.regIdExists regid (bspAccounts bsp)
 
 doCreateAccount :: (SupportsPersistentState pv m) => PersistentBlockState pv -> ID.GlobalContext -> AccountAddress -> ID.AccountCredential ->  m (Maybe (PersistentAccount (AccountVersionFor pv)), PersistentBlockState pv)
 doCreateAccount pbs cryptoParams acctAddr credential = do

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/Accounts.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/Accounts.hs
@@ -71,7 +71,7 @@ checkEquivalent ba pa = do
   let bath = getHash (B.accountTable ba) :: H.Hash
   path <- getHashM (P.accountTable pa)
   checkBinary (==) bath path "==" "Basic account table hash" "Persistent account table hash"
-  (pregids, _) <- P.loadRegIds pa
+  pregids <- P.loadRegIds pa
   checkBinary (==) (B.accountRegIds ba) pregids "==" "Basic registration ids" "Persistent registration ids"
   where
     -- Check whether an in-memory account-index and account pair is equivalent to a persistent account-index and account pair
@@ -99,7 +99,7 @@ data AccountAction
 
 randomizeAccount :: AccountAddress -> ID.CredentialPublicKeys -> Gen (Account (AccountVersionFor PV))
 randomizeAccount _accountAddress _accountVerificationKeys = do
-  let vfKey = snd . head $ (OrdMap.toAscList (ID.credKeys _accountVerificationKeys))
+  let vfKey = snd . head $ OrdMap.toAscList (ID.credKeys _accountVerificationKeys)
   let cred = dummyCredential dummyCryptographicParameters _accountAddress vfKey dummyMaxValidTo dummyCreatedAt
   let a0 = newAccount dummyCryptographicParameters _accountAddress cred
   nonce <- Nonce <$> arbitrary
@@ -239,9 +239,9 @@ runAccountAction ArchivePersistent (ba, pa) = do
   return (ba, pa')
 runAccountAction (RegIdExists rid) (ba, pa) = do
   let be = B.regIdExists rid ba
-  (pe, pa') <- P.regIdExists rid pa
+  pe <- P.regIdExists rid pa
   checkBinary (==) be pe "<->" "regid exists in basic" "regid exists in persistent"
-  return (ba, pa')
+  return (ba, pa)
 runAccountAction (RecordRegId rid ai) (ba, pa) = do
   let ba' = B.recordRegId (ID.toRawCredRegId rid) ai ba
   pa' <- P.recordRegId rid ai pa


### PR DESCRIPTION
## Purpose

Addresses #490.

This removes the in-memory map from credential registration IDs to account indexes. The persisted map is modified to be always on disk only.

Based on benchmarking, look-ups in the persisted map are ~1000 times slower than having the map in memory (around 100 microseconds). But the context in which this is used (primarily in credential deployments) this cost is acceptable.

## Changes

- Introduce `UnbufferedRef` reference type that is not cached in memory after it is flushed to the blob store.
- Introduce `UnbufferedFix`, a fixpoint combinator analogous to `BufferedFix` but using `UnbufferedRef` instead of `BufferedRef`.
- Support for migrating Tries that use `UnbufferedFix`.
- Remove the `accountRegIds` map, and handle all queries and additions in the Trie only.
- Add a benchmark for comparing the performance of querying by credential registration IDs with different indexes.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
