### PR TITLE
Database exporter issues

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -49,7 +49,7 @@ on:
   workflow_dispatch: # allow manual trigger
 
 env:
-  dummy: 8                 # change to force cache invalidation
+  dummy: 9                 # change to force cache invalidation
   CARGO_TERM_COLOR: always # implicitly adds '--color=always' to all cargo commands
   TEST_LEVEL: 1            # for stack tests
 

--- a/concordium-consensus/package.yaml
+++ b/concordium-consensus/package.yaml
@@ -51,6 +51,7 @@ dependencies:
 - concordium-base
 - base16-bytestring
 - aeson >= 1.4.2
+- attoparsec >= 0.14.4
 - text >= 1.2
 - filepath >= 1.4
 - directory >= 1.3
@@ -59,7 +60,6 @@ dependencies:
 - file-embed >= 0.0.11
 - lmdb
 - primitive
-- split
 - proto-lens >= 0.7
 - proto-lens-protobuf-types >= 0.7
 - proto-lens-runtime >= 0.7

--- a/concordium-consensus/tools/database-exporter/Main.hs
+++ b/concordium-consensus/tools/database-exporter/Main.hs
@@ -3,6 +3,7 @@
 -- blocks is correctly serialized.
 module Main where
 
+import Control.Monad
 import Data.Functor.Identity
 import Data.Serialize (runGet)
 import Data.Time
@@ -47,8 +48,12 @@ main = do
     Identity conf <- execParser opts
     case conf of
         Check file -> checkDatabase file
-        Export db filepath n | n > 0 -> exportDatabaseV3 db filepath n
-        Export _ _ _ -> putStrLn "Chunk size should be larger than 0"
+        Export db filepath n | n > 0 -> do
+            exportError <- exportDatabaseV3 db filepath n
+            when exportError $ exitWith $ ExitFailure 1
+        Export{} -> do
+            putStrLn "Chunk size should be larger than 0"
+            exitWith $ ExitFailure 2
   where
     opts =
         info


### PR DESCRIPTION
## Purpose

The database exporter currently has a few issues, primarily regarding usability. It could benefit from improving on a few things, notably:

- When the user provides an invalid database directory, changes are made to the filesystem anyways. User-specified parameters should be checked and invoking the exporter should be idempotent in case wrong parameters were provided.
- Parsing relies on `!!` and `read` in which case the exporter crashes with error messages that do not convey any useful information to the user.
- The exporter relies on genesis indices and block heights to decide which blocks to export, however it does not use the genesis hash. Specifically this means that it is possibly to export a database corresponding to one chain "on top of" an exported database from another chain.
- The block index file becomes messy over time, with duplicate entries. This works, but it looks ugly and is perhaps error-prone when compared to using a parser and accompanied with some intermediate representation of the file, as the following snippet shows:
```
...
blocks-2-1300001.dat,2,1300001,1383656
# genesis hash ea4a52a04ba905c2692b4598aa344707327781d588573d374125b449a1ce0bcc
blocks-3-1.dat,3,1,100000
blocks-3-100001.dat,3,100001,200000
blocks-3-200001.dat,3,200001,300000
blocks-3-300001.dat,3,300001,400000
blocks-3-400001.dat,3,400001,500000
blocks-3-500001.dat,3,500001,600000
blocks-3-600001.dat,3,600001,700000
blocks-3-700001.dat,3,700001,800000
# genesis hash ea4a52a04ba905c2692b4598aa344707327781d588573d374125b449a1ce0bcc
# genesis hash ea4a52a04ba905c2692b4598aa344707327781d588573d374125b449a1ce0bcc
# genesis hash ea4a52a04ba905c2692b4598aa344707327781d588573d374125b449a1ce0bcc
...
```
It would be nicer to have it look like:
```
...
blocks-2-1300001.dat,2,1300001,1383656
# genesis hash ea4a52a04ba905c2692b4598aa344707327781d588573d374125b449a1ce0bcc
blocks-3-1.dat,3,1,100000
blocks-3-100001.dat,3,100001,200000
blocks-3-200001.dat,3,200001,300000
blocks-3-300001.dat,3,300001,400000
blocks-3-400001.dat,3,400001,500000
blocks-3-500001.dat,3,500001,600000
blocks-3-600001.dat,3,600001,700000
blocks-3-700001.dat,3,700001,800000
...
```
- When a chunk is replaced by a new chunk in the block index, the new chunk is versioned and its filename is updated in the block index file. This leaves the old chunk file in the file system. It would be useful to include a flag indicating whether to use versioned chunk files or to simply overwrite existing chunks when applicable.
- If an error occurs, a line is removed from the `blocks.idx` file, but it is not reinserted. This block contains the finalization records of the database. When this happens, in some cases it seems that the chunk files listed in the block index file no longer corresponds to the format of the exported database. This can be currently fixed by performing a subsequent (successful) run of the exporter, but it would be better to have the exporter recover the database to an intact state when this happens.

## Changes

- [x] Add datatype for representing the block index file, `blocks.idx`.
- [x] Add `attoparsec` parser for parsing the block index file. The choice of library was made because it is a transitive dependency also used by `aeson`.
- [x] Add functionality for writing the block index representation to a string representation corresponding to the contents of `blocks.idx`
- [x] Add functionality for cleaning up existing, messy block index files output from previous versions of the database exporter.
- [x] Ensure that block index output files do not contain duplicate or dangling block hash section "headers". 
- [x] Add flag for indicating whether chunks should be overwritten or versioned copies should be made.
- [x] Add functionality for restoring the database to an intact state in case of an error.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.