### PR TITLE
Use `select` instead of condition variables for message queue handling.

### DIFF
--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -601,7 +601,6 @@ dependencies = [
  "mio 0.7.14",
  "nohash-hasher",
  "noiseexplorer_xx",
- "parking_lot",
  "preferences",
  "prometheus",
  "prost",

--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -28,7 +28,6 @@ concordium_base = { path = "../concordium-base/rust-src/concordium_base" }
 wasm-chain-integration = { path = "../concordium-base/smart-contracts/wasm-chain-integration", default-features=false }
 
 # External dependencies
-parking_lot = "0.12"
 structopt = "0.3"
 rand = "0.7"
 mio = { version = "0.7", features = ["os-poll", "tcp"] }


### PR DESCRIPTION
## Purpose

This is an alternative solution to #632. That addressed the issue of missed wake-ups in the message queue handlers by setting a timeout (100ms) on waiting on the condition variable. While this handles the issue, it does not solve the underlying problem: missed wake-ups can still happen, but this will just lead to (small) delays. Moreover, it causes many spurious wake-ups, which is generally undesirable.

This change removes the condition variable altogether and instead waits on the message queues using [`select`](https://docs.rs/crossbeam/latest/crossbeam/macro.select.html), which allows waiting for a message on either queue.

## Changes

- Use `select` in the message handler loops to wait for new messages.
- Remove the condition variables previously used.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.