### PR TITLE
Fix ownership of build artifacts

### DIFF
--- a/jenkinsfiles/bootstrapper.Jenkinsfile
+++ b/jenkinsfiles/bootstrapper.Jenkinsfile
@@ -53,8 +53,8 @@ pipeline {
         }
         stage('Build debian package') {
             environment {
-                EXTERNAL_UID = "${sh(script: 'id -u', returnStdout: true)}"
-                EXTERNAL_GID = "${sh(script: 'id -g', returnStdout: true)}"
+                EXTERNAL_UID = "${sh(script: 'id -u', returnStdout: true).trim()}"
+                EXTERNAL_GID = "${sh(script: 'id -g', returnStdout: true).trim()}"
             }
             steps {
                sh '''\

--- a/jenkinsfiles/database-exporter.Jenkinsfile
+++ b/jenkinsfiles/database-exporter.Jenkinsfile
@@ -43,6 +43,10 @@ pipeline {
             }
         }
         stage('build') {
+            environment {
+                EXTERNAL_UID = "${sh(script: 'id -u', returnStdout: true).trim()}"
+                EXTERNAL_GID = "${sh(script: 'id -g', returnStdout: true).trim()}"
+            }
             steps {
                sh '''\
                    docker build \

--- a/scripts/bootstrapper/copy.sh
+++ b/scripts/bootstrapper/copy.sh
@@ -5,7 +5,7 @@ set -euxo pipefail
 rm -rf /out/*
 cp /build/*.deb /out
 
-# Change ownership of build artifacts, this is used to unsure Jenkins 
+# Change ownership of build artifacts, this is used to ensure Jenkins 
 # can clean up build artifacts, as these a generated in docker image running as root.
 if [[ ! -z ${EXTERNAL_UID+x} ]] && [[ ! -z ${EXTERNAL_GID+x} ]]
 then

--- a/scripts/db-exporter/copy.sh
+++ b/scripts/db-exporter/copy.sh
@@ -5,7 +5,7 @@ set -euxo pipefail
 rm -rf /out/*
 cp /build/*.deb /out
 
-# Change ownership of build artifacts, this is used to unsure Jenkins 
+# Change ownership of build artifacts, this is used to ensure Jenkins 
 # can clean up build artifacts, as these a generated in docker image running as root.
 if [[ ! -z ${EXTERNAL_UID+x} ]] && [[ ! -z ${EXTERNAL_GID+x} ]]
 then

--- a/scripts/db-exporter/copy.sh
+++ b/scripts/db-exporter/copy.sh
@@ -5,5 +5,9 @@ set -euxo pipefail
 rm -rf /out/*
 cp /build/*.deb /out
 
-#TODO: Fix permissions on output
-#chown -R $EXTERNAL_UID:$EXTERNAL_GID /out
+# Change ownership of build artifacts, this is used to unsure Jenkins 
+# can clean up build artifacts, as these a generated in docker image running as root.
+if [[ ! -z ${EXTERNAL_UID+x} ]] && [[ ! -z ${EXTERNAL_GID+x} ]]
+then
+    chown -R $EXTERNAL_UID:$EXTERNAL_GID /out
+fi


### PR DESCRIPTION
## Purpose

Build artifacts built in docker containers running as root, will be owned by root, which means that Jenkins does not have permissions to remove the generated files.

## Changes

Added command to change ownership to whatever user Jenkins is running as, for all files copied out of the docker container.

## Checklist

- [ ] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

