### PR TITLE
Implement the health check endpoint.

### DIFF
--- a/concordium-consensus/src/Concordium/GRPC2.hs
+++ b/concordium-consensus/src/Concordium/GRPC2.hs
@@ -2578,9 +2578,17 @@ getBlockFinalizationSummaryV2 cptr blockType blockHashPtr outHash outVec copierC
     res <- runMVR (Q.getBlockFinalizationSummary bhi) mvr
     returnMessageWithBlock (copier outVec) outHash res
 
-{- |Write the hash to the provided pointer, and if the message is given encode and
-   write it using the provided callback.
--}
+-- |Get the slot time of the last finalized block.
+getLastFinalizedBlockSlotTimeV2 ::
+        StablePtr Ext.ConsensusRunner ->
+        IO Timestamp
+getLastFinalizedBlockSlotTimeV2 cptr = do
+    Ext.ConsensusRunner mvr <- deRefStablePtr cptr
+    runMVR Q.getLastFinalizedSlotTime mvr
+
+
+-- |Write the hash to the provided pointer, and if the message is given encode and
+-- write it using the provided callback.
 returnMessageWithBlock ::
     (Proto.Message (Output a), ToProto a) =>
     (Ptr Word8 -> Int64 -> IO ()) ->
@@ -3110,3 +3118,8 @@ foreign export ccall getBlockFinalizationSummaryV2 ::
     -- |Callback to output data.
     FunPtr CopyToVecCallback ->
     IO Int64
+
+foreign export ccall
+    getLastFinalizedBlockSlotTimeV2 ::
+        StablePtr Ext.ConsensusRunner ->
+        IO Timestamp

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -330,6 +330,14 @@ getConsensusStatus = MVR $ \mvr -> do
                     csFinalizationPeriodEMSD = sqrt <$> stats ^. finalizationPeriodEMVar
                 return ConsensusStatus{..}
 
+-- |Retrieve the slot time of the last finalized block.
+getLastFinalizedSlotTime :: MVR gsconf finconf Timestamp
+getLastFinalizedSlotTime = MVR $ \mvr -> do
+    versions <- readIORef (mvVersions mvr)
+    liftSkovQuery mvr (Vec.last versions) $ do
+        lfb <- lastFinalizedBlock
+        utcTimeToTimestamp <$> getSlotTime (blockSlot lfb)
+
 -- * Queries against latest version
 
 -- ** Blocks

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -636,6 +636,7 @@ dependencies = [
  "toml",
  "tonic",
  "tonic-build",
+ "tonic-reflection",
  "tonic-web",
  "tower-http",
  "twox-hash",
@@ -3898,6 +3899,21 @@ dependencies = [
  "prost-build",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tonic-reflection"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0455f730d540a1484bffc3c55c94100b18a662597b982c2e9073f2c55c602616"
+dependencies = [
+ "bytes",
+ "prost",
+ "prost-types",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-build",
 ]
 
 [[package]]

--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -72,6 +72,7 @@ libc = "0.2"
 
 # gRPC dependencies
 tonic = { version = "0.8", features = ["tls"] }
+tonic-reflection = "0.5"
 tower-http = { version = "0.3", features = ["trace"] }
 tonic-web = "0.4"
 prost = "0.11"

--- a/concordium-node/build.rs
+++ b/concordium-node/build.rs
@@ -625,6 +625,19 @@ fn build_grpc2(proto_root_input: &str) -> std::io::Result<()> {
     // deserialization) we cannot build the client. But we also don't need it in the
     // node.
     tonic_build::manual::Builder::new().build_client(false).compile(&[query_service]);
+
+    {
+        let health = format!("{}/v2/concordium/health.proto", proto_root_input);
+        let descriptor_path =
+            std::path::PathBuf::from(env::var("OUT_DIR").unwrap()).join("health_descriptor.bin");
+        // build the health service with reflection support
+        tonic_build::configure()
+            .build_server(true)
+            .build_client(false)
+            .file_descriptor_set_path(descriptor_path)
+            .compile(&[&health], &[proto_root_input])
+            .expect("Failed to compile gRPC health definitions!");
+    }
     Ok(())
 }
 

--- a/concordium-node/src/configuration.rs
+++ b/concordium-node/src/configuration.rs
@@ -340,7 +340,7 @@ pub struct GRPC2Config {
         help = "Address the GRPC server should listen on, e.g., 127.0.0.1",
         env = "CONCORDIUM_NODE_GRPC2_LISTEN_ADDRESS"
     )]
-    pub listen_addr:      Option<std::net::IpAddr>,
+    pub listen_addr:                Option<std::net::IpAddr>,
     #[structopt(
         name = "grpc2-listen-port",
         long = "grpc2-listen-port",
@@ -348,7 +348,7 @@ pub struct GRPC2Config {
         help = "Address the GRPC server should listen on, e.g. 11000",
         env = "CONCORDIUM_NODE_GRPC2_LISTEN_PORT"
     )]
