### PR TITLE
Use persistent block state in SchedulerTests

### DIFF
--- a/concordium-consensus/tests/scheduler/SchedulerTests/AccountTransactionSpecs.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/AccountTransactionSpecs.hs
@@ -79,7 +79,7 @@ testAccountCreation _ = do
             @pv
             testConfig
             initialBlockState
-            checkState
+            (Helpers.checkReloadCheck checkState)
             transactions
 
     let Sch.FilteredTransactions{..} = srTransactions
@@ -103,17 +103,7 @@ testAccountCreation _ = do
   where
     checkState :: Helpers.SchedulerResult -> BS.PersistentBlockState pv -> Helpers.PersistentBSM pv Assertion
     checkState _ state = do
-        doAssertState <- blockStateAssertions state
-        reloadedState <- Helpers.reloadBlockState state
-        doAssertReloadedState <- blockStateAssertions reloadedState
-        return $ do
-            doAssertState
-            doAssertReloadedState
-
-    blockStateAssertions :: BS.PersistentBlockState pv -> Helpers.PersistentBSM pv Assertion
-    blockStateAssertions state = do
-        hashedState <- BS.hashBlockState state
-        doInvariantAssertions <- Helpers.assertBlockStateInvariants hashedState 0
+        doInvariantAssertions <- Helpers.assertBlockStateInvariantsH state 0
         let addedAccountAddresses =
                 map
                     (accountAddressFromCredential . Types.credential)

--- a/concordium-consensus/tests/scheduler/SchedulerTests/AccountTransactionSpecs.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/AccountTransactionSpecs.hs
@@ -101,8 +101,8 @@ testAccountCreation _ = do
         (map snd ftFailedCredentials)
     assertEqual "Execution cost should be 0." 0 srExecutionCosts
   where
-    checkState :: BS.PersistentBlockState pv -> Helpers.PersistentBSM pv Assertion
-    checkState state = do
+    checkState :: Helpers.SchedulerResult -> BS.PersistentBlockState pv -> Helpers.PersistentBSM pv Assertion
+    checkState _ state = do
         doAssertState <- blockStateAssertions state
         reloadedState <- Helpers.reloadBlockState state
         doAssertReloadedState <- blockStateAssertions reloadedState

--- a/concordium-consensus/tests/scheduler/SchedulerTests/BakerTransactions.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/BakerTransactions.hs
@@ -273,7 +273,7 @@ tests = do
                 @PV1
                 Helpers.defaultTestConfig
                 initialBlockState
-                BS.bsoGetActiveBakers
+                (\_ -> BS.bsoGetActiveBakers)
                 txs
     let results = first (Helpers.getResults . Sch.ftAdded . Helpers.srTransactions) <$> outcomes
 

--- a/concordium-consensus/tests/scheduler/SchedulerTests/BakerTransactions.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/BakerTransactions.hs
@@ -273,7 +273,7 @@ tests = do
                 @PV1
                 Helpers.defaultTestConfig
                 initialBlockState
-                (\_ -> BS.bsoGetActiveBakers)
+                (const BS.bsoGetActiveBakers)
                 txs
     let results = first (Helpers.getResults . Sch.ftAdded . Helpers.srTransactions) <$> outcomes
 

--- a/concordium-consensus/tests/scheduler/SchedulerTests/BlockEnergyLimitSpec.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/BlockEnergyLimitSpec.hs
@@ -10,9 +10,9 @@ import Test.Hspec
 
 import qualified Concordium.GlobalState.Persistent.BlockState as BS
 import qualified Concordium.Scheduler as Sch
+import qualified Concordium.Scheduler.EnvironmentImplementation as EI
 import Concordium.Scheduler.Runner
 import qualified Concordium.Scheduler.Types as Types
-import qualified Concordium.Scheduler.EnvironmentImplementation as EI
 
 import Concordium.Scheduler.DummyData
 
@@ -151,7 +151,7 @@ testMaxBlockEnergy _ = do
         Helpers.assertBlockStateInvariants hashedState (Helpers.srExecutionCosts result)
 
 tests :: Spec
-tests = do
+tests =
     describe "Maximum block energy limit test:" $
         sequence_ $
             Helpers.forEveryProtocolVersion $ \spv pvString ->

--- a/concordium-consensus/tests/scheduler/SchedulerTests/BlockEnergyLimitSpec.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/BlockEnergyLimitSpec.hs
@@ -12,6 +12,7 @@ import qualified Concordium.GlobalState.Persistent.BlockState as BS
 import qualified Concordium.Scheduler as Sch
 import Concordium.Scheduler.Runner
 import qualified Concordium.Scheduler.Types as Types
+import qualified Concordium.Scheduler.EnvironmentImplementation as EI
 
 import Concordium.Scheduler.DummyData
 
@@ -30,6 +31,18 @@ usedTransactionEnergy = Helpers.simpleTransferCost
 
 maxBlockEnergy :: Types.Energy
 maxBlockEnergy = usedTransactionEnergy * 2
+
+testConfig :: Helpers.TestConfig
+testConfig =
+    Helpers.defaultTestConfig
+        { Helpers.tcContextState = contextState
+        }
+  where
+    contextState =
+        Helpers.defaultContextState
+            { -- Set the max energy block energy to enough for 2 successful transfers.
+              EI._maxBlockEnergy = maxBlockEnergy
+            }
 
 transactions :: [TransactionJSON]
 transactions =
@@ -67,7 +80,7 @@ testMaxBlockEnergy _ = do
                 : ts' -- dummy arrival time of 0
     (Helpers.SchedulerResult{..}, doBlockStateAssertions) <-
         Helpers.runSchedulerTest
-            Helpers.defaultTestConfig
+            testConfig
             initialBlockState
             checkState
             ts

--- a/concordium-consensus/tests/scheduler/SchedulerTests/Delegation.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/Delegation.hs
@@ -1,7 +1,10 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 
 -- | Test that reducing delegation and removing delegators always works, regardless
 --  of whether the new stake would violate any of the cap bounds.
@@ -12,189 +15,140 @@ module SchedulerTests.Delegation (tests) where
 
 import Lens.Micro.Platform
 
-import Concordium.Crypto.DummyData
 import qualified Concordium.Crypto.SignatureScheme as SigScheme
 import Concordium.ID.Types as ID
 import Concordium.Types.Accounts
-import Concordium.Types.DummyData
 
 import Concordium.GlobalState.BakerInfo
-import Concordium.GlobalState.Basic.BlockState
-import Concordium.GlobalState.Basic.BlockState.Account
-import Concordium.GlobalState.Basic.BlockState.Accounts as Acc
+import qualified Concordium.GlobalState.Persistent.Account as BS
+import qualified Concordium.GlobalState.Persistent.BlobStore as Blob
+import qualified Concordium.GlobalState.Persistent.BlockState as BS
+import qualified Concordium.Scheduler as Sch
 import qualified Concordium.Scheduler.Runner as Runner
 import Concordium.Scheduler.Types
+import qualified Concordium.Scheduler.Types as Types
 
 import Concordium.GlobalState.DummyData
 import Concordium.Scheduler.DummyData
-import SchedulerTests.TestUtils
-import System.Random
-import Test.HUnit (assertEqual)
+import qualified SchedulerTests.Helpers as Helpers
+import Test.HUnit
 import Test.Hspec
 
--- |Account of the baker 0
-baker0Address :: AccountAddress
-baker0Address = accountAddressFrom 16
-
--- |Account keys of the baker0 account.
-baker0KP :: SigScheme.KeyPair
-baker0KP = uncurry SigScheme.KeyPairEd25519 . fst $ randomEd25519KeyPair (mkStdGen 16)
-
-baker0VK :: SigScheme.VerifyKey
-baker0VK = SigScheme.correspondingVerifyKey baker0KP
-
-baker0Account :: Account 'AccountV1
-baker0Account =
-    (mkAccount @'AccountV1 baker0VK baker0Address 1_000_000)
-        { _accountStaking =
-            AccountStakeBaker
-                AccountBaker
-                    { _stakedAmount = 1_000_000,
-                      _stakeEarnings = True,
-                      _accountBakerInfo =
-                        BakerInfoExV1
-                            { _bieBakerInfo = mkFullBaker 16 0 ^. _1 . theBakerInfo,
-                              _bieBakerPoolInfo =
-                                BakerPoolInfo
-                                    { _poolOpenStatus = OpenForAll,
-                                      _poolMetadataUrl = UrlText "Some URL",
-                                      _poolCommissionRates =
-                                        CommissionRates
-                                            { _finalizationCommission = makeAmountFraction 50_000,
-                                              _bakingCommission = makeAmountFraction 50_000,
-                                              _transactionCommission = makeAmountFraction 50_000
-                                            }
-                                    }
-                            },
-                      _bakerPendingChange = NoChange
+makeTestBakerV1FromSeed ::
+    (IsAccountVersion av, Blob.MonadBlobStore m, AVSupportsDelegation av) =>
+    Amount ->
+    Amount ->
+    BakerId ->
+    Int ->
+    m (BS.PersistentAccount av)
+makeTestBakerV1FromSeed amount stake bakerId seed = do
+    account <- Helpers.makeTestAccountFromSeed amount seed
+    let (fulBaker, _, _, _) = mkFullBaker seed bakerId
+    let bakerInfoEx =
+            BakerInfoExV1
+                { _bieBakerInfo = fulBaker ^. theBakerInfo,
+                  _bieBakerPoolInfo = poolInfo
+                }
+    BS.addAccountBakerV1 bakerInfoEx stake True account
+  where
+    poolInfo =
+        BakerPoolInfo
+            { _poolOpenStatus = OpenForAll,
+              _poolMetadataUrl = UrlText "Some URL",
+              _poolCommissionRates =
+                CommissionRates
+                    { _finalizationCommission = makeAmountFraction 50_000,
+                      _bakingCommission = makeAmountFraction 50_000,
+                      _transactionCommission = makeAmountFraction 50_000
                     }
-        }
+            }
 
--- |Account of the baker 2
-baker2Address :: AccountAddress
-baker2Address = accountAddressFrom 18
+makeTestDelegatorFromSeed ::
+    (IsAccountVersion av, Blob.MonadBlobStore m, AVSupportsDelegation av) =>
+    Amount ->
+    AccountDelegation av ->
+    Int ->
+    m (BS.PersistentAccount av)
+makeTestDelegatorFromSeed amount accountDelegation seed = do
+    account <- Helpers.makeTestAccountFromSeed amount seed
+    BS.addAccountDelegator accountDelegation account
 
--- |Account keys of the baker2 account.
-baker2KP :: SigScheme.KeyPair
-baker2KP = uncurry SigScheme.KeyPairEd25519 . fst $ randomEd25519KeyPair (mkStdGen 18)
+-- Accounts
 
-baker2VK :: SigScheme.VerifyKey
-baker2VK = SigScheme.correspondingVerifyKey baker2KP
+-- |Account of the baker 0.
+baker0Account ::
+    (IsAccountVersion av, Blob.MonadBlobStore m, AVSupportsDelegation av) =>
+    m (BS.PersistentAccount av)
+baker0Account = makeTestBakerV1FromSeed 1_000_000 1_000_000 bakerId seed
+  where
+    bakerId = 0
+    seed = 16
 
-baker2Account :: Account 'AccountV1
-baker2Account =
-    (mkAccount @'AccountV1 baker2VK baker2Address 1_000_000)
-        { _accountStaking =
-            AccountStakeBaker
-                AccountBaker
-                    { _stakedAmount = 1_000,
-                      _stakeEarnings = True,
-                      _accountBakerInfo =
-                        BakerInfoExV1
-                            { _bieBakerInfo = mkFullBaker 18 2 ^. _1 . theBakerInfo,
-                              _bieBakerPoolInfo =
-                                BakerPoolInfo
-                                    { _poolOpenStatus = OpenForAll,
-                                      _poolMetadataUrl = UrlText "Some URL",
-                                      _poolCommissionRates =
-                                        CommissionRates
-                                            { _finalizationCommission = makeAmountFraction 50_000,
-                                              _bakingCommission = makeAmountFraction 50_000,
-                                              _transactionCommission = makeAmountFraction 50_000
-                                            }
-                                    }
-                            },
-                      _bakerPendingChange = NoChange
-                    }
-        }
+-- |Account of the delegator1.
+delegator1Account ::
+    (IsAccountVersion av, Blob.MonadBlobStore m, AVSupportsDelegation av) =>
+    m (BS.PersistentAccount av)
+delegator1Account = makeTestDelegatorFromSeed 20_000_000 accountDelegation 17
+  where
+    accountDelegation =
+        AccountDelegationV1
+            { _delegationIdentity = 1,
+              _delegationStakedAmount = 19_000_000, -- leverage cap is set to 5 in createBlockState, so this puts it over the cap.
+              _delegationStakeEarnings = False,
+              _delegationTarget = DelegateToBaker 0,
+              _delegationPendingChange = NoChange
+            }
 
--- |Account of the delegator1
+-- |Account address of the delegator1.
 delegator1Address :: AccountAddress
-delegator1Address = accountAddressFrom 17
+delegator1Address = Helpers.accountAddressFromSeed 17
 
 -- |Account keys of the delegator1 account.
 delegator1KP :: SigScheme.KeyPair
-delegator1KP = uncurry SigScheme.KeyPairEd25519 . fst $ randomEd25519KeyPair (mkStdGen 17)
+delegator1KP = Helpers.keyPairFromSeed 17
 
-delegator1VK :: SigScheme.VerifyKey
-delegator1VK = SigScheme.correspondingVerifyKey delegator1KP
+-- |Account of the baker 2.
+baker2Account ::
+    (IsAccountVersion av, Blob.MonadBlobStore m, AVSupportsDelegation av) =>
+    m (BS.PersistentAccount av)
+baker2Account = makeTestBakerV1FromSeed balance stake bakerId seed
+  where
+    balance = 1_000_000
+    stake = 1_000
+    bakerId = 2
+    seed = 18
 
-delegator1Account :: Account 'AccountV1
-delegator1Account =
-    (mkAccount @'AccountV1 delegator1VK delegator1Address 20_000_000)
-        { _accountStaking =
-            AccountStakeDelegate
-                AccountDelegationV1
-                    { _delegationIdentity = 1,
-                      _delegationStakedAmount = 19_000_000, -- leverage cap is set to 5 in createBlockState, so this puts it over the cap.
-                      _delegationStakeEarnings = False,
-                      _delegationTarget = DelegateToBaker 0,
-                      _delegationPendingChange = NoChange
-                    }
-        }
+-- |Account of the delegator3.
+delegator3Account ::
+    (IsAccountVersion av, Blob.MonadBlobStore m, AVSupportsDelegation av) =>
+    m (BS.PersistentAccount av)
+delegator3Account = makeTestDelegatorFromSeed 20_000_000 accountDelegation 19
+  where
+    accountDelegation =
+        AccountDelegationV1
+            { _delegationIdentity = 3,
+              _delegationStakedAmount = 1_000, -- leverage cap is set to 5 in createBlockState, so this puts it over the cap.
+              _delegationStakeEarnings = False,
+              _delegationTarget = DelegateToBaker 2,
+              _delegationPendingChange = NoChange
+            }
 
--- |Account of the delegator3
+-- |Account address of the delegator3.
 delegator3Address :: AccountAddress
-delegator3Address = accountAddressFrom 19
+delegator3Address = Helpers.accountAddressFromSeed 19
 
 -- |Account keys of the delegator3 account.
 delegator3KP :: SigScheme.KeyPair
-delegator3KP = uncurry SigScheme.KeyPairEd25519 . fst $ randomEd25519KeyPair (mkStdGen 19)
+delegator3KP = Helpers.keyPairFromSeed 19
 
-delegator3VK :: SigScheme.VerifyKey
-delegator3VK = SigScheme.correspondingVerifyKey delegator3KP
-
-delegator3Account :: Account 'AccountV1
-delegator3Account =
-    (mkAccount @'AccountV1 delegator3VK delegator3Address 20_000_000)
-        { _accountStaking =
-            AccountStakeDelegate
-                AccountDelegationV1
-                    { _delegationIdentity = 3,
-                      _delegationStakedAmount = 1_000,
-                      _delegationStakeEarnings = False,
-                      _delegationTarget = DelegateToBaker 2,
-                      _delegationPendingChange = NoChange
-                    }
-        }
-
--- |Account of the baker 2
-baker4Address :: AccountAddress
-baker4Address = accountAddressFrom 20
-
--- |Account keys of the baker4 account.
-baker4KP :: SigScheme.KeyPair
-baker4KP = uncurry SigScheme.KeyPairEd25519 . fst $ randomEd25519KeyPair (mkStdGen 20)
-
-baker4VK :: SigScheme.VerifyKey
-baker4VK = SigScheme.correspondingVerifyKey baker4KP
-
-baker4Account :: Account 'AccountV1
-baker4Account =
-    (mkAccount @'AccountV1 baker4VK baker4Address 1_000_000)
-        { _accountStaking =
-            AccountStakeBaker
-                AccountBaker
-                    { _stakedAmount = 1_000,
-                      _stakeEarnings = True,
-                      _accountBakerInfo =
-                        BakerInfoExV1
-                            { _bieBakerInfo = mkFullBaker 20 4 ^. _1 . theBakerInfo,
-                              _bieBakerPoolInfo =
-                                BakerPoolInfo
-                                    { _poolOpenStatus = OpenForAll,
-                                      _poolMetadataUrl = UrlText "Some URL",
-                                      _poolCommissionRates =
-                                        CommissionRates
-                                            { _finalizationCommission = makeAmountFraction 50_000,
-                                              _bakingCommission = makeAmountFraction 50_000,
-                                              _transactionCommission = makeAmountFraction 50_000
-                                            }
-                                    }
-                            },
-                      _bakerPendingChange = NoChange
-                    }
-        }
+-- |Account of the baker 4.
+baker4Account ::
+    (IsAccountVersion av, Blob.MonadBlobStore m, AVSupportsDelegation av) =>
+    m (BS.PersistentAccount av)
+baker4Account = makeTestBakerV1FromSeed 1_000_000 1_000 bakerId seed
+  where
+    bakerId = 4
+    seed = 20
 
 -- |Create initial block state with account
 -- account index 0 is baker0
@@ -202,28 +156,29 @@ baker4Account =
 -- account index 2 is baker 2
 -- account index 3 is delegator3 (delegates to baker 2)
 -- account index 4 is baker 4
-initialBlockState :: BlockState PV4
+initialBlockState ::
+    (IsProtocolVersion pv, SupportsDelegation pv) =>
+    Helpers.PersistentBSM pv (BS.HashedPersistentBlockState pv)
 initialBlockState =
-    createBlockState
-        ( foldr
-            Acc.putAccountWithRegIds
-            Acc.emptyAccounts
-            [ baker4Account,
-              delegator3Account,
-              baker2Account,
-              delegator1Account,
-              baker0Account
-            ]
-        )
+    Helpers.createTestBlockStateWithAccountsM
+        [ baker0Account,
+          delegator1Account,
+          baker2Account,
+          delegator3Account,
+          baker4Account
+        ]
 
 -- Test removing a delegator even if the stake is over the threshold.
-testCases1 :: [TestCase PV4]
-testCases1 =
-    [ TestCase
-        { tcName = "Remove delegation",
-          tcParameters = (defaultParams @PV4){tpInitialBlockState = initialBlockState, tpChainMeta = ChainMetadata{slotTime = 100}},
-          tcTransactions =
-            [   ( Runner.TJSON
+testCase1 ::
+    forall pv.
+    (IsProtocolVersion pv, SupportsDelegation pv) =>
+    SProtocolVersion pv ->
+    String ->
+    SpecWith (Arg Assertion)
+testCase1 _ pvString =
+    specify (pvString ++ ": Remove delegation") $ do
+        let transactions =
+                [ Runner.TJSON
                     { payload =
                         Runner.ConfigureDelegation
                             { cdCapital = Just 0,
@@ -232,21 +187,44 @@ testCases1 =
                             },
                       metadata = makeDummyHeader delegator1Address 1 1_000,
                       keys = [(0, [(0, delegator1KP)])]
-                    },
-                  (Success (assertEqual "Remove delegation" [DelegationRemoved 1 delegator1Address]), const (return ()))
-                )
-            ]
-        }
-    ]
+                    }
+                ]
+        -- Run the test
+        (Helpers.SchedulerResult{..}, doBlockStateAssertions) <-
+            Helpers.runSchedulerTestTransactionJson
+                Helpers.defaultTestConfig
+                (initialBlockState @pv)
+                (Helpers.checkReloadCheck checkState)
+                transactions
+        -- Assertions
+        let Sch.FilteredTransactions{..} = srTransactions
+        events <- case Helpers.getResults ftAdded of
+            [(_, Types.TxSuccess{vrEvents})] -> return vrEvents
+            _ -> assertFailure "Transaction should succeed"
+        assertEqual
+            "Delegator was removed"
+            [DelegationRemoved 1 delegator1Address]
+            events
+        doBlockStateAssertions
+  where
+    checkState ::
+        Helpers.SchedulerResult ->
+        BS.PersistentBlockState pv ->
+        Helpers.PersistentBSM pv Assertion
+    checkState result blockState = do
+        Helpers.assertBlockStateInvariantsH blockState (Helpers.srExecutionCosts result)
 
 -- Test reducing delegator stake in such a way that it stays above the cap threshold.
-testCases2 :: [TestCase PV4]
-testCases2 =
-    [ TestCase
-        { tcName = "Reduce delegation stake with overstaking",
-          tcParameters = (defaultParams @PV4){tpInitialBlockState = initialBlockState, tpChainMeta = ChainMetadata{slotTime = 100}},
-          tcTransactions =
-            [   ( Runner.TJSON
+testCase2 ::
+    forall pv.
+    (IsProtocolVersion pv, SupportsDelegation pv) =>
+    SProtocolVersion pv ->
+    String ->
+    SpecWith (Arg Assertion)
+testCase2 _ pvString =
+    specify (pvString ++ ": Reduce delegation stake with overstaking") $ do
+        let transactions =
+                [ Runner.TJSON
                     { payload =
                         Runner.ConfigureDelegation
                             { cdCapital = Just 18_999_999,
@@ -255,21 +233,42 @@ testCases2 =
                             },
                       metadata = makeDummyHeader delegator1Address 1 1_000,
                       keys = [(0, [(0, delegator1KP)])]
-                    },
-                  (Success (assertEqual "Reduce delegation stake" [DelegationStakeDecreased 1 delegator1Address 18_999_999]), const (return ()))
-                )
-            ]
-        }
-    ]
+                    }
+                ]
+        (Helpers.SchedulerResult{..}, doBlockStateAssertions) <-
+            Helpers.runSchedulerTestTransactionJson
+                Helpers.defaultTestConfig
+                (initialBlockState @pv)
+                (Helpers.checkReloadCheck checkState)
+                transactions
+        let Sch.FilteredTransactions{..} = srTransactions
+        events <- case Helpers.getResults ftAdded of
+            [(_, Types.TxSuccess{vrEvents})] -> return vrEvents
+            _ -> assertFailure "Transaction should succeed"
+        assertEqual
+            "Stake was decreased"
+            [DelegationStakeDecreased 1 delegator1Address 18_999_999]
+            events
+        doBlockStateAssertions
+  where
+    checkState ::
+        Helpers.SchedulerResult ->
+        BS.PersistentBlockState pv ->
+        Helpers.PersistentBSM pv Assertion
+    checkState result blockState =
+        Helpers.assertBlockStateInvariantsH blockState (Helpers.srExecutionCosts result)
 
--- Test increasing stake.
-testCases3 :: [TestCase PV4]
-testCases3 =
-    [ TestCase
-        { tcName = "Increase stake with overstaking",
-          tcParameters = (defaultParams @PV4){tpInitialBlockState = initialBlockState, tpChainMeta = ChainMetadata{slotTime = 100}},
-          tcTransactions =
-            [   ( Runner.TJSON
+-- Test transaction rejects if increasing stake above the threshold of the pool
+testCase3 ::
+    forall pv.
+    (IsProtocolVersion pv, SupportsDelegation pv) =>
+    SProtocolVersion pv ->
+    String ->
+    SpecWith (Arg Assertion)
+testCase3 _ pvString =
+    specify (pvString ++ ": Increase stake with overstaking") $ do
+        let transactions =
+                [ Runner.TJSON
                     { payload =
                         Runner.ConfigureDelegation
                             { cdCapital = Just 19_000_001,
@@ -278,21 +277,43 @@ testCases3 =
                             },
                       metadata = makeDummyHeader delegator1Address 1 1_000,
                       keys = [(0, [(0, delegator1KP)])]
-                    },
-                  (Reject StakeOverMaximumThresholdForPool, const (return ()))
-                )
-            ]
-        }
-    ]
+                    }
+                ]
+        (Helpers.SchedulerResult{..}, doBlockStateAssertions) <-
+            Helpers.runSchedulerTestTransactionJson
+                Helpers.defaultTestConfig
+                (initialBlockState @pv)
+                (Helpers.checkReloadCheck checkState)
+                transactions
+        let Sch.FilteredTransactions{..} = srTransactions
+        reason <- case Helpers.getResults ftAdded of
+            [(_, Types.TxReject{vrRejectReason})] -> return vrRejectReason
+            _ -> assertFailure "Transaction should reject"
+        assertEqual
+            "Reject with reason: stake over maximum threshold for pool"
+            reason
+            StakeOverMaximumThresholdForPool
+        doBlockStateAssertions
+  where
+    checkState ::
+        Helpers.SchedulerResult ->
+        BS.PersistentBlockState pv ->
+        Helpers.PersistentBSM pv Assertion
+    checkState result blockState =
+        Helpers.assertBlockStateInvariantsH blockState (Helpers.srExecutionCosts result)
 
--- Test reducing delegator stake **and changing target** such that the new stake is above the cap for the new target.
-testCases4 :: [TestCase PV4]
-testCases4 =
-    [ TestCase
-        { tcName = "Reduce stake and change target 1",
-          tcParameters = (defaultParams @PV4){tpInitialBlockState = initialBlockState, tpChainMeta = ChainMetadata{slotTime = 100}},
-          tcTransactions =
-            [   ( Runner.TJSON
+-- Test reducing delegator stake **and changing target** such that the new stake is above the cap
+-- for the new target.
+testCase4 ::
+    forall pv.
+    (IsProtocolVersion pv, SupportsDelegation pv) =>
+    SProtocolVersion pv ->
+    String ->
+    SpecWith (Arg Assertion)
+testCase4 _ pvString =
+    specify (pvString ++ ": Reduce stake and change target 1") $ do
+        let transactions =
+                [ Runner.TJSON
                     { payload =
                         Runner.ConfigureDelegation
                             { cdCapital = Just 18_000_000,
@@ -301,22 +322,43 @@ testCases4 =
                             },
                       metadata = makeDummyHeader delegator1Address 1 1_000,
                       keys = [(0, [(0, delegator1KP)])]
-                    },
-                  (Reject StakeOverMaximumThresholdForPool, const (return ()))
-                )
-            ]
-        }
-    ]
+                    }
+                ]
+        (Helpers.SchedulerResult{..}, doBlockStateAssertions) <-
+            Helpers.runSchedulerTestTransactionJson
+                Helpers.defaultTestConfig
+                (initialBlockState @pv)
+                (Helpers.checkReloadCheck checkState)
+                transactions
+        let Sch.FilteredTransactions{..} = srTransactions
+        reason <- case Helpers.getResults ftAdded of
+            [(_, Types.TxReject{vrRejectReason})] -> return vrRejectReason
+            _ -> assertFailure "Transaction should reject"
+        assertEqual
+            "Reject with reason: stake over maximum threshold for pool"
+            reason
+            StakeOverMaximumThresholdForPool
+        doBlockStateAssertions
+  where
+    checkState ::
+        Helpers.SchedulerResult ->
+        BS.PersistentBlockState pv ->
+        Helpers.PersistentBSM pv Assertion
+    checkState result blockState =
+        Helpers.assertBlockStateInvariantsH blockState (Helpers.srExecutionCosts result)
 
 -- Test changing the target and decreasing stake such that the new stake is acceptable for the new target.
 -- This still fails because the change of target is only effected after the cooldown period.
-testCases5 :: [TestCase PV4]
-testCases5 =
-    [ TestCase
-        { tcName = "Reduce stake and change target 2",
-          tcParameters = (defaultParams @PV4){tpInitialBlockState = initialBlockState, tpChainMeta = ChainMetadata{slotTime = 100}},
-          tcTransactions =
-            [   ( Runner.TJSON
+testCase5 ::
+    forall pv.
+    (IsProtocolVersion pv, SupportsDelegation pv) =>
+    SProtocolVersion pv ->
+    String ->
+    SpecWith (Arg Assertion)
+testCase5 _ pvString =
+    specify (pvString ++ ": Reduce stake and change target 2") $ do
+        let transactions =
+                [ Runner.TJSON
                     { payload =
                         Runner.ConfigureDelegation
                             { cdCapital = Just 1,
@@ -325,21 +367,42 @@ testCases5 =
                             },
                       metadata = makeDummyHeader delegator1Address 1 1_000,
                       keys = [(0, [(0, delegator1KP)])]
-                    },
-                  (Reject StakeOverMaximumThresholdForPool, const (return ()))
-                )
-            ]
-        }
-    ]
+                    }
+                ]
+        (Helpers.SchedulerResult{..}, doBlockStateAssertions) <-
+            Helpers.runSchedulerTestTransactionJson
+                Helpers.defaultTestConfig
+                (initialBlockState @pv)
+                (Helpers.checkReloadCheck checkState)
+                transactions
+        let Sch.FilteredTransactions{..} = srTransactions
+        reason <- case Helpers.getResults ftAdded of
+            [(_, Types.TxReject{vrRejectReason})] -> return vrRejectReason
+            _ -> assertFailure "Transaction should reject"
+        assertEqual
+            "Reject with reason: stake over maximum threshold for pool"
+            reason
+            StakeOverMaximumThresholdForPool
+        doBlockStateAssertions
+  where
+    checkState ::
+        Helpers.SchedulerResult ->
+        BS.PersistentBlockState pv ->
+        Helpers.PersistentBSM pv Assertion
+    checkState result blockState =
+        Helpers.assertBlockStateInvariantsH blockState (Helpers.srExecutionCosts result)
 
 -- Increase stake successfully.
-testCases6 :: [TestCase PV4]
-testCases6 =
-    [ TestCase
-        { tcName = "Increase stake successfully.",
-          tcParameters = (defaultParams @PV4){tpInitialBlockState = initialBlockState, tpChainMeta = ChainMetadata{slotTime = 100}},
-          tcTransactions =
-            [   ( Runner.TJSON
+testCase6 ::
+    forall pv.
+    (IsProtocolVersion pv, SupportsDelegation pv) =>
+    SProtocolVersion pv ->
+    String ->
+    SpecWith (Arg Assertion)
+testCase6 _ pvString =
+    specify (pvString ++ ": Increase stake successfully.") $ do
+        let transactions =
+                [ Runner.TJSON
                     { payload =
                         Runner.ConfigureDelegation
                             { cdCapital = Just 1_001,
@@ -348,16 +411,39 @@ testCases6 =
                             },
                       metadata = makeDummyHeader delegator3Address 1 1_000,
                       keys = [(0, [(0, delegator3KP)])]
-                    },
-                  (Success (assertEqual "Increase delegation stake" [DelegationStakeIncreased 3 delegator3Address 1_001]), const (return ()))
-                )
-            ]
-        },
-      TestCase
-        { tcName = "Increase stake and change target successfully.",
-          tcParameters = (defaultParams @PV4){tpInitialBlockState = initialBlockState, tpChainMeta = ChainMetadata{slotTime = 100}},
-          tcTransactions =
-            [   ( Runner.TJSON
+                    }
+                ]
+        (Helpers.SchedulerResult{..}, doBlockStateAssertions) <-
+            Helpers.runSchedulerTestTransactionJson
+                Helpers.defaultTestConfig
+                (initialBlockState @pv)
+                (Helpers.checkReloadCheck checkState)
+                transactions
+        let Sch.FilteredTransactions{..} = srTransactions
+        events <- case Helpers.getResults ftAdded of
+            [(_, Types.TxSuccess{vrEvents})] -> return vrEvents
+            _ -> assertFailure "Transaction should succeed"
+        assertEqual "Increase delegation stake" [DelegationStakeIncreased 3 delegator3Address 1_001] events
+        doBlockStateAssertions
+  where
+    checkState ::
+        Helpers.SchedulerResult ->
+        BS.PersistentBlockState pv ->
+        Helpers.PersistentBSM pv Assertion
+    checkState result blockState =
+        Helpers.assertBlockStateInvariantsH blockState (Helpers.srExecutionCosts result)
+
+-- Increase stake and change target successfully.
+testCase7 ::
+    forall pv.
+    (IsProtocolVersion pv, SupportsDelegation pv) =>
+    SProtocolVersion pv ->
+    String ->
+    SpecWith (Arg Assertion)
+testCase7 _ pvString =
+    specify (pvString ++ ": Increase stake and change target successfully.") $ do
+        let transactions =
+                [ Runner.TJSON
                     { payload =
                         Runner.ConfigureDelegation
                             { cdCapital = Just 1_001,
@@ -366,24 +452,44 @@ testCases6 =
                             },
                       metadata = makeDummyHeader delegator3Address 1 1_000,
                       keys = [(0, [(0, delegator3KP)])]
-                    },
-                    ( Success
-                        ( assertEqual
-                            "Increase delegation stake"
-                            [ DelegationSetDelegationTarget 3 delegator3Address (DelegateToBaker 4),
-                              DelegationStakeIncreased 3 delegator3Address 1_001
-                            ]
-                        ),
-                      const (return ())
-                    )
-                )
+                    }
+                ]
+        (Helpers.SchedulerResult{..}, doBlockStateAssertions) <-
+            Helpers.runSchedulerTestTransactionJson
+                Helpers.defaultTestConfig
+                (initialBlockState @pv)
+                (Helpers.checkReloadCheck checkState)
+                transactions
+        let Sch.FilteredTransactions{..} = srTransactions
+        events <- case Helpers.getResults ftAdded of
+            [(_, Types.TxSuccess{vrEvents})] -> return vrEvents
+            _ -> assertFailure "Transaction should succeed"
+        assertEqual
+            "Increase delegation stake"
+            [ DelegationSetDelegationTarget 3 delegator3Address (DelegateToBaker 4),
+              DelegationStakeIncreased 3 delegator3Address 1_001
             ]
-        },
-      TestCase
-        { tcName = "Increase stake and change target so that results is overdelegation.",
-          tcParameters = (defaultParams @PV4){tpInitialBlockState = initialBlockState, tpChainMeta = ChainMetadata{slotTime = 100}},
-          tcTransactions =
-            [   ( Runner.TJSON
+            events
+        doBlockStateAssertions
+  where
+    checkState ::
+        Helpers.SchedulerResult ->
+        BS.PersistentBlockState pv ->
+        Helpers.PersistentBSM pv Assertion
+    checkState result blockState =
+        Helpers.assertBlockStateInvariantsH blockState (Helpers.srExecutionCosts result)
+
+-- Increase stake and change target rejects with reason: maximum threshold for pool.
+testCase8 ::
+    forall pv.
+    (IsProtocolVersion pv, SupportsDelegation pv) =>
+    SProtocolVersion pv ->
+    String ->
+    SpecWith (Arg Assertion)
+testCase8 _ pvString =
+    specify (pvString ++ ": Increase stake and change target so that results is overdelegation.") $ do
+        let transactions =
+                [ Runner.TJSON
                     { payload =
                         Runner.ConfigureDelegation
                             { cdCapital = Just 1_000_001,
@@ -392,16 +498,42 @@ testCases6 =
                             },
                       metadata = makeDummyHeader delegator3Address 1 1_000,
                       keys = [(0, [(0, delegator3KP)])]
-                    },
-                  (Reject StakeOverMaximumThresholdForPool, const (return ()))
-                )
-            ]
-        },
-      TestCase
-        { tcName = "Change target to overdelegated pool.",
-          tcParameters = (defaultParams @PV4){tpInitialBlockState = initialBlockState, tpChainMeta = ChainMetadata{slotTime = 100}},
-          tcTransactions =
-            [   ( Runner.TJSON
+                    }
+                ]
+        (Helpers.SchedulerResult{..}, doBlockStateAssertions) <-
+            Helpers.runSchedulerTestTransactionJson
+                Helpers.defaultTestConfig
+                (initialBlockState @pv)
+                (Helpers.checkReloadCheck checkState)
+                transactions
+        let Sch.FilteredTransactions{..} = srTransactions
+        reason <- case Helpers.getResults ftAdded of
+            [(_, Types.TxReject{vrRejectReason})] -> return vrRejectReason
+            _ -> assertFailure "Transaction should reject"
+        assertEqual
+            "Reject with reason: stake over maximum threshold for pool"
+            reason
+            StakeOverMaximumThresholdForPool
+        doBlockStateAssertions
+  where
+    checkState ::
+        Helpers.SchedulerResult ->
+        BS.PersistentBlockState pv ->
+        Helpers.PersistentBSM pv Assertion
+    checkState result blockState =
+        Helpers.assertBlockStateInvariantsH blockState (Helpers.srExecutionCosts result)
+
+-- Increase stake and change target rejects with reason: maximum threshold for pool.
+testCase9 ::
+    forall pv.
+    (IsProtocolVersion pv, SupportsDelegation pv) =>
+    SProtocolVersion pv ->
+    String ->
+    SpecWith (Arg Assertion)
+testCase9 _ pvString =
+    specify (pvString ++ ": Change target to overdelegated pool.") $ do
+        let transactions =
+                [ Runner.TJSON
                     { payload =
                         Runner.ConfigureDelegation
                             { cdCapital = Nothing,
@@ -410,18 +542,48 @@ testCases6 =
                             },
                       metadata = makeDummyHeader delegator3Address 1 1_000,
                       keys = [(0, [(0, delegator3KP)])]
-                    },
-                  (Reject StakeOverMaximumThresholdForPool, const (return ()))
-                )
-            ]
-        }
-    ]
+                    }
+                ]
+        (Helpers.SchedulerResult{..}, doBlockStateAssertions) <-
+            Helpers.runSchedulerTestTransactionJson
+                Helpers.defaultTestConfig
+                (initialBlockState @pv)
+                (Helpers.checkReloadCheck checkState)
+                transactions
+        let Sch.FilteredTransactions{..} = srTransactions
+        reason <- case Helpers.getResults ftAdded of
+            [(_, Types.TxReject{vrRejectReason})] -> return vrRejectReason
+            _ -> assertFailure "Transaction should reject"
+        assertEqual
+            "Reject with reason: stake over maximum threshold for pool"
+            reason
+            StakeOverMaximumThresholdForPool
+        doBlockStateAssertions
+  where
+    checkState ::
+        Helpers.SchedulerResult ->
+        BS.PersistentBlockState pv ->
+        Helpers.PersistentBSM pv Assertion
+    checkState result blockState =
+        Helpers.assertBlockStateInvariantsH blockState (Helpers.srExecutionCosts result)
 
 tests :: Spec
