### PR TITLE
Add helpers for using persistent block state in tests

### DIFF
--- a/concordium-consensus/tests/scheduler/SchedulerTests/BakerTransactions.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/BakerTransactions.hs
@@ -1,52 +1,43 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module SchedulerTests.BakerTransactions where
 
+import Control.Monad
+import Data.Bifunctor (first)
+import qualified Data.List as List
+import Lens.Micro.Platform
+import System.Random
 import Test.Hspec
 
 import Concordium.GlobalState.BakerInfo
-import Concordium.GlobalState.Basic.BlockState
-import Concordium.GlobalState.Basic.BlockState.Accounts as Acc
-import Concordium.GlobalState.Basic.BlockState.Bakers
-import Concordium.GlobalState.Basic.BlockState.Invariants
+import qualified Concordium.GlobalState.Basic.BlockState.Account as Basic
+import qualified Concordium.GlobalState.BlockState as BS
+import qualified Concordium.GlobalState.Persistent.BlockState as BS
 import qualified Concordium.Scheduler as Sch
-import qualified Concordium.Scheduler.EnvironmentImplementation as Types
 import Concordium.Scheduler.Runner
 import qualified Concordium.Scheduler.Types as Types
-import Concordium.TransactionVerification
 import Concordium.Types.Accounts (
     bakerAggregationVerifyKey,
     bakerElectionVerifyKey,
     bakerInfo,
     bakerSignatureVerifyKey,
  )
-import Control.Monad
-import Data.Foldable
-import qualified Data.Map.Strict as Map
-import Data.Maybe
-import System.Random
 
 import qualified Concordium.Crypto.BlockSignature as BlockSig
 import qualified Concordium.Crypto.BlsSignature as Bls
+import Concordium.Crypto.DummyData
 import qualified Concordium.Crypto.SignatureScheme as SigScheme
 import qualified Concordium.Crypto.VRF as VRF
-
-import Lens.Micro.Platform
-
-import Concordium.Crypto.DummyData
 import Concordium.GlobalState.DummyData
 import Concordium.Scheduler.DummyData
 import Concordium.Types.DummyData
 
-import SchedulerTests.Helpers
+import qualified SchedulerTests.Helpers as H
 import SchedulerTests.TestUtils
-
-import qualified Concordium.GlobalState.Basic.BlockState.LFMBTree as L
-
-shouldReturnP :: Show a => IO a -> (a -> Bool) -> IO ()
-shouldReturnP action f = action >>= (`shouldSatisfy` f)
 
 keyPair :: Int -> SigScheme.KeyPair
 keyPair = uncurry SigScheme.KeyPairEd25519 . fst . randomEd25519KeyPair . mkStdGen
@@ -54,13 +45,11 @@ keyPair = uncurry SigScheme.KeyPairEd25519 . fst . randomEd25519KeyPair . mkStdG
 account :: Int -> Types.AccountAddress
 account = accountAddressFrom
 
-initialBlockState :: BlockState PV1
-initialBlockState =
-    createBlockState $
-        foldr
-            putAccountWithRegIds
-            Acc.emptyAccounts
-            [mkAccount (SigScheme.correspondingVerifyKey (keyPair i)) (account i) 400_000_000_000 | i <- reverse [0 .. 3]]
+accounts :: (Types.IsAccountVersion av) => [Basic.Account av]
+accounts = [mkAccount (SigScheme.correspondingVerifyKey (keyPair i)) (account i) 400_000_000_000 | i <- [0 .. 3]]
+
+initialBlockState :: (Types.IsProtocolVersion pv) => H.PersistentBSM pv (BS.HashedPersistentBlockState pv)
+initialBlockState = H.createTestBlockStateWithAccounts accounts
 
 baker0 :: (FullBakerInfo, VRF.SecretKey, BlockSig.SignKey, Bls.SecretKey)
 baker0 = mkFullBaker 0 0
@@ -88,7 +77,7 @@ transactionsInput =
                 (baker0 ^. _4)
                 300_000_000_000
                 True,
-          metadata = makeDummyHeader (account 0) 1 10000,
+          metadata = makeDummyHeader (account 0) 1 10_000,
           keys = [(0, [(0, keyPair 0)])]
         },
       -- Add baker on account 1 (OK)
@@ -103,7 +92,7 @@ transactionsInput =
                 (baker1 ^. _4)
                 300_000_000_000
                 False,
-          metadata = makeDummyHeader (account 1) 1 10000,
+          metadata = makeDummyHeader (account 1) 1 10_000,
           keys = [(0, [(0, keyPair 1)])]
         },
       -- Add baker on account 2, duplicate aggregation key of baker 0 (FAIL)
@@ -118,7 +107,7 @@ transactionsInput =
                 (baker0 ^. _4)
                 300_000_000_000
                 False,
-          metadata = makeDummyHeader (account 2) 1 10000,
+          metadata = makeDummyHeader (account 2) 1 10_000,
           keys = [(0, [(0, keyPair 2)])]
         },
       -- Add baker on account 2, duplicate sign and election key of baker 0 (OK)