-    pub listen_port:      Option<u16>,
+    pub listen_port:                Option<u16>,
     #[structopt(
         long = "grpc2-x509-cert",
         help = "Certificate used to enable TLS support for the GRPC V2 server.",
@@ -356,7 +356,7 @@ pub struct GRPC2Config {
         requires = "grpc2-listen-addr",
         requires = "grpc2-cert-private-key"
     )]
-    pub x509_cert:        Option<PathBuf>,
+    pub x509_cert:                  Option<PathBuf>,
     #[structopt(
         long = "grpc2-cert-private-key",
         help = "Private key corresponding to the certificate",
@@ -364,14 +364,14 @@ pub struct GRPC2Config {
         requires = "grpc2-listen-addr",
         requires = "grpc2-x509-cert"
     )]
-    pub cert_private_key: Option<PathBuf>,
+    pub cert_private_key:           Option<PathBuf>,
     #[structopt(
         long = "grpc2-enable-grpc-web",
         help = "Enable support for GRPC-Web protocol.",
         env = "CONCORDIUM_NODE_GRPC2_ENABLE_GRPC_WEB",
         requires = "grpc2-listen-addr"
     )]
-    pub enable_grpc_web:  bool,
+    pub enable_grpc_web:            bool,
     #[structopt(
         long = "grpc2-endpoint-config",
         help = "Configuration file for endpoints, listing which endpoints should be enabled or \
@@ -380,7 +380,16 @@ pub struct GRPC2Config {
         env = "CONCORDIUM_NODE_GRPC2_ENDPOINT_CONFIG",
         requires = "grpc2-listen-addr"
     )]
-    pub endpoint_config:  Option<PathBuf>,
+    pub endpoint_config:            Option<PathBuf>,
+    #[structopt(
+        long = "grpc2-health-max-finalized-delay",
+        help = "Maximum amount of seconds that the time of the last finalized block can be behind \
+                present before the health check fails.",
+        env = "CONCORDIUM_NODE_GRPC2_HEALTH_MAX_FINALIZED_DELAY",
+        default_value = "300",
+        requires = "grpc2-listen-addr"
+    )]
+    pub health_max_finalized_delay: concordium_base::base::DurationSeconds,
 }
 
 impl GRPC2Config {

--- a/concordium-node/src/configuration.rs
+++ b/concordium-node/src/configuration.rs
@@ -386,8 +386,7 @@ pub struct GRPC2Config {
         help = "Maximum amount of seconds that the time of the last finalized block can be behind \
                 present before the health check fails.",
         env = "CONCORDIUM_NODE_GRPC2_HEALTH_MAX_FINALIZED_DELAY",
-        default_value = "300",
-        requires = "grpc2-listen-addr"
+        default_value = "300"
     )]
     pub health_max_finalized_delay: concordium_base::base::DurationSeconds,
 }

--- a/concordium-node/src/consensus_ffi/ffi.rs
+++ b/concordium-node/src/consensus_ffi/ffi.rs
@@ -1268,6 +1268,9 @@ extern "C" {
         out: *mut Vec<u8>,
         copier: CopyToVecCallback,
     ) -> i64;
+
+    /// Get the slot time (in milliseconds) of the last finalized block.
+    pub fn getLastFinalizedBlockSlotTimeV2(consensus: *mut consensus_runner) -> u64;
 }
 
 /// This is the callback invoked by consensus on newly arrived, and newly
