### PR TITLE
Add documentation on enabling and configuring the prometheus exporter

### DIFF
--- a/docs/prometheus-exporter.md
+++ b/docs/prometheus-exporter.md
@@ -1,0 +1,24 @@
+# Prometheus exporter
+
+This document describes how to configure `concordium-node` to run a [Prometheus exporter](https://prometheus.io/) and documentation for what each of the exported metrics mean.
+
+## Enable the exporter
+
+Concordium node does not run the Prometheus exporter by default. To enable it at node startup, the listening port for the exporter must be provided either through a command line argument `--prometheus-listen-port` or the environment variable `CONCORDIUM_NODE_PROMETHEUS_LISTEN_PORT`.
+
+Likewise, the IP address to listen on can be specified using command line argument `--prometheus-listen-addr` or environment variable `CONCORDIUM_NODE_PROMETHEUS_LISTEN_ADDRESS`. Defaults to `127.0.0.1` when not provided.
+
+To verify the exporter is running open the provided listen address and port in a browser. Which should display the text "Operational".
+
+## Push metrics to a Pushgateway
+
+Concordium node also supports pushing metrics to a Prometheus Pushgateway. This is enabled by providing the URL for the Pushgateway using either the command line argument `--prometheus-push-gateway` or by setting the environment variable `CONCORDIUM_NODE_PROMETHEUS_PUSH_GATEWAY`.
+
+The following options are available for configuring the pushing of metrics:
+
+- `--prometheus-instance-name` (`CONCORDIUM_NODE_PROMETHEUS_INSTANCE_NAME`) Set the instance label to include in metrics pushed to Pushgateway. If not present the id of the node is used.
+- `--prometheus-job-name` (`CONCORDIUM_NODE_PROMETHEUS_JOB_NAME`) Set the instance label to include in metrics pushed to Pushgateway. If not present, `concordium_node_push` is used.
+- `--prometheus-push-gateway-interval` (`CONCORDIUM_NODE_PROMETHEUS_PUSH_GATEWAY_INTERVAL`) Duration in seconds between pushes to Pushgateway. If not present `2` is used.
+- `--prometheus-push-gateway-password` (`CONCORDIUM_NODE_PROMETHEUS_PUSH_GATEWAY_PASSWORD`) Password to use for push gateway, both username or password must be provided to enable authentication.
+- `--prometheus-push-gateway-username` (`CONCORDIUM_NODE_PROMETHEUS_PUSH_GATEWAY_USERNAME`) Username to use for push gateway, both username or password must be provided to enable authentication.
+

--- a/docs/prometheus-exporter.md
+++ b/docs/prometheus-exporter.md
@@ -8,7 +8,7 @@ Concordium node does not run the Prometheus exporter by default. To enable it at
 
 Likewise, the IP address to listen on can be specified using command line argument `--prometheus-listen-addr` or environment variable `CONCORDIUM_NODE_PROMETHEUS_LISTEN_ADDRESS`. Defaults to `127.0.0.1` when not provided.
 
-To verify the exporter is running open the provided listen address and port in a browser. Which should display the text "Operational".
+To verify whether the exporter is running, then open the provided listen address and port in a browser. Which should display the text "Operational".
 
 ## Push metrics to a Pushgateway
 
@@ -16,9 +16,13 @@ Concordium node also supports pushing metrics to a Prometheus Pushgateway. This 
 
 The following options are available for configuring the pushing of metrics:
 
-- `--prometheus-instance-name` (`CONCORDIUM_NODE_PROMETHEUS_INSTANCE_NAME`) Set the instance label to include in metrics pushed to Pushgateway. If not present the id of the node is used.
-- `--prometheus-job-name` (`CONCORDIUM_NODE_PROMETHEUS_JOB_NAME`) Set the instance label to include in metrics pushed to Pushgateway. If not present, `concordium_node_push` is used.
-- `--prometheus-push-gateway-interval` (`CONCORDIUM_NODE_PROMETHEUS_PUSH_GATEWAY_INTERVAL`) Duration in seconds between pushes to Pushgateway. If not present `2` is used.
-- `--prometheus-push-gateway-password` (`CONCORDIUM_NODE_PROMETHEUS_PUSH_GATEWAY_PASSWORD`) Password to use for push gateway, both username or password must be provided to enable authentication.
-- `--prometheus-push-gateway-username` (`CONCORDIUM_NODE_PROMETHEUS_PUSH_GATEWAY_USERNAME`) Username to use for push gateway, both username or password must be provided to enable authentication.
-
+- `--prometheus-instance-name` (`CONCORDIUM_NODE_PROMETHEUS_INSTANCE_NAME`)
+  Set the instance label to include in metrics pushed to Pushgateway. If not present the id of the node is used.
+- `--prometheus-job-name` (`CONCORDIUM_NODE_PROMETHEUS_JOB_NAME`)
+  Set the instance label to include in metrics pushed to Pushgateway. If not present, `concordium_node_push` is used.
+- `--prometheus-push-gateway-interval` (`CONCORDIUM_NODE_PROMETHEUS_PUSH_GATEWAY_INTERVAL`)
+  Duration in seconds between pushes to Pushgateway. If not present `2` is used.
+- `--prometheus-push-gateway-password` (`CONCORDIUM_NODE_PROMETHEUS_PUSH_GATEWAY_PASSWORD`)
+  Password to use for push gateway, both username or password must be provided to enable authentication.
+- `--prometheus-push-gateway-username` (`CONCORDIUM_NODE_PROMETHEUS_PUSH_GATEWAY_USERNAME`)
+  Username to use for push gateway, both username or password must be provided to enable authentication.


### PR DESCRIPTION
## Purpose

Related to #709.

## Changes

- Add markdown documentation on enabling and configuring the Prometheus exporter in `docs/`