@@ -133,7 +122,7 @@ transactionsInput =
                 (baker2 ^. _4)
                 300_000_000_000
                 False,
-          metadata = makeDummyHeader (account 2) 2 10000,
+          metadata = makeDummyHeader (account 2) 2 10_000,
           keys = [(0, [(0, keyPair 2)])]
         },
       -- Update baker 0 with original keys (OK)
@@ -146,7 +135,7 @@ transactionsInput =
                 (baker0 ^. _3)
                 (baker0 ^. _1 . bakerInfo . bakerAggregationVerifyKey)
                 (baker0 ^. _4),
-          metadata = makeDummyHeader (account 0) 2 10000,
+          metadata = makeDummyHeader (account 0) 2 10_000,
           keys = [(0, [(0, keyPair 0)])]
         },
       -- Update baker 0 with baker1's aggregation key (FAIL)
@@ -159,7 +148,7 @@ transactionsInput =
                 (baker0 ^. _3)
                 (baker1 ^. _1 . bakerInfo . bakerAggregationVerifyKey)
                 (baker1 ^. _4),
-          metadata = makeDummyHeader (account 0) 3 10000,
+          metadata = makeDummyHeader (account 0) 3 10_000,
           keys = [(0, [(0, keyPair 0)])]
         },
       -- Add baker on account 3, bad election key proof (FAIL)
@@ -174,7 +163,7 @@ transactionsInput =
                 (baker3 ^. _4)
                 300_000_000_000
                 False,
-          metadata = makeDummyHeader (account 3) 1 10000,
+          metadata = makeDummyHeader (account 3) 1 10_000,
           keys = [(0, [(0, keyPair 3)])]
         },
       -- Add baker on account 3, bad sign key proof (FAIL)
@@ -189,7 +178,7 @@ transactionsInput =
                 (baker3 ^. _4)
                 300_000_000_000
                 False,
-          metadata = makeDummyHeader (account 3) 2 10000,
+          metadata = makeDummyHeader (account 3) 2 10_000,
           keys = [(0, [(0, keyPair 3)])]
         },
       -- Add baker on account 3, bad aggregation key proof (FAIL)
@@ -204,19 +193,19 @@ transactionsInput =
                 (baker0 ^. _4)
                 300_000_000_000
                 False,
-          metadata = makeDummyHeader (account 3) 3 10000,
+          metadata = makeDummyHeader (account 3) 3 10_000,
           keys = [(0, [(0, keyPair 3)])]
         },
       -- Remove baker 3 (FAIL)
       TJSON
         { payload = RemoveBaker,
-          metadata = makeDummyHeader (account 3) 4 10000,
+          metadata = makeDummyHeader (account 3) 4 10_000,
           keys = [(0, [(0, keyPair 3)])]
         },
       -- Remove baker 0 (OK)
       TJSON
         { payload = RemoveBaker,
-          metadata = makeDummyHeader (account 0) 4 10000,
+          metadata = makeDummyHeader (account 0) 4 10_000,
           keys = [(0, [(0, keyPair 0)])]
         },
       -- Add baker on account 3 with baker 0's keys (FAIL)
@@ -232,7 +221,7 @@ transactionsInput =
                 (baker0 ^. _4)
                 300_000_000_000
                 False,
-          metadata = makeDummyHeader (account 3) 5 10000,
+          metadata = makeDummyHeader (account 3) 5 10_000,
           keys = [(0, [(0, keyPair 3)])]
         },
       -- Update baker 1 with bad sign key proof (FAIL)
@@ -245,7 +234,7 @@ transactionsInput =
                 (baker1 ^. _3)
                 (baker1 ^. _1 . bakerInfo . bakerAggregationVerifyKey)
                 (baker1 ^. _4),
-          metadata = makeDummyHeader (account 1) 2 10000,
+          metadata = makeDummyHeader (account 1) 2 10_000,
           keys = [(0, [(0, keyPair 1)])]
         },
       -- Update baker 1 with bad election key proof (FAIL)
@@ -258,7 +247,7 @@ transactionsInput =
                 (baker3 ^. _3)
                 (baker1 ^. _1 . bakerInfo . bakerAggregationVerifyKey)
                 (baker1 ^. _4),
-          metadata = makeDummyHeader (account 1) 3 10000,
+          metadata = makeDummyHeader (account 1) 3 10_000,
           keys = [(0, [(0, keyPair 1)])]
         },
       -- Update baker 1 with bad aggregation key proof (FAIL)
@@ -271,125 +260,96 @@ transactionsInput =
                 (baker1 ^. _3)
                 (baker1 ^. _1 . bakerInfo . bakerAggregationVerifyKey)
                 (baker3 ^. _4),
-          metadata = makeDummyHeader (account 1) 4 10000,
+          metadata = makeDummyHeader (account 1) 4 10_000,
           keys = [(0, [(0, keyPair 1)])]
         }
     ]
 