-tests = describe "Delegate in different scenarios" $ do
-    mkSpecs testCases1
-    mkSpecs testCases2
-    mkSpecs testCases3
-    mkSpecs testCases4
-    mkSpecs testCases5
-    mkSpecs testCases6
+tests =
+    describe "Delegate in different scenarios" $
+        sequence_ $
+            Helpers.forEveryProtocolVersion testCases
+  where
+    testCases :: forall pv. IsProtocolVersion pv => SProtocolVersion pv -> String -> SpecWith (Arg Assertion)
+    testCases spv pvString =
+        case delegationSupport @(AccountVersionFor pv) of
+            SAVDelegationNotSupported -> return ()
+            SAVDelegationSupported -> do
+                testCase1 spv pvString
+                testCase2 spv pvString
+                testCase3 spv pvString
+                testCase4 spv pvString
+                testCase5 spv pvString
+                testCase6 spv pvString
+                testCase7 spv pvString
+                testCase8 spv pvString
+                testCase9 spv pvString

--- a/concordium-consensus/tests/scheduler/SchedulerTests/EncryptedTransfersTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/EncryptedTransfersTest.hs
@@ -1,31 +1,35 @@
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
 module SchedulerTests.EncryptedTransfersTest where
 
-import Data.Maybe (fromJust)
+import qualified Data.ByteString.Short as BSS
+import Data.Maybe
 import qualified Data.Sequence as Seq
-import Lens.Micro.Platform
 
-import Concordium.Crypto.DummyData
 import Concordium.Crypto.EncryptedTransfers
 import Concordium.Crypto.FFIDataTypes (ElgamalSecretKey)
-import Concordium.GlobalState.Basic.BlockState
-import Concordium.GlobalState.Basic.BlockState.Account
-import Concordium.GlobalState.Basic.BlockState.Accounts as Acc
+
+import qualified Concordium.GlobalState.BlockState as BS
+import qualified Concordium.GlobalState.Persistent.Account as BS
+import qualified Concordium.GlobalState.Persistent.BlockState as BS
+import qualified Concordium.Scheduler as Sch
+
+import qualified Concordium.Crypto.SignatureScheme as SigScheme
 import Concordium.GlobalState.DummyData
 import Concordium.ID.DummyData (dummyEncryptionSecretKey)
-import Concordium.ID.Types (AccountEncryptionKey (..), unsafeEncryptionKeyFromRaw)
-import Concordium.Types.DummyData
-import qualified Data.ByteString.Short as BSS
+import qualified Concordium.ID.Types as ID
 
 import Concordium.Scheduler.DummyData
 import qualified Concordium.Scheduler.Runner as Runner
-import Concordium.Scheduler.Types
+import qualified Concordium.Scheduler.Types as Types
 
-import SchedulerTests.TestUtils
+import qualified SchedulerTests.Helpers as Helpers
 
-import qualified Test.HUnit as HUnit
+import Control.Monad
+import Test.HUnit
 import Test.Hspec
 
 -- This test will perform the following transactions and check that the resulting
@@ -71,949 +75,1365 @@ import Test.Hspec
 --- |                                  | incomingAmounts |        [] |            [] |
 --- |----------------------------------+-----------------+-----------+---------------|
 
-initialBlockState :: BlockState PV1
+initialBlockState ::
+    Types.IsProtocolVersion pv =>
+    Helpers.PersistentBSM pv (BS.HashedPersistentBlockState pv)
 initialBlockState =
-    blockStateWithAlesAccount
-        10000000000
-        (Acc.putAccountWithRegIds (mkAccount thomasVK thomasAccount 10000000000) Acc.emptyAccounts)
+    Helpers.createTestBlockStateWithAccountsM
+        [ Helpers.makeTestAccountFromSeed 10_000_000_000 0,
+          Helpers.makeTestAccountFromSeed 10_000_000_000 1
+        ]
 
-initialBlockState2 :: BlockState PV2
-initialBlockState2 =
-    blockStateWithAlesAccount
-        10000000000
-        (Acc.putAccountWithRegIds (mkAccount thomasVK thomasAccount 10000000000) Acc.emptyAccounts)
+accountAddress0 :: Types.AccountAddress
+accountAddress0 = Helpers.accountAddressFromSeed 0
 
-alesEncryptionSecretKey :: ElgamalSecretKey
-alesEncryptionSecretKey = dummyEncryptionSecretKey dummyCryptographicParameters alesAccount
-alesEncryptionPublicKey :: AccountEncryptionKey
-alesEncryptionPublicKey = unsafeEncryptionKeyFromRaw ((fromJust $ Acc.getAccount alesAccount (initialBlockState ^. blockAccounts)) ^. accountEncryptionKey)
+accountAddress1 :: Types.AccountAddress
+accountAddress1 = Helpers.accountAddressFromSeed 1
 
-thomasEncryptionSecretKey :: ElgamalSecretKey
-thomasEncryptionSecretKey = dummyEncryptionSecretKey dummyCryptographicParameters thomasAccount
-thomasEncryptionPublicKey :: AccountEncryptionKey
-thomasEncryptionPublicKey = unsafeEncryptionKeyFromRaw ((fromJust $ Acc.getAccount thomasAccount (initialBlockState ^. blockAccounts)) ^. accountEncryptionKey)
+keyPair0 :: SigScheme.KeyPair
+keyPair0 = Helpers.keyPairFromSeed 0
 
-createEncryptedTransferData :: AccountEncryptionKey -> ElgamalSecretKey -> AggregatedDecryptedAmount -> Amount -> IO (Maybe EncryptedAmountTransferData)
-createEncryptedTransferData (AccountEncryptionKey receiverPK) senderSK aggDecAmount amount =
-    makeEncryptedAmountTransferData (initialBlockState ^. blockCryptographicParameters . unhashed) receiverPK senderSK aggDecAmount amount
+keyPair1 :: SigScheme.KeyPair
+keyPair1 = Helpers.keyPairFromSeed 1
 
-createSecToPubTransferData :: ElgamalSecretKey -> AggregatedDecryptedAmount -> Amount -> IO (Maybe SecToPubAmountTransferData)
-createSecToPubTransferData secret aggAmount amount =
-    makeSecToPubAmountTransferData (initialBlockState ^. blockCryptographicParameters . unhashed) secret aggAmount amount
+encryptionSecretKey0 :: ElgamalSecretKey
+encryptionSecretKey0 = dummyEncryptionSecretKey dummyCryptographicParameters accountAddress0
 
--- Transaction 1. Pub to sec (1000)
-encryptedAmount1000 :: EncryptedAmount
-encryptedAmount1000 = encryptAmountZeroRandomness (initialBlockState ^. blockCryptographicParameters . unhashed) 1000
+encryptionSecretKey1 :: ElgamalSecretKey
+encryptionSecretKey1 = dummyEncryptionSecretKey dummyCryptographicParameters accountAddress1
 
--- Transaction 2. EncTransfer (A->T, 100) with previous amounts
-aggregatedDecryptedAmount1 :: AggregatedDecryptedAmount
-aggregatedDecryptedAmount1 = makeAggregatedDecryptedAmount encryptedAmount1000 1000 0
-mkEncryptedTransferData1 :: IO EncryptedAmountTransferData
-mkEncryptedTransferData1 = fromJust <$> createEncryptedTransferData thomasEncryptionPublicKey alesEncryptionSecretKey aggregatedDecryptedAmount1 100
+encryptionPublicKey0 :: ID.AccountEncryptionKey
+encryptionPublicKey0 =
+    ID.makeEncryptionKey dummyCryptographicParameters $
+        ID.credId $
+            Helpers.makeTestCredentialFromSeed 0
 
-mkTestCases :: IO ([TestCase PV1], [TestCase PV2])
-mkTestCases = do
-    encryptedTransferData1 <- mkEncryptedTransferData1
+encryptionPublicKey1 :: ID.AccountEncryptionKey
+encryptionPublicKey1 =
+    ID.makeEncryptionKey dummyCryptographicParameters $
+        ID.credId $
+            Helpers.makeTestCredentialFromSeed 1
 
