### PR TITLE
Have services signal main thread to shut down (gracefully) when an er…

### DIFF
--- a/concordium-node/src/bin/cli.rs
+++ b/concordium-node/src/bin/cli.rs
@@ -159,8 +159,8 @@ async fn main() -> anyhow::Result<()> {
                     }
                     // The statistics service crashed.
                     Ok(NodeShutdownCause::StatsServer) => {}
-                    // Another service crashed.
-                    Ok(_) => {}
+                    // A signal was sent to terminate the node.
+                    Ok(NodeShutdownCause::Signal) => {}
                     Err(e) => {
                         error!(
                             "Node shutdown channel was dropped unexpectedly. This should not \

--- a/concordium-node/src/common/mod.rs
+++ b/concordium-node/src/common/mod.rs
@@ -15,3 +15,13 @@ pub use self::{
     p2p_node_id::P2PNodeId,
     p2p_peer::{P2PPeer, PeerStats, PeerType, RemotePeer},
 };
+
+/// Causes for shutting down the node. Used for notifying the main thread about
+/// signals and error conditions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum NodeShutdownCause {
+    RPCServer,
+    GRPC2Server,
+    StatsServer,
+    Signal,
+}

--- a/concordium-node/src/rpc.rs
+++ b/concordium-node/src/rpc.rs
@@ -2,7 +2,7 @@
 //! calls.
 
 use crate::{
-    common::{grpc_api::*, p2p_peer::RemotePeerId, PeerType},
+    common::{grpc_api::*, p2p_peer::RemotePeerId, NodeShutdownCause, PeerType},
     configuration,
     connection::ConnChange,
     consensus_ffi::{
@@ -61,10 +61,23 @@ impl RpcServerImpl {
     pub async fn start_server(
         &mut self,
         shutdown_signal: impl Future<Output = ()>,
+        shutdown_sender: tokio::sync::broadcast::Sender<NodeShutdownCause>,
     ) -> anyhow::Result<()> {
         let self_clone = self.clone();
         let server = Server::builder().add_service(P2pServer::new(self_clone));
-        server.serve_with_shutdown(self.listen_addr, shutdown_signal).await.map_err(|e| e.into())
+        let result = server
+            .serve_with_shutdown(self.listen_addr, shutdown_signal)
+            .await
+            .map_err(|e| e.into());
+        // If we are here, either an error occured, or the server was shut down.
+        if let Err(ref err) = result {
+            // Log an error and notify main thread that an error occured.
+            error!("A runtime error occurred in the GRPC2 server: {}", err);
+            if let Err(e) = shutdown_sender.send(NodeShutdownCause::RPCServer) {
+                error!("An error occurred while trying to signal the main node thread: {}.", e)
+            }
+        }
+        result
     }
 }
 
@@ -963,7 +976,8 @@ mod tests {
         config.cli.rpc.rpc_server_addr = "127.0.0.1".to_owned();
         config.cli.rpc.rpc_server_token = TOKEN.to_owned();
         let mut rpc_server = RpcServerImpl::new(node.clone(), None, &config.cli.rpc)?;
-        tokio::spawn(async move { rpc_server.start_server(future::pending()).await });
+        let (error_sender, _) = tokio::sync::broadcast::channel(1);
+        tokio::spawn(async move { rpc_server.start_server(future::pending(), error_sender).await });
         tokio::task::yield_now().await;
 
         let addr: &'static str =

--- a/concordium-node/src/rpc.rs
+++ b/concordium-node/src/rpc.rs
@@ -72,7 +72,7 @@ impl RpcServerImpl {
         // If we are here, either an error occured, or the server was shut down.
         if let Err(ref err) = result {
             // Log an error and notify main thread that an error occured.
-            error!("A runtime error occurred in the GRPC2 server: {}", err);
+            error!("A runtime error occurred in the RPC server: {}", err);
             if let Err(e) = shutdown_sender.send(NodeShutdownCause::RPCServer) {
                 error!("An error occurred while trying to signal the main node thread: {}.", e)
             }


### PR DESCRIPTION
## Purpose

If services that were configured to start fail, the node currently just resumes operation. In case this happens, it makes more sense to shut down the node gracefully.

## Changes

- [X] Allow services to message the main thread to stop.
- [X] Have services send messages to the main thread on errors.
- [X] Let the main thread terminate gracefully in the event of a failure.

## Tests
Test that the node terminates in case the
- [X] P2P server fails.
- [X] GRPC server fails.
- [X] GRPC2 server fails.
- [X] Instrumentation fails.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.