### PR TITLE
Fix missing ar_data bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased changes
+- Fix a bug in the `GetAccountInfo` endpoint in GRPCv2 where the `ar_data` field
+  always would be empty.
 
 ## 5.1.2
 

--- a/concordium-consensus/src/Concordium/GRPC2.hs
+++ b/concordium-consensus/src/Concordium/GRPC2.hs
@@ -592,6 +592,12 @@ instance ToProto CredentialDeploymentCommitments where
                 cmmAttributes
         ProtoFields.idCredSecSharingCoeff .= map toProto cmmIdCredSecSharingCoeff
 
+instance ToProto (Map.Map ArIdentity ChainArData) where
+    type Output (Map.Map ArIdentity ChainArData) = Map.Map Word32 Proto.ChainArData
+    toProto = Map.fromAscList . map (\(k, v) -> (coerce k, dataToProto v)) . Map.toAscList
+      where
+        dataToProto d = Proto.make (ProtoFields.encIdCredPubShare .= S.encode d)
+
 instance ToProto RawAccountCredential where
     type Output RawAccountCredential = Proto.AccountCredential
     toProto (InitialAC InitialCredentialDeploymentValues{..}) =
@@ -614,6 +620,7 @@ instance ToProto RawAccountCredential where
                         ProtoFields.ipId .= toProto cdvIpId
                         ProtoFields.policy .= toProto cdvPolicy
                         ProtoFields.arThreshold .= toProto cdvThreshold
+                        ProtoFields.arData .= toProto cdvArData
                         ProtoFields.commitments .= toProto commitments
                     )
 


### PR DESCRIPTION
## Purpose

The `ar_data` field is never set in the `GetAccountInfo` endpoint of GRPCv2.

Thanks to @rasmus-kirk for noticing the issue ;) 

## Changes

- Set the field

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.