### PR TITLE
Fix for handling of protocol updates by the catch-up downloader.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add support for protocol version 5. This adds the following features
   - support for smart contract upgradability
+- Fix an issue where the catch-up downloader would fail at a protocol update.
 
 ## 4.5.0
 

--- a/concordium-node/src/bin/cli.rs
+++ b/concordium-node/src/bin/cli.rs
@@ -608,6 +608,7 @@ async fn import_missing_blocks(
         genesis_hash
     );
 
+    let mut mayskip = true;
     let mut chunk_records = csv_async::AsyncReaderBuilder::new()
         .comment(Some(b'#'))
         .has_headers(false)
@@ -621,8 +622,9 @@ async fn import_missing_blocks(
 
         let block_chunk_data: BlockChunkData = result?;
         // no need to reimport blocks that are present in the database
-        if block_chunk_data.genesis_index < current_genesis_index
-            || block_chunk_data.last_block_height <= last_finalized_block_height
+        if mayskip
+            && (block_chunk_data.genesis_index < current_genesis_index
+                || block_chunk_data.last_block_height <= last_finalized_block_height)
         {
             trace!(
                 "Skipping chunk {}: no blocks above last finalized block height",
@@ -630,6 +632,7 @@ async fn import_missing_blocks(
             );
             continue;
         }
+        mayskip = false;
         let block_chunk_url = index_url.join(&block_chunk_data.filename)?;
         let path = download_chunk(http_client.clone(), block_chunk_url, data_dir_path).await?;
         let import_result = consensus.import_blocks(&path);

--- a/concordium-node/src/bin/cli.rs
+++ b/concordium-node/src/bin/cli.rs
@@ -608,6 +608,9 @@ async fn import_missing_blocks(
         genesis_hash
     );
 
+    // We skip chunks until the first chunk that is at least at the current genesis
+    // index and finalized height relative to genesis. Once we have found one
+    // such chunk, we do not skip any further chunks.
     let mut mayskip = true;
     let mut chunk_records = csv_async::AsyncReaderBuilder::new()
         .comment(Some(b'#'))


### PR DESCRIPTION
## Purpose

Fixes #568.

Previously, the catch-up downloader would skip importing chunks where the genesis index was less than the genesis index at start up, or the height of all blocks (from latest genesis) was less than the height at start-up. This meant that after a protocol update the downloader could end up skipping chunks and then trying to process later chunks that have insufficient context.

## Changes

This changes the handling to only skip an initial portion of chunks. Once a valid chunk is encountered, all subsequent chunks will be imported (until a failure occurs).

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.