-    -- Transaction 3. EncTransfer (A->T, 100) with previous amounts
-    let aggregatedDecryptedAmount2 :: AggregatedDecryptedAmount
-        aggregatedDecryptedAmount2 = makeAggregatedDecryptedAmount (eatdRemainingAmount encryptedTransferData1) 900 0
-        mkEncryptedTransferData2 :: IO EncryptedAmountTransferData
-        mkEncryptedTransferData2 = fromJust <$> createEncryptedTransferData thomasEncryptionPublicKey alesEncryptionSecretKey aggregatedDecryptedAmount2 100
-
-    encryptedTransferData2 <- mkEncryptedTransferData2
-
-    -- Transaction 4. EncTransfer (A->T, 100) with previous amounts
-    let aggregatedDecryptedAmount3 :: AggregatedDecryptedAmount
-        aggregatedDecryptedAmount3 = makeAggregatedDecryptedAmount (eatdRemainingAmount encryptedTransferData2) 800 0
-        mkEncryptedTransferData3 :: IO EncryptedAmountTransferData
-        mkEncryptedTransferData3 = fromJust <$> createEncryptedTransferData thomasEncryptionPublicKey alesEncryptionSecretKey aggregatedDecryptedAmount3 100
-
-    encryptedTransferData3 <- mkEncryptedTransferData3
-
-    -- Transaction 5. EncTransfer (T->A, 150) with previous amounts
-    let aggregatedEncryptedAmount4 :: EncryptedAmount
-        aggregatedEncryptedAmount4 = aggregateAmounts mempty $ aggregateAmounts (eatdTransferAmount encryptedTransferData1) (eatdTransferAmount encryptedTransferData2)
-        aggregatedDecryptedAmount4 :: AggregatedDecryptedAmount
-        aggregatedDecryptedAmount4 = makeAggregatedDecryptedAmount aggregatedEncryptedAmount4 200 2
-        mkEncryptedTransferData4 :: IO EncryptedAmountTransferData
-        mkEncryptedTransferData4 = fromJust <$> createEncryptedTransferData alesEncryptionPublicKey thomasEncryptionSecretKey aggregatedDecryptedAmount4 150
-
-    encryptedTransferData4 <- mkEncryptedTransferData4
-
-    -- Transaction 6. EncTransfer (T->A, 150) with previous amounts
-    let aggregatedEncryptedAmount5 :: EncryptedAmount
-        aggregatedEncryptedAmount5 = aggregateAmounts (eatdRemainingAmount encryptedTransferData4) (eatdTransferAmount encryptedTransferData3)
-        aggregatedDecryptedAmount5 :: AggregatedDecryptedAmount
-        aggregatedDecryptedAmount5 = makeAggregatedDecryptedAmount aggregatedEncryptedAmount5 150 3
-        mkEncryptedTransferData5 :: IO EncryptedAmountTransferData
-        mkEncryptedTransferData5 = fromJust <$> createEncryptedTransferData alesEncryptionPublicKey thomasEncryptionSecretKey aggregatedDecryptedAmount5 150
-
-    encryptedTransferData5 <- mkEncryptedTransferData5
-
-    -- Transaction 7. Sec to Pub 650 (to not consume fully the selfAmount which is 700 rn)
-    let aggregatedDecryptedAmount6 :: AggregatedDecryptedAmount
-        aggregatedDecryptedAmount6 = makeAggregatedDecryptedAmount (eatdRemainingAmount encryptedTransferData3) 700 0
-        mkSecToPubTransferData1 :: IO SecToPubAmountTransferData
-        mkSecToPubTransferData1 = fromJust <$> createSecToPubTransferData alesEncryptionSecretKey aggregatedDecryptedAmount6 650
-
-    secToPubTransferData1 <- mkSecToPubTransferData1
-
-    -- Transaction 8. Sec to Pub 150
-    let aggregatedEncryptedAmount7 :: EncryptedAmount
-        aggregatedEncryptedAmount7 = aggregateAmounts (stpatdRemainingAmount secToPubTransferData1) (eatdTransferAmount encryptedTransferData4)
-        aggregatedDecryptedAmount7 :: AggregatedDecryptedAmount
-        aggregatedDecryptedAmount7 = makeAggregatedDecryptedAmount aggregatedEncryptedAmount7 200 1
-        mkSecToPubTransferData2 :: IO SecToPubAmountTransferData
-        mkSecToPubTransferData2 = fromJust <$> createSecToPubTransferData alesEncryptionSecretKey aggregatedDecryptedAmount7 150
-
-    secToPubTransferData2 <- mkSecToPubTransferData2
-
-    -- Transaction 8. Sec to Pub 200
-    let aggregatedEncryptedAmount8 :: EncryptedAmount
-        aggregatedEncryptedAmount8 = aggregateAmounts (stpatdRemainingAmount secToPubTransferData2) (eatdTransferAmount encryptedTransferData5)
-        aggregatedDecryptedAmount8 :: AggregatedDecryptedAmount
-        aggregatedDecryptedAmount8 = makeAggregatedDecryptedAmount aggregatedEncryptedAmount8 200 2
-        mkSecToPubTransferData3 :: IO SecToPubAmountTransferData
-        mkSecToPubTransferData3 = fromJust <$> createSecToPubTransferData alesEncryptionSecretKey aggregatedDecryptedAmount8 200
-        incomingAmounts8A :: Seq.Seq EncryptedAmount
-        incomingAmounts8A = Seq.empty
-
-    secToPubTransferData3 <- mkSecToPubTransferData3
-
-    let incomingAmounts1 :: Seq.Seq EncryptedAmount
-        incomingAmounts1 = Seq.singleton $ eatdTransferAmount encryptedTransferData1
-        incomingAmounts2 :: Seq.Seq EncryptedAmount
-        incomingAmounts2 = incomingAmounts1 Seq.:|> eatdTransferAmount encryptedTransferData2
-        incomingAmounts3 :: Seq.Seq EncryptedAmount
-        incomingAmounts3 = incomingAmounts2 Seq.:|> eatdTransferAmount encryptedTransferData3
-
-        incomingAmounts4A, incomingAmounts4T :: Seq.Seq EncryptedAmount
-        incomingAmounts4A = Seq.singleton $ eatdTransferAmount encryptedTransferData4
-        incomingAmounts4T = Seq.singleton $ eatdTransferAmount encryptedTransferData3
-
-        incomingAmounts5A, incomingAmounts5T :: Seq.Seq EncryptedAmount
-        incomingAmounts5A = incomingAmounts4A Seq.:|> eatdTransferAmount encryptedTransferData5
-        incomingAmounts5T = Seq.empty
-
-        incomingAmounts7A :: Seq.Seq EncryptedAmount
-        incomingAmounts7A = Seq.singleton $ eatdTransferAmount encryptedTransferData5
-
-    return $
-        (   [ TestCase
-                { tcName = "Makes an encrypted transfer",
-                  tcParameters = (defaultParams @PV1){tpInitialBlockState = initialBlockState},
-                  tcTransactions =
-                    [   ( Runner.TJSON
-                            { payload = Runner.TransferToEncrypted 1000,
-                              metadata = makeDummyHeader alesAccount 1 100000,
-                              keys = [(0, [(0, alesKP)])]
-                            },
-                            ( SuccessE
-                                [ EncryptedSelfAmountAdded
-                                    { eaaAccount = alesAccount,
-                                      eaaNewAmount = encryptedAmount1000,
-                                      eaaAmount = 1000
-                                    }
-                                ],
-                              checkEncryptedBalance initialAccountEncryptedAmount{_selfAmount = encryptedAmount1000} alesAccount
-                            )
-                        ),
-                        ( Runner.TJSON
-                            { payload = Runner.EncryptedAmountTransferWithMemo thomasAccount (Memo $ BSS.pack [0, 1, 2, 3]) encryptedTransferData1,
-                              metadata = makeDummyHeader alesAccount 2 100000,
-                              keys = [(0, [(0, alesKP)])]
-                            },
-                          (Reject SerializationFailure, checkEncryptedBalance initialAccountEncryptedAmount{_selfAmount = encryptedAmount1000} alesAccount)
-                        ),
-                      let EncryptedAmountTransferData{..} = encryptedTransferData1
-                      in  ( Runner.TJSON
-                                { payload = Runner.EncryptedAmountTransfer thomasAccount encryptedTransferData1,
-                                  metadata = makeDummyHeader alesAccount 3 100000,
-                                  keys = [(0, [(0, alesKP)])]
-                                },
-                              ( SuccessE
-                                    [ EncryptedAmountsRemoved
-                                        { earAccount = alesAccount,
-                                          earUpToIndex = 0,
-                                          earNewAmount = eatdRemainingAmount,
-                                          earInputAmount = encryptedAmount1000
-                                        },
-                                      NewEncryptedAmount
-                                        { neaAccount = thomasAccount,
-                                          neaNewIndex = 0,
-                                          neaEncryptedAmount = eatdTransferAmount
-                                        }
-                                    ],
-                                \bs -> do
-                                    checkEncryptedBalance initialAccountEncryptedAmount{_selfAmount = eatdRemainingAmount} alesAccount bs
-                                    checkEncryptedBalance
-                                        initialAccountEncryptedAmount
-                                            { _startIndex = 0,
-                                              _incomingEncryptedAmounts = incomingAmounts1
-                                            }
-                                        thomasAccount
-                                        bs
-                              )
-                          ),
-                      let EncryptedAmountTransferData{..} = encryptedTransferData2
-                      in  ( Runner.TJSON
-                                { payload = Runner.EncryptedAmountTransfer thomasAccount encryptedTransferData2,
-                                  metadata = makeDummyHeader alesAccount 4 100000,
-                                  keys = [(0, [(0, alesKP)])]
-                                },
-                              ( SuccessE
-                                    [ EncryptedAmountsRemoved
-                                        { earAccount = alesAccount,
-                                          earUpToIndex = 0,
-                                          earNewAmount = eatdRemainingAmount,
-                                          earInputAmount = Concordium.Crypto.EncryptedTransfers.eatdRemainingAmount encryptedTransferData1
-                                        },
-                                      NewEncryptedAmount
-                                        { neaAccount = thomasAccount,
-                                          neaNewIndex = 1,
-                                          neaEncryptedAmount = eatdTransferAmount
-                                        }
-                                    ],
-                                \bs -> do
-                                    checkEncryptedBalance initialAccountEncryptedAmount{_selfAmount = eatdRemainingAmount} alesAccount bs
-                                    checkEncryptedBalance
-                                        initialAccountEncryptedAmount
-                                            { _startIndex = 0,
-                                              _incomingEncryptedAmounts = incomingAmounts2
-                                            }
-                                        thomasAccount
-                                        bs
-                              )
-                          ),
-                      let EncryptedAmountTransferData{..} = encryptedTransferData3
-                      in  ( Runner.TJSON
-                                { payload = Runner.EncryptedAmountTransfer thomasAccount encryptedTransferData3,
-                                  metadata = makeDummyHeader alesAccount 5 100000,
-                                  keys = [(0, [(0, alesKP)])]
-                                },
-                              ( SuccessE
-                                    [ EncryptedAmountsRemoved
-                                        { earAccount = alesAccount,
-                                          earUpToIndex = 0,
-                                          earNewAmount = eatdRemainingAmount,
-                                          earInputAmount = Concordium.Crypto.EncryptedTransfers.eatdRemainingAmount encryptedTransferData2
-                                        },
-                                      NewEncryptedAmount
-                                        { neaAccount = thomasAccount,
-                                          neaNewIndex = 2,
-                                          neaEncryptedAmount = eatdTransferAmount
-                                        }
-                                    ],
-                                \bs -> do
-                                    checkEncryptedBalance initialAccountEncryptedAmount{_selfAmount = eatdRemainingAmount} alesAccount bs
-                                    checkEncryptedBalance
-                                        initialAccountEncryptedAmount
-                                            { _startIndex = 0,
-                                              _incomingEncryptedAmounts = incomingAmounts3
-                                            }
-                                        thomasAccount
-                                        bs
-                              )
-                          ),
-                        ( Runner.TJSON
-                            { payload = Runner.EncryptedAmountTransfer alesAccount encryptedTransferData4,
-                              metadata = makeDummyHeader thomasAccount 1 100000,
-                              keys = [(0, [(0, thomasKP)])]
-                            },
-                            ( SuccessE
-                                [ EncryptedAmountsRemoved
-                                    { earAccount = thomasAccount,
-                                      earUpToIndex = 2,
-                                      earNewAmount = eatdRemainingAmount encryptedTransferData4,
-                                      earInputAmount = aggregatedEncryptedAmount4
-                                    },
-                                  NewEncryptedAmount
-                                    { neaAccount = alesAccount,
-                                      neaNewIndex = 0,
-                                      neaEncryptedAmount = eatdTransferAmount encryptedTransferData4
-                                    }
-                                ],
-                              \bs -> do
-                                checkEncryptedBalance
-                                    initialAccountEncryptedAmount
-                                        { _selfAmount = eatdRemainingAmount encryptedTransferData3,
-                                          _startIndex = 0,
-                                          _incomingEncryptedAmounts = incomingAmounts4A
-                                        }
-                                    alesAccount
-                                    bs
-                                checkEncryptedBalance
-                                    initialAccountEncryptedAmount
-                                        { _selfAmount = eatdRemainingAmount encryptedTransferData4,
-                                          _startIndex = 2,
-                                          _incomingEncryptedAmounts = incomingAmounts4T
-                                        }
-                                    thomasAccount
-                                    bs
-                            )
-                        ),
-                        ( Runner.TJSON
-                            { payload = Runner.EncryptedAmountTransfer alesAccount encryptedTransferData5,
-                              metadata = makeDummyHeader thomasAccount 2 100000,
-                              keys = [(0, [(0, thomasKP)])]
-                            },
-                            ( SuccessE
-                                [ EncryptedAmountsRemoved
-                                    { earAccount = thomasAccount,
-                                      earUpToIndex = 3,
-                                      earNewAmount = eatdRemainingAmount encryptedTransferData5,
-                                      earInputAmount = aggregatedEncryptedAmount5
-                                    },
-                                  NewEncryptedAmount
-                                    { neaAccount = alesAccount,
-                                      neaNewIndex = 1,
-                                      neaEncryptedAmount = eatdTransferAmount encryptedTransferData5
-                                    }
-                                ],
-                              \bs -> do
-                                checkEncryptedBalance
-                                    initialAccountEncryptedAmount
-                                        { _selfAmount = eatdRemainingAmount encryptedTransferData3,
-                                          _startIndex = 0,
-                                          _incomingEncryptedAmounts = incomingAmounts5A
-                                        }
-                                    alesAccount
-                                    bs
-                                checkEncryptedBalance
-                                    initialAccountEncryptedAmount
-                                        { _selfAmount = eatdRemainingAmount encryptedTransferData5,
-                                          _startIndex = 3,
-                                          _incomingEncryptedAmounts = incomingAmounts5T
-                                        }
-                                    thomasAccount
-                                    bs
-                            )
-                        ),
-                        ( Runner.TJSON
-                            { payload = Runner.TransferToPublic secToPubTransferData1,
-                              metadata = makeDummyHeader alesAccount 6 100000,
-                              keys = [(0, [(0, alesKP)])]
-                            },
-                            ( SuccessE
-                                [ EncryptedAmountsRemoved
-                                    { earAccount = alesAccount,
-                                      earUpToIndex = 0,
-                                      earNewAmount = stpatdRemainingAmount secToPubTransferData1,
-                                      earInputAmount = Concordium.Crypto.EncryptedTransfers.eatdRemainingAmount encryptedTransferData3
-                                    },
-                                  AmountAddedByDecryption
-                                    { aabdAccount = alesAccount,
-                                      aabdAmount = 650
-                                    }
-                                ],
-                              checkEncryptedBalance
-                                initialAccountEncryptedAmount
-                                    { _selfAmount = stpatdRemainingAmount secToPubTransferData1,
-                                      _startIndex = 0,
-                                      _incomingEncryptedAmounts = incomingAmounts5A
-                                    }
-                                alesAccount
-                            )
-                        ),
-                        ( Runner.TJSON
-                            { payload = Runner.TransferToPublic secToPubTransferData2,
-                              metadata = makeDummyHeader alesAccount 7 100000,
-                              keys = [(0, [(0, alesKP)])]
-                            },
-                            ( SuccessE
-                                [ EncryptedAmountsRemoved
-                                    { earAccount = alesAccount,
-                                      earUpToIndex = 1,
-                                      earNewAmount = stpatdRemainingAmount secToPubTransferData2,
-                                      earInputAmount = aggregatedEncryptedAmount7
-                                    },
-                                  AmountAddedByDecryption
-                                    { aabdAccount = alesAccount,
-                                      aabdAmount = 150
-                                    }
-                                ],
-                              checkEncryptedBalance
-                                initialAccountEncryptedAmount
-                                    { _selfAmount = stpatdRemainingAmount secToPubTransferData2,
-                                      _startIndex = 1,
-                                      _incomingEncryptedAmounts = incomingAmounts7A
-                                    }
-                                alesAccount
-                            )
-                        ),
-                        ( Runner.TJSON
-                            { payload = Runner.TransferToPublic secToPubTransferData3,
-                              metadata = makeDummyHeader alesAccount 8 100000,
-                              keys = [(0, [(0, alesKP)])]
-                            },
-                            ( SuccessE
-                                [ EncryptedAmountsRemoved
-                                    { earAccount = alesAccount,
-                                      earUpToIndex = 2,
-                                      earNewAmount = stpatdRemainingAmount secToPubTransferData3,
-                                      earInputAmount = aggregatedEncryptedAmount8
-                                    },
-                                  AmountAddedByDecryption
-                                    { aabdAccount = alesAccount,
-                                      aabdAmount = 200
-                                    }
-                                ],
-                              checkEncryptedBalance
-                                initialAccountEncryptedAmount
-                                    { _selfAmount = stpatdRemainingAmount secToPubTransferData3,
-                                      _startIndex = 2,
-                                      _incomingEncryptedAmounts = incomingAmounts8A
-                                    }
-                                alesAccount
-                            )
-                        )
-                    ]
-                }
-            ],
-            [ TestCase
-                { tcName = "Makes an encrypted transfer where protocol version is 2",
-                  tcParameters = (defaultParams @PV1){tpInitialBlockState = initialBlockState2},
-                  tcTransactions =
-                    [   ( Runner.TJSON
-                            { payload = Runner.TransferToEncrypted 1000,
-                              metadata = makeDummyHeader alesAccount 1 100000,
-                              keys = [(0, [(0, alesKP)])]
-                            },
-                            ( SuccessE
-                                [ EncryptedSelfAmountAdded
-                                    { eaaAccount = alesAccount,
-                                      eaaNewAmount = encryptedAmount1000,
-                                      eaaAmount = 1000
-                                    }
-                                ],
-                              checkEncryptedBalance initialAccountEncryptedAmount{_selfAmount = encryptedAmount1000} alesAccount
-                            )
-                        ),
-                      let EncryptedAmountTransferData{..} = encryptedTransferData1
-                      in  ( Runner.TJSON
-                                { payload = Runner.EncryptedAmountTransfer thomasAccount encryptedTransferData1,
-                                  metadata = makeDummyHeader alesAccount 2 100000,
-                                  keys = [(0, [(0, alesKP)])]
-                                },
-                              ( SuccessE
-                                    [ EncryptedAmountsRemoved
-                                        { earAccount = alesAccount,
-                                          earUpToIndex = 0,
-                                          earNewAmount = eatdRemainingAmount,
-                                          earInputAmount = encryptedAmount1000
-                                        },
-                                      NewEncryptedAmount
-                                        { neaAccount = thomasAccount,
-                                          neaNewIndex = 0,
-                                          neaEncryptedAmount = eatdTransferAmount
-                                        }
-                                    ],
-                                \bs -> do
-                                    checkEncryptedBalance initialAccountEncryptedAmount{_selfAmount = eatdRemainingAmount} alesAccount bs
-                                    checkEncryptedBalance
-                                        initialAccountEncryptedAmount
-                                            { _startIndex = 0,
-                                              _incomingEncryptedAmounts = incomingAmounts1
-                                            }
-                                        thomasAccount
-                                        bs
-                              )
-                          ),
-                      let EncryptedAmountTransferData{..} = encryptedTransferData2
-                      in  ( Runner.TJSON
-                                { payload = Runner.EncryptedAmountTransfer thomasAccount encryptedTransferData2,
-                                  metadata = makeDummyHeader alesAccount 3 100000,
-                                  keys = [(0, [(0, alesKP)])]
-                                },
-                              ( SuccessE
-                                    [ EncryptedAmountsRemoved
-                                        { earAccount = alesAccount,
-                                          earUpToIndex = 0,
-                                          earNewAmount = eatdRemainingAmount,
-                                          earInputAmount = Concordium.Crypto.EncryptedTransfers.eatdRemainingAmount encryptedTransferData1
-                                        },
-                                      NewEncryptedAmount
-                                        { neaAccount = thomasAccount,
-                                          neaNewIndex = 1,
-                                          neaEncryptedAmount = eatdTransferAmount
-                                        }
-                                    ],
-                                \bs -> do
-                                    checkEncryptedBalance initialAccountEncryptedAmount{_selfAmount = eatdRemainingAmount} alesAccount bs
-                                    checkEncryptedBalance
-                                        initialAccountEncryptedAmount
-                                            { _startIndex = 0,
-                                              _incomingEncryptedAmounts = incomingAmounts2
-                                            }
-                                        thomasAccount
-                                        bs
-                              )
-                          ),
-                      let EncryptedAmountTransferData{..} = encryptedTransferData3
-                      in  ( Runner.TJSON
-                                { payload = Runner.EncryptedAmountTransfer thomasAccount encryptedTransferData3,
-                                  metadata = makeDummyHeader alesAccount 4 100000,
-                                  keys = [(0, [(0, alesKP)])]
-                                },
-                              ( SuccessE
-                                    [ EncryptedAmountsRemoved
-                                        { earAccount = alesAccount,
-                                          earUpToIndex = 0,
-                                          earNewAmount = eatdRemainingAmount,
-                                          earInputAmount = Concordium.Crypto.EncryptedTransfers.eatdRemainingAmount encryptedTransferData2
-                                        },
-                                      NewEncryptedAmount
-                                        { neaAccount = thomasAccount,
-                                          neaNewIndex = 2,
-                                          neaEncryptedAmount = eatdTransferAmount
-                                        }
-                                    ],
-                                \bs -> do
-                                    checkEncryptedBalance initialAccountEncryptedAmount{_selfAmount = eatdRemainingAmount} alesAccount bs
-                                    checkEncryptedBalance
-                                        initialAccountEncryptedAmount
-                                            { _startIndex = 0,
-                                              _incomingEncryptedAmounts = incomingAmounts3
-                                            }
-                                        thomasAccount
-                                        bs
-                              )
-                          ),
-                        ( Runner.TJSON
-                            { payload = Runner.EncryptedAmountTransfer alesAccount encryptedTransferData4,
-                              metadata = makeDummyHeader thomasAccount 1 100000,
-                              keys = [(0, [(0, thomasKP)])]
-                            },
-                            ( SuccessE
-                                [ EncryptedAmountsRemoved
-                                    { earAccount = thomasAccount,
-                                      earUpToIndex = 2,
-                                      earNewAmount = eatdRemainingAmount encryptedTransferData4,
-                                      earInputAmount = aggregatedEncryptedAmount4
-                                    },
-                                  NewEncryptedAmount
-                                    { neaAccount = alesAccount,
-                                      neaNewIndex = 0,
-                                      neaEncryptedAmount = eatdTransferAmount encryptedTransferData4
-                                    }
-                                ],
-                              \bs -> do
-                                checkEncryptedBalance
-                                    initialAccountEncryptedAmount
-                                        { _selfAmount = eatdRemainingAmount encryptedTransferData3,
-                                          _startIndex = 0,
-                                          _incomingEncryptedAmounts = incomingAmounts4A
-                                        }
-                                    alesAccount
-                                    bs
-                                checkEncryptedBalance
-                                    initialAccountEncryptedAmount
-                                        { _selfAmount = eatdRemainingAmount encryptedTransferData4,
-                                          _startIndex = 2,
-                                          _incomingEncryptedAmounts = incomingAmounts4T
-                                        }
-                                    thomasAccount
-                                    bs
-                            )
-                        ),
-                        ( Runner.TJSON
-                            { payload = Runner.EncryptedAmountTransfer alesAccount encryptedTransferData5,
-                              metadata = makeDummyHeader thomasAccount 2 100000,
-                              keys = [(0, [(0, thomasKP)])]
-                            },
-                            ( SuccessE
-                                [ EncryptedAmountsRemoved
-                                    { earAccount = thomasAccount,
-                                      earUpToIndex = 3,
-                                      earNewAmount = eatdRemainingAmount encryptedTransferData5,
-                                      earInputAmount = aggregatedEncryptedAmount5
-                                    },
-                                  NewEncryptedAmount
-                                    { neaAccount = alesAccount,
-                                      neaNewIndex = 1,
-                                      neaEncryptedAmount = eatdTransferAmount encryptedTransferData5
-                                    }
-                                ],
-                              \bs -> do
-                                checkEncryptedBalance
-                                    initialAccountEncryptedAmount
-                                        { _selfAmount = eatdRemainingAmount encryptedTransferData3,
-                                          _startIndex = 0,
-                                          _incomingEncryptedAmounts = incomingAmounts5A
-                                        }
-                                    alesAccount
-                                    bs
-                                checkEncryptedBalance
-                                    initialAccountEncryptedAmount
-                                        { _selfAmount = eatdRemainingAmount encryptedTransferData5,
-                                          _startIndex = 3,
-                                          _incomingEncryptedAmounts = incomingAmounts5T
-                                        }
-                                    thomasAccount
-                                    bs
-                            )
-                        ),
-                        ( Runner.TJSON
-                            { payload = Runner.TransferToPublic secToPubTransferData1,
-                              metadata = makeDummyHeader alesAccount 5 100000,
-                              keys = [(0, [(0, alesKP)])]
-                            },
-                            ( SuccessE
-                                [ EncryptedAmountsRemoved
-                                    { earAccount = alesAccount,
-                                      earUpToIndex = 0,
-                                      earNewAmount = stpatdRemainingAmount secToPubTransferData1,
-                                      earInputAmount = Concordium.Crypto.EncryptedTransfers.eatdRemainingAmount encryptedTransferData3
-                                    },
-                                  AmountAddedByDecryption
-                                    { aabdAccount = alesAccount,
-                                      aabdAmount = 650
-                                    }
-                                ],
-                              checkEncryptedBalance
-                                initialAccountEncryptedAmount
-                                    { _selfAmount = stpatdRemainingAmount secToPubTransferData1,
-                                      _startIndex = 0,
-                                      _incomingEncryptedAmounts = incomingAmounts5A
-                                    }
-                                alesAccount
-                            )
-                        ),
-                        ( Runner.TJSON
-                            { payload = Runner.TransferToPublic secToPubTransferData2,
-                              metadata = makeDummyHeader alesAccount 6 100000,
-                              keys = [(0, [(0, alesKP)])]
-                            },
-                            ( SuccessE
-                                [ EncryptedAmountsRemoved
-                                    { earAccount = alesAccount,
-                                      earUpToIndex = 1,
-                                      earNewAmount = stpatdRemainingAmount secToPubTransferData2,
-                                      earInputAmount = aggregatedEncryptedAmount7
-                                    },
-                                  AmountAddedByDecryption
-                                    { aabdAccount = alesAccount,
-                                      aabdAmount = 150
-                                    }
-                                ],
-                              checkEncryptedBalance
-                                initialAccountEncryptedAmount
-                                    { _selfAmount = stpatdRemainingAmount secToPubTransferData2,
-                                      _startIndex = 1,
-                                      _incomingEncryptedAmounts = incomingAmounts7A
-                                    }
-                                alesAccount
-                            )
-                        ),
-                        ( Runner.TJSON
-                            { payload = Runner.TransferToPublic secToPubTransferData3,
-                              metadata = makeDummyHeader alesAccount 7 100000,
-                              keys = [(0, [(0, alesKP)])]
-                            },
-                            ( SuccessE
-                                [ EncryptedAmountsRemoved
-                                    { earAccount = alesAccount,
-                                      earUpToIndex = 2,
-                                      earNewAmount = stpatdRemainingAmount secToPubTransferData3,
-                                      earInputAmount = aggregatedEncryptedAmount8
-                                    },
-                                  AmountAddedByDecryption
-                                    { aabdAccount = alesAccount,
-                                      aabdAmount = 200
-                                    }
-                                ],
-                              checkEncryptedBalance
-                                initialAccountEncryptedAmount
-                                    { _selfAmount = stpatdRemainingAmount secToPubTransferData3,
-                                      _startIndex = 2,
-                                      _incomingEncryptedAmounts = incomingAmounts8A
-                                    }
-                                alesAccount
-                            )
-                        )
-                    ]
-                },
-              TestCase
-                { tcName = "Makes an encrypted transfer with memo where protocol version is 2",
-                  tcParameters = (defaultParams @PV1){tpInitialBlockState = initialBlockState2},
-                  tcTransactions =
-                    [   ( Runner.TJSON
-                            { payload = Runner.TransferToEncrypted 1000,
-                              metadata = makeDummyHeader alesAccount 1 100000,
-                              keys = [(0, [(0, alesKP)])]
-                            },
-                            ( SuccessE
-                                [ EncryptedSelfAmountAdded
-                                    { eaaAccount = alesAccount,
-                                      eaaNewAmount = encryptedAmount1000,
-                                      eaaAmount = 1000
-                                    }
-                                ],
-                              checkEncryptedBalance initialAccountEncryptedAmount{_selfAmount = encryptedAmount1000} alesAccount
-                            )
-                        ),
-                      let EncryptedAmountTransferData{..} = encryptedTransferData1
-                      in  ( Runner.TJSON
-                                { payload = Runner.EncryptedAmountTransferWithMemo thomasAccount (Memo $ BSS.pack [0, 1, 2, 3]) encryptedTransferData1,
-                                  metadata = makeDummyHeader alesAccount 2 100000,
-                                  keys = [(0, [(0, alesKP)])]
-                                },
-                              ( SuccessE
-                                    [ EncryptedAmountsRemoved
-                                        { earAccount = alesAccount,
-                                          earUpToIndex = 0,
-                                          earNewAmount = eatdRemainingAmount,
-                                          earInputAmount = encryptedAmount1000
-                                        },
-                                      NewEncryptedAmount
-                                        { neaAccount = thomasAccount,
-                                          neaNewIndex = 0,
-                                          neaEncryptedAmount = eatdTransferAmount
-                                        },
-                                      TransferMemo (Memo $ BSS.pack [0, 1, 2, 3])
-                                    ],
-                                \bs -> do
-                                    checkEncryptedBalance initialAccountEncryptedAmount{_selfAmount = eatdRemainingAmount} alesAccount bs
-                                    checkEncryptedBalance
-                                        initialAccountEncryptedAmount
-                                            { _startIndex = 0,
-                                              _incomingEncryptedAmounts = incomingAmounts1
-                                            }
-                                        thomasAccount
-                                        bs
-                              )
-                          ),
-                      let EncryptedAmountTransferData{..} = encryptedTransferData2
-                      in  ( Runner.TJSON
-                                { payload = Runner.EncryptedAmountTransferWithMemo thomasAccount (Memo $ BSS.pack [0, 1, 2, 3]) encryptedTransferData2,
-                                  metadata = makeDummyHeader alesAccount 3 100000,
-                                  keys = [(0, [(0, alesKP)])]
-                                },
-                              ( SuccessE
-                                    [ EncryptedAmountsRemoved
-                                        { earAccount = alesAccount,
-                                          earUpToIndex = 0,
-                                          earNewAmount = eatdRemainingAmount,
-                                          earInputAmount = Concordium.Crypto.EncryptedTransfers.eatdRemainingAmount encryptedTransferData1
-                                        },
-                                      NewEncryptedAmount
-                                        { neaAccount = thomasAccount,
-                                          neaNewIndex = 1,
-                                          neaEncryptedAmount = eatdTransferAmount
-                                        },
-                                      TransferMemo (Memo $ BSS.pack [0, 1, 2, 3])
-                                    ],
-                                \bs -> do
-                                    checkEncryptedBalance initialAccountEncryptedAmount{_selfAmount = eatdRemainingAmount} alesAccount bs
-                                    checkEncryptedBalance
-                                        initialAccountEncryptedAmount
-                                            { _startIndex = 0,
-                                              _incomingEncryptedAmounts = incomingAmounts2
-                                            }
-                                        thomasAccount
-                                        bs
-                              )
-                          ),
-                      let EncryptedAmountTransferData{..} = encryptedTransferData3
-                      in  ( Runner.TJSON
-                                { payload = Runner.EncryptedAmountTransferWithMemo thomasAccount (Memo $ BSS.pack [0, 1, 2, 3]) encryptedTransferData3,
-                                  metadata = makeDummyHeader alesAccount 4 100000,
-                                  keys = [(0, [(0, alesKP)])]
-                                },
-                              ( SuccessE
-                                    [ EncryptedAmountsRemoved
-                                        { earAccount = alesAccount,
-                                          earUpToIndex = 0,
-                                          earNewAmount = eatdRemainingAmount,
-                                          earInputAmount = Concordium.Crypto.EncryptedTransfers.eatdRemainingAmount encryptedTransferData2
-                                        },
-                                      NewEncryptedAmount
-                                        { neaAccount = thomasAccount,
-                                          neaNewIndex = 2,
-                                          neaEncryptedAmount = eatdTransferAmount
-                                        },
-                                      TransferMemo (Memo $ BSS.pack [0, 1, 2, 3])
-                                    ],
-                                \bs -> do
-                                    checkEncryptedBalance initialAccountEncryptedAmount{_selfAmount = eatdRemainingAmount} alesAccount bs
-                                    checkEncryptedBalance
-                                        initialAccountEncryptedAmount
-                                            { _startIndex = 0,
-                                              _incomingEncryptedAmounts = incomingAmounts3
-                                            }
-                                        thomasAccount
-                                        bs
-                              )
-                          ),
-                        ( Runner.TJSON
-                            { payload = Runner.EncryptedAmountTransferWithMemo alesAccount (Memo $ BSS.pack [0, 1, 2, 3]) encryptedTransferData4,
-                              metadata = makeDummyHeader thomasAccount 1 100000,
-                              keys = [(0, [(0, thomasKP)])]
-                            },
-                            ( SuccessE
-                                [ EncryptedAmountsRemoved
-                                    { earAccount = thomasAccount,
-                                      earUpToIndex = 2,
-                                      earNewAmount = eatdRemainingAmount encryptedTransferData4,
-                                      earInputAmount = aggregatedEncryptedAmount4
-                                    },
-                                  NewEncryptedAmount
-                                    { neaAccount = alesAccount,
-                                      neaNewIndex = 0,
-                                      neaEncryptedAmount = eatdTransferAmount encryptedTransferData4
-                                    },
-                                  TransferMemo (Memo $ BSS.pack [0, 1, 2, 3])
-                                ],
-                              \bs -> do
-                                checkEncryptedBalance
-                                    initialAccountEncryptedAmount
-                                        { _selfAmount = eatdRemainingAmount encryptedTransferData3,
-                                          _startIndex = 0,
-                                          _incomingEncryptedAmounts = incomingAmounts4A
-                                        }
-                                    alesAccount
-                                    bs
-                                checkEncryptedBalance
-                                    initialAccountEncryptedAmount
-                                        { _selfAmount = eatdRemainingAmount encryptedTransferData4,
-                                          _startIndex = 2,
-                                          _incomingEncryptedAmounts = incomingAmounts4T
-                                        }
-                                    thomasAccount
-                                    bs
-                            )
-                        ),
-                        ( Runner.TJSON
-                            { payload = Runner.EncryptedAmountTransferWithMemo alesAccount (Memo $ BSS.pack [0, 1, 2, 3]) encryptedTransferData5,
-                              metadata = makeDummyHeader thomasAccount 2 100000,
-                              keys = [(0, [(0, thomasKP)])]
-                            },
-                            ( SuccessE
-                                [ EncryptedAmountsRemoved
-                                    { earAccount = thomasAccount,
-                                      earUpToIndex = 3,
-                                      earNewAmount = eatdRemainingAmount encryptedTransferData5,
-                                      earInputAmount = aggregatedEncryptedAmount5
-                                    },
-                                  NewEncryptedAmount
-                                    { neaAccount = alesAccount,
-                                      neaNewIndex = 1,
-                                      neaEncryptedAmount = eatdTransferAmount encryptedTransferData5
-                                    },
-                                  TransferMemo (Memo $ BSS.pack [0, 1, 2, 3])
-                                ],
-                              \bs -> do
-                                checkEncryptedBalance
-                                    initialAccountEncryptedAmount
-                                        { _selfAmount = eatdRemainingAmount encryptedTransferData3,
-                                          _startIndex = 0,
-                                          _incomingEncryptedAmounts = incomingAmounts5A
-                                        }
-                                    alesAccount
-                                    bs
-                                checkEncryptedBalance
-                                    initialAccountEncryptedAmount
-                                        { _selfAmount = eatdRemainingAmount encryptedTransferData5,
-                                          _startIndex = 3,
-                                          _incomingEncryptedAmounts = incomingAmounts5T
-                                        }
-                                    thomasAccount
-                                    bs
-                            )
-                        ),
-                        ( Runner.TJSON
-                            { payload = Runner.TransferToPublic secToPubTransferData1,
-                              metadata = makeDummyHeader alesAccount 5 100000,
-                              keys = [(0, [(0, alesKP)])]
-                            },
-                            ( SuccessE
-                                [ EncryptedAmountsRemoved
-                                    { earAccount = alesAccount,
-                                      earUpToIndex = 0,
-                                      earNewAmount = stpatdRemainingAmount secToPubTransferData1,
-                                      earInputAmount = Concordium.Crypto.EncryptedTransfers.eatdRemainingAmount encryptedTransferData3
-                                    },
-                                  AmountAddedByDecryption
-                                    { aabdAccount = alesAccount,
-                                      aabdAmount = 650
-                                    }
-                                ],
-                              checkEncryptedBalance
-                                initialAccountEncryptedAmount
-                                    { _selfAmount = stpatdRemainingAmount secToPubTransferData1,
-                                      _startIndex = 0,
-                                      _incomingEncryptedAmounts = incomingAmounts5A
-                                    }
-                                alesAccount
-                            )
-                        ),
-                        ( Runner.TJSON
-                            { payload = Runner.TransferToPublic secToPubTransferData2,
-                              metadata = makeDummyHeader alesAccount 6 100000,
-                              keys = [(0, [(0, alesKP)])]
-                            },
-                            ( SuccessE
-                                [ EncryptedAmountsRemoved
-                                    { earAccount = alesAccount,
-                                      earUpToIndex = 1,
-                                      earNewAmount = stpatdRemainingAmount secToPubTransferData2,
-                                      earInputAmount = aggregatedEncryptedAmount7
-                                    },
-                                  AmountAddedByDecryption
-                                    { aabdAccount = alesAccount,
-                                      aabdAmount = 150
-                                    }
-                                ],
-                              checkEncryptedBalance
-                                initialAccountEncryptedAmount
-                                    { _selfAmount = stpatdRemainingAmount secToPubTransferData2,
-                                      _startIndex = 1,
-                                      _incomingEncryptedAmounts = incomingAmounts7A
-                                    }
-                                alesAccount
-                            )
-                        ),
-                        ( Runner.TJSON
-                            { payload = Runner.TransferToPublic secToPubTransferData3,
-                              metadata = makeDummyHeader alesAccount 7 100000,
-                              keys = [(0, [(0, alesKP)])]
-                            },
-                            ( SuccessE
-                                [ EncryptedAmountsRemoved
-                                    { earAccount = alesAccount,
-                                      earUpToIndex = 2,
-                                      earNewAmount = stpatdRemainingAmount secToPubTransferData3,
-                                      earInputAmount = aggregatedEncryptedAmount8
-                                    },
-                                  AmountAddedByDecryption
-                                    { aabdAccount = alesAccount,
-                                      aabdAmount = 200
-                                    }
-                                ],
-                              checkEncryptedBalance
-                                initialAccountEncryptedAmount
-                                    { _selfAmount = stpatdRemainingAmount secToPubTransferData3,
-                                      _startIndex = 2,
-                                      _incomingEncryptedAmounts = incomingAmounts8A
-                                    }
-                                alesAccount
-                            )
-                        )
-                    ]
-                }
-            ]
-        )
-  where
-    checkEncryptedBalance accEncAmount acc =
-        ( \bs -> specify ("Correct final balance on " ++ show acc) $
-            case Acc.getAccount acc (bs ^. blockAccounts) of
-                Nothing -> HUnit.assertFailure $ "Account with id '" ++ show acc ++ "' not found"
-                Just account -> HUnit.assertEqual "Expected encrypted amount matches" accEncAmount (account ^. accountEncryptedAmount)
-        )
+assertEncryptedBalance ::
+    Types.IsProtocolVersion pv =>
+    Types.AccountEncryptedAmount ->
+    Types.AccountAddress ->
+    BS.PersistentBlockState pv ->
+    Helpers.PersistentBSM pv Assertion
+assertEncryptedBalance expectedEncryptedAmount address blockState = do
+    maybeAccount <- BS.bsoGetAccount blockState address
+    case maybeAccount of
+        Nothing -> return $ assertFailure $ "No account found for address: " ++ show address
+        Just (_, account) -> do
+            accountEncryptedAmount <- BS.accountEncryptedAmount account
+            return $
+                assertEqual
+                    "Encrypted amounts matches"
+                    accountEncryptedAmount
+                    expectedEncryptedAmount
 
 tests :: Spec
 tests = do
