### PR TITLE
Avoid some deadlocks in message threads.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased changes
 
+- Avoid deadlocks during node shutdown in specific scenarios.
 - Remove the "instrumentation" feature of the node and build the node with
   Prometheus support enabled by default.
   - Remove the `CONCORDIUM_NODE_PROMETHEUS_SERVER` environment variable.

--- a/concordium-node/src/bin/cli.rs
+++ b/concordium-node/src/bin/cli.rs
@@ -48,6 +48,12 @@ use tokio::sync::{broadcast, oneshot};
 use concordium_node::stats_export_service::start_push_gateway;
 use std::net::{IpAddr, SocketAddr};
 
+/// Maximum time that threads that process inbound and outbound consensus
+/// messages are blocked on the condition variable per iteration of the loop.
+/// 100ms seems like a reasonable value. The loop which this controls is cheap
+/// if nothing has happened and the wakeup due to timeout was needless.
+const MESSAGE_THREAD_WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(100);
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let (conf, mut app_prefs) = get_config_and_logging_setup()?;
@@ -153,6 +159,7 @@ async fn main() -> anyhow::Result<()> {
             serv.start_server(shutdown_rpc_signal.map(|_| ()))
                 .await
                 .expect("Can't start the RPC server");
+            serv.start_server(shutdown_rpc_signal.map(|_| ())).await
         });
         Some(task)
     } else {
@@ -413,9 +420,14 @@ fn start_consensus_message_threads(
                     break 'outer_loop;
                 }
             }
-
             if exhausted {
-                cvar.wait(&mut lock_guard);
+                // Only wait for a limited amount of time.
+                // This is necessary since `notify_one` and `notify_all` are not buffered,
+                // and so events can be missed. In particular this happens during shutdown
+                // but it can also happen during normal operation. However in that case
+                // another message will likely be enqueued waking up the condvar, so
+                // the node would likely proceed correctly.
+                cvar.wait_for(&mut lock_guard, MESSAGE_THREAD_WAIT_TIMEOUT);
             }
         }
     }));
@@ -467,7 +479,13 @@ fn start_consensus_message_threads(
             }
 
             if exhausted {
-                cvar.wait(&mut lock_guard);
+                // Only wait for a limited amount of time.
+                // This is necessary since `notify_one` and `notify_all` are not buffered,
+                // and so events can be missed. In particular this happens during shutdown
+                // but it can also happen during normal operation. However in that case
+                // another message will likely be enqueued waking up the condvar, so
+                // the node would likely proceed correctly, albeit after some delay perhaps.
+                cvar.wait_for(&mut lock_guard, MESSAGE_THREAD_WAIT_TIMEOUT);
             }
         }
     }));


### PR DESCRIPTION
## Purpose

Likely addresses the remaining part of https://github.com/Concordium/concordium-node/issues/469

## Changes

Make the internal message loops more interactive. In particular avoid issues with missed notifications on the condition variable.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