-type TestResult =
-    ( [ ( [(BlockItemWithStatus, Types.ValidResult)],
-          [(TransactionWithStatus, Types.FailureKind)],
-          BasicBirkParameters 'Types.AccountV0
-        )
-      ],
-      BlockState PV1,
-      Types.Amount
-    )
-
-runWithIntermediateStates :: IO TestResult
-runWithIntermediateStates = do
-    txs <- processUngroupedTransactions transactionsInput
-    let (res, state, feeTotal) =
-            foldl'
-                ( \(acc, st, fees) tx ->
-                    let (Sch.FilteredTransactions{..}, st') =
-                            Types.runSI
-                                (Sch.filterTransactions dummyBlockSize dummyBlockTimeout (Types.fromTransactions [tx]))
-                                dummyChainMeta
-                                maxBound
-                                maxBound
-                                st
-                    in  (acc ++ [(getResults ftAdded, ftFailed, st' ^. Types.ssBlockState . blockBirkParameters)], st' ^. Types.schedulerBlockState, fees + st' ^. Types.schedulerExecutionCosts)
-                )
-                ([], initialBlockState, 0)
-                (Types.perAccountTransactions txs)
-    return (res, state, feeTotal)
-
-keysL :: L.LFMBTree Types.BakerId (Maybe FullBakerInfo) -> [Types.BakerId]
-keysL t =
-    let l = L.toAscPairList t
-    in  [i | (i, Just _) <- l]
-
-getL :: L.LFMBTree Types.BakerId (Maybe FullBakerInfo) -> Types.BakerId -> FullBakerInfo
-getL t bid = fromJust $ join $ L.lookup bid t
+type TestResult pv = ([(H.SchedulerResult, [Types.BakerId])], BS.HashedPersistentBlockState pv)
 
 tests :: Spec
 tests = do
-    (results, endState, feeTotal) <- runIO runWithIntermediateStates
-    describe "Baker transactions." $ do
-        specify "Result state satisfies invariant" $
-            case invariantBlockState endState feeTotal of
-                Left f -> expectationFailure f
-                Right _ -> return ()
+    (outcomes, endState) <- runIO $ do
+        txs <- processUngroupedTransactions transactionsInput
+        H.runSchedulerTestWithIntermediateStates @PV1 H.defaultTestConfig initialBlockState BS.bsoGetActiveBakers txs
+    let results = first (H.getResults . Sch.ftAdded . H.srTransactions) <$> outcomes
+
+    describe "P1: Baker transactions." $ do
+        specify "Result state satisfies invariant" $ do
+            let feeTotal = sum $ H.srExecutionCosts . fst <$> outcomes
+            join $ H.runTestBlockState $ H.assertBlockStateInvariants endState feeTotal
         specify "Correct number of transactions" $
             length results `shouldBe` length transactionsInput
+        specify "No failed transactions" $ do
+            let failedTransactions = List.concatMap (Sch.ftFailed . H.srTransactions . fst) outcomes
+            failedTransactions `shouldSatisfy` List.null
         specify "Adding two bakers from initial empty state" $
             case take 2 results of
-                [ ([(_, Types.TxSuccess [Types.BakerAdded{ebaBakerId = 0}])], [], bps1),
-                  ([(_, Types.TxSuccess [Types.BakerAdded{ebaBakerId = 1}])], [], bps2)
+                [ ([(_, Types.TxSuccess [Types.BakerAdded{ebaBakerId = 0}])], bakers1),
+                  ([(_, Types.TxSuccess [Types.BakerAdded{ebaBakerId = 1}])], bakers2)
                     ] -> do
-                        Map.keys (bps1 ^. birkActiveBakers . activeBakers) `shouldBe` [0]
-                        Map.keys (bps2 ^. birkActiveBakers . activeBakers) `shouldBe` [0, 1]
-                _ -> expectationFailure $ show (take 2 results)
+                        bakers1 `shouldBe` [0]
+                        bakers2 `shouldBe` [0, 1]
+                r -> expectationFailure $ "Unexpected outcome: " ++ show r
         specify "Fail to add baker with duplicate aggregation key" $
             case results !! 2 of
-                ([(_, Types.TxReject (Types.DuplicateAggregationKey _))], [], bps) ->
-                    Map.keys (bps ^. birkActiveBakers . activeBakers) `shouldBe` [0, 1]
+                ([(_, Types.TxReject (Types.DuplicateAggregationKey _))], bakers) ->
+                    bakers `shouldBe` [0, 1]
                 r -> expectationFailure $ "Unexpected outcome: " ++ show r
         specify "Add baker with duplicate sign and election keys" $
             case results !! 3 of
-                ([(_, Types.TxSuccess [Types.BakerAdded{ebaBakerId = 2}])], [], bps) ->
-                    Map.keys (bps ^. birkActiveBakers . activeBakers) `shouldBe` [0, 1, 2]
+                ([(_, Types.TxSuccess [Types.BakerAdded{ebaBakerId = 2}])], bakers) ->
+                    bakers `shouldBe` [0, 1, 2]
                 r -> expectationFailure $ "Unexpected outcome: " ++ show r
         specify "Update baker 0 with original keys" $
             case results !! 4 of
-                ([(_, Types.TxSuccess [Types.BakerKeysUpdated 0 _ _ _ _])], [], bps) ->
-                    Map.keys (bps ^. birkActiveBakers . activeBakers) `shouldBe` [0, 1, 2]
+                ([(_, Types.TxSuccess [Types.BakerKeysUpdated 0 _ _ _ _])], bakers) ->
+                    bakers `shouldBe` [0, 1, 2]
                 r -> expectationFailure $ "Unexpected outcome: " ++ show r
         specify "Fail to update baker 0 with baker 1's aggregation key" $
             case results !! 5 of
-                ([(_, Types.TxReject (Types.DuplicateAggregationKey _))], [], _) -> return ()
+                ([(_, Types.TxReject (Types.DuplicateAggregationKey _))], _) -> return ()
                 r -> expectationFailure $ "Unexpected outcome: " ++ show r
         specify "Fail to add baker with bad election key proof" $
             case results !! 6 of
-                ([(_, Types.TxReject Types.InvalidProof)], [], _) -> return ()
+                ([(_, Types.TxReject Types.InvalidProof)], _) -> return ()
                 r -> expectationFailure $ "Unexpected outcome: " ++ show r
         specify "Fail to add baker with bad sign key proof" $
             case results !! 7 of
-                ([(_, Types.TxReject Types.InvalidProof)], [], _) -> return ()
+                ([(_, Types.TxReject Types.InvalidProof)], _) -> return ()
                 r -> expectationFailure $ "Unexpected outcome: " ++ show r
         specify "Fail to add baker with bad aggregation key proof" $
             case results !! 8 of
-                ([(_, Types.TxReject Types.InvalidProof)], [], _) -> return ()
+                ([(_, Types.TxReject Types.InvalidProof)], _) -> return ()
                 r -> expectationFailure $ "Unexpected outcome: " ++ show r
         specify "Fail to remove non-existent baker" $
             case results !! 9 of
-                ([(_, Types.TxReject (Types.NotABaker acct))], [], bps) -> do
-                    Map.keys (bps ^. birkActiveBakers . activeBakers) `shouldBe` [0, 1, 2]
+                ([(_, Types.TxReject (Types.NotABaker acct))], bakers) -> do
+                    bakers `shouldBe` [0, 1, 2]
                     acct `shouldBe` account 3
                 r -> expectationFailure $ "Unexpected outcome: " ++ show r
         specify "Remove baker 0" $
             case results !! 10 of
-                ([(_, Types.TxSuccess [Types.BakerRemoved 0 acct])], [], bps) -> do
+                ([(_, Types.TxSuccess [Types.BakerRemoved 0 acct])], bakers) -> do
                     -- The baker should still be in the active bakers due to cooldown
-                    Map.keys (bps ^. birkActiveBakers . activeBakers) `shouldBe` [0, 1, 2]
+                    bakers `shouldBe` [0, 1, 2]
                     acct `shouldBe` account 0
                 r -> expectationFailure $ "Unexpected outcome: " ++ show r
         specify "Fail to add baker with baker 0's keys" $
             case results !! 11 of
-                ([(_, Types.TxReject (Types.DuplicateAggregationKey _))], [], bps) ->
+                ([(_, Types.TxReject (Types.DuplicateAggregationKey _))], bakers) ->
                     -- The baker should still be in the active bakers due to cooldown
-                    Map.keys (bps ^. birkActiveBakers . activeBakers) `shouldBe` [0, 1, 2]
+                    bakers `shouldBe` [0, 1, 2]
                 r -> expectationFailure $ "Unexpected outcome: " ++ show r
         specify "Fail to update baker with bad election key proof" $
             case results !! 12 of
-                ([(_, Types.TxReject Types.InvalidProof)], [], _) -> return ()
+                ([(_, Types.TxReject Types.InvalidProof)], _) -> return ()
                 r -> expectationFailure $ "Unexpected outcome: " ++ show r
         specify "Fail to update baker with bad sign key proof" $
             case results !! 13 of
-                ([(_, Types.TxReject Types.InvalidProof)], [], _) -> return ()
+                ([(_, Types.TxReject Types.InvalidProof)], _) -> return ()
                 r -> expectationFailure $ "Unexpected outcome: " ++ show r
         specify "Fail to update baker with bad aggregation key proof" $
             case results !! 14 of
-                ([(_, Types.TxReject Types.InvalidProof)], [], _) -> return ()
+                ([(_, Types.TxReject Types.InvalidProof)], _) -> return ()
                 r -> expectationFailure $ "Unexpected outcome: " ++ show r

--- a/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
@@ -1,24 +1,429 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module SchedulerTests.Helpers where
 
-import qualified Concordium.Cost as Cost
-import Concordium.Scheduler.Types
-import qualified Concordium.Scheduler.Types as Types
+import qualified Control.Monad.Except as Except
+import Control.Monad.RWS.Strict
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import Data.Time
 import Data.Word
+import Lens.Micro.Platform
+import Test.HUnit
 
-getResults :: [(a, TransactionSummary)] -> [(a, ValidResult)]
-getResults = map (\(x, r) -> (x, tsResult r))
+import qualified Concordium.Crypto.SHA256 as Hash
+import qualified Concordium.ID.Types as Types
+import qualified Concordium.Types.Accounts.Releases as Types
+import Concordium.Types.SeedState (initialSeedState)
+
+import qualified Concordium.Cost as Cost
+import qualified Concordium.GlobalState.Basic.BlockState.Account as Basic
+import qualified Concordium.GlobalState.BlockState as BS
+import qualified Concordium.GlobalState.DummyData as DummyData
+import qualified Concordium.GlobalState.Persistent.Account as BS
+import qualified Concordium.GlobalState.Persistent.BlobStore as Blob
+import qualified Concordium.GlobalState.Persistent.BlockState as BS
+import qualified Concordium.GlobalState.Persistent.BlockState.Modules as BS
+import Concordium.GlobalState.Persistent.Cache
+import qualified Concordium.GlobalState.Rewards as Rewards
+import Concordium.GlobalState.Types
+import Concordium.Logger
+import Concordium.Scheduler
+import qualified Concordium.Scheduler.DummyData as DummyData
+import qualified Concordium.Scheduler.EnvironmentImplementation as EI
+import qualified Concordium.Scheduler.Runner as SchedTest
+import Concordium.Scheduler.TreeStateEnvironment
+import qualified Concordium.Scheduler.Types as Types
+import Concordium.TimeMonad
+
+getResults :: [(a, Types.TransactionSummary)] -> [(a, Types.ValidResult)]
+getResults = map (\(x, r) -> (x, Types.tsResult r))
 
 -- | The cost for processing a simple transfer (account to account)
 -- with one signature in the transaction.
 --
 -- * @SPEC: <$DOCS/Transactions#transaction-cost-header-simple-transfer>
-simpleTransferCost :: Energy
+simpleTransferCost :: Types.Energy
 simpleTransferCost = Cost.baseCost (Types.transactionHeaderSize + 41) 1 + Cost.simpleTransferCost
 
-simpleTransferCostWithMemo1 :: Word64 -> Energy
-simpleTransferCostWithMemo1 memoSize = Cost.baseCost (Types.transactionHeaderSize + 41 + 2 + memoSize) 1
+simpleTransferCostWithMemo1 :: Word64 -> Types.Energy
+simpleTransferCostWithMemo1 memoSize =
+    Cost.baseCost
+        (Types.transactionHeaderSize + 41 + 2 + memoSize)
+        1
 
-simpleTransferCostWithMemo2 :: Word64 -> Energy
-simpleTransferCostWithMemo2 memoSize = Cost.baseCost (Types.transactionHeaderSize + 41 + 2 + memoSize) 1 + Cost.simpleTransferCost
+simpleTransferCostWithMemo2 :: Word64 -> Types.Energy
+simpleTransferCostWithMemo2 memoSize =
+    Cost.baseCost
+        (Types.transactionHeaderSize + 41 + 2 + memoSize)
+        1
+        + Cost.simpleTransferCost
+
+-- | Monad that implements the necessary constraints to be used for running the scheduler.
+newtype PersistentBSM pv a = PersistentBSM
+    { _runPersistentBSM ::
+        BS.PersistentBlockStateMonad
+            pv
+            (BS.PersistentBlockStateContext pv)
+            (Blob.BlobStoreM' (BS.PersistentBlockStateContext pv))
+            a
+    }
+    deriving
+        ( Applicative,
+          Functor,
+          Monad,
+          BS.AccountOperations,
+          BS.ContractStateOperations,
+          BS.ModuleQuery,
+          MonadProtocolVersion,
+          BlockStateTypes,
+          Blob.MonadBlobStore,
+          BS.BlockStateQuery,
+          BS.BlockStateOperations,
+          MonadIO,
+          MonadCache BS.ModuleCache,
+          BS.BlockStateStorage
+        )
+
+deriving instance
+    (Types.AccountVersionFor pv ~ av) =>
+    MonadCache (BS.AccountCache av) (PersistentBSM pv)
+
+instance MonadLogger (PersistentBSM pv) where
+    logEvent _ _ _ = return ()
+
+instance TimeMonad (PersistentBSM pv) where
+    currentTime = return $ read "1970-01-01 13:27:13.257285424 UTC"
+
+-- |Call a function for each protocol version, returning a list of results.
+-- This is used to run a test against every protocol version.
+forEveryProtocolVersion ::
+    (forall pv. (Types.IsProtocolVersion pv) => Types.SProtocolVersion pv -> String -> a) ->
+    [a]
+forEveryProtocolVersion check =
+    [ check Types.SP1 "P1",
+      check Types.SP2 "P2",
+      check Types.SP3 "P3",
+      check Types.SP4 "P4",
+      check Types.SP5 "P5"
+    ]
+
+-- |Construct a test block state containing the provided accounts.
+createTestBlockStateWithAccounts ::
+    (Types.IsProtocolVersion pv) =>
+    [Basic.Account (Types.AccountVersionFor pv)] ->
+    PersistentBSM pv (BS.HashedPersistentBlockState pv)
+createTestBlockStateWithAccounts accounts =
+    BS.initialPersistentState
+        (initialSeedState (Hash.hash "") 1_000)
+        DummyData.dummyCryptographicParameters
+        accounts
+        DummyData.dummyIdentityProviders
+        DummyData.dummyArs
+        DummyData.dummyKeyCollection
+        DummyData.dummyChainParameters
+
+-- |Run test block state computation provided a cache size.
+runTestBlockStateWithCacheSize :: Int -> PersistentBSM pv a -> IO a
+runTestBlockStateWithCacheSize cacheSize computation =
+    Blob.runBlobStoreTemp "." $
+        BS.withNewAccountCache cacheSize $
+            BS.runPersistentBlockStateMonad $
+                _runPersistentBSM computation
+
+-- |Run test block state computation with a cache size of 100.
+runTestBlockState :: PersistentBSM pv a -> IO a
+runTestBlockState = runTestBlockStateWithCacheSize 100
+
+-- |Config the for running the scheduler in a test environment.
+data TestConfig = TestConfig
+    { -- | Maximum block size in bytes.
+      tcBlockSize :: Integer,
+      -- |Timeout for block construction.
+      -- This is the absolute time after which we stop trying to add new transctions to the block.
+      tcBlockTimeout :: UTCTime,
+      -- |The context state used for running the scheduler.
+      tcContextState :: EI.ContextState
+    }
+
+-- |Default settings the running the scheduler in a test environment.
+defaultTestConfig :: TestConfig
+defaultTestConfig =
+    TestConfig
+        { tcBlockSize = DummyData.dummyBlockSize,
+          tcBlockTimeout = DummyData.dummyBlockTimeout,
+          tcContextState = defaultContextState
+        }
+
+defaultContextState :: EI.ContextState
+defaultContextState =
+    EI.ContextState
+        { _chainMetadata = DummyData.dummyChainMeta,
+          _maxBlockEnergy = maxBound,
+          _accountCreationLimit = maxBound
+        }
+
+-- |Result from running the scheduler in a test environment.
+data SchedulerResult = SchedulerResult
+    { -- | The outcome for constructing a block.
+      srTransactions :: FilteredTransactions,
+      -- | The total execution cost of the block.
+      srExecutionCosts :: Types.Amount,
+      -- | The total execution energy of the block.
+      srUsedEnergy :: Types.Energy
+    }
+
+-- | Run the scheduler on transactions in a test environment.
+runScheduler ::
+    forall pv.
+    (Types.IsProtocolVersion pv) =>
+    TestConfig ->
+    BS.HashedPersistentBlockState pv ->
+    Types.GroupedTransactions ->
+    PersistentBSM pv (SchedulerResult, BS.PersistentBlockState pv)
+runScheduler TestConfig{..} stateBefore transactions = do
+    blockStateBefore <- BS.thawBlockState stateBefore
+    let txs = filterTransactions tcBlockSize tcBlockTimeout transactions
+    let schedulerState = EI.mkInitialSS @(PersistentBSM pv) blockStateBefore
+    (filteredTransactions, stateAfter, ()) <- runRWST (_runBSM txs) tcContextState schedulerState
+
+    let result =
+            SchedulerResult
+                { srTransactions = filteredTransactions,
+                  srExecutionCosts = EI._ssSchedulerExecutionCosts stateAfter,
+                  srUsedEnergy = EI._ssSchedulerEnergyUsed stateAfter
+                }
+    return (result, EI._ssBlockState stateAfter)
+
+-- | Run the scheduler on transactions in a test environment.
+-- Allows for a block state monad computation for constructing the initial block state and takes a
+-- block state monad computation for extracting relevant values.
+runSchedulerTest ::
+    forall pv a.
+    (Types.IsProtocolVersion pv) =>
+    TestConfig ->
+    PersistentBSM pv (BS.HashedPersistentBlockState pv) ->
+    (BS.PersistentBlockState pv -> PersistentBSM pv a) ->
+    Types.GroupedTransactions ->
+    IO (SchedulerResult, a)
+runSchedulerTest config constructState extractor transactions = runTestBlockState computation
+  where
+    computation :: PersistentBSM pv (SchedulerResult, a)
+    computation = do
+        blockStateBefore <- constructState
+        (result, blockStateAfter) <- runScheduler config blockStateBefore transactions
+        (result,) <$> extractor blockStateAfter
+
+-- | Run the scheduler on transactions in a test environment.
+-- Allows for a block state monad computation for constructing the initial block state and takes a
+-- block state monad computation for extracting relevant values.
+--
+-- The transactions are provided using TransactionJSON.
+runSchedulerTestTransactionJson ::
+    forall pv a.
+    (Types.IsProtocolVersion pv) =>
+    TestConfig ->
+    PersistentBSM pv (BS.HashedPersistentBlockState pv) ->
+    (BS.PersistentBlockState pv -> PersistentBSM pv a) ->
+    [SchedTest.TransactionJSON] ->
+    IO (SchedulerResult, a)
+runSchedulerTestTransactionJson config constructState extractor transactionJsonList = do
+    transactions <- SchedTest.processUngroupedTransactions transactionJsonList
+    runSchedulerTest config constructState extractor transactions
+
+-- | Intermediate results collected while running a number of transactions.
+type IntermediateResults a = [(SchedulerResult, a)]
+
+-- | Run the scheduler on transactions in a test environment, while collecting all of the
+-- intermediate results and extracted values.
+runSchedulerTestWithIntermediateStates ::
+    forall pv a.
+    (Types.IsProtocolVersion pv) =>
+    TestConfig ->
+    PersistentBSM pv (BS.HashedPersistentBlockState pv) ->
+    (BS.PersistentBlockState pv -> PersistentBSM pv a) ->
+    Types.GroupedTransactions ->
+    IO (IntermediateResults a, BS.HashedPersistentBlockState pv)
+runSchedulerTestWithIntermediateStates config constructState extractor transactions =
+    runTestBlockState blockStateComputation
+  where
+    blockStateComputation :: PersistentBSM pv (IntermediateResults a, BS.HashedPersistentBlockState pv)
+    blockStateComputation = do
+        blockStateBefore <- constructState
+        foldM transactionRunner ([], blockStateBefore) transactions
+
+    transactionRunner ::
+        (IntermediateResults a, BS.HashedPersistentBlockState pv) ->
+        Types.TransactionGroup ->
+        PersistentBSM pv (IntermediateResults a, BS.HashedPersistentBlockState pv)
+    transactionRunner (acc, currentState) tx = do
+        (result, updatedState) <- runScheduler config currentState [tx]
+        extracted <- extractor updatedState
+        nextState <- BS.freezeBlockState updatedState
+        return (acc ++ [(result, extracted)], nextState)
+
+-- | Save and load block state, used to test the block state written to disc.
+reloadBlockState ::
+    (Types.IsProtocolVersion pv) =>
+    BS.PersistentBlockState pv ->
+    PersistentBSM pv (BS.PersistentBlockState pv)
+reloadBlockState persistentState = do
+    frozen <- BS.freezeBlockState persistentState
+    br <- BS.saveBlockState frozen
+    BS.thawBlockState =<< BS.loadBlockState (BS.hpbsHash frozen) br
+
+-- | Information accumulated when iterating the accounts in block state during
+-- checkBlockStateInvariants.
+type AccountAccumulated =
+    ( Map.Map Types.AccountAddress Types.AccountIndex,
+      Map.Map Types.RawCredentialRegistrationID Types.AccountIndex,
+      Set.Set Types.BakerId,
+      Types.Amount
+    )
+
+-- | Check block state for a number of invariants.
+assertBlockStateInvariants ::
+    (Types.IsProtocolVersion pv) =>
+    BS.HashedPersistentBlockState pv ->
+    Types.Amount ->
+    PersistentBSM pv Assertion
+assertBlockStateInvariants bs extraBalance = do
+    result <- Except.runExceptT $ checkBlockStateInvariants bs extraBalance
+    return $ either assertFailure return result
+
+-- | Check block state for a number of invariants.
+checkBlockStateInvariants ::
+    forall pv.
+    (Types.IsProtocolVersion pv) =>
+    BS.HashedPersistentBlockState pv ->
+    Types.Amount ->
+    Except.ExceptT String (PersistentBSM pv) ()
+checkBlockStateInvariants bs extraBalance = do
+    -- Iterate all of the accounts in block state, check and accumulate the total public balance.
+    allAccounts <- BS.getAccountList bs
+    allActiveBakers <- Set.fromList <$> BS.getActiveBakers bs
+    (_, _, bakerIdsLeft, totalAmountAccounts) <-
+        foldM
+            checkAccount
+            (Map.empty, Map.empty, allActiveBakers, 0)
+            allAccounts
+    -- Ensure all of the active bakers were covered by the above iteration of accounts.
+    unless (Set.null bakerIdsLeft) $
+        Except.throwError $
+            "Active bakers with no baker record: " ++ show bakerIdsLeft
+
+    -- Check the totol amount of CCD matches the one being tracked in block state.
+    allInstances <- lift $ BS.getContractInstanceList bs
+    totalAmountInstances <- foldM sumInstanceBalance 0 allInstances
+    bankStatus <- lift $ BS.bsoGetBankStatus =<< BS.thawBlockState bs
+    let totalAmountCalculated =
+            totalAmountAccounts
+                + (bankStatus ^. Rewards.totalEncryptedGTU)
+                + totalAmountInstances
+                + (bankStatus ^. Rewards.bankRewardAccounts . to Rewards.rewardsTotal)
+                + extraBalance
+    let totalAmountBank = bankStatus ^. Rewards.totalGTU
+    unless (totalAmountBank == totalAmountCalculated) $
+        Except.throwError $
+            "Total CCD "
+                ++ show totalAmountBank
+                ++ " does not match the sum of all accounts, instances and rewards "
+                ++ show totalAmountCalculated
+  where
+    checkAccount ::
+        AccountAccumulated ->
+        Types.AccountAddress ->
+        Except.ExceptT String (PersistentBSM pv) AccountAccumulated
+    checkAccount (accountsSoFar, credentialsSoFar, bakerIdsLeft, totalAccountAmount) accountAddress = do
+        -- check that we didn't already find this same account
+        when (Map.member accountAddress accountsSoFar) $
+            Except.throwError $
+                "Duplicate account address: " ++ show accountAddress
+
+        maybeAccount <- lift $ BS.getAccount bs accountAddress
+        (accountIndex, account) <-
+            maybe
+                (Except.throwError $ "No account information for address: " ++ show accountAddress)
+                return
+                maybeAccount
+
+        let nextAccountsSoFar = Map.insert accountAddress accountIndex accountsSoFar
+
+        -- check that we didn't already find this credential
+        credentials <- lift $ BS.accountCredentials account
+        nextCredentialsSoFar <-
+            foldM
+                (checkAndInsertAccountCredential accountIndex)
+                credentialsSoFar
+                credentials
+
+        -- check that the locked balance is the same as the sum of the pending releases
+        lockedBalance <- lift $ BS.accountLockedAmount account
+        sumOfReleases <- lift $ Types.releaseTotal <$> BS.accountReleaseSummary account
+        unless (sumOfReleases == lockedBalance) $
+            Except.throwError $
+                "Sum of pending releases ("
+                    ++ show sumOfReleases
+                    ++ ") does not match the total locked amount "
+                    ++ show lockedBalance
+                    ++ " for account "
+                    ++ show accountAddress
+
+        maybeAccountBakerInfoRef <- lift $ BS.accountBakerInfoRef account
+        nextBakerIdsLeft <- case maybeAccountBakerInfoRef of
+            Nothing -> return bakerIdsLeft
+            Just bakerInfoRef -> do
+                bakerId <- BS.loadBakerId bakerInfoRef
+                unless (bakerId == fromIntegral accountIndex) $
+                    Except.throwError $
+                        "Baker ID ("
+                            ++ show bakerId
+                            ++ ") does not match the account index ("
+                            ++ show accountIndex
+                            ++ ") for account "
+                            ++ show accountAddress
+                unless (Set.member bakerId bakerIdsLeft) $
+                    Except.throwError $
+                        "Account has baker record, but is not an active baker "
+                            ++ show bakerId
+                            ++ " account "
+                            ++ show accountAddress
+                return $ Set.delete bakerId bakerIdsLeft
+
+        publicBalance <- lift $ BS.accountAmount account
+        let nextTotalAccountAmount = totalAccountAmount + publicBalance
+
+        return (nextAccountsSoFar, nextCredentialsSoFar, nextBakerIdsLeft, nextTotalAccountAmount)
+
+    sumInstanceBalance :: Types.Amount -> Types.ContractAddress -> Except.ExceptT String (PersistentBSM pv) Types.Amount
+    sumInstanceBalance totalInstanceAmount instanceAddress = do
+        maybeInstance <- lift $ BS.getContractInstance bs instanceAddress
+        instanceInfo <-
+            maybe
+                (Except.throwError $ "No instance information for address: " ++ show instanceAddress)
+                return
+                maybeInstance
+        let instanceAmount = case instanceInfo of
+                BS.InstanceInfoV0 info -> BS.iiBalance info
+                BS.InstanceInfoV1 info -> BS.iiBalance info
+        return $ totalInstanceAmount + instanceAmount
+
+    checkAndInsertAccountCredential ::
+        Types.AccountIndex ->
+        Map.Map Types.RawCredentialRegistrationID Types.AccountIndex ->
+        Types.RawAccountCredential ->
+        Except.ExceptT String (PersistentBSM pv) (Map.Map Types.RawCredentialRegistrationID Types.AccountIndex)
+    checkAndInsertAccountCredential accountIndex credentialsSoFar credential = do
+        let credentialRegistrationId = Types.credId credential
+        when (Map.member credentialRegistrationId credentialsSoFar) $
+            Except.throwError $
+                "Duplicate account credentials: " ++ show credential
+        return $ Map.insert credentialRegistrationId accountIndex credentialsSoFar


### PR DESCRIPTION
## Purpose

Add helpers for using persistent block state in scheduler unit tests.

## Changes

- Add helpers for running the scheduler using persistent block state.
- Rewrite unit tests for account creation and baker transactions to use persistent state.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