-    (t1, t2) <- runIO mkTestCases
-    describe "Encrypted transfers." $ mkSpecs t1
-    describe "Encrypted transfers with memo." $ mkSpecs t2
+    describe "Encrypted transfers:" $
+        sequence_ $
+            Helpers.forEveryProtocolVersion $ \spv pvString -> do
+                testCase0 spv pvString
+                testCase1 spv pvString
+                testCase2 spv pvString
+
+createEncryptedTransferData ::
+    ID.AccountEncryptionKey ->
+    ElgamalSecretKey ->
+    AggregatedDecryptedAmount ->
+    Types.Amount ->
+    IO (Maybe EncryptedAmountTransferData)
+createEncryptedTransferData (ID.AccountEncryptionKey receiverPK) =
+    makeEncryptedAmountTransferData dummyCryptographicParameters receiverPK
+
+createSecToPubTransferData :: ElgamalSecretKey -> AggregatedDecryptedAmount -> Types.Amount -> IO (Maybe SecToPubAmountTransferData)
+createSecToPubTransferData = makeSecToPubAmountTransferData dummyCryptographicParameters
+
+testCase0 ::
+    forall pv.
+    (Types.IsProtocolVersion pv) =>
+    Types.SProtocolVersion pv ->
+    String ->
+    SpecWith (Arg Assertion)
+testCase0 _ pvString = specify
+    (pvString ++ ": Chain of encrypted transfer")
+    $ do
+        transactionsAndAssertions <- makeTransactions
+        Helpers.runSchedulerTestAssertIntermediateStates
+            @pv
+            Helpers.defaultTestConfig
+            initialBlockState
+            transactionsAndAssertions
+  where
+    makeTransactions = do
+        -- Transaction 1. Pub to sec (1000)
+        let encryptedAmount1000 :: EncryptedAmount
+            encryptedAmount1000 = encryptAmountZeroRandomness dummyCryptographicParameters 1_000
+
+        -- Transaction 2. EncTransfer (A0->A1, 100) with previous amounts
+        let aggregatedDecryptedAmount1 :: AggregatedDecryptedAmount
+            aggregatedDecryptedAmount1 = makeAggregatedDecryptedAmount encryptedAmount1000 1_000 0
+
+        encryptedTransferData1 :: EncryptedAmountTransferData <-
+            fromJust
+                <$> createEncryptedTransferData
+                    encryptionPublicKey1
+                    encryptionSecretKey0
+                    aggregatedDecryptedAmount1
+                    100
+
+        let incomingAmounts1 :: Seq.Seq EncryptedAmount
+            incomingAmounts1 = Seq.singleton $ eatdTransferAmount encryptedTransferData1
+
+        -- Transaction 3. EncTransfer (A0->A1, 100) with previous amounts
+        let aggregatedDecryptedAmount2 :: AggregatedDecryptedAmount
+            aggregatedDecryptedAmount2 =
+                makeAggregatedDecryptedAmount
+                    (eatdRemainingAmount encryptedTransferData1)
+                    900
+                    0
+
+        encryptedTransferData2 :: EncryptedAmountTransferData <-
+            fromJust
+                <$> createEncryptedTransferData
+                    encryptionPublicKey1
+                    encryptionSecretKey0
+                    aggregatedDecryptedAmount2
+                    100
+
+        let incomingAmounts2 :: Seq.Seq EncryptedAmount
+            incomingAmounts2 = incomingAmounts1 Seq.:|> eatdTransferAmount encryptedTransferData2
+
+        -- Transaction 4. EncTransfer (A0->A1, 100) with previous amounts
+        let aggregatedDecryptedAmount3 :: AggregatedDecryptedAmount
+            aggregatedDecryptedAmount3 =
+                makeAggregatedDecryptedAmount
+                    (eatdRemainingAmount encryptedTransferData2)
+                    800
+                    0
+
+        encryptedTransferData3 :: EncryptedAmountTransferData <-
+            fromJust
+                <$> createEncryptedTransferData
+                    encryptionPublicKey1
+                    encryptionSecretKey0
+                    aggregatedDecryptedAmount3
+                    100
+
+        let incomingAmounts3 :: Seq.Seq EncryptedAmount
+            incomingAmounts3 = incomingAmounts2 Seq.:|> eatdTransferAmount encryptedTransferData3
+
+        -- Transaction 5. EncTransfer (A1->A0, 150) with previous amounts
+        let aggregatedEncryptedAmount4 :: EncryptedAmount
+            aggregatedEncryptedAmount4 =
+                aggregateAmounts mempty $
+                    aggregateAmounts
+                        (eatdTransferAmount encryptedTransferData1)
+                        (eatdTransferAmount encryptedTransferData2)
+
+            aggregatedDecryptedAmount4 :: AggregatedDecryptedAmount
+            aggregatedDecryptedAmount4 =
+                makeAggregatedDecryptedAmount
+                    aggregatedEncryptedAmount4
+                    200
+                    2
+
+        encryptedTransferData4 :: EncryptedAmountTransferData <-
+            fromJust
+                <$> createEncryptedTransferData
+                    encryptionPublicKey0
+                    encryptionSecretKey1
+                    aggregatedDecryptedAmount4
+                    150
+
+        let incomingAmounts4account0 :: Seq.Seq EncryptedAmount
+            incomingAmounts4account0 = Seq.singleton $ eatdTransferAmount encryptedTransferData4
+
+            incomingAmounts4account1 :: Seq.Seq EncryptedAmount
+            incomingAmounts4account1 = Seq.singleton $ eatdTransferAmount encryptedTransferData3
+
+        -- Transaction 6. EncTransfer (T->A, 150) with previous amounts
+        let aggregatedEncryptedAmount5 :: EncryptedAmount
+            aggregatedEncryptedAmount5 =
+                aggregateAmounts
+                    (eatdRemainingAmount encryptedTransferData4)
+                    (eatdTransferAmount encryptedTransferData3)
+            aggregatedDecryptedAmount5 :: AggregatedDecryptedAmount
+            aggregatedDecryptedAmount5 =
+                makeAggregatedDecryptedAmount
+                    aggregatedEncryptedAmount5
+                    150
+                    3
+
+        encryptedTransferData5 :: EncryptedAmountTransferData <-
+            fromJust
+                <$> createEncryptedTransferData
+                    encryptionPublicKey0
+                    encryptionSecretKey1
+                    aggregatedDecryptedAmount5
+                    150
+
+        let incomingAmounts5account0 :: Seq.Seq EncryptedAmount
+            incomingAmounts5account0 =
+                incomingAmounts4account0
+                    Seq.:|> eatdTransferAmount encryptedTransferData5
+
+            incomingAmounts5account1 :: Seq.Seq EncryptedAmount
+            incomingAmounts5account1 = Seq.empty
+
+        -- Transaction 7. Sec to Pub 650 (to not consume fully the selfAmount which is 700 rn)
+        let aggregatedDecryptedAmount6 :: AggregatedDecryptedAmount
+            aggregatedDecryptedAmount6 =
+                makeAggregatedDecryptedAmount
+                    (eatdRemainingAmount encryptedTransferData3)
+                    700
+                    0
+
+        secToPubTransferData1 :: SecToPubAmountTransferData <-
+            fromJust <$> createSecToPubTransferData encryptionSecretKey0 aggregatedDecryptedAmount6 650
+
+        let incomingAmounts7account0 :: Seq.Seq EncryptedAmount
+            incomingAmounts7account0 = Seq.singleton $ eatdTransferAmount encryptedTransferData5
+
+        -- Transaction 8. Sec to Pub 150
+        let aggregatedEncryptedAmount7 :: EncryptedAmount
+            aggregatedEncryptedAmount7 =
+                aggregateAmounts
+                    (stpatdRemainingAmount secToPubTransferData1)
+                    (eatdTransferAmount encryptedTransferData4)
+
+            aggregatedDecryptedAmount7 :: AggregatedDecryptedAmount
+            aggregatedDecryptedAmount7 = makeAggregatedDecryptedAmount aggregatedEncryptedAmount7 200 1
+
+        secToPubTransferData2 :: SecToPubAmountTransferData <-
+            fromJust
+                <$> createSecToPubTransferData
+                    encryptionSecretKey0
+                    aggregatedDecryptedAmount7
+                    150
+
+        -- Transaction 9. Sec to Pub 200
+        let aggregatedEncryptedAmount8 :: EncryptedAmount
+            aggregatedEncryptedAmount8 =
+                aggregateAmounts
+                    (stpatdRemainingAmount secToPubTransferData2)
+                    (eatdTransferAmount encryptedTransferData5)
+
+            aggregatedDecryptedAmount8 :: AggregatedDecryptedAmount
+            aggregatedDecryptedAmount8 =
+                makeAggregatedDecryptedAmount
+                    aggregatedEncryptedAmount8
+                    200
+                    2
+
+        secToPubTransferData3 :: SecToPubAmountTransferData <-
+            fromJust
+                <$> createSecToPubTransferData
+                    encryptionSecretKey0
+                    aggregatedDecryptedAmount8
+                    200
+
+        let incomingAmounts8account0 :: Seq.Seq EncryptedAmount
+            incomingAmounts8account0 = Seq.empty
+
+        return
+            [   ( Runner.TJSON
+                    { payload = Runner.TransferToEncrypted 1_000,
+                      metadata = makeDummyHeader accountAddress0 1 100_000,
+                      keys = [(0, [(0, keyPair0)])]
+                    },
+                  \Helpers.SchedulerResult{..} state -> do
+                    doInvariantAssertions <-
+                        Helpers.assertBlockStateInvariantsH
+                            state
+                            srExecutionCosts
+                    doEncryptedBalanceAssertions <-
+                        assertEncryptedBalance
+                            Types.initialAccountEncryptedAmount
+                                { Types._selfAmount = encryptedAmount1000
+                                }
+                            accountAddress0
+                            state
+                    return $ do
+                        case Helpers.getResults $ Sch.ftAdded srTransactions of
+                            [(_, Types.TxSuccess{..})] ->
+                                assertEqual
+                                    "The correct encrypt self amount event is produced"
+                                    [ Types.EncryptedSelfAmountAdded
+                                        { eaaAccount = accountAddress0,
+                                          eaaNewAmount = encryptedAmount1000,
+                                          eaaAmount = 1_000
+                                        }
+                                    ]
+                                    vrEvents
+                            _ -> assertFailure "First transaction should succeed"
+                        doInvariantAssertions
+                        doEncryptedBalanceAssertions
+                ),
+                ( Runner.TJSON
+                    { payload =
+                        Runner.EncryptedAmountTransfer
+                            accountAddress1
+                            encryptedTransferData1,
+                      metadata = makeDummyHeader accountAddress0 2 100_000,
+                      keys = [(0, [(0, keyPair0)])]
+                    },
+                  \Helpers.SchedulerResult{..} state -> do
+                    doEncryptedBalanceAssertionSender <-
+                        assertEncryptedBalance
+                            Types.initialAccountEncryptedAmount
+                                { Types._selfAmount = eatdRemainingAmount encryptedTransferData1
+                                }
+                            accountAddress0
+                            state
+                    doEncryptedBalanceAssertionReceiver <-
+                        assertEncryptedBalance
+                            Types.initialAccountEncryptedAmount
+                                { Types._startIndex = 0,
+                                  Types._incomingEncryptedAmounts =
+                                    incomingAmounts1
+                                }
+                            accountAddress1
+                            state
+                    return $ do
+                        case Helpers.getResults $ Sch.ftAdded srTransactions of
+                            [(_, Types.TxSuccess{..})] ->
+                                assertEqual
+                                    "The correct events are produced"
+                                    [ Types.EncryptedAmountsRemoved
+                                        { earAccount = accountAddress0,
+                                          earUpToIndex = 0,
+                                          earNewAmount = eatdRemainingAmount encryptedTransferData1,
+                                          earInputAmount = encryptedAmount1000
+                                        },
+                                      Types.NewEncryptedAmount
+                                        { neaAccount = accountAddress1,
+                                          neaNewIndex = 0,
+                                          neaEncryptedAmount =
+                                            eatdTransferAmount
+                                                encryptedTransferData1
+                                        }
+                                    ]
+                                    vrEvents
+                            _ -> assertFailure "Third transaction should succeed"
+                        doEncryptedBalanceAssertionSender
+                        doEncryptedBalanceAssertionReceiver
+                ),
+                ( Runner.TJSON
+                    { payload =
+                        Runner.EncryptedAmountTransfer
+                            accountAddress1
+                            encryptedTransferData2,
+                      metadata = makeDummyHeader accountAddress0 3 100_000,
+                      keys = [(0, [(0, keyPair0)])]
+                    },
+                  \Helpers.SchedulerResult{..} state -> do
+                    doEncryptedBalanceAssertionSender <-
+                        assertEncryptedBalance
+                            Types.initialAccountEncryptedAmount
+                                { Types._selfAmount = eatdRemainingAmount encryptedTransferData2
+                                }
+                            accountAddress0
+                            state
+                    doEncryptedBalanceAssertionReceiver <-
+                        assertEncryptedBalance
+                            Types.initialAccountEncryptedAmount
+                                { Types._startIndex = 0,
+                                  Types._incomingEncryptedAmounts = incomingAmounts2
+                                }
+                            accountAddress1
+                            state
+                    return $ do
+                        case Helpers.getResults $ Sch.ftAdded srTransactions of
+                            [(_, Types.TxSuccess{..})] ->
+                                assertEqual
+                                    "The correct events are produced"
+                                    [ Types.EncryptedAmountsRemoved
+                                        { earAccount = accountAddress0,
+                                          earUpToIndex = 0,
+                                          earNewAmount = eatdRemainingAmount encryptedTransferData2,
+                                          earInputAmount =
+                                            eatdRemainingAmount
+                                                encryptedTransferData1
+                                        },
+                                      Types.NewEncryptedAmount
+                                        { neaAccount = accountAddress1,
+                                          neaNewIndex = 1,
+                                          neaEncryptedAmount =
+                                            eatdTransferAmount
+                                                encryptedTransferData2
+                                        }
+                                    ]
+                                    vrEvents
+                            _ -> assertFailure "Forth transaction should succeed"
+                        doEncryptedBalanceAssertionSender
+                        doEncryptedBalanceAssertionReceiver
+                ),
+                ( Runner.TJSON
+                    { payload =
+                        Runner.EncryptedAmountTransfer
+                            accountAddress1
+                            encryptedTransferData3,
+                      metadata = makeDummyHeader accountAddress0 4 100_000,
+                      keys = [(0, [(0, keyPair0)])]
+                    },
+                  \Helpers.SchedulerResult{..} state -> do
+                    doEncryptedBalanceAssertionSender <-
+                        assertEncryptedBalance
+                            Types.initialAccountEncryptedAmount
+                                { Types._selfAmount = eatdRemainingAmount encryptedTransferData3
+                                }
+                            accountAddress0
+                            state
+                    doEncryptedBalanceAssertionReceiver <-
+                        assertEncryptedBalance
+                            Types.initialAccountEncryptedAmount
+                                { Types._startIndex = 0,
+                                  Types._incomingEncryptedAmounts = incomingAmounts3
+                                }
+                            accountAddress1
+                            state
+                    return $ do
+                        case Helpers.getResults $ Sch.ftAdded srTransactions of
+                            [(_, Types.TxSuccess{..})] ->
+                                assertEqual
+                                    "The correct events are produced"
+                                    [ Types.EncryptedAmountsRemoved
+                                        { earAccount = accountAddress0,
+                                          earUpToIndex = 0,
+                                          earNewAmount = eatdRemainingAmount encryptedTransferData3,
+                                          earInputAmount =
+                                            eatdRemainingAmount
+                                                encryptedTransferData2
+                                        },
+                                      Types.NewEncryptedAmount
+                                        { neaAccount = accountAddress1,
+                                          neaNewIndex = 2,
+                                          neaEncryptedAmount =
+                                            eatdTransferAmount
+                                                encryptedTransferData3
+                                        }
+                                    ]
+                                    vrEvents
+                            _ -> assertFailure "Fifth transaction should succeed"
+                        doEncryptedBalanceAssertionSender
+                        doEncryptedBalanceAssertionReceiver
+                ),
+                ( Runner.TJSON
+                    { payload = Runner.EncryptedAmountTransfer accountAddress0 encryptedTransferData4,
+                      metadata = makeDummyHeader accountAddress1 1 100_000,
+                      keys = [(0, [(0, keyPair1)])]
+                    },
+                  \Helpers.SchedulerResult{..} state -> do
+                    doEncryptedBalanceAssertionSender <-
+                        assertEncryptedBalance
+                            Types.initialAccountEncryptedAmount
+                                { Types._selfAmount = eatdRemainingAmount encryptedTransferData4,
+                                  Types._startIndex = 2,
+                                  Types._incomingEncryptedAmounts = incomingAmounts4account1
+                                }
+                            accountAddress1
+                            state
+                    doEncryptedBalanceAssertionReceiver <-
+                        assertEncryptedBalance
+                            Types.initialAccountEncryptedAmount
+                                { Types._selfAmount = eatdRemainingAmount encryptedTransferData3,
+                                  Types._startIndex = 0,
+                                  Types._incomingEncryptedAmounts = incomingAmounts4account0
+                                }
+                            accountAddress0
+                            state
+                    return $ do
+                        case Helpers.getResults $ Sch.ftAdded srTransactions of
+                            [(_, Types.TxSuccess{..})] ->
+                                assertEqual
+                                    "The correct events are produced"
+                                    [ Types.EncryptedAmountsRemoved
+                                        { earAccount = accountAddress1,
+                                          earUpToIndex = 2,
+                                          earNewAmount = eatdRemainingAmount encryptedTransferData4,
+                                          earInputAmount = aggregatedEncryptedAmount4
+                                        },
+                                      Types.NewEncryptedAmount
+                                        { neaAccount = accountAddress0,
+                                          neaNewIndex = 0,
+                                          neaEncryptedAmount =
+                                            eatdTransferAmount
+                                                encryptedTransferData4
+                                        }
+                                    ]
+                                    vrEvents
+                            _ -> assertFailure "Sixth transaction should succeed"
+                        doEncryptedBalanceAssertionSender
+                        doEncryptedBalanceAssertionReceiver
+                ),
+                ( Runner.TJSON
+                    { payload =
+                        Runner.EncryptedAmountTransfer
+                            accountAddress0
+                            encryptedTransferData5,
+                      metadata = makeDummyHeader accountAddress1 2 100_000,
+                      keys = [(0, [(0, keyPair1)])]
+                    },
+                  \Helpers.SchedulerResult{..} state -> do
+                    doEncryptedBalanceAssertionSender <-
+                        assertEncryptedBalance
+                            Types.initialAccountEncryptedAmount
+                                { Types._selfAmount = eatdRemainingAmount encryptedTransferData5,
+                                  Types._startIndex = 3,
+                                  Types._incomingEncryptedAmounts = incomingAmounts5account1
+                                }
+                            accountAddress1
+                            state
+                    doEncryptedBalanceAssertionReceiver <-
+                        assertEncryptedBalance
+                            Types.initialAccountEncryptedAmount
+                                { Types._selfAmount = eatdRemainingAmount encryptedTransferData3,
+                                  Types._startIndex = 0,
+                                  Types._incomingEncryptedAmounts = incomingAmounts5account0
+                                }
+                            accountAddress0
+                            state
+                    return $ do
+                        case Helpers.getResults $ Sch.ftAdded srTransactions of
+                            [(_, Types.TxSuccess{..})] ->
+                                assertEqual
+                                    "The correct events are produced"
+                                    [ Types.EncryptedAmountsRemoved
+                                        { earAccount = accountAddress1,
+                                          earUpToIndex = 3,
+                                          earNewAmount = eatdRemainingAmount encryptedTransferData5,
+                                          earInputAmount = aggregatedEncryptedAmount5
+                                        },
+                                      Types.NewEncryptedAmount
+                                        { neaAccount = accountAddress0,
+                                          neaNewIndex = 1,
+                                          neaEncryptedAmount =
+                                            eatdTransferAmount
+                                                encryptedTransferData5
+                                        }
+                                    ]
+                                    vrEvents
+                            _ -> assertFailure "Seventh transaction should succeed"
+                        doEncryptedBalanceAssertionSender
+                        doEncryptedBalanceAssertionReceiver
+                ),
+                ( Runner.TJSON
+                    { payload = Runner.TransferToPublic secToPubTransferData1,
+                      metadata = makeDummyHeader accountAddress0 5 100_000,
+                      keys = [(0, [(0, keyPair0)])]
+                    },
+                  \Helpers.SchedulerResult{..} state -> do
+                    doEncryptedBalanceAssertion <-
+                        assertEncryptedBalance
+                            Types.initialAccountEncryptedAmount
+                                { Types._selfAmount = stpatdRemainingAmount secToPubTransferData1,
+                                  Types._startIndex = 0,
+                                  Types._incomingEncryptedAmounts = incomingAmounts5account0
+                                }
+                            accountAddress0
+                            state
+                    return $ do
+                        case Helpers.getResults $ Sch.ftAdded srTransactions of
+                            [(_, Types.TxSuccess{..})] ->
+                                assertEqual
+                                    "The correct events are produced"
+                                    [ Types.EncryptedAmountsRemoved
+                                        { earAccount = accountAddress0,
+                                          earUpToIndex = 0,
+                                          earNewAmount =
+                                            stpatdRemainingAmount
+                                                secToPubTransferData1,
+                                          earInputAmount =
+                                            eatdRemainingAmount
+                                                encryptedTransferData3
+                                        },
+                                      Types.AmountAddedByDecryption
+                                        { aabdAccount = accountAddress0,
+                                          aabdAmount = 650
+                                        }
+                                    ]
+                                    vrEvents
+                            _ -> assertFailure "Eigth transaction should succeed"
+                        doEncryptedBalanceAssertion
+                ),
+                ( Runner.TJSON
+                    { payload = Runner.TransferToPublic secToPubTransferData2,
+                      metadata = makeDummyHeader accountAddress0 6 100_000,
+                      keys = [(0, [(0, keyPair0)])]
+                    },
+                  \Helpers.SchedulerResult{..} state -> do
+                    doEncryptedBalanceAssertion <-
+                        assertEncryptedBalance
+                            Types.initialAccountEncryptedAmount
+                                { Types._selfAmount = stpatdRemainingAmount secToPubTransferData2,
+                                  Types._startIndex = 1,
+                                  Types._incomingEncryptedAmounts = incomingAmounts7account0
+                                }
+                            accountAddress0
+                            state
+                    return $ do
+                        case Helpers.getResults $ Sch.ftAdded srTransactions of
+                            [(_, Types.TxSuccess{..})] ->
+                                assertEqual
+                                    "The correct events are produced"
+                                    [ Types.EncryptedAmountsRemoved
+                                        { earAccount = accountAddress0,
+                                          earUpToIndex = 1,
+                                          earNewAmount =
+                                            stpatdRemainingAmount
+                                                secToPubTransferData2,
+                                          earInputAmount = aggregatedEncryptedAmount7
+                                        },
+                                      Types.AmountAddedByDecryption
+                                        { aabdAccount = accountAddress0,
+                                          aabdAmount = 150
+                                        }
+                                    ]
+                                    vrEvents
+                            _ -> assertFailure "Nineth transaction should succeed"
+                        doEncryptedBalanceAssertion
+                ),
+                ( Runner.TJSON
+                    { payload = Runner.TransferToPublic secToPubTransferData3,
+                      metadata = makeDummyHeader accountAddress0 7 100_000,
+                      keys = [(0, [(0, keyPair0)])]
+                    },
+                  \Helpers.SchedulerResult{..} state -> do
+                    doEncryptedBalanceAssertion <-
+                        assertEncryptedBalance
+                            Types.initialAccountEncryptedAmount
+                                { Types._selfAmount = stpatdRemainingAmount secToPubTransferData3,
+                                  Types._startIndex = 2,
+                                  Types._incomingEncryptedAmounts = incomingAmounts8account0
+                                }
+                            accountAddress0
+                            state
+                    return $ do
+                        case Helpers.getResults $ Sch.ftAdded srTransactions of
+                            [(_, Types.TxSuccess{..})] ->
+                                assertEqual
+                                    "The correct events are produced"
+                                    [ Types.EncryptedAmountsRemoved
+                                        { earAccount = accountAddress0,
+                                          earUpToIndex = 2,
+                                          earNewAmount =
+                                            stpatdRemainingAmount
+                                                secToPubTransferData3,
+                                          earInputAmount = aggregatedEncryptedAmount8
+                                        },
+                                      Types.AmountAddedByDecryption
+                                        { aabdAccount = accountAddress0,
+                                          aabdAmount = 200
+                                        }
+                                    ]
+                                    vrEvents
+                            _ -> assertFailure "Tenth transaction should succeed"
+                        doEncryptedBalanceAssertion
+                )
+            ]
+
+testCase1 ::
+    forall pv.
+    (Types.IsProtocolVersion pv) =>
+    Types.SProtocolVersion pv ->
+    String ->
+    SpecWith (Arg Assertion)
+testCase1 spv pvString =
+    unless (Types.supportsMemo spv)
+        $ specify
+            (pvString ++ ": Fail deserializing encrypted transfer with memo")
+        $ do
+            transactionsAndAssertions <- makeTransactions
+            Helpers.runSchedulerTestAssertIntermediateStates
+                @pv
+                Helpers.defaultTestConfig
+                initialBlockState
+                transactionsAndAssertions
+  where
+    makeTransactions = do
+        -- Transaction 1. Pub to sec (1000)
+        let encryptedAmount1000 :: EncryptedAmount
+            encryptedAmount1000 = encryptAmountZeroRandomness dummyCryptographicParameters 1_000
+
+        -- Transaction 2. EncTransfer (A0->A1, 100) with previous amounts
+        let aggregatedDecryptedAmount1 :: AggregatedDecryptedAmount
+            aggregatedDecryptedAmount1 = makeAggregatedDecryptedAmount encryptedAmount1000 1_000 0
+
+        encryptedTransferData1 :: EncryptedAmountTransferData <-
+            fromJust
+                <$> createEncryptedTransferData
+                    encryptionPublicKey1
+                    encryptionSecretKey0
+                    aggregatedDecryptedAmount1
+                    100
+
+        let memo = Types.Memo $ BSS.pack [0, 1, 2, 3]
+
+        return
+            [   ( Runner.TJSON
+                    { payload = Runner.TransferToEncrypted 1_000,
+                      metadata = makeDummyHeader accountAddress0 1 100_000,
+                      keys = [(0, [(0, keyPair0)])]
+                    },
+                  \Helpers.SchedulerResult{..} state -> do
+                    doInvariantAssertions <-
+                        Helpers.assertBlockStateInvariantsH
+                            state
+                            srExecutionCosts
+                    doEncryptedBalanceAssertions <-
+                        assertEncryptedBalance
+                            Types.initialAccountEncryptedAmount
+                                { Types._selfAmount = encryptedAmount1000
+                                }
+                            accountAddress0
+                            state
+                    return $ do
+                        case Helpers.getResults $ Sch.ftAdded srTransactions of
+                            [(_, Types.TxSuccess{..})] ->
+                                assertEqual
+                                    "The correct encrypt self amount event is produced"
+                                    [ Types.EncryptedSelfAmountAdded
+                                        { eaaAccount = accountAddress0,
+                                          eaaNewAmount = encryptedAmount1000,
+                                          eaaAmount = 1_000
+                                        }
+                                    ]
+                                    vrEvents
+                            _ -> assertFailure "First transaction should succeed"
+                        doInvariantAssertions
+                        doEncryptedBalanceAssertions
+                ),
+                ( Runner.TJSON
+                    { payload =
+                        Runner.EncryptedAmountTransferWithMemo
+                            accountAddress1
+                            memo
+                            encryptedTransferData1,
+                      metadata = makeDummyHeader accountAddress0 2 100_000,
+                      keys = [(0, [(0, keyPair0)])]
+                    },
+                  \Helpers.SchedulerResult{..} state -> do
+                    doEncryptedBalanceAssertions <-
+                        assertEncryptedBalance
+                            Types.initialAccountEncryptedAmount
+                                { Types._selfAmount = encryptedAmount1000
+                                }
+                            accountAddress0
+                            state
+                    return $ do
+                        case Helpers.getResults $ Sch.ftAdded srTransactions of
+                            [(_, Types.TxReject{..})] ->
+                                assertEqual
+                                    "The correct events are produced"
+                                    Types.SerializationFailure
+                                    vrRejectReason
+                            _ -> assertFailure "Second transaction should reject"
+                        doEncryptedBalanceAssertions
+                )
+            ]
+
+testCase2 ::
+    forall pv.
+    (Types.IsProtocolVersion pv) =>
+    Types.SProtocolVersion pv ->
+    String ->
+    SpecWith (Arg Assertion)
+testCase2 spv pvString =
+    when (Types.supportsMemo spv)
+        $ specify
+            (pvString ++ ": Chain of encrypted transfer with memo")
+        $ do
+            transactionsAndAssertions <- makeTransactions
+            Helpers.runSchedulerTestAssertIntermediateStates
+                @pv
+                Helpers.defaultTestConfig
+                initialBlockState
+                transactionsAndAssertions
+  where
+    makeTransactions = do
+        -- Transaction 1. Pub to sec (1000)
+        let encryptedAmount1000 :: EncryptedAmount
+            encryptedAmount1000 = encryptAmountZeroRandomness dummyCryptographicParameters 1_000
+
+        -- Transaction 2. EncTransfer (A0->A1, 100) with previous amounts
+        let aggregatedDecryptedAmount1 :: AggregatedDecryptedAmount
+            aggregatedDecryptedAmount1 = makeAggregatedDecryptedAmount encryptedAmount1000 1_000 0
+
+        encryptedTransferData1 :: EncryptedAmountTransferData <-
+            fromJust
+                <$> createEncryptedTransferData
+                    encryptionPublicKey1
+                    encryptionSecretKey0
+                    aggregatedDecryptedAmount1
+                    100
+
+        let incomingAmounts1 :: Seq.Seq EncryptedAmount
+            incomingAmounts1 = Seq.singleton $ eatdTransferAmount encryptedTransferData1
+
+        -- Transaction 3. EncTransfer (A0->A1, 100) with previous amounts
+        let aggregatedDecryptedAmount2 :: AggregatedDecryptedAmount
+            aggregatedDecryptedAmount2 =
+                makeAggregatedDecryptedAmount
+                    (eatdRemainingAmount encryptedTransferData1)
+                    900
+                    0
+
+        encryptedTransferData2 :: EncryptedAmountTransferData <-
+            fromJust
+                <$> createEncryptedTransferData
+                    encryptionPublicKey1
+                    encryptionSecretKey0
+                    aggregatedDecryptedAmount2
+                    100
+
+        let incomingAmounts2 :: Seq.Seq EncryptedAmount
+            incomingAmounts2 = incomingAmounts1 Seq.:|> eatdTransferAmount encryptedTransferData2
+
+        -- Transaction 4. EncTransfer (A0->A1, 100) with previous amounts
+        let aggregatedDecryptedAmount3 :: AggregatedDecryptedAmount
+            aggregatedDecryptedAmount3 =
+                makeAggregatedDecryptedAmount
+                    (eatdRemainingAmount encryptedTransferData2)
+                    800
+                    0
+
+        encryptedTransferData3 :: EncryptedAmountTransferData <-
+            fromJust
+                <$> createEncryptedTransferData
+                    encryptionPublicKey1
+                    encryptionSecretKey0
+                    aggregatedDecryptedAmount3
+                    100
+
+        let incomingAmounts3 :: Seq.Seq EncryptedAmount
+            incomingAmounts3 = incomingAmounts2 Seq.:|> eatdTransferAmount encryptedTransferData3
+
+        -- Transaction 5. EncTransfer (A1->A0, 150) with previous amounts
+        let aggregatedEncryptedAmount4 :: EncryptedAmount
+            aggregatedEncryptedAmount4 =
+                aggregateAmounts mempty $
+                    aggregateAmounts
+                        (eatdTransferAmount encryptedTransferData1)
+                        (eatdTransferAmount encryptedTransferData2)
+
+            aggregatedDecryptedAmount4 :: AggregatedDecryptedAmount
+            aggregatedDecryptedAmount4 =
+                makeAggregatedDecryptedAmount
+                    aggregatedEncryptedAmount4
+                    200
+                    2
+
+        encryptedTransferData4 :: EncryptedAmountTransferData <-
+            fromJust
+                <$> createEncryptedTransferData
+                    encryptionPublicKey0
+                    encryptionSecretKey1
+                    aggregatedDecryptedAmount4
+                    150
+
+        let incomingAmounts4account0 :: Seq.Seq EncryptedAmount
+            incomingAmounts4account0 = Seq.singleton $ eatdTransferAmount encryptedTransferData4
+
+            incomingAmounts4account1 :: Seq.Seq EncryptedAmount
+            incomingAmounts4account1 = Seq.singleton $ eatdTransferAmount encryptedTransferData3
+
+        -- Transaction 6. EncTransfer (T->A, 150) with previous amounts
+        let aggregatedEncryptedAmount5 :: EncryptedAmount
+            aggregatedEncryptedAmount5 =
+                aggregateAmounts
+                    (eatdRemainingAmount encryptedTransferData4)
+                    (eatdTransferAmount encryptedTransferData3)
+            aggregatedDecryptedAmount5 :: AggregatedDecryptedAmount
+            aggregatedDecryptedAmount5 =
+                makeAggregatedDecryptedAmount
+                    aggregatedEncryptedAmount5
+                    150
+                    3
+
+        encryptedTransferData5 :: EncryptedAmountTransferData <-
+            fromJust
+                <$> createEncryptedTransferData
+                    encryptionPublicKey0
+                    encryptionSecretKey1
+                    aggregatedDecryptedAmount5
+                    150
+
+        let incomingAmounts5account0 :: Seq.Seq EncryptedAmount
+            incomingAmounts5account0 =
+                incomingAmounts4account0
+                    Seq.:|> eatdTransferAmount encryptedTransferData5
+
+            incomingAmounts5account1 :: Seq.Seq EncryptedAmount
+            incomingAmounts5account1 = Seq.empty
+
+        -- Transaction 7. Sec to Pub 650 (to not consume fully the selfAmount which is 700 rn)
+        let aggregatedDecryptedAmount6 :: AggregatedDecryptedAmount
+            aggregatedDecryptedAmount6 =
+                makeAggregatedDecryptedAmount
+                    (eatdRemainingAmount encryptedTransferData3)
+                    700
+                    0
+
+        secToPubTransferData1 :: SecToPubAmountTransferData <-
+            fromJust <$> createSecToPubTransferData encryptionSecretKey0 aggregatedDecryptedAmount6 650
+
+        let incomingAmounts7account0 :: Seq.Seq EncryptedAmount
+            incomingAmounts7account0 = Seq.singleton $ eatdTransferAmount encryptedTransferData5
+
+        -- Transaction 8. Sec to Pub 150
+        let aggregatedEncryptedAmount7 :: EncryptedAmount
+            aggregatedEncryptedAmount7 =
+                aggregateAmounts
+                    (stpatdRemainingAmount secToPubTransferData1)
+                    (eatdTransferAmount encryptedTransferData4)
+
+            aggregatedDecryptedAmount7 :: AggregatedDecryptedAmount
+            aggregatedDecryptedAmount7 = makeAggregatedDecryptedAmount aggregatedEncryptedAmount7 200 1
+
+        secToPubTransferData2 :: SecToPubAmountTransferData <-
+            fromJust
+                <$> createSecToPubTransferData
+                    encryptionSecretKey0
+                    aggregatedDecryptedAmount7
+                    150
+
+        -- Transaction 9. Sec to Pub 200
+        let aggregatedEncryptedAmount8 :: EncryptedAmount
+            aggregatedEncryptedAmount8 =
+                aggregateAmounts
+                    (stpatdRemainingAmount secToPubTransferData2)
+                    (eatdTransferAmount encryptedTransferData5)
+
+            aggregatedDecryptedAmount8 :: AggregatedDecryptedAmount
+            aggregatedDecryptedAmount8 =
+                makeAggregatedDecryptedAmount
+                    aggregatedEncryptedAmount8
+                    200
+                    2
+
+        secToPubTransferData3 :: SecToPubAmountTransferData <-
+            fromJust
+                <$> createSecToPubTransferData
+                    encryptionSecretKey0
+                    aggregatedDecryptedAmount8
+                    200
+
+        let incomingAmounts8account0 :: Seq.Seq EncryptedAmount
+            incomingAmounts8account0 = Seq.empty
+
+        let memo = Types.Memo $ BSS.pack [0, 1, 2, 3]
+
+        return
+            [   ( Runner.TJSON
+                    { payload = Runner.TransferToEncrypted 1_000,
+                      metadata = makeDummyHeader accountAddress0 1 100_000,
+                      keys = [(0, [(0, keyPair0)])]
+                    },
+                  \Helpers.SchedulerResult{..} state -> do
+                    doInvariantAssertions <-
+                        Helpers.assertBlockStateInvariantsH
+                            state
+                            srExecutionCosts
+                    doEncryptedBalanceAssertions <-
+                        assertEncryptedBalance
+                            Types.initialAccountEncryptedAmount
+                                { Types._selfAmount = encryptedAmount1000
+                                }
+                            accountAddress0
+                            state
+                    return $ do
+                        case Helpers.getResults $ Sch.ftAdded srTransactions of
+                            [(_, Types.TxSuccess{..})] ->
+                                assertEqual
+                                    "The correct encrypt self amount event is produced"
+                                    [ Types.EncryptedSelfAmountAdded
+                                        { eaaAccount = accountAddress0,
+                                          eaaNewAmount = encryptedAmount1000,
+                                          eaaAmount = 1_000
+                                        }
+                                    ]
+                                    vrEvents
+                            _ -> assertFailure "First transaction should succeed"
+                        doInvariantAssertions
+                        doEncryptedBalanceAssertions
+                ),
+                ( Runner.TJSON
+                    { payload =
+                        Runner.EncryptedAmountTransferWithMemo
+                            accountAddress1
+                            memo
+                            encryptedTransferData1,
+                      metadata = makeDummyHeader accountAddress0 2 100_000,
+                      keys = [(0, [(0, keyPair0)])]
+                    },
+                  \Helpers.SchedulerResult{..} state -> do
+                    doEncryptedBalanceAssertionSender <-
+                        assertEncryptedBalance
+                            Types.initialAccountEncryptedAmount
+                                { Types._selfAmount = eatdRemainingAmount encryptedTransferData1
+                                }
+                            accountAddress0
+                            state
+                    doEncryptedBalanceAssertionReceiver <-
+                        assertEncryptedBalance
+                            Types.initialAccountEncryptedAmount
+                                { Types._startIndex = 0,
+                                  Types._incomingEncryptedAmounts =
+                                    incomingAmounts1
+                                }
+                            accountAddress1
+                            state
+                    return $ do
+                        case Helpers.getResults $ Sch.ftAdded srTransactions of
+                            [(_, Types.TxSuccess{..})] ->
+                                assertEqual
+                                    "The correct events are produced"
+                                    [ Types.EncryptedAmountsRemoved
+                                        { earAccount = accountAddress0,
+                                          earUpToIndex = 0,
+                                          earNewAmount = eatdRemainingAmount encryptedTransferData1,
+                                          earInputAmount = encryptedAmount1000
+                                        },
+                                      Types.NewEncryptedAmount
+                                        { neaAccount = accountAddress1,
+                                          neaNewIndex = 0,
+                                          neaEncryptedAmount =
+                                            eatdTransferAmount
+                                                encryptedTransferData1
+                                        },
+                                      Types.TransferMemo memo
+                                    ]
+                                    vrEvents
+                            _ -> assertFailure "Third transaction should succeed"
+                        doEncryptedBalanceAssertionSender
+                        doEncryptedBalanceAssertionReceiver
+                ),
+                ( Runner.TJSON
+                    { payload =
+                        Runner.EncryptedAmountTransferWithMemo
+                            accountAddress1
+                            memo
+                            encryptedTransferData2,
+                      metadata = makeDummyHeader accountAddress0 3 100_000,
+                      keys = [(0, [(0, keyPair0)])]
+                    },
+                  \Helpers.SchedulerResult{..} state -> do
+                    doEncryptedBalanceAssertionSender <-
+                        assertEncryptedBalance
+                            Types.initialAccountEncryptedAmount
+                                { Types._selfAmount = eatdRemainingAmount encryptedTransferData2
+                                }
+                            accountAddress0
+                            state
+                    doEncryptedBalanceAssertionReceiver <-
+                        assertEncryptedBalance
+                            Types.initialAccountEncryptedAmount
+                                { Types._startIndex = 0,
+                                  Types._incomingEncryptedAmounts = incomingAmounts2
+                                }
+                            accountAddress1
+                            state
+                    return $ do
+                        case Helpers.getResults $ Sch.ftAdded srTransactions of
+                            [(_, Types.TxSuccess{..})] ->
+                                assertEqual
+                                    "The correct events are produced"
+                                    [ Types.EncryptedAmountsRemoved
+                                        { earAccount = accountAddress0,
+                                          earUpToIndex = 0,
+                                          earNewAmount = eatdRemainingAmount encryptedTransferData2,
+                                          earInputAmount =
+                                            eatdRemainingAmount
+                                                encryptedTransferData1
+                                        },
+                                      Types.NewEncryptedAmount
+                                        { neaAccount = accountAddress1,
+                                          neaNewIndex = 1,
+                                          neaEncryptedAmount =
+                                            eatdTransferAmount
+                                                encryptedTransferData2
+                                        },
+                                      Types.TransferMemo memo
+                                    ]
+                                    vrEvents
+                            _ -> assertFailure "Forth transaction should succeed"
+                        doEncryptedBalanceAssertionSender
+                        doEncryptedBalanceAssertionReceiver
+                ),
+                ( Runner.TJSON
+                    { payload =
+                        Runner.EncryptedAmountTransferWithMemo
+                            accountAddress1
+                            memo
+                            encryptedTransferData3,
+                      metadata = makeDummyHeader accountAddress0 4 100_000,
+                      keys = [(0, [(0, keyPair0)])]
+                    },
+                  \Helpers.SchedulerResult{..} state -> do
+                    doEncryptedBalanceAssertionSender <-
+                        assertEncryptedBalance
+                            Types.initialAccountEncryptedAmount
+                                { Types._selfAmount = eatdRemainingAmount encryptedTransferData3
+                                }
+                            accountAddress0
+                            state
+                    doEncryptedBalanceAssertionReceiver <-
+                        assertEncryptedBalance
+                            Types.initialAccountEncryptedAmount
+                                { Types._startIndex = 0,
+                                  Types._incomingEncryptedAmounts = incomingAmounts3
+                                }
+                            accountAddress1
+                            state
+                    return $ do
+                        case Helpers.getResults $ Sch.ftAdded srTransactions of
+                            [(_, Types.TxSuccess{..})] ->
+                                assertEqual
+                                    "The correct events are produced"
+                                    [ Types.EncryptedAmountsRemoved
+                                        { earAccount = accountAddress0,
+                                          earUpToIndex = 0,
+                                          earNewAmount = eatdRemainingAmount encryptedTransferData3,
+                                          earInputAmount =
+                                            eatdRemainingAmount
+                                                encryptedTransferData2
+                                        },
+                                      Types.NewEncryptedAmount
+                                        { neaAccount = accountAddress1,
+                                          neaNewIndex = 2,
+                                          neaEncryptedAmount =
+                                            eatdTransferAmount
+                                                encryptedTransferData3
+                                        },
+                                      Types.TransferMemo memo
+                                    ]
+                                    vrEvents
+                            _ -> assertFailure "Fifth transaction should succeed"
+                        doEncryptedBalanceAssertionSender
+                        doEncryptedBalanceAssertionReceiver
+                ),
+                ( Runner.TJSON
+                    { payload =
+                        Runner.EncryptedAmountTransferWithMemo
+                            accountAddress0
+                            memo
+                            encryptedTransferData4,
+                      metadata = makeDummyHeader accountAddress1 1 100_000,
+                      keys = [(0, [(0, keyPair1)])]
+                    },
+                  \Helpers.SchedulerResult{..} state -> do
+                    doEncryptedBalanceAssertionSender <-
+                        assertEncryptedBalance
+                            Types.initialAccountEncryptedAmount
+                                { Types._selfAmount = eatdRemainingAmount encryptedTransferData4,
+                                  Types._startIndex = 2,
+                                  Types._incomingEncryptedAmounts = incomingAmounts4account1
+                                }
+                            accountAddress1
+                            state
+                    doEncryptedBalanceAssertionReceiver <-
+                        assertEncryptedBalance
+                            Types.initialAccountEncryptedAmount
+                                { Types._selfAmount = eatdRemainingAmount encryptedTransferData3,
+                                  Types._startIndex = 0,
+                                  Types._incomingEncryptedAmounts = incomingAmounts4account0
+                                }
+                            accountAddress0
+                            state
+                    return $ do
+                        case Helpers.getResults $ Sch.ftAdded srTransactions of
+                            [(_, Types.TxSuccess{..})] ->
+                                assertEqual
+                                    "The correct events are produced"
+                                    [ Types.EncryptedAmountsRemoved
+                                        { earAccount = accountAddress1,
+                                          earUpToIndex = 2,
+                                          earNewAmount = eatdRemainingAmount encryptedTransferData4,
+                                          earInputAmount = aggregatedEncryptedAmount4
+                                        },
+                                      Types.NewEncryptedAmount
+                                        { neaAccount = accountAddress0,
+                                          neaNewIndex = 0,
+                                          neaEncryptedAmount =
+                                            eatdTransferAmount
+                                                encryptedTransferData4
+                                        },
+                                      Types.TransferMemo memo
+                                    ]
+                                    vrEvents
+                            _ -> assertFailure "Sixth transaction should succeed"
+                        doEncryptedBalanceAssertionSender
+                        doEncryptedBalanceAssertionReceiver
+                ),
+                ( Runner.TJSON
+                    { payload =
+                        Runner.EncryptedAmountTransferWithMemo
+                            accountAddress0
+                            memo
+                            encryptedTransferData5,
+                      metadata = makeDummyHeader accountAddress1 2 100_000,
+                      keys = [(0, [(0, keyPair1)])]
+                    },
+                  \Helpers.SchedulerResult{..} state -> do
+                    doEncryptedBalanceAssertionSender <-
+                        assertEncryptedBalance
+                            Types.initialAccountEncryptedAmount
+                                { Types._selfAmount = eatdRemainingAmount encryptedTransferData5,
+                                  Types._startIndex = 3,
+                                  Types._incomingEncryptedAmounts = incomingAmounts5account1
+                                }
+                            accountAddress1
+                            state
+                    doEncryptedBalanceAssertionReceiver <-
+                        assertEncryptedBalance
+                            Types.initialAccountEncryptedAmount
+                                { Types._selfAmount = eatdRemainingAmount encryptedTransferData3,
+                                  Types._startIndex = 0,
+                                  Types._incomingEncryptedAmounts = incomingAmounts5account0
+                                }
+                            accountAddress0
+                            state
+                    return $ do
+                        case Helpers.getResults $ Sch.ftAdded srTransactions of
+                            [(_, Types.TxSuccess{..})] ->
+                                assertEqual
+                                    "The correct events are produced"
+                                    [ Types.EncryptedAmountsRemoved
+                                        { earAccount = accountAddress1,
+                                          earUpToIndex = 3,
+                                          earNewAmount = eatdRemainingAmount encryptedTransferData5,
+                                          earInputAmount = aggregatedEncryptedAmount5
+                                        },
+                                      Types.NewEncryptedAmount
+                                        { neaAccount = accountAddress0,
+                                          neaNewIndex = 1,
+                                          neaEncryptedAmount =
+                                            eatdTransferAmount
+                                                encryptedTransferData5
+                                        },
+                                      Types.TransferMemo memo
+                                    ]
+                                    vrEvents
+                            _ -> assertFailure "Seventh transaction should succeed"
+                        doEncryptedBalanceAssertionSender
+                        doEncryptedBalanceAssertionReceiver
+                ),
+                ( Runner.TJSON
+                    { payload = Runner.TransferToPublic secToPubTransferData1,
+                      metadata = makeDummyHeader accountAddress0 5 100_000,
+                      keys = [(0, [(0, keyPair0)])]
+                    },
+                  \Helpers.SchedulerResult{..} state -> do
+                    doEncryptedBalanceAssertion <-
+                        assertEncryptedBalance
+                            Types.initialAccountEncryptedAmount
+                                { Types._selfAmount = stpatdRemainingAmount secToPubTransferData1,
+                                  Types._startIndex = 0,
+                                  Types._incomingEncryptedAmounts = incomingAmounts5account0
+                                }
+                            accountAddress0
+                            state
+                    return $ do
+                        case Helpers.getResults $ Sch.ftAdded srTransactions of
+                            [(_, Types.TxSuccess{..})] ->
+                                assertEqual
+                                    "The correct events are produced"
+                                    [ Types.EncryptedAmountsRemoved
+                                        { earAccount = accountAddress0,
+                                          earUpToIndex = 0,
+                                          earNewAmount =
+                                            stpatdRemainingAmount
+                                                secToPubTransferData1,
+                                          earInputAmount =
+                                            eatdRemainingAmount
+                                                encryptedTransferData3
+                                        },
+                                      Types.AmountAddedByDecryption
+                                        { aabdAccount = accountAddress0,
+                                          aabdAmount = 650
+                                        }
+                                    ]
+                                    vrEvents
+                            _ -> assertFailure "Eigth transaction should succeed"
+                        doEncryptedBalanceAssertion
+                ),
+                ( Runner.TJSON
+                    { payload = Runner.TransferToPublic secToPubTransferData2,
+                      metadata = makeDummyHeader accountAddress0 6 100_000,
+                      keys = [(0, [(0, keyPair0)])]
+                    },
+                  \Helpers.SchedulerResult{..} state -> do
+                    doEncryptedBalanceAssertion <-
+                        assertEncryptedBalance
+                            Types.initialAccountEncryptedAmount
+                                { Types._selfAmount = stpatdRemainingAmount secToPubTransferData2,
+                                  Types._startIndex = 1,
+                                  Types._incomingEncryptedAmounts = incomingAmounts7account0
+                                }
+                            accountAddress0
+                            state
+                    return $ do
+                        case Helpers.getResults $ Sch.ftAdded srTransactions of
+                            [(_, Types.TxSuccess{..})] ->
+                                assertEqual
+                                    "The correct events are produced"
+                                    [ Types.EncryptedAmountsRemoved
+                                        { earAccount = accountAddress0,
+                                          earUpToIndex = 1,
+                                          earNewAmount =
+                                            stpatdRemainingAmount
+                                                secToPubTransferData2,
+                                          earInputAmount = aggregatedEncryptedAmount7
+                                        },
+                                      Types.AmountAddedByDecryption
+                                        { aabdAccount = accountAddress0,
+                                          aabdAmount = 150
+                                        }
+                                    ]
+                                    vrEvents
+                            _ -> assertFailure "Nineth transaction should succeed"
+                        doEncryptedBalanceAssertion
+                ),
+                ( Runner.TJSON
+                    { payload = Runner.TransferToPublic secToPubTransferData3,
+                      metadata = makeDummyHeader accountAddress0 7 100_000,
+                      keys = [(0, [(0, keyPair0)])]
+                    },
+                  \Helpers.SchedulerResult{..} state -> do
+                    doEncryptedBalanceAssertion <-
+                        assertEncryptedBalance
+                            Types.initialAccountEncryptedAmount
+                                { Types._selfAmount = stpatdRemainingAmount secToPubTransferData3,
+                                  Types._startIndex = 2,
+                                  Types._incomingEncryptedAmounts = incomingAmounts8account0
+                                }
+                            accountAddress0
+                            state
+                    return $ do
+                        case Helpers.getResults $ Sch.ftAdded srTransactions of
+                            [(_, Types.TxSuccess{..})] ->
+                                assertEqual
+                                    "The correct events are produced"
+                                    [ Types.EncryptedAmountsRemoved
+                                        { earAccount = accountAddress0,
+                                          earUpToIndex = 2,
+                                          earNewAmount =
+                                            stpatdRemainingAmount
+                                                secToPubTransferData3,
+                                          earInputAmount = aggregatedEncryptedAmount8
+                                        },
+                                      Types.AmountAddedByDecryption
+                                        { aabdAccount = accountAddress0,
+                                          aabdAmount = 200
+                                        }
+                                    ]
+                                    vrEvents
+                            _ -> assertFailure "Tenth transaction should succeed"
+                        doEncryptedBalanceAssertion
+                )
+            ]

