### PR TITLE
Remove unused NoLogSchedulerState and rename LogSchedulerState

### DIFF
--- a/concordium-consensus/src/Concordium/Scheduler/EnvironmentImplementation.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/EnvironmentImplementation.hs
@@ -53,31 +53,6 @@ class HasSchedulerState a where
 
     nextIndex :: Lens' a TransactionIndex
 
-data NoLogSchedulerState (m :: DK.Type -> DK.Type) = NoLogSchedulerState
-    { _ssBlockState :: !(UpdatableBlockState m),
-      _ssSchedulerEnergyUsed :: !Energy,
-      _ssSchedulerExecutionCosts :: !Amount,
-      _ssNextIndex :: !TransactionIndex
-    }
-
-mkInitialSS :: forall m. UpdatableBlockState m -> NoLogSchedulerState m
-mkInitialSS _ssBlockState =
-    NoLogSchedulerState
-        { _ssSchedulerEnergyUsed = 0,
-          _ssSchedulerExecutionCosts = 0,
-          _ssNextIndex = 0,
-          ..
-        }
-
-makeLenses ''NoLogSchedulerState
-
-instance HasSchedulerState (NoLogSchedulerState m) where
-    type SS (NoLogSchedulerState m) = UpdatableBlockState m
-    schedulerBlockState = ssBlockState
-    schedulerEnergyUsed = ssSchedulerEnergyUsed
-    schedulerExecutionCosts = ssSchedulerExecutionCosts
-    nextIndex = ssNextIndex
-
 newtype BSOMonadWrapper (r :: DK.Type) (state :: DK.Type) (m :: DK.Type -> DK.Type) (a :: DK.Type) = BSOMonadWrapper (m a)
     deriving
         ( Functor,

--- a/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
@@ -52,6 +52,7 @@ import qualified Concordium.Scheduler.DummyData as DummyData
 import qualified Concordium.Scheduler.EnvironmentImplementation as EI
 import qualified Concordium.Scheduler.Runner as SchedTest
 import Concordium.Scheduler.TreeStateEnvironment
+import qualified Concordium.Scheduler.TreeStateEnvironment as TreeStateEnv
 import qualified Concordium.Scheduler.Types as Types
 import Concordium.TimeMonad
 
@@ -223,16 +224,16 @@ runScheduler ::
 runScheduler TestConfig{..} stateBefore transactions = do
     blockStateBefore <- BS.thawBlockState stateBefore
     let txs = filterTransactions tcBlockSize (Time.timestampToUTCTime tcBlockTimeout) transactions
-    let schedulerState = EI.mkInitialSS @(PersistentBSM pv) blockStateBefore
+    let schedulerState = TreeStateEnv.mkInitialSS @(PersistentBSM pv) blockStateBefore
     (filteredTransactions, stateAfter, ()) <- runRWST (_runBSM txs) tcContextState schedulerState
 
     let result =
             SchedulerResult
                 { srTransactions = filteredTransactions,
-                  srExecutionCosts = EI._ssSchedulerExecutionCosts stateAfter,
-                  srUsedEnergy = EI._ssSchedulerEnergyUsed stateAfter
+                  srExecutionCosts = stateAfter ^. EI.schedulerExecutionCosts,
+                  srUsedEnergy = stateAfter ^. EI.schedulerEnergyUsed
                 }
-    return (result, EI._ssBlockState stateAfter)
+    return (result, stateAfter ^. EI.schedulerBlockState)
 
 -- | Run the scheduler on transactions in a test environment.
 -- Allows for a block state monad computation for constructing the initial block state and takes a


### PR DESCRIPTION
## Purpose

Minor simplification of SchedulerState

Should be merged into main after #685.
Related to #669.

## Changes

- Remove the now unused `NoLogSchedulerState`
- Rename `LogSchedulerState` to `SchedulerState`, since the database logging which this is referring to is not relevant anymore.
