### PR TITLE
Make distributions builds support prometheus. Bump version to 5.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased changes
+
+## 5.1.1
+
 - Relay blocks earlier. In particular this means that blocks are now processed in 
   two steps, `block receive` and `block execute`. The former performs verification of block meta data
   while the latter adds the block to the tree.

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -564,7 +564,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_node"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "anyhow",
  "app_dirs2",

--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium_node"
-version = "5.1.0" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
+version = "5.1.1" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
 description = "Concordium Node"
 authors = ["Concordium <developers@concordium.com>"]
 exclude = [".gitignore", ".gitlab-ci.yml", "test/**/*","**/**/.gitignore","**/**/.gitlab-ci.yml"]

--- a/jenkinsfiles/ubuntu.Jenkinsfile
+++ b/jenkinsfiles/ubuntu.Jenkinsfile
@@ -79,7 +79,7 @@ pipeline {
         stage('Build static-node-binaries') {
             environment {
                 STATIC_LIBRARIES_IMAGE_TAG = "latest"
-                EXTRA_FEATURES = "collector"
+                EXTRA_FEATURES = "collector,instrumentation"
             }
             steps {
                 sh './scripts/static-binaries/build-static-binaries.sh'

--- a/scripts/distribution/docker/build-distribution-image.sh
+++ b/scripts/distribution/docker/build-distribution-image.sh
@@ -24,7 +24,7 @@
 set -euxo pipefail
 
 # Build the image and tag it as static-node-binaries
-GHC_VERSION="${ghc_version}" UBUNTU_VERSION=20.04 STATIC_LIBRARIES_IMAGE_TAG="${static_libraries_image_tag}" STATIC_BINARIES_IMAGE_TAG="${static_binaries_image_tag:-latest}" EXTRA_FEATURES="collector" ./scripts/static-binaries/build-static-binaries.sh
+GHC_VERSION="${ghc_version}" UBUNTU_VERSION=20.04 STATIC_LIBRARIES_IMAGE_TAG="${static_libraries_image_tag}" STATIC_BINARIES_IMAGE_TAG="${static_binaries_image_tag:-latest}" EXTRA_FEATURES="collector,instrumentation" ./scripts/static-binaries/build-static-binaries.sh
 
 # Then pack it all together with genesis
 DOCKER_BUILDKIT=1 docker build\

--- a/scripts/distribution/macOS-package/build.sh
+++ b/scripts/distribution/macOS-package/build.sh
@@ -163,7 +163,7 @@ function compileConsensus() {
 function compileNodeAndCollector() {
     cd "$nodeDir"
     logInfo "Building Node and Collector..."
-    cargo build --bin concordium-node --bin node-collector --features collector --release
+    cargo build --bin concordium-node --bin node-collector --features collector,instrumentation --release
     logInfo "Done"
 }
 

--- a/scripts/distribution/ubuntu-packages/build-mainnet-deb.sh
+++ b/scripts/distribution/ubuntu-packages/build-mainnet-deb.sh
@@ -15,7 +15,7 @@ if ! docker inspect --type=image static-node-binaries:$STATIC_BINARIES_IMAGE_TAG
     # build static binaries
     export STATIC_LIBRARIES_IMAGE_TAG="${STATIC_LIBRARIES_IMAGE_TAG:-latest}"
     export GHC_VERSION="${GHC_VERSION:-9.0.2}"
-    export EXTRA_FEATURES="collector"
+    export EXTRA_FEATURES="collector,instrumentation"
     (cd ../../../; ./scripts/static-binaries/build-static-binaries.sh)
 fi
 

--- a/scripts/distribution/ubuntu-packages/build-testnet-deb.sh
+++ b/scripts/distribution/ubuntu-packages/build-testnet-deb.sh
@@ -17,7 +17,7 @@ if ! docker inspect --type=image static-node-binaries:$STATIC_BINARIES_IMAGE_TAG
     # build static binaries
     export STATIC_LIBRARIES_IMAGE_TAG="${STATIC_LIBRARIES_IMAGE_TAG:-latest}"
     export GHC_VERSION="${GHC_VERSION:-9.0.2}"
-    export EXTRA_FEATURES="collector"
+    export EXTRA_FEATURES="collector,instrumentation"
     (cd ../../../; ./scripts/static-binaries/build-static-binaries.sh)
 fi
 

--- a/scripts/distribution/windows/build-all.ps1
+++ b/scripts/distribution/windows/build-all.ps1
@@ -13,7 +13,7 @@ stack build
 if ($LASTEXITCODE -ne 0) { throw "Failed building consensus" }
 
 Write-Output "Building node..."
-stack exec -- cargo build --manifest-path concordium-node\Cargo.toml --release --features collector
+stack exec -- cargo build --manifest-path concordium-node\Cargo.toml --release --features collector,instrumentation
 if ($LASTEXITCODE -ne 0) { throw "Failed building node" }
 
 Write-Output "Building node runner service..."

--- a/service/windows/installer/Node.wxs
+++ b/service/windows/installer/Node.wxs
@@ -2,9 +2,9 @@
 <!-- When updating the product version, the Product Id should be refreshed, otherwise it will not be
     possible to upgrade an existing installation.
 -->
-<?define VersionNumber="5.0.6" ?>
+<?define VersionNumber="5.1.1" ?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:Util="http://schemas.microsoft.com/wix/UtilExtension">
-    <Product Name="Concordium Node" Manufacturer="Concordium Software" Id="4963a0a4-d308-4e31-8648-16345da64ab3" UpgradeCode="297295b4-c716-4d33-8170-0f6136663bfd" Language="1033" Codepage="1252" Version="$(var.VersionNumber)">
+    <Product Name="Concordium Node" Manufacturer="Concordium Software" Id="6804a6cd-ef89-4e1b-944d-3d8a39791992" UpgradeCode="297295b4-c716-4d33-8170-0f6136663bfd" Language="1033" Codepage="1252" Version="$(var.VersionNumber)">
         <Package Id="*" Keywords="Concordium Installer" Description="Concordium Node $(var.VersionNumber) Installer" Manufacturer="Concordium Software" InstallerVersion="500" Languages="1033" Compressed="yes" InstallScope="perMachine" />
         <MajorUpgrade Schedule="afterInstallValidate" DowngradeErrorMessage="The currently-installed version of [ProductName] is newer than the version you are trying to install. The installation cannot continue. If you wish to install this version, please remove the newer version first." />
         <Media Id="1" Cabinet="Node.cab" EmbedCab="yes" />


### PR DESCRIPTION
## Purpose

- Prepare for stagenet release
- In order to support using the released distributions internally they have to support the prometheus server. Build the node with support for it.

## Changes

- Bump version
- Enable prometheus configuration in all node distributions


## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.