--- a/concordium-consensus/tests/scheduler/SchedulerTests/FibonacciSelfMessageTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/FibonacciSelfMessageTest.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
 -- | This tests sending messages to contracts. Concretely it invokes
@@ -9,7 +11,7 @@
 --    See ../smart-contracts/rust-contracts/example-contracts/fib for the source code.
 module SchedulerTests.FibonacciSelfMessageTest where
 
-import Test.HUnit (assertEqual, assertFailure)
+import Test.HUnit
 import Test.Hspec
 
 import Control.Monad
@@ -17,32 +19,41 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Short as BSS
 import Data.Serialize (putWord64le, runPut)
 import Data.Word
-import Lens.Micro.Platform
-
-import qualified Concordium.Crypto.SHA256 as Hash
-import Concordium.Scheduler.Runner
-import qualified Concordium.Scheduler.Types as Types
-import Concordium.TransactionVerification
 
 import qualified Concordium.Cost as Cost
-import Concordium.GlobalState.Basic.BlockState
-import Concordium.GlobalState.Basic.BlockState.Accounts as Acc
-import Concordium.GlobalState.Basic.BlockState.Instances
-import Concordium.GlobalState.Instance
+import qualified Concordium.Crypto.SHA256 as Hash
+import qualified Concordium.GlobalState.BlockState as BS
+import qualified Concordium.GlobalState.Persistent.BlockState as BS
+import qualified Concordium.GlobalState.Persistent.Instances as Instances
+import qualified Concordium.Scheduler as Sch
+import Concordium.Scheduler.DummyData
+import qualified Concordium.Scheduler.Runner as Runner
+import qualified Concordium.Scheduler.Types as Types
 import Concordium.Wasm
 
