### PR TITLE
Bump dependency to remove warning about security advisory.

### DIFF
--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -942,6 +942,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "destructure_traitobject"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c877555693c14d2f84191cfd3ad8582790fc52b5e2274b40b59cf5f5cea25c7"
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1938,9 +1944,9 @@ checksum = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
 
 [[package]]
 name = "log4rs"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "893eaf59f4bef8e2e94302adf56385db445a0306b9823582b0b8d5a06d8822f3"
+checksum = "d36ca1786d9e79b8193a68d480a0907b612f109537115c6ff655a3a1967533fd"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1960,7 +1966,7 @@ dependencies = [
  "thiserror",
  "thread-id",
  "toml",
- "typemap",
+ "typemap-ors",
  "winapi 0.3.9",
 ]
 
@@ -4042,12 +4048,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "traitobject"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
-
-[[package]]
 name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4066,12 +4066,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "typemap"
-version = "0.3.3"
+name = "typemap-ors"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "653be63c80a3296da5551e1bfd2cca35227e13cdd08c6668903ae2f4f77aa1f6"
+checksum = "a68c24b707f02dd18f1e4ccceb9d49f2058c2fb86384ef9972592904d7a28867"
 dependencies = [
- "unsafe-any",
+ "unsafe-any-ors",
 ]
 
 [[package]]
@@ -4129,12 +4129,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
-name = "unsafe-any"
-version = "0.4.2"
+name = "unsafe-any-ors"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30360d7979f5e9c6e6cea48af192ea8fab4afb3cf72597154b8f08935bc9c7f"
+checksum = "e0a303d30665362d9680d7d91d78b23f5f899504d4f08b3c4cf08d055d87c0ad"
 dependencies = [
- "traitobject",
+ "destructure_traitobject",
 ]
 
 [[package]]

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -579,7 +579,7 @@ dependencies = [
  "concordium_base",
  "criterion",
  "crossbeam-channel",
- "csv-async",
+ "csv",
  "digest 0.9.0",
  "env_logger",
  "flatbuffers",
@@ -830,21 +830,6 @@ dependencies = [
  "bstr",
  "csv-core",
  "itoa 0.4.8",
- "ryu",
- "serde 1.0.145",
-]
-
-[[package]]
-name = "csv-async"
-version = "1.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19b33b32fd48f83388821bd8f534b59e1b1ffd5c6c83771d1b23abd3dac2685"
-dependencies = [
- "bstr",
- "cfg-if",
- "csv-core",
- "futures",
- "itoa 1.0.4",
  "ryu",
  "serde 1.0.145",
 ]
@@ -3237,9 +3222,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26947345339603ae8395f68e2f3d85a6b0a8ddfe6315818e80b8504415099db0"
+checksum = "295642060261c80709ac034f52fca8e5a9fa2c7d341ded5cdb164b7c33768b2a"
 dependencies = [
  "secp256k1-sys",
 ]

--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -33,7 +33,7 @@ rand = "0.7"
 mio = { version = "0.7", features = ["os-poll", "tcp"] }
 log = "0.4"
 env_logger = "0.8.3"
-log4rs = { version = "1.1", features = ["all_components", "config_parsing", "toml_format", "yaml_format", "gzip"] }
+log4rs = { version = "1.2", features = ["all_components", "config_parsing", "toml_format", "yaml_format", "gzip"] }
 toml = "0.5"
 byteorder = "1.3"
 preferences = "1.1"


### PR DESCRIPTION
## Purpose

The secp256k1, used by wasm-chain-integration, has an issue that does not affect our usage directly, but nevertheless makes automated tools flag the dependency.

The version bump fixes it.

See https://github.com/advisories/GHSA-969w-q74q-9j8v
See https://github.com/advisories/GHSA-vfv3-9w6v-23jp

Depends on
- [x] https://github.com/Concordium/concordium-base/pull/279

## Changes

- Bump the dependency versions in Cargo.toml.
- Regenerate the relevant lock files.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
