### PR TITLE
Remove non-existent job link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 - [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](https://github.com/Concordium/.github/blob/main/.github/CODE_OF_CONDUCT.md)
 
-- ![Format](https://github.com/Concordium/concordium-node/actions/workflows/rustfmt.yaml/badge.svg)
-
 - ![Build and test](https://github.com/Concordium/concordium-node/actions/workflows/build-test.yaml/badge.svg)
 
 This repository contains the implementation of the concordium p2p node with its


### PR DESCRIPTION
## Purpose

Remove the "format" link since we don't have a separate format job.