-import Concordium.Crypto.DummyData
-import Concordium.GlobalState.DummyData
-import Concordium.Scheduler.DummyData
-import Concordium.Types.DummyData
+import qualified SchedulerTests.Helpers as Helpers
 
-import SchedulerTests.TestUtils
+tests :: Spec
+tests = do
+    describe "Self-referential Fibonacci." $
+        sequence_ $
+            Helpers.forEveryProtocolVersion $ \spv pvString -> do
+                testCase1 spv pvString
 
-initialBlockState :: BlockState PV1
+initialBlockState ::
+    Types.IsProtocolVersion pv =>
+    Helpers.PersistentBSM pv (BS.HashedPersistentBlockState pv)
 initialBlockState =
-    blockStateWithAlesAccount
-        100000000
-        (Acc.putAccountWithRegIds (mkAccount thomasVK thomasAccount 100000000) Acc.emptyAccounts)
+    Helpers.createTestBlockStateWithAccountsM
+        [ Helpers.makeTestAccountFromSeed 100_000_000 0,
+          Helpers.makeTestAccountFromSeed 100_000_000 1
+        ]
+
+accountAddress0 :: Types.AccountAddress
+accountAddress0 = Helpers.accountAddressFromSeed 0
+
+accountAddress1 :: Types.AccountAddress
+accountAddress1 = Helpers.accountAddressFromSeed 1
 
 fibParamBytes :: Word64 -> BSS.ShortByteString
 fibParamBytes n = BSS.toShort $ runPut (putWord64le n)
@@ -50,60 +61,82 @@ fibParamBytes n = BSS.toShort $ runPut (putWord64le n)
 fibSourceFile :: FilePath
 fibSourceFile = "./testdata/contracts/fib.wasm"
 
-testCases :: [TestCase PV1]
-testCases =
-    [ -- NOTE: Could also check resulting balances on each affected account or contract, but
-      -- the block state invariant at least tests that the total amount is preserved.
-      TestCase
-        { tcName = "Error handling in contracts.",
-          tcParameters = (defaultParams @PV1){tpInitialBlockState = initialBlockState},
-          tcTransactions =
-            [   ( TJSON
-                    { payload = DeployModule V0 fibSourceFile,
-                      metadata = makeDummyHeader alesAccount 1 100000,
-                      keys = [(0, [(0, alesKP)])]
-                    },
-                  (SuccessWithSummary deploymentCostCheck, emptySpec)
-                ),
-                ( TJSON
-                    { payload = InitContract 0 V0 "./testdata/contracts/fib.wasm" "init_fib" "",
-                      metadata = makeDummyHeader alesAccount 2 100000,
-                      keys = [(0, [(0, alesKP)])]
-                    },
-                  (SuccessWithSummary initializationCostCheck, emptySpec)
-                ),
-              -- compute F(10)
-                ( TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "fib.receive" (fibParamBytes 10),
-                      metadata = makeDummyHeader alesAccount 3 700000,
-                      keys = [(0, [(0, alesKP)])]
-                    },
-                  (SuccessWithSummary ensureAllUpdates, fibSpec 10)
-                )
-            ]
-        }
-    ]
+testCase1 ::
+    forall pv.
+    (Types.IsProtocolVersion pv) =>
+    Types.SProtocolVersion pv ->
+    String ->
+    SpecWith (Arg Assertion)
+testCase1 _ pvString =
+    specify
+        (pvString ++ ": Error handling in contracts.")
+        $ Helpers.runSchedulerTestAssertIntermediateStates
+            @pv
+            Helpers.defaultTestConfig
+            initialBlockState
+            transactions
   where
-    deploymentCostCheck :: BlockItemWithStatus -> Types.TransactionSummary -> Expectation
-    deploymentCostCheck _ Types.TransactionSummary{..} = do
+    transactions =
+        [   ( Runner.TJSON
+                { payload = Runner.DeployModule V0 fibSourceFile,
+                  metadata = makeDummyHeader accountAddress0 1 100_000,
+                  keys = [(0, [(0, Helpers.keyPairFromSeed 0)])]
+                },
+              deploymentCostCheck
+            ),
+            ( Runner.TJSON
+                { payload = Runner.InitContract 0 V0 fibSourceFile "init_fib" "",
+                  metadata = makeDummyHeader accountAddress0 2 100_000,
+                  keys = [(0, [(0, Helpers.keyPairFromSeed 0)])]
+                },
+              initializationCostCheck
+            ),
+          -- compute F(10)
+            ( Runner.TJSON
+                { payload = Runner.Update 0 (Types.ContractAddress 0 0) "fib.receive" (fibParamBytes 10),
+                  metadata = makeDummyHeader accountAddress0 3 700_000,
+                  keys = [(0, [(0, Helpers.keyPairFromSeed 0)])]
+                },
+              ensureAllUpdates
+            )
+        ]
+    deploymentCostCheck ::
+        Helpers.SchedulerResult ->
+        BS.PersistentBlockState pv ->
+        Helpers.PersistentBSM pv Assertion
+    deploymentCostCheck Helpers.SchedulerResult{..} _ = return $ do
         moduleSource <- BS.readFile fibSourceFile
         let len = fromIntegral $ BS.length moduleSource
             -- size of the module deploy payload
-            payloadSize = Types.payloadSize (Types.encodePayload (Types.DeployModule (WasmModuleV0 (WasmModuleV ModuleSource{..}))))
+            payloadSize =
+                Types.payloadSize $
+                    Types.encodePayload $
+                        Types.DeployModule $
+                            WasmModuleV0 $
+                                WasmModuleV ModuleSource{..}
             -- size of the transaction minus the signatures.
             txSize = Types.transactionHeaderSize + fromIntegral payloadSize
         -- transaction is signed with 1 signature
-        assertEqual "Deployment has correct cost " (Cost.baseCost txSize 1 + Cost.deployModuleCost len) tsEnergyCost
+        assertEqual
+            "Deployment has correct cost "
+            (Cost.baseCost txSize 1 + Cost.deployModuleCost len)
+            srUsedEnergy
 
     -- check that the initialization cost was at least the administrative cost.
     -- It is not practical to check the exact cost because the execution cost of the init function is hard to
     -- have an independent number for, other than executing.
-    initializationCostCheck :: BlockItemWithStatus -> Types.TransactionSummary -> Expectation
-    initializationCostCheck _ Types.TransactionSummary{..} = do
+    initializationCostCheck ::
+        Helpers.SchedulerResult ->
+        BS.PersistentBlockState pv ->
+        Helpers.PersistentBSM pv Assertion
+    initializationCostCheck Helpers.SchedulerResult{..} _ = return $ do
         moduleSource <- BS.readFile fibSourceFile
         let modLen = fromIntegral $ BS.length moduleSource
             modRef = Types.ModuleRef (Hash.hash moduleSource)
-            payloadSize = Types.payloadSize (Types.encodePayload (Types.InitContract 0 modRef (InitName "init_fib") (Parameter "")))
+            payloadSize =
+                Types.payloadSize $
+                    Types.encodePayload $
+                        Types.InitContract 0 modRef (InitName "init_fib") (Parameter "")
             -- size of the transaction minus the signatures.
             txSize = Types.transactionHeaderSize + fromIntegral payloadSize
             -- transaction is signed with 1 signature
@@ -111,48 +144,55 @@ testCases =
             -- lower bound on the cost of the transaction, assuming no interpreter energy
             -- we know the size of the state should be 8 bytes
             costLowerBound = baseTxCost + Cost.initializeContractInstanceCost 0 modLen (Just 8)
-        unless (tsEnergyCost >= costLowerBound) $
+        unless (srUsedEnergy >= costLowerBound) $
             assertFailure $
-                "Actual initialization cost " ++ show tsEnergyCost ++ " not more than lower bound " ++ show costLowerBound
+                "Actual initialization cost " ++ show srUsedEnergy ++ " not more than lower bound " ++ show costLowerBound
 
-    ensureAllUpdates :: BlockItemWithStatus -> Types.TransactionSummary -> Expectation
-    ensureAllUpdates _ Types.TransactionSummary{..} =
-        case tsResult of
-            Types.TxSuccess evs -> do
-                mapM_ p evs -- check that all updates are the right ones
-                -- and check that the cost was adequate (we again only check the lower bound only)
-                moduleSource <- BS.readFile fibSourceFile
-                let modLen = fromIntegral $ BS.length moduleSource
-                    payloadSize = Types.payloadSize (Types.encodePayload (Types.Update 0 (Types.ContractAddress 0 0) (ReceiveName "fib.receive") (Parameter (fibParamBytes 10))))
-                    -- size of the transaction minus the signatures.
-                    txSize = Types.transactionHeaderSize + fromIntegral payloadSize
-                    -- transaction is signed with 1 signature
-                    baseTxCost = Cost.baseCost txSize 1
-                    -- lower bound on the cost of the transaction, assuming no interpreter energy and the instance is not created.
-                    -- the number of invocations of the smart contract is fibOne 10, see below for the definition of fibOne
-                    -- the size of the contract state is 8 bytes (one u64)
-                    costLowerBound = baseTxCost + (fibOne 10) * Cost.updateContractInstanceCost 0 modLen 8 (Just 8)
-                unless (tsEnergyCost >= costLowerBound) $
-                    assertFailure $
-                        "Actual update cost " ++ show tsEnergyCost ++ " not more than lower bound " ++ show costLowerBound
-            Types.TxReject rr -> assertFailure $ "Fibonacci update should succeed, but it failed with " ++ show rr
+    ensureAllUpdates ::
+        Helpers.SchedulerResult ->
+        BS.PersistentBlockState pv ->
+        Helpers.PersistentBSM pv Assertion
+    ensureAllUpdates Helpers.SchedulerResult{..} bs = do
+        maybeInstance <- BS.bsoGetInstance bs (Types.ContractAddress 0 0)
+        return $ do
+            -- Check that the contract state contains the n-th Fib number.
+            case maybeInstance of
+                Nothing -> assertFailure "Instnace at <0,0> does not exist."
+                Just (BS.InstanceInfoV0 ii) -> do
+                    let Instances.InstanceStateV0 s = BS.iiState ii
+                    assertEqual "State contains the n-th Fibonacci number." (fibNBytes 10) s
+                Just _ -> assertFailure "Expected V0 instance."
+
+            case Helpers.getResults $ Sch.ftAdded srTransactions of
+                [(_, Types.TxSuccess evs)] -> do
+                    mapM_ p evs -- check that all updates are the right ones
+                    -- and check that the cost was adequate (we again only check the lower bound only)
+                    moduleSource <- BS.readFile fibSourceFile
+                    let modLen = fromIntegral $ BS.length moduleSource
+                        payloadSize = Types.payloadSize (Types.encodePayload (Types.Update 0 (Types.ContractAddress 0 0) (ReceiveName "fib.receive") (Parameter (fibParamBytes 10))))
+                        -- size of the transaction minus the signatures.
+                        txSize = Types.transactionHeaderSize + fromIntegral payloadSize
+                        -- transaction is signed with 1 signature
+                        baseTxCost = Cost.baseCost txSize 1
+                        -- lower bound on the cost of the transaction, assuming no interpreter energy and the instance is not created.
+                        -- the number of invocations of the smart contract is fibOne 10, see below for the definition of fibOne
+                        -- the size of the contract state is 8 bytes (one u64)
+                        costLowerBound = baseTxCost + (fibOne 10) * Cost.updateContractInstanceCost 0 modLen 8 (Just 8)
+                    unless (srUsedEnergy >= costLowerBound) $
+                        assertFailure $
+                            "Actual update cost " ++ show srUsedEnergy ++ " not more than lower bound " ++ show costLowerBound
+                [(_, Types.TxReject rr)] -> assertFailure $ "Fibonacci update should succeed, but it failed with " ++ show rr
+                _ -> assertFailure "Fibonacci update should succeed, but failed"
+
     p
         Types.Updated
             { euAmount = 0,
               euEvents = [],
               ..
             } = case euInstigator of
