### PR TITLE
Migrate account schedules without using basic

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/AccountReleaseSchedule.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/AccountReleaseSchedule.hs
@@ -374,6 +374,7 @@ nextReleaseTimestamp :: AccountReleaseSchedule -> Maybe Timestamp
 nextReleaseTimestamp = fmap fst . Map.lookupMin . _arsPrioQueue
 
 -- |List a release as timestamp and amount pairs.
+-- The list will always be non-empty.
 listRelease :: MonadBlobStore m => Release -> m [(Timestamp, Amount)]
 listRelease loadedRelease = do
     next <- case _rNext loadedRelease of

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/AccountReleaseSchedule.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/AccountReleaseSchedule.hs
@@ -374,7 +374,7 @@ nextReleaseTimestamp :: AccountReleaseSchedule -> Maybe Timestamp
 nextReleaseTimestamp = fmap fst . Map.lookupMin . _arsPrioQueue
 
 -- |List a release as timestamp and amount pairs.
--- The list will always be non-empty.
+-- The list will never be empty.
 listRelease :: MonadBlobStore m => Release -> m [(Timestamp, Amount)]
 listRelease loadedRelease = do
     next <- case _rNext loadedRelease of


### PR DESCRIPTION
## Purpose

Migrate account release schedule during the P4 to P5 upgrade without using the pure representation defined in Basic block state.
Closes #616.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

