### PR TITLE
Ignore stack.yaml.lock generated in root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ hie.yaml
 **/**/TAGS
 .DS_Store
 /concordium-node/*.log
+/stack.yaml.lock
 
 # MacOS distribution
 /scripts/distribution/macOS-package/tools


### PR DESCRIPTION
## Purpose

When building consensus from other folders than within `/concordium-consensus/`, the `stack.yaml.lock` file is placed in the root.

## Changes

- Add ignore rule in gitignore