-            Types.AddressAccount addr -> assertEqual "Only the initial account can be in events." addr alesAccount
+            Types.AddressAccount addr -> assertEqual "Only the initial account can be in events." addr accountAddress0
             Types.AddressContract addr -> assertEqual "Contract address is self-address" addr euAddress
     p event = assertFailure ("Unexpected event: " ++ show event)
-
-    -- Check that the contract state contains the n-th Fib number.
-    fibSpec n bs = specify "Contract state" $
-        case getInstance (Types.ContractAddress 0 0) (bs ^. blockInstances) of
-            Nothing -> assertFailure "Instnace at <0,0> does not exist."
-            Just (InstanceV0 InstanceV{_instanceVModel = InstanceStateV0 s}) ->
-                assertEqual "State contains the n-th Fibonacci number." (fibNBytes n) s
-            _ -> assertFailure "Expected instance version 0"
 
     fib n =
         let go = 1 : 1 : zipWith (+) go (tail go)
@@ -161,8 +201,3 @@ testCases =
 
     -- the number of invocations of the contract follows https://oeis.org/A001595
     fibOne n = 2 * fib n - 1
-
-tests :: Spec
-tests =
-    describe "Self-referential Fibonacci." $
-        mkSpecs testCases

--- a/concordium-consensus/tests/scheduler/SchedulerTests/FibonacciSelfMessageTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/FibonacciSelfMessageTest.hs
@@ -157,7 +157,7 @@ testCase1 _ pvString =
         return $ do
             -- Check that the contract state contains the n-th Fib number.
             case maybeInstance of
-                Nothing -> assertFailure "Instnace at <0,0> does not exist."
+                Nothing -> assertFailure "Instance at <0,0> does not exist."
                 Just (BS.InstanceInfoV0 ii) -> do
                     let Instances.InstanceStateV0 s = BS.iiState ii
                     assertEqual "State contains the n-th Fibonacci number." (fibNBytes 10) s

--- a/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
@@ -180,7 +180,8 @@ forEveryProtocolVersion check =
       check Types.SP2 "P2",
       check Types.SP3 "P3",
       check Types.SP4 "P4",
-      check Types.SP5 "P5"
+      check Types.SP5 "P5",
+      check Types.SP6 "P6"
     ]
 
 -- |Construct a test block state containing the provided accounts.

--- a/concordium-consensus/tests/scheduler/SchedulerTests/InitContextTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/InitContextTest.hs
@@ -106,7 +106,7 @@ testInit spv pvString = specify
                 Just (BS.InstanceInfoV0 ii) -> do
                     let Instances.InstanceStateV0 model = BS.iiState ii
                     assertEqual
-                        "Instance model is the sender address of the account which inialized it."
+                        "Instance model is the sender address of the account which initialized it."
                         model
                         (ContractState $ encode $ senderAccount spv)
                 Just _ -> assertFailure "Expected V0 instance."

--- a/concordium-consensus/tests/scheduler/SchedulerTests/InitContextTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/InitContextTest.hs
@@ -2,114 +2,111 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 
 -- | Test that the init context of a contract is passed correctly by the scheduler.
 module SchedulerTests.InitContextTest where
 
-import Concordium.Types.ProtocolVersion
-import Control.Monad.IO.Class
-import Data.Proxy
 import Data.Serialize
-import Lens.Micro.Platform
 import Test.HUnit
 import Test.Hspec
 
+import qualified Concordium.Crypto.SignatureScheme as SigScheme
 import qualified Concordium.Scheduler as Sch
-import qualified Concordium.Scheduler.EnvironmentImplementation as Types
-import Concordium.Scheduler.Runner
+import qualified Concordium.Scheduler.Runner as Runner
 import qualified Concordium.Scheduler.Types as Types
-import Concordium.TransactionVerification
+import Concordium.Types.ProtocolVersion
 
-import Concordium.GlobalState.Basic.BlockState
-import Concordium.GlobalState.Basic.BlockState.Accounts
-import Concordium.GlobalState.Basic.BlockState.Instances
-import Concordium.GlobalState.Basic.BlockState.Invariants
-import Concordium.GlobalState.Instance
+import qualified Concordium.GlobalState.BlockState as BS
+import qualified Concordium.GlobalState.Persistent.BlockState as BS
 import Concordium.Wasm
 
-import Concordium.Crypto.DummyData
-import Concordium.GlobalState.DummyData
 import Concordium.Scheduler.DummyData
-import Concordium.Types.DummyData
 
-import SchedulerTests.Helpers
+import qualified Concordium.GlobalState.Persistent.Instances as Instances
+import qualified SchedulerTests.Helpers as Helpers
 import SchedulerTests.TestUtils
 
-initialBlockState :: (IsProtocolVersion pv) => BlockState pv
-initialBlockState = blockStateWithAlesAccount 1000000000 emptyAccounts
+tests :: Spec
+tests =
+    describe "Init context in transactions." $ do
+        sequence_ $ Helpers.forEveryProtocolVersion $ \spv pvString ->
+            testInit spv pvString
+
+initialBlockState ::
+    (IsProtocolVersion pv) =>
+    Helpers.PersistentBSM pv (BS.HashedPersistentBlockState pv)
+initialBlockState =
+    Helpers.createTestBlockStateWithAccountsM
+        [Helpers.makeTestAccountFromSeed 1000000000 0]
+
+accountAddress0 :: Types.AccountAddress
+accountAddress0 = Helpers.accountAddressFromSeed 0
+
+keyPair0 :: SigScheme.KeyPair
+keyPair0 = Helpers.keyPairFromSeed 0
 
 chainMeta :: Types.ChainMetadata
 chainMeta = Types.ChainMetadata{slotTime = 444}
 
-senderAccount :: forall pv. IsProtocolVersion pv => Proxy pv -> Types.AccountAddress
-senderAccount Proxy
-    | demoteProtocolVersion (protocolVersion @pv) >= P3 = createAlias alesAccount 17
-    | otherwise = alesAccount
+senderAccount :: forall pv. IsProtocolVersion pv => SProtocolVersion pv -> Types.AccountAddress
+senderAccount spv
+    | demoteProtocolVersion spv >= P3 = createAlias accountAddress0 17
+    | otherwise = accountAddress0
 
