### PR TITLE
Fix out-of-band catch-up timeout bug

### DIFF
--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -64,7 +64,7 @@ thiserror = "1.0"
 futures = { version = "0.3" }
 url = "2.2"
 reqwest = { version = "0.11", features = ["stream", "native-tls-vendored"] }
-csv = "1.1.6"
+csv = "1.1"
 tokio-util = { version = "0.7.3", features = ["io"] }
 libc = "0.2"
 mime = { version = "0.3" }

--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -64,7 +64,7 @@ thiserror = "1.0"
 futures = { version = "0.3" }
 url = "2.2"
 reqwest = { version = "0.11", features = ["stream", "native-tls-vendored"] }
-csv-async = "1.2"
+csv = "1.1.6"
 tokio-util = { version = "0.7.3", features = ["io"] }
 libc = "0.2"
 mime = { version = "0.3" }

--- a/concordium-node/src/bin/cli.rs
+++ b/concordium-node/src/bin/cli.rs
@@ -630,14 +630,13 @@ async fn import_missing_blocks(
         .await
         .context("Unable to get the catchup index file response text.")?;
 
-    let mut reader = csv::ReaderBuilder::new().has_headers(false).from_reader(index_str.as_bytes());
-    let first_line = reader.records().next().context(
+    let mut lines = index_str.lines();
+    let first_line = lines.next().context(
         "The catchup index file was empty. Please verify that you specified a correct catchup \
          service URL. If the specified URL is correct, contact the catchup service administrator.",
-    )??;
+    )?;
 
     let index_genesis_block_hash = first_line
-        .as_slice()
         .strip_prefix("# genesis hash ")
         .context(
             "The catchup index file does not begin with a line containing the genesis block hash. \


### PR DESCRIPTION
## Purpose

When performing the out-of-band catch-up with an exported database specified by an URL, the node aborts the catch-up before completing.

This happens since a TCP stream of the file `blocks.idx` is opened at the beginning of the out-of-band catch-up, and is expected to be remail until the `blocks.idx` transfer is completed. However, the client receives roughly 40-60 lines of the file corresponding to chunks that are downloaded and processed before receiving the next batch of lines in the stream. When processing the chunks in the batch takes longer than the request timeout, the stream times out and the out-of-band catch-up is aborted (see `import_missing_blocks` in `cli.rs` for the details).

## Changes

Fully download out-of-band catchup block index file rather than streaming it in `import_missing_blocks` in `cli.rs`.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.