### PR TITLE
Fix windows build. Link the threaded runtime library.

### DIFF
--- a/concordium-consensus/package.yaml
+++ b/concordium-consensus/package.yaml
@@ -97,7 +97,7 @@ library:
   when:
     - condition: os(windows)
       then:
-        ghc-options: -static -shared lib.def -L../concordium-base/smart-contracts/lib -lwasm_chain_integration
+        ghc-options: -threaded -static -shared lib.def -L../concordium-base/smart-contracts/lib -lwasm_chain_integration
       else:
         when:
           - condition: flag(dynamic)


### PR DESCRIPTION
## Purpose

The haskell library must be built with the threaded runtime for proper linking (since the -static flag is also supplied on windows, which embeds the runtime library).

Fixes #663 

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.