-transactionInputs :: forall pv. IsProtocolVersion pv => Proxy pv -> [TransactionJSON]
-transactionInputs proxy =
-    [ TJSON
-        { metadata = makeDummyHeader (senderAccount proxy) 1 100000,
-          payload = DeployModule V0 "./testdata/contracts/chain-meta-test.wasm",
-          keys = [(0, [(0, alesKP)])]
+transactionInputs :: forall pv. IsProtocolVersion pv => SProtocolVersion pv -> [Runner.TransactionJSON]
+transactionInputs spv =
+    [ Runner.TJSON
+        { metadata = makeDummyHeader (senderAccount spv) 1 100000,
+          payload = Runner.DeployModule V0 "./testdata/contracts/chain-meta-test.wasm",
+          keys = [(0, [(0, keyPair0)])]
         },
-      TJSON
-        { metadata = makeDummyHeader (senderAccount proxy) 2 100000,
-          payload = InitContract 9 V0 "./testdata/contracts/chain-meta-test.wasm" "init_origin" "",
-          keys = [(0, [(0, alesKP)])]
+      Runner.TJSON
+        { metadata = makeDummyHeader (senderAccount spv) 2 100000,
+          payload = Runner.InitContract 9 V0 "./testdata/contracts/chain-meta-test.wasm" "init_origin" "",
+          keys = [(0, [(0, keyPair0)])]
         }
     ]
 
-type TestResult =
-    ( [(BlockItemWithStatus, Types.ValidResult)],
-      [(TransactionWithStatus, Types.FailureKind)],
-      [(Types.ContractAddress, Types.BasicInstance)]
-    )
-
-testInit :: forall pv. IsProtocolVersion pv => Proxy pv -> IO TestResult
-testInit proxy = do
-    transactions <- processUngroupedTransactions (transactionInputs proxy)
-    let (Sch.FilteredTransactions{..}, finState) =
-            Types.runSI
-                (Sch.filterTransactions dummyBlockSize dummyBlockTimeout transactions)
-                chainMeta
-                maxBound
-                maxBound
+testInit :: forall pv. IsProtocolVersion pv => SProtocolVersion pv -> String -> SpecWith (Arg Assertion)
+testInit spv pvString = specify
+    (pvString ++ ": Passing init context to contract")
+    $ do
+        (result, doBlockStateAssertions) <-
+            Helpers.runSchedulerTestTransactionJson
+                Helpers.defaultTestConfig
                 initialBlockState
-    let gs = finState ^. Types.ssBlockState
-    case invariantBlockState @pv gs (finState ^. Types.schedulerExecutionCosts) of
-        Left f -> liftIO $ assertFailure $ f ++ " " ++ show gs
-        _ -> return ()
-    return (getResults ftAdded, ftFailed, gs ^.. blockInstances . foldInstances . to (\i -> (instanceAddress i, i)))
-
-checkInitResult :: forall pv. IsProtocolVersion pv => Proxy pv -> TestResult -> Assertion
-checkInitResult proxy (suc, fails, instances) = do
-    assertEqual "There should be no failed transactions." [] fails
-    assertEqual "There should be no rejected transactions." [] reject
-    assertEqual "There should be 1 instance." 1 (length instances)
-    model <- case snd . head $ instances of
-        InstanceV0 InstanceV{_instanceVModel = InstanceStateV0 s} -> return (contractState s)
-        _ -> assertFailure "Expected instance version 0"
-    assertEqual "Instance model is the sender address of the account which inialized it." model (encode (senderAccount proxy))
+                (Helpers.checkReloadCheck checkState)
+                (transactionInputs spv)
+        let Sch.FilteredTransactions{..} = Helpers.srTransactions result
+        assertEqual "There should be no failed transactions." [] ftFailed
+        assertEqual "There should be no rejected transactions." []
+            $ filter
+                ( \case
+                    (_, Types.TxSuccess{}) -> False
+                    (_, Types.TxReject{}) -> True
+                )
+            $ Helpers.getResults ftAdded
+        doBlockStateAssertions
   where
-    reject =
-        filter
-            ( \case
-                (_, Types.TxSuccess{}) -> False
-                (_, Types.TxReject{}) -> True
-            )
-            suc
+    checkState ::
+        Helpers.SchedulerResult ->
+        BS.PersistentBlockState pv ->
+        Helpers.PersistentBSM pv Assertion
+    checkState result state = do
+        hashedState <- BS.hashBlockState state
+        doInvariantAssertions <- Helpers.assertBlockStateInvariants hashedState (Helpers.srExecutionCosts result)
+        instances <- BS.getContractInstanceList hashedState
+        maybeInstance <- BS.bsoGetInstance state (Types.ContractAddress 0 0)
+        return $ do
+            doInvariantAssertions
+            assertEqual "There should be 1 instance." 1 (length instances)
 
-tests :: SpecWith ()
-tests =
-    describe "Init context in transactions." $ do
-        specify
-            "Passing init context to contract P1"
-            (testInit (Proxy @'P1) >>= checkInitResult (Proxy @'P1))
-        specify "Passing init context to contract P2" $
-            testInit (Proxy @'P2) >>= checkInitResult (Proxy @'P2)
-        specify "Passing init context to contract P3" $
-            testInit (Proxy @'P3) >>= checkInitResult (Proxy @'P3)
-        specify "Passing init context to contract P4" $
-            testInit (Proxy @'P4) >>= checkInitResult (Proxy @'P4)
+            case maybeInstance of
+                Nothing -> assertFailure "Instance at <0,0> does not exist."
+                Just (BS.InstanceInfoV0 ii) -> do
+                    let Instances.InstanceStateV0 model = BS.iiState ii
+                    assertEqual
+                        "Instance model is the sender address of the account which inialized it."
+                        model
+                        (ContractState $ encode $ senderAccount spv)
+                Just _ -> assertFailure "Expected V0 instance."

--- a/concordium-consensus/tests/scheduler/SchedulerTests/InitPoliciesTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/InitPoliciesTest.hs
@@ -19,7 +19,8 @@ import Concordium.Scheduler.WasmIntegration
 import Concordium.Wasm
 
 import Concordium.Scheduler.DummyData
-import Concordium.Types.DummyData
+
+import qualified SchedulerTests.Helpers as Helpers
 
 setup :: String -> IO (ModuleInterfaceV V0)
 setup errString = do
@@ -29,13 +30,16 @@ setup errString = do
     assertBool ("Module not valid " ++ errString) (isJust miface)
     return (fromJust miface)
 
+accountAddress0 :: AccountAddress
+accountAddress0 = Helpers.accountAddressFromSeed 0
+
 testNoAttributes :: Assertion
 testNoAttributes = do
     iface <- setup "testNoAttributes"
     let artifact = miModule iface
     let initCtx1 =
             InitContext
-                { initOrigin = alesAccount,
+                { initOrigin = accountAddress0,
                   icSenderPolicies = []
                 }
     let res1 = applyInitFun artifact dummyChainMeta initCtx1 (InitName "init_context_test") (Parameter mempty) False 0 100000
@@ -48,7 +52,7 @@ testNoAttributes = do
 
     let initCtx2 =
             InitContext
-                { initOrigin = alesAccount,
+                { initOrigin = accountAddress0,
                   icSenderPolicies =
                     [ SenderPolicy
                         { spIdentityProvider = IP_ID 17,
@@ -72,7 +76,7 @@ testSingleAttribute = do
     let artifact = miModule iface
     let initCtx3 =
             InitContext
-                { initOrigin = alesAccount,
+                { initOrigin = accountAddress0,
                   icSenderPolicies =
                     [ SenderPolicy
                         { spIdentityProvider = IP_ID 17,
@@ -100,7 +104,7 @@ testTwoPoliciesTwoAttributes = do
     let artifact = miModule iface
     let initCtx4 =
             InitContext
-                { initOrigin = alesAccount,
+                { initOrigin = accountAddress0,
                   icSenderPolicies =
                     [ SenderPolicy
                         { spIdentityProvider = IP_ID 17,

--- a/concordium-consensus/tests/scheduler/SchedulerTests/MaxIncomingAmountsTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/MaxIncomingAmountsTest.hs
@@ -1,6 +1,8 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
-module SchedulerTests.MaxIncomingAmountsTest where
+module SchedulerTests.MaxIncomingAmountsTest (tests) where
 
 {-
 This test will:
@@ -19,29 +21,228 @@ For now `numberOfTransactions == maxNumIncoming + 2`.
 import Data.Foldable
 import Data.Maybe (fromJust)
 import qualified Data.Sequence as Seq
-import Lens.Micro.Platform
-
-import SchedulerTests.TestUtils
-
-import qualified Test.HUnit as HUnit
+import Test.HUnit
 import Test.Hspec
 
 import Concordium.Constants
-import Concordium.Crypto.DummyData
 import Concordium.Crypto.EncryptedTransfers
 import Concordium.Crypto.FFIDataTypes (ElgamalSecretKey)
-import Concordium.GlobalState.Basic.BlockState
-import Concordium.GlobalState.Basic.BlockState.Account
-import Concordium.GlobalState.Basic.BlockState.Accounts as Acc
+import qualified Concordium.Crypto.SignatureScheme as SigScheme
+import qualified Concordium.GlobalState.BlockState as BS
 import Concordium.GlobalState.DummyData
+import qualified Concordium.GlobalState.Persistent.Account as BS
+import qualified Concordium.GlobalState.Persistent.BlockState as BS
 import Concordium.ID.DummyData (dummyEncryptionSecretKey)
-import Concordium.ID.Types (AccountEncryptionKey (..), unsafeEncryptionKeyFromRaw)
-import Concordium.Types
-import Concordium.Types.DummyData
-
+import Concordium.ID.Types (AccountEncryptionKey (..))
+import qualified Concordium.ID.Types as ID
+import qualified Concordium.Scheduler as Sch
 import Concordium.Scheduler.DummyData
 import qualified Concordium.Scheduler.Runner as Runner
 import qualified Concordium.Scheduler.Types as Types
+import Concordium.Types
+
+import qualified SchedulerTests.Helpers as Helpers
+
+tests :: Spec
+tests = do
+    describe "Encrypted transfers with aggregation." $
+        sequence_ $
+            Helpers.forEveryProtocolVersion $ \spv pvString -> do
+                testCase0 spv pvString
+
+testCase0 ::
+    forall pv.
+    (Types.IsProtocolVersion pv) =>
+    Types.SProtocolVersion pv ->
+    String ->
+    SpecWith (Arg Assertion)
+testCase0 _ pvString = specify
+    (pvString ++ ": Makes a chain of encrypted transfers testing maxNumIncoming")
+    $ do
+        transactionsAndAssertions <- makeTransactionsAndAssertions
+        Helpers.runSchedulerTestAssertIntermediateStates
+            @pv
+            Helpers.defaultTestConfig
+            initialBlockState
+            transactionsAndAssertions
+  where
+    makeTransactionsAndAssertions :: IO [Helpers.TransactionsAndAssertion pv]
+    makeTransactionsAndAssertions = do
+        -- Transaction 1. Pub to sec (1000)
+        let encryptedAmount1000 :: EncryptedAmount
+            encryptedAmount1000 = encryptAmountZeroRandomness dummyCryptographicParameters 1_000
+
+        encryptedTransferData1 <-
+            fromJust
+                <$> createEncryptedTransferData
+                    encryptionPublicKey1
+                    encryptionSecretKey0
+                    (makeAggregatedDecryptedAmount encryptedAmount1000 1_000 0)
+                    10
+
+        allTransferData <-
+            fmap fst
+                <$> iterateLimitM
+                    numberOfTransactions
+                    makeNext
+                    (encryptedTransferData1, 990)
+        -- A normal transaction is a transfer before maxNumIncoming amounts have been received.
+        let (normal, interesting) = splitAt maxNumIncoming $ zip [1 ..] allTransferData
+
+        let generatedTransactions =
+                ( fmap
+                    ( \(idx, x) ->
+                        makeTransaction
+                            (makeNormalBlockStateAssertion allTransferData x idx)
+                            x
+                            idx
+                    )
+                    normal
+                )
+                    ++ fmap
+                        ( \(idx, x) ->
+                            makeTransaction
+                                (makeInterestingBlockStateAssertion allTransferData x idx)
+                                x
+                                idx
+                        )
+                        interesting
+
+        -- Transaction that will transfer 340 to account1 public balancesecToPubTransferData.
+
+        let allAmounts = foldl' aggregateAmounts mempty (eatdTransferAmount <$> allTransferData)
+            aggAmount =
+                makeAggregatedDecryptedAmount
+                    allAmounts
+                    (numberOfTransactions * 10)
+                    numberOfTransactions
+
+        secToPubTransferData <-
+            fromJust
+                <$> createSecToPubTransferData
+                    encryptionSecretKey1
+                    aggAmount
+                    (numberOfTransactions * 10)
+
+        return $
+            [   ( Runner.TJSON
+                    { payload = Runner.TransferToEncrypted 1_000,
+                      metadata = makeDummyHeader accountAddress0 1 100_000,
+                      keys = [(0, [(0, keyPair0)])]
+                    },
+                  \Helpers.SchedulerResult{..} state -> do
+                    doInvariantAssertions <-
+                        Helpers.assertBlockStateInvariantsH
+                            state
+                            srExecutionCosts
+                    doEncryptedBalanceAssertions <-
+                        assertEncryptedBalance
+                            Types.initialAccountEncryptedAmount
+                                { Types._selfAmount = encryptedAmount1000
+                                }
+                            accountAddress0
+                            state
+                    return $ do
+                        case Helpers.getResults $ Sch.ftAdded srTransactions of
+                            [(_, Types.TxSuccess events)] ->
+                                assertEqual
+                                    "The correct encrypt self amount event is produced"
+                                    [ Types.EncryptedSelfAmountAdded
+                                        { eaaAccount = accountAddress0,
+                                          eaaNewAmount = encryptedAmount1000,
+                                          eaaAmount = 1_000
+                                        }
+                                    ]
+                                    events
+                            _ -> assertFailure "First transaction should succeed"
+                        doInvariantAssertions
+                        doEncryptedBalanceAssertions
+                )
+            ]
+                -- Now send 34 transactions of 10 tokens from account0 to account1
+                ++ generatedTransactions
+                -- Send the encrypted 340 tokens on account1 to public balance
+                ++ [   ( Runner.TJSON
+                            { payload = Runner.TransferToPublic secToPubTransferData,
+                              metadata = makeDummyHeader accountAddress1 1 100000,
+                              keys = [(0, [(0, keyPair1)])]
+                            },
+                         \Helpers.SchedulerResult{..} state -> do
+                            doEncryptedBalanceAssertions <-
+                                assertEncryptedBalance
+                                    Types.initialAccountEncryptedAmount
+                                        { _selfAmount = stpatdRemainingAmount secToPubTransferData,
+                                          _startIndex = numberOfTransactions,
+                                          _incomingEncryptedAmounts = Seq.empty
+                                        }
+                                    accountAddress1
+                                    state
+                            return $ do
+                                case Helpers.getResults $ Sch.ftAdded srTransactions of
+                                    [ ( _,
+                                        Types.TxSuccess
+                                            [ Types.EncryptedAmountsRemoved{..},
+                                              Types.AmountAddedByDecryption{..}
+                                                ]
+                                        )
+                                        ] -> do
+                                            assertEqual
+                                                "Account encrypted amounts removed"
+                                                earAccount
+                                                accountAddress1
+                                            assertEqual
+                                                "Used up indices"
+                                                earUpToIndex
+                                                numberOfTransactions
+                                            assertEqual "New amount" earNewAmount $
+                                                stpatdRemainingAmount secToPubTransferData
+                                            assertEqual
+                                                "Decryption address"
+                                                aabdAccount
+                                                accountAddress1
+                                            assertEqual "Amount added" aabdAmount $
+                                                numberOfTransactions * 10
+                                    [(_, Types.TxSuccess e)] ->
+                                        assertFailure $ "Unexpected final outcome: " ++ show e
+                                    other ->
+                                        assertFailure $
+                                            "Last transaction should succeed: " ++ show other
+                                doEncryptedBalanceAssertions
+                       )
+                   ]
+
+initialBlockState ::
+    Types.IsProtocolVersion pv =>
+    Helpers.PersistentBSM pv (BS.HashedPersistentBlockState pv)
+initialBlockState =
+    Helpers.createTestBlockStateWithAccountsM
+        [ Helpers.makeTestAccountFromSeed 10_000_000_000 0,
+          Helpers.makeTestAccountFromSeed 10_000_000_000 1
+        ]
+
+accountAddress0 :: Types.AccountAddress
+accountAddress0 = Helpers.accountAddressFromSeed 0
+
+accountAddress1 :: Types.AccountAddress
+accountAddress1 = Helpers.accountAddressFromSeed 1
+
+keyPair0 :: SigScheme.KeyPair
+keyPair0 = Helpers.keyPairFromSeed 0
+
+keyPair1 :: SigScheme.KeyPair
+keyPair1 = Helpers.keyPairFromSeed 1
+
+encryptionSecretKey0 :: ElgamalSecretKey
+encryptionSecretKey0 = dummyEncryptionSecretKey dummyCryptographicParameters accountAddress0
+
+encryptionSecretKey1 :: ElgamalSecretKey
+encryptionSecretKey1 = dummyEncryptionSecretKey dummyCryptographicParameters accountAddress1
+
+encryptionPublicKey1 :: ID.AccountEncryptionKey
+encryptionPublicKey1 =
+    ID.makeEncryptionKey dummyCryptographicParameters $
+        ID.credId $
+            Helpers.makeTestCredentialFromSeed 1
 
 iterateLimitM :: Monad m => Int -> (a -> m a) -> a -> m [a]
 iterateLimitM n f = go 0
@@ -51,24 +252,6 @@ iterateLimitM n f = go 0
         | otherwise = do
             y <- f x
             (x :) <$> go (m + 1) y
-
-initialBlockState :: BlockState PV1
-initialBlockState =
-    blockStateWithAlesAccount
-        10000000000
-        (Acc.putAccountWithRegIds (mkAccount thomasVK thomasAccount 10000000000) Acc.emptyAccounts)
-
--- Ales' keys
-alesEncryptionSecretKey :: ElgamalSecretKey
-alesEncryptionSecretKey = dummyEncryptionSecretKey dummyCryptographicParameters alesAccount
-alesEncryptionPublicKey :: AccountEncryptionKey
-alesEncryptionPublicKey = unsafeEncryptionKeyFromRaw (fromJust (Acc.getAccount alesAccount (initialBlockState ^. blockAccounts)) ^. accountEncryptionKey)
-
--- Thomas' keys
-thomasEncryptionSecretKey :: ElgamalSecretKey
-thomasEncryptionSecretKey = dummyEncryptionSecretKey dummyCryptographicParameters thomasAccount
-thomasEncryptionPublicKey :: AccountEncryptionKey
-thomasEncryptionPublicKey = unsafeEncryptionKeyFromRaw (fromJust (Acc.getAccount thomasAccount (initialBlockState ^. blockAccounts)) ^. accountEncryptionKey)
 
 -- Helpers for creating the transfer datas
 createEncryptedTransferData ::
@@ -82,177 +265,144 @@ createEncryptedTransferData ::
     Amount ->
     IO (Maybe EncryptedAmountTransferData)
 createEncryptedTransferData (AccountEncryptionKey receiverPK) =
-    makeEncryptedAmountTransferData (initialBlockState ^. blockCryptographicParameters . unhashed) receiverPK
+    makeEncryptedAmountTransferData dummyCryptographicParameters receiverPK
 
-createSecToPubTransferData :: ElgamalSecretKey -> AggregatedDecryptedAmount -> Amount -> IO (Maybe SecToPubAmountTransferData)
-createSecToPubTransferData =
-    makeSecToPubAmountTransferData (initialBlockState ^. blockCryptographicParameters . unhashed)
+createSecToPubTransferData :: ElgamalSecretKey -> AggregatedDecryptedAmount -> Types.Amount -> IO (Maybe SecToPubAmountTransferData)
+createSecToPubTransferData = makeSecToPubAmountTransferData dummyCryptographicParameters
 
 -- Helper for checking the encrypted balance of an account.
-checkEncryptedBalance :: AccountEncryptedAmount -> AccountAddress -> BlockState PV1 -> SpecWith ()
-checkEncryptedBalance accEncAmount acc bs =
-    specify ("Correct final balance on " ++ show acc) $
-        case Acc.getAccount acc (bs ^. blockAccounts) of
-            Nothing -> HUnit.assertFailure $ "Account with id '" ++ show acc ++ "' not found"
-            Just account -> HUnit.assertEqual "Expected encrypted amount matches" accEncAmount (account ^. accountEncryptedAmount)
-
---------------------------------- Transactions ---------------------------------
+assertEncryptedBalance ::
+    Types.IsProtocolVersion pv =>
+    Types.AccountEncryptedAmount ->
+    Types.AccountAddress ->
+    BS.PersistentBlockState pv ->
+    Helpers.PersistentBSM pv Assertion
+assertEncryptedBalance expectedEncryptedAmount address blockState = do
+    maybeAccount <- BS.bsoGetAccount blockState address
+    case maybeAccount of
+        Nothing -> return $ assertFailure $ "No account found for address: " ++ show address
+        Just (_, account) -> do
+            accountEncryptedAmount <- BS.accountEncryptedAmount account
+            return $
+                assertEqual
+                    "Encrypted amounts matches"
+                    accountEncryptedAmount
+                    expectedEncryptedAmount
 
 numberOfTransactions :: Num a => a
 numberOfTransactions = fromIntegral maxNumIncoming + 2
-
--- Transaction 1. Pub to sec (1000)
-encryptedAmount1000 :: EncryptedAmount
-encryptedAmount1000 = encryptAmountZeroRandomness (initialBlockState ^. blockCryptographicParameters . unhashed) 1000
-
--- Initial transfer transaction
-encryptedTransferData1 :: IO EncryptedAmountTransferData
-encryptedTransferData1 = fromJust <$> createEncryptedTransferData thomasEncryptionPublicKey alesEncryptionSecretKey (makeAggregatedDecryptedAmount encryptedAmount1000 1000 0) 10
 
 -- Function used to generate all the transfer datas based on encryptedTransferData1
 -- each transaction sends 10 tokens from Ales' self amount to Thomas
 makeNext :: (EncryptedAmountTransferData, Amount) -> IO (EncryptedAmountTransferData, Amount)
 makeNext (d, a) = do
-    newData <- fromJust <$> createEncryptedTransferData thomasEncryptionPublicKey alesEncryptionSecretKey (makeAggregatedDecryptedAmount (eatdRemainingAmount d) a 0) 10
+    newData <-
+        fromJust
+            <$> createEncryptedTransferData
+                encryptionPublicKey1
+                encryptionSecretKey0
+                (makeAggregatedDecryptedAmount (eatdRemainingAmount d) a 0)
+                10
     return (newData, a - 10)
 
--- A list of all the input transactions 'numberOfTransactions'.
-allTxsIO :: IO [(EncryptedAmountTransferData, Amount)]
-allTxsIO = do
-    start <- encryptedTransferData1
-    iterateLimitM numberOfTransactions makeNext (start, 990)
+makeNormalBlockStateAssertion ::
+    (Types.IsProtocolVersion pv) =>
+    [EncryptedAmountTransferData] ->
+    EncryptedAmountTransferData ->
+    EncryptedAmountAggIndex ->
+    Helpers.TransactionAssertion pv
+makeNormalBlockStateAssertion allTxs transferData idx = \_ state -> do
+    -- Account0 amount should be the remaining amount on the transaction
+    doEncryptedBalanceAssertionsSender <-
+        assertEncryptedBalance
+            initialAccountEncryptedAmount{_selfAmount = eatdRemainingAmount transferData}
+            accountAddress0
+            state
+    doEncryptedBalanceAssertionsReceiver <-
+        assertEncryptedBalance
+            initialAccountEncryptedAmount
+                { -- no amounts have been used on account1.
+                  _startIndex = 0,
+                  -- It should have all the received amounts until this index.
+                  _incomingEncryptedAmounts =
+                    Seq.fromList $ take (fromIntegral idx) (eatdTransferAmount <$> allTxs)
+                }
+            accountAddress1
+            state
 
--- Infinite list of transaction specs that before `maxNumIncoming` transactions
--- considers that transferred amounts are added to the incoming amounts and
--- after that it checks that the initial incoming amounts are being
--- automatically aggregated.
-transactionsIO ::
-    IO
-        ( [(Runner.TransactionJSON, (TResultSpec, BlockState PV1 -> Spec))],
-          [(EncryptedAmountTransferData, Amount)]
-        )
-transactionsIO = do
-    allTxs <- allTxsIO
-    let (normal, interesting) = splitAt maxNumIncoming allTxs
-    -- A normal transaction is a transfer before maxNumIncoming amounts have been received.
-    let makeNormalTransaction :: EncryptedAmountTransferData -> EncryptedAmountAggIndex -> (Runner.TransactionJSON, (TResultSpec, BlockState PV1 -> Spec))
-        makeNormalTransaction x idx = makeTransaction x idx $
-            \bs -> do
-                checkEncryptedBalance initialAccountEncryptedAmount{_selfAmount = eatdRemainingAmount x} alesAccount bs -- Ales amount should be the remaining amount on the transaction
-                checkEncryptedBalance
-                    initialAccountEncryptedAmount
-                        { _startIndex = 0, -- no amounts have been used on Thomas account
-                          _incomingEncryptedAmounts = Seq.fromList [eatdTransferAmount n | (n, _) <- take (fromIntegral idx) normal] -- It should have all the received amounts until this index
-                        }
-                    thomasAccount
-                    bs
+    return $ do
+        doEncryptedBalanceAssertionsSender
+        doEncryptedBalanceAssertionsReceiver
 
-        -- An interesting transaction is a transfer after maxNumIncoming amounts have been received.
-        makeInterestingTransaction :: EncryptedAmountTransferData -> EncryptedAmountAggIndex -> (Runner.TransactionJSON, (TResultSpec, BlockState PV1 -> Spec))
-        makeInterestingTransaction x idx = makeTransaction x idx $
-            \bs -> do
-                checkEncryptedBalance initialAccountEncryptedAmount{_selfAmount = eatdRemainingAmount x} alesAccount bs -- Ales amount should be the remaining amount on the transaction
-                let (combined, kept) = Seq.splitAt ((fromIntegral idx - fromIntegral maxNumIncoming) + 1) (Seq.fromList [eatdTransferAmount n | (n, _) <- take (fromIntegral idx) allTxs]) -- get which amounts should be combined into combinedAmount
-                    combinedAmount = foldl' aggregateAmounts mempty combined -- combine them
-                checkEncryptedBalance
-                    initialAccountEncryptedAmount
-                        { _startIndex = idx - fromIntegral maxNumIncoming, -- the start index should have increased
-                          _incomingEncryptedAmounts = kept, -- the list of incoming amounts will hold the `rest` of the amounts
-                          _aggregatedAmount = Just (combinedAmount, fromIntegral (idx - fromIntegral maxNumIncoming + 1)) -- the combined amount goes into the `_aggregatedAmount` field together with the number of aggregated amounts until this point.
-                        }
-                    thomasAccount
-                    bs
-        makeTransaction :: EncryptedAmountTransferData -> EncryptedAmountAggIndex -> (BlockState PV1 -> Spec) -> (Runner.TransactionJSON, (TResultSpec, BlockState PV1 -> Spec))
-        makeTransaction x@EncryptedAmountTransferData{..} idx checks =
-            ( Runner.TJSON
-                { payload = Runner.EncryptedAmountTransfer thomasAccount x, -- create an encrypted transfer to Thomas
-                  metadata = makeDummyHeader alesAccount (fromIntegral idx + 1) 100000, -- from Ales with nonce idx + 1
-                  keys = [(0, [(0, alesKP)])]
-                },
-                ( Success $ \case
-                    [Types.EncryptedAmountsRemoved{..}, Types.NewEncryptedAmount{..}] -> do
-                        HUnit.assertEqual "Account encrypted amounts removed" earAccount alesAccount
-                        HUnit.assertEqual "Used up indices" earUpToIndex 0
-                        HUnit.assertEqual "New amount" earNewAmount eatdRemainingAmount
-                        HUnit.assertEqual "Receiver address" neaAccount thomasAccount
-                        HUnit.assertEqual "New receiver index" neaNewIndex $ fromIntegral idx - 1
-                        HUnit.assertEqual "Received amount" neaEncryptedAmount eatdTransferAmount
-                    e -> HUnit.assertFailure $ "Unexpected outcome: " ++ show e,
-                  checks
-                )
-            )
+-- An interesting transaction is a transfer after maxNumIncoming amounts have been received.
+makeInterestingBlockStateAssertion ::
+    (Types.IsProtocolVersion pv) =>
+    [EncryptedAmountTransferData] ->
+    EncryptedAmountTransferData ->
+    EncryptedAmountAggIndex ->
+    Helpers.TransactionAssertion pv
+makeInterestingBlockStateAssertion allTxs transferData idx = \_ state -> do
+    -- Account0 amount should be the remaining amount on the transaction
+    doEncryptedBalanceAssertionsSender <-
+        assertEncryptedBalance
+            initialAccountEncryptedAmount{_selfAmount = eatdRemainingAmount transferData}
+            accountAddress0
+            state
 
-    return
-        ( [makeNormalTransaction x idx | (idx, (x, _)) <- zip [1 ..] normal]
-            ++ [makeInterestingTransaction tx (fromIntegral idx) | (idx, (tx, _)) <- zip [maxNumIncoming + 1 ..] interesting],
-          allTxs
-        )
+    let (combined, kept) =
+            Seq.splitAt
+                ((fromIntegral idx - fromIntegral maxNumIncoming) + 1)
+                -- get which amounts should be combined into combinedAmount
+                (Seq.fromList $ take (fromIntegral idx) (eatdTransferAmount <$> allTxs))
 
--- Transaction that will transfer 340 to Thomas's public balancesecToPubTransferData :: IO SecToPubAmountTransferData
-mkSecToPubTransferData :: [(EncryptedAmountTransferData, a)] -> IO SecToPubAmountTransferData
-mkSecToPubTransferData transactions = fromJust <$> createSecToPubTransferData thomasEncryptionSecretKey aggAmount (numberOfTransactions * 10)
-  where
-    aggAmount = makeAggregatedDecryptedAmount allAmounts (numberOfTransactions * 10) numberOfTransactions
-    allAmounts = foldl' aggregateAmounts mempty [eatdTransferAmount n | (n, _) <- transactions]
+        combinedAmount = foldl' aggregateAmounts mempty combined -- combine them
+    doEncryptedBalanceAssertionsReceiver <-
+        assertEncryptedBalance
+            initialAccountEncryptedAmount
+                { -- the start index should have increased
+                  _startIndex = idx - fromIntegral maxNumIncoming,
+                  -- the list of incoming amounts will hold the `rest` of the amounts
+                  _incomingEncryptedAmounts = kept,
+                  -- the combined amount goes into the `_aggregatedAmount` field together with the
+                  -- number of aggregated amounts until this point.
+                  _aggregatedAmount =
+                    Just
+                        ( combinedAmount,
+                          fromIntegral (idx - fromIntegral maxNumIncoming + 1)
+                        )
+                }
+            accountAddress1
+            state
+    return $ do
+        doEncryptedBalanceAssertionsSender
+        doEncryptedBalanceAssertionsReceiver
 
-------------------------------------- Test -------------------------------------
-
-testCases :: [(Runner.TransactionJSON, (TResultSpec, BlockState PV1 -> Spec))] -> [TestCase PV1]
-testCases transactions =
-    [ TestCase
-        { tcName = "Makes an encrypted transfer",
-          tcParameters = (defaultParams @PV1){tpInitialBlockState = initialBlockState},
-          tcTransactions =
-            -- First transfer some money to Ales' private balance
-            ( Runner.TJSON
-                { payload = Runner.TransferToEncrypted 1000,
-                  metadata = makeDummyHeader alesAccount 1 100000,
-                  keys = [(0, [(0, alesKP)])]
-                },
-                ( SuccessE
-                    [ Types.EncryptedSelfAmountAdded
-                        { eaaAccount = alesAccount,
-                          eaaNewAmount = encryptedAmount1000,
-                          eaaAmount = 1000
-                        }
-                    ],
-                  checkEncryptedBalance initialAccountEncryptedAmount{_selfAmount = encryptedAmount1000} alesAccount
-                )
-            )
-                :
-                -- Now send 34 transactions of 10 tokens from Ales to Thomas
-                transactions
-        }
-    ]
-
-tests :: Spec
-tests = do
-    (transactions, allTxs) <- runIO transactionsIO
-    lastTransaction <- runIO $ do
-        secToPubTransferData <- mkSecToPubTransferData allTxs
-        -- Send the encrypted 340 tokens on Thomas' account to his public balance
-        return
-            [   ( Runner.TJSON
-                    { payload = Runner.TransferToPublic secToPubTransferData,
-                      metadata = makeDummyHeader thomasAccount 1 100000,
-                      keys = [(0, [(0, thomasKP)])]
-                    },
-                    ( Success $ \case
-                        [Types.EncryptedAmountsRemoved{..}, Types.AmountAddedByDecryption{..}] -> do
-                            HUnit.assertEqual "Account encrypted amounts removed" earAccount thomasAccount
-                            HUnit.assertEqual "Used up indices" earUpToIndex numberOfTransactions
-                            HUnit.assertEqual "New amount" earNewAmount $ stpatdRemainingAmount secToPubTransferData
-                            HUnit.assertEqual "Decryption address" aabdAccount thomasAccount
-                            HUnit.assertEqual "Amount added" aabdAmount $ numberOfTransactions * 10
-                        e -> HUnit.assertFailure $ "Unexpected final outcome: " ++ show e,
-                      checkEncryptedBalance
-                        initialAccountEncryptedAmount
-                            { _selfAmount = stpatdRemainingAmount secToPubTransferData,
-                              _startIndex = numberOfTransactions,
-                              _incomingEncryptedAmounts = Seq.empty
-                            }
-                        thomasAccount
-                    )
-                )
-            ]
-    describe "Encrypted transfers with aggregation." $ mkSpecs (testCases (transactions ++ lastTransaction))
+makeTransaction ::
+    (Types.IsProtocolVersion pv) =>
+    Helpers.TransactionAssertion pv ->
+    EncryptedAmountTransferData ->
+    EncryptedAmountAggIndex ->
+    (Runner.TransactionJSON, Helpers.TransactionAssertion pv)
+makeTransaction blockStateChecks transferData idx =
+    ( Runner.TJSON
+        { payload = Runner.EncryptedAmountTransfer accountAddress1 transferData, -- create an encrypted transfer to account1
+          metadata = makeDummyHeader accountAddress0 (fromIntegral idx + 1) 100000, -- from account0 with nonce idx + 1
+          keys = [(0, [(0, keyPair0)])]
+        },
+      \result state -> do
+        doBlockStateChecks <- blockStateChecks result state
+        return $ do
+            case Helpers.getResults $ Sch.ftAdded $ Helpers.srTransactions result of
+                [(_, Types.TxSuccess events)] ->
+                    case events of
+                        [Types.EncryptedAmountsRemoved{..}, Types.NewEncryptedAmount{..}] -> do
+                            assertEqual "Account encrypted amounts removed" earAccount accountAddress0
+                            assertEqual "Used up indices" earUpToIndex 0
+                            assertEqual "New amount" earNewAmount (eatdRemainingAmount transferData)
+                            assertEqual "Receiver address" neaAccount accountAddress1
+                            assertEqual "New receiver index" neaNewIndex $ fromIntegral idx - 1
+                            assertEqual "Received amount" neaEncryptedAmount (eatdTransferAmount transferData)
+                        e -> assertFailure $ "Unexpected outcome: " ++ show e
+                e -> assertFailure $ "Transaction should succeed: " ++ show e
+            doBlockStateChecks
+    )

--- a/concordium-consensus/tests/scheduler/SchedulerTests/RandomBakerTransactions.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/RandomBakerTransactions.hs
@@ -1,54 +1,46 @@
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-deprecations #-}
 
-module SchedulerTests.RandomBakerTransactions where
+module SchedulerTests.RandomBakerTransactions (tests) where
 
 import Test.Hspec
 import Test.QuickCheck
 
 import Control.Monad
+import qualified Control.Monad.Except as Except
+import qualified Data.List as List
 import qualified Data.Map as Map
+import Lens.Micro.Platform
+import System.Random
 
 import qualified Concordium.Scheduler as Sch
-import qualified Concordium.Scheduler.EnvironmentImplementation as EI
 import Concordium.Scheduler.Runner
 
-import Concordium.GlobalState.Basic.BlockState
-import Concordium.GlobalState.Basic.BlockState.Accounts as Acc
-import Concordium.GlobalState.Basic.BlockState.Invariants
-
+import Concordium.Crypto.DummyData
 import Concordium.Crypto.SignatureScheme as Sig
+import Concordium.GlobalState.DummyData
+import qualified Concordium.GlobalState.Persistent.BlockState as BS
 import Concordium.ID.Types (randomAccountAddress)
-
+import Concordium.Scheduler.DummyData
+import Concordium.Scheduler.Types hiding (Payload (..))
 import Concordium.Types.Accounts (
     bakerAggregationVerifyKey,
     bakerElectionVerifyKey,
     bakerInfo,
     bakerSignatureVerifyKey,
  )
-
-import Concordium.Scheduler.Types hiding (Payload (..))
-
-import Lens.Micro.Platform
-import System.Random
-
-import Concordium.Crypto.DummyData
-import Concordium.GlobalState.DummyData
-import Concordium.Scheduler.DummyData
-
-import SchedulerTests.Helpers
-import SchedulerTests.TestUtils
-
-import qualified Data.List as List
+import qualified SchedulerTests.Helpers as Helpers
 
 -- | The amount of energy to deposit in every test transaction.
 energy :: Energy
-energy = 10000
+energy = 10_000
 
 staticKeys :: [(KeyPair, AccountAddress)]
-staticKeys = ks (mkStdGen 1333)
+staticKeys = ks (mkStdGen 1_333)
   where
     ks g =
         let (k, g') = randomEd25519KeyPair g
@@ -58,12 +50,14 @@ staticKeys = ks (mkStdGen 1333)
 numAccounts :: Int
 numAccounts = 10
 
-initialBlockState :: BlockState PV1
+initialBlockState ::
+    (IsProtocolVersion pv) =>
+    Helpers.PersistentBSM pv (BS.HashedPersistentBlockState pv)
 initialBlockState =
-    createBlockState
-        (foldr addAcc Acc.emptyAccounts (take numAccounts staticKeys))
+    Helpers.createTestBlockStateWithAccountsM $
+        toTestAccount <$> take numAccounts staticKeys
   where
-    addAcc (kp, addr) = Acc.putAccountWithRegIds (mkAccount (correspondingVerifyKey kp) addr initBal)
+    toTestAccount (kp, addr) = Helpers.makeTestAccount (correspondingVerifyKey kp) addr initBal
     initBal = 10 ^ (12 :: Int) :: Amount
 
 data BakerStatus
@@ -145,7 +139,7 @@ updateBaker m0 = do
                     )
 
         updateBakerStake = do
-            newStake <- elements [0, 100000, 100_000_000_000, 300_000_000_000, 300_000_000_100]
+            newStake <- elements [0, 100_000, 100_000_000_000, 300_000_000_000, 300_000_000_100]
             let update (Baker v)
                     -- if stake is decreased and under threshold, no change is done
                     | v > newStake, newStake < 300_000_000_000 = Baker v
@@ -196,7 +190,7 @@ updateBaker m0 = do
             let (fbkr, electionSecretKey, signKey, aggregationKey) = mkFullBaker (m0 ^. mNextSeed) 0
                 bkr = fbkr ^. bakerInfo
 
-            initStake <- elements [0, 100000, 100_000_000_000, 300_000_000_000, 300_000_000_100]
+            initStake <- elements [0, 100_000, 100_000_000_000, 300_000_000_000, 300_000_000_100]
             let update NoBaker =
                     if initStake < 300_000_000_000
                         then NoBaker
@@ -230,7 +224,7 @@ simpleTransfer :: Model -> Gen (TransactionJSON, Model)
 simpleTransfer m0 = do
     (srcAcct, (srcKp, srcN, _)) <- elements (Map.toList $ _mAccounts m0)
     destAcct <- elements $ Map.keys $ _mAccounts m0
-    amt <- fromIntegral <$> choose (0, 1000 :: Word)
+    amt <- fromIntegral <$> choose (0, 1_000 :: Word)
     return
         ( TJSON
             { payload = Transfer{toaddress = destAcct, amount = amt},
@@ -250,20 +244,23 @@ makeTransactions = sized (mt initialModel)
             (_1 %~ (t :)) <$> mt m' (sz - 1)
         | otherwise = return ([], reverse (m ^. mRejects))
 
-testTransactions :: Property
-testTransactions = forAll makeTransactions (ioProperty . tt)
+testTransactions :: forall pv. (IsProtocolVersion pv) => SProtocolVersion pv -> Property
+testTransactions spv = forAll makeTransactions (ioProperty . tt)
   where
     tt (tl, predRejects) = do
-        transactions <- processUngroupedTransactions tl
-        let (Sch.FilteredTransactions{..}, finState) =
-                EI.runSI
-                    (Sch.filterTransactions dummyBlockSize dummyBlockTimeout transactions)
-                    dummyChainMeta
-                    maxBound
-                    maxBound
-                    initialBlockState
-        let gs = finState ^. EI.ssBlockState
-        let rejs = [(z, decodePayload SP1 (thPayloadSize . atrHeader $ z) (atrPayload z), rr) | ((WithMetadata{wmdData = NormalTransaction z}, _), TxReject rr) <- getResults ftAdded]
+        (result, doCheckState) <-
+            Helpers.runSchedulerTestTransactionJson
+                Helpers.defaultTestConfig
+                initialBlockState
+                constructStateChecks
+                tl
+        let Sch.FilteredTransactions{..} = Helpers.srTransactions result
+
+        let rejs =
+                [ (z, decodePayload spv (thPayloadSize . atrHeader $ z) (atrPayload z), rr)
+                  | ((WithMetadata{wmdData = NormalTransaction z}, _), TxReject rr) <-
+                        Helpers.getResults ftAdded
+                ]
         let checkRejects [] [] = return ()
             checkRejects [] _ = Left "Expected additional rejected transactions"
             checkRejects rs [] = Left $ "Unexpected rejected transactions:" ++ show rs
@@ -273,15 +270,31 @@ testTransactions = forAll makeTransactions (ioProperty . tt)
                     checkRejects rs prs
                 | otherwise = Left $ "Unexpected rejected transaction:" ++ show r
         let checkResults = do
-                invariantBlockState gs (finState ^. EI.schedulerExecutionCosts)
                 unless (null ftFailed) $ Left $ "some transactions failed: " ++ show ftFailed
                 checkRejects rejs $ map head $ List.group predRejects
+                doCheckState
         case checkResults of
             Left f -> return $ counterexample f False
             Right _ -> return $ property True
+    constructStateChecks ::
+        Helpers.SchedulerResult ->
+        BS.PersistentBlockState pv ->
+        Helpers.PersistentBSM pv (Either String ())
+    constructStateChecks result state = do
+        hashedState <- BS.hashBlockState @pv state
+        Except.runExceptT $
+            Helpers.checkBlockStateInvariants
+                hashedState
+                (Helpers.srExecutionCosts result)
 
 tests :: Spec
-tests =
+tests = do
     describe "SchedulerTests.RandomBakerTransactions" $
-        it "Random baker transactions" $
-            withMaxSuccess 100 testTransactions
+        sequence_ $
+            Helpers.forEveryProtocolVersion testCases
+  where
+    testCases :: forall pv. IsProtocolVersion pv => SProtocolVersion pv -> String -> Spec
+    testCases spv pvString =
+        unless (supportsDelegation spv) $ do
+            specify (pvString ++ ": Random baker transactions") $
+                withMaxSuccess 100 (testTransactions spv)

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/QueriesPersistent.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/QueriesPersistent.hs
@@ -101,7 +101,7 @@ runQueryTests changeState reloadState = do
         then assertEqual "State was updated" 1 (BS.index newState 0) -- non-empty state serialization starts with a 1 tag.
         else assertEqual "State was not updated" (BS.singleton 0) newState -- empty state serialization just puts a 0 tag.
   where
-    extractor ubs = do
+    extractor _ ubs = do
         blockState <-
             if reloadState
                 then Helpers.reloadBlockState ubs

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/TransfersPersistent.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/TransfersPersistent.hs
@@ -103,7 +103,7 @@ runTransferTests changeState reloadState = do
         then assertEqual "State was updated" 1 (BS.index newState 0) -- non-empty state serialization starts with a 1 tag.
         else assertEqual "State was not updated" (BS.singleton 0) newState -- empty state serialization just puts a 0 tag.
   where
-    extractor ubs = do
+    extractor _ ubs = do
         blockState <-
             if reloadState
                 then Helpers.reloadBlockState ubs

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/UpgradingPersistent.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/UpgradingPersistent.hs
@@ -131,7 +131,7 @@ runUpgradeTests changeAmount changeState reloadState = do
         then assertEqual "State was updated" 1 (BS.index newState 0) -- non-empty state serialization starts with a 1 tag.
         else assertEqual "State was not updated" (BS.singleton 0) newState -- empty state serialization just puts a 0 tag.
   where
-    extractor ubs = do
+    extractor _ ubs = do
         blockState <-
             if reloadState
                 then Helpers.reloadBlockState ubs


### PR DESCRIPTION
## Purpose

Related to #626.
Rewrite 9 scheduler tests from using basic block state implementation to use persistent block state implementation.