@@ -2775,6 +2778,15 @@ impl ConsensusContainer {
         .try_into()?;
         response.ensure_ok("block")?;
         Ok((out_hash, out_data))
+    }
+
+    /// Get the slot time (in milliseconds) of the last finalized block.
+    pub fn get_last_finalized_block_slot_time_v2(
+        &self,
+    ) -> concordium_base::common::types::Timestamp {
+        let consensus = self.consensus.load(Ordering::SeqCst);
+        let millis = unsafe { getLastFinalizedBlockSlotTimeV2(consensus) };
+        millis.into()
     }
 }
 

--- a/concordium-node/src/health.rs
+++ b/concordium-node/src/health.rs
@@ -1,4 +1,4 @@
-//! Implementation of the healt check service that is part of the GRPC2
+//! Implementation of the health check service that is part of the GRPC2
 //! interface.
 
 use crate::consensus_ffi::consensus::ConsensusContainer;

--- a/concordium-node/src/health.rs
+++ b/concordium-node/src/health.rs
@@ -1,0 +1,47 @@
+//! Implementation of the healt check service that is part of the GRPC2
+//! interface.
+
+use crate::consensus_ffi::consensus::ConsensusContainer;
+
+include!(concat!(env!("OUT_DIR"), "/concordium.health.rs"));
+
+pub(crate) static HEALTH_DESCRIPTOR: &[u8] =
+    tonic::include_file_descriptor_set!("health_descriptor");
+
+/// The type that implements the service that responds to queries.
+pub(crate) struct HealthServiceImpl {
+    pub(crate) consensus:                     ConsensusContainer,
+    pub(crate) health_max_finalization_delay: concordium_base::base::DurationSeconds,
+}
+
+#[tonic::async_trait]
+impl health_server::Health for HealthServiceImpl {
+    async fn check(
+        &self,
+        _request: tonic::Request<NodeHealthRequest>,
+    ) -> Result<tonic::Response<NodeHealthResponse>, tonic::Status> {
+        let consensus_running = self.consensus.is_consensus_running();
+
+        if !consensus_running {
+            return Err(tonic::Status::unavailable("Consensus is not running."));
+        }
+
+        let last_fin_slot_time = self.consensus.get_last_finalized_block_slot_time_v2();
+
+        let current_time = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|_| tonic::Status::internal("Time went backwards."))?
+            .as_millis() as u64;
+
+        // If the slot time is in the future that is also good. We do accept blocks
+        // a little bit in the future, but consensus ensures they are not too far.
+        // That is why using saturating_sub is sensible.
+        let delta = current_time.saturating_sub(last_fin_slot_time.millis);
+
+        if delta > 1000 * u64::from(self.health_max_finalization_delay) {
+            return Err(tonic::Status::unavailable("Last finalized block is too far behind."));
+        }
+
+        Ok(tonic::Response::new(NodeHealthResponse {}))
+    }
+}

--- a/concordium-node/src/lib.rs
+++ b/concordium-node/src/lib.rs
@@ -52,3 +52,4 @@ pub mod flatbuffers_shim;
 mod macos_log;
 
 pub mod grpc2;
+mod health;

--- a/docs/grpc2.md
+++ b/docs/grpc2.md
@@ -31,6 +31,9 @@ If these are enabled then the following options become available
 - `--grpc2-enable-grpc-web` (`CONCORDIUM_NODE_GRPC2_ENABLE_GRPC_WEB`) if set,
   enables the server support for [grpc-web](https://github.com/grpc/grpc-web)
   over HTTP 1.1. This allows the node's API to be used directly from a browser.
+- `--grpc2-health-max-finalized-delay` is a configuration for the
+  `GetNodeHealth` endpoint. It specifies (in seconds) the maximum delay in last
+  finalized block time before the health check fails.
 - `--grpc2-endpoint-config` (`CONCORDIUM_NODE_GRPC2_ENDPOINT_CONFIG`) if
   supplied, it should point to a `.toml` file with the configuration of
   endpoints. If this option is not supplied all endpoints are enabled. If it is


### PR DESCRIPTION
## Purpose

Implement a basic health check service. The health check service has reflection enabled since that is required by automatic health checks in, e.g., AWS load balancers.

## Changes

Add a new health check endpoint that mainly checks whether we have recent enough finalized blocks.

If it becomes necessary we can configure additional checks later.

Depends on
- [ ] https://github.com/Concordium/concordium-grpc-api/pull/28


## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.