### PR TITLE
Polish and document the current Prometheus metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased changes
 
+- Rename a number of metrics from exposed by the Prometheus exporter:
+  - `peer_number` is now `network_connected_peers`.
+  - `conn_received` is now `network_connections_received_total`.
+  - `packets_received` is now `network_packets_received_total`.
+  - `packets_sent` is now `network_packets_sent_total`.
+  - `inbound_high_priority_consensus_drops` is now `network_inbound_high_priority_message_drops_total`.
+  - `inbound_low_priority_consensus_drops` is now `network_inbound_low_priority_message_drops_total`.
+  - `inbound_high_priority_consensus_counter` is now `network_inbound_high_priority_messages_total`.
+  - `inbound_low_priority_consensus_counter` is now `network_inbound_low_priority_messages_total`.
+  - `inbound_high_priority_consensus_size` is now `network_inbound_high_priority_message_queue_size`.
+  - `inbound_low_priority_consensus_size` is now `network_inbound_low_priority_message_queue_size`.
+  - `outbound_high_priority_consensus_size` is now `network_outbound_high_priority_message_queue_size`.
+  - `outbound_low_priority_consensus_size` is now `network_outbound_low_priority_message_queue_size`.
+  - `bytes_received` is now `network_received_bytes`.
+  - `bytes_sent` is now `network_sent_bytes`.
+- Remove `last_throughput_measurement_timestamp`, `avg_bps_in` and `avg_bps_out` metrics exposed by the Prometheus exporter.
+
 ## 5.2.1
 
 - Fix a bug in `GetAccountInfo` endpoint in GRPCv2 where `incoming_amounts`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased changes
 
-- Rename a number of metrics from exposed by the Prometheus exporter:
+- Rename a number of metrics exposed by the Prometheus exporter:
   - `peer_number` is now `network_connected_peers`.
   - `conn_received` is now `network_connections_received_total`.
   - `packets_received` is now `network_packets_received_total`.

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -2627,7 +2627,6 @@ dependencies = [
  "memchr",
  "parking_lot",
  "protobuf",
- "protobuf-codegen-pure",
  "reqwest",
  "thiserror",
 ]
@@ -2690,25 +2689,6 @@ name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
-
-[[package]]
-name = "protobuf-codegen"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "033460afb75cf755fcfc16dfaed20b86468082a2ea24e05ac35ab4a099a017d6"
-dependencies = [
- "protobuf",
-]
-
-[[package]]
-name = "protobuf-codegen-pure"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a29399fc94bcd3eeaa951c715f7bea69409b2445356b00519740bcd6ddd865"
-dependencies = [
- "protobuf",
- "protobuf-codegen",
-]
 
 [[package]]
 name = "ps_sig"

--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -69,7 +69,8 @@ libc = "0.2"
 mime = { version = "0.3" }
 gotham = { version = "0.6" }
 gotham_derive = { version = "0.6" }
-prometheus = { version = "0.13", default-features = false, features = ["gen", "push"] }
+# Disable default features of prometheus to disable the unneeded protobuf encoder.
+prometheus = { version = "0.13", default-features = false, features = ["push"] }
 http = { version = "0.2" }
 hyper = { version = "0.14" }
 

--- a/concordium-node/src/bin/cli.rs
+++ b/concordium-node/src/bin/cli.rs
@@ -398,12 +398,14 @@ fn start_consensus_message_threads(
         'outer_loop: loop {
             exhausted = false;
             // Update size of queues
-            node_ref.stats.set_inbound_low_priority_consensus_size(
-                consensus_receiver_low_priority.len() as i64,
-            );
-            node_ref.stats.set_inbound_high_priority_consensus_size(
-                consensus_receiver_high_priority.len() as i64,
-            );
+            node_ref
+                .stats
+                .inbound_low_priority_message_queue_size
+                .set(consensus_receiver_low_priority.len() as i64);
+            node_ref
+                .stats
+                .inbound_high_priority_message_queue_size
+                .set(consensus_receiver_high_priority.len() as i64);
             // instead of using `try_iter()` we specifically only loop over the max numbers
             // possible to ever be in the queue
             for _ in 0..CONSENSUS_QUEUE_DEPTH_IN_HI {
@@ -466,12 +468,14 @@ fn start_consensus_message_threads(
         'outer_loop: loop {
             exhausted = false;
             // Update size of queues
-            node_ref.stats.set_outbound_low_priority_consensus_size(
-                consensus_receiver_low_priority.len() as i64,
-            );
-            node_ref.stats.set_outbound_high_priority_consensus_size(
-                consensus_receiver_high_priority.len() as i64,
-            );
+            node_ref
+                .stats
+                .outbound_low_priority_message_queue_size
+                .set(consensus_receiver_low_priority.len() as i64);
+            node_ref
+                .stats
+                .outbound_high_priority_message_queue_size
+                .set(consensus_receiver_high_priority.len() as i64);
             // instead of using `try_iter()` we specifically only loop over the max numbers
             // possible to ever be in the queue
             for _ in 0..CONSENSUS_QUEUE_DEPTH_OUT_HI {

--- a/concordium-node/src/connection/mod.rs
+++ b/concordium-node/src/connection/mod.rs
@@ -519,7 +519,7 @@ impl Connection {
         self.stats.messages_received.fetch_add(1, Ordering::Relaxed);
         self.stats.bytes_received.fetch_add(bytes.len() as u64, Ordering::Relaxed);
         self.handler.connection_handler.total_received.fetch_add(1, Ordering::Relaxed);
-        self.handler.stats.pkt_received_inc();
+        self.handler.stats.packets_received.inc();
 
         #[cfg(feature = "network_dump")]
         {
@@ -553,7 +553,7 @@ impl Connection {
     ) {
         self.remote_peer.self_id = Some(id);
         self.remote_peer.external_port = peer_port;
-        self.handler.stats.peers_inc();
+        self.handler.stats.connected_peers.inc();
         if self.remote_peer.peer_type == PeerType::Bootstrapper {
             self.handler.update_last_bootstrap();
         }
@@ -725,7 +725,7 @@ impl Connection {
             self.low_level.write_to_socket(msg.clone())?;
 
             self.handler.connection_handler.total_sent.fetch_add(1, Ordering::Relaxed);
-            self.handler.stats.pkt_sent_inc();
+            self.handler.stats.packets_sent.inc();
             self.stats.messages_sent.fetch_add(1, Ordering::Relaxed);
             self.stats.bytes_sent.fetch_add(msg.len() as u64, Ordering::Relaxed);
 
@@ -747,7 +747,7 @@ impl Drop for Connection {
 
         // update peer stats if it was post-handshake
         if self.remote_id().is_some() {
-            self.handler.stats.peers_dec();
+            self.handler.stats.connected_peers.dec();
         }
 
         if let Err(e) = self.handler.poll_registry.deregister(&mut self.low_level.socket) {

--- a/concordium-node/src/grpc2.rs
+++ b/concordium-node/src/grpc2.rs
@@ -2039,8 +2039,8 @@ pub mod server {
                     .connection_handler
                     .total_received
                     .load(std::sync::atomic::Ordering::Relaxed);
-                let avg_bps_in = self.node.stats.get_avg_bps_in();
-                let avg_bps_out = self.node.stats.get_avg_bps_out();
+                let avg_bps_in = self.node.stats.avg_bps_in.get();
+                let avg_bps_out = self.node.stats.avg_bps_out.get();
 
                 types::node_info::NetworkInfo {
                     node_id: Some(types::PeerId {

--- a/concordium-node/src/p2p/connectivity.rs
+++ b/concordium-node/src/p2p/connectivity.rs
@@ -364,7 +364,7 @@ pub fn accept(
     socket: TcpStream,
     addr: SocketAddr,
 ) -> Result<Token, AcceptFailureReason> {
-    node.stats.conn_received_inc();
+    node.stats.connections_received.inc();
 
     // if we fail to read the database we allow the connection.
     // This is fine as long as we assume that nobody can corrupt our ban database.
@@ -498,7 +498,7 @@ pub fn connect(
     match TcpStream::connect(peer_addr) {
         Ok(socket) => {
             trace!("Connected to {}", peer_addr);
-            node.stats.conn_received_inc();
+            node.stats.connections_received.inc();
 
             let token = Token(node.connection_handler.next_token.fetch_add(1, Ordering::SeqCst));
 

--- a/concordium-node/src/p2p/peers.rs
+++ b/concordium-node/src/p2p/peers.rs
@@ -54,8 +54,8 @@ impl P2PNode {
     /// Measures the node's average byte throughput as bps i.e., bytes per
     /// second.
     pub fn measure_throughput(&self, peer_stats: &[PeerStats]) -> anyhow::Result<()> {
-        let prev_bytes_received = self.stats.get_bytes_received();
-        let prev_bytes_sent = self.stats.get_bytes_sent();
+        let prev_bytes_received = self.stats.received_bytes.get();
+        let prev_bytes_sent = self.stats.sent_bytes.get();
 
         let (bytes_received, bytes_sent) = peer_stats
             .iter()
@@ -63,21 +63,21 @@ impl P2PNode {
             .map(|ps| (ps.bytes_received, ps.bytes_sent))
             .fold((0, 0), |(acc_i, acc_o), (i, o)| (acc_i + i, acc_o + o));
 
-        self.stats.set_bytes_received(bytes_received);
-        self.stats.set_bytes_sent(bytes_sent);
+        self.stats.received_bytes.set(bytes_received);
+        self.stats.sent_bytes.set(bytes_sent);
 
         let now = Utc::now().timestamp_millis();
         let (avg_bps_in, avg_bps_out) = calculate_average_throughput(
-            self.stats.get_last_throughput_measurement_timestamp(),
+            self.stats.last_throughput_measurement_timestamp.get(),
             now,
             prev_bytes_received,
             bytes_received,
             prev_bytes_sent,
             bytes_sent,
         )?;
-        self.stats.set_avg_bps_in(avg_bps_in);
-        self.stats.set_avg_bps_out(avg_bps_out);
-        self.stats.set_last_throughput_measurement_timestamp(now);
+        self.stats.avg_bps_in.set(avg_bps_in);
+        self.stats.avg_bps_out.set(avg_bps_out);
+        self.stats.last_throughput_measurement_timestamp.set(now);
         Ok(())
     }
 

--- a/concordium-node/src/plugins/consensus.rs
+++ b/concordium-node/src/plugins/consensus.rs
@@ -174,7 +174,7 @@ pub fn handle_pkt_out(
         if let Err(e) = CALLBACK_QUEUE.send_in_low_priority_message(request) {
             match e.downcast::<TrySendError<QueueMsg<ConsensusMessage>>>()? {
                 TrySendError::Full(_) => {
-                    node.stats.inbound_low_priority_consensus_drops_inc();
+                    node.stats.inbound_low_priority_message_drops.inc();
                     node.bad_events.inc_dropped_low_queue(peer_id);
                 }
                 TrySendError::Disconnected(_) => {
@@ -182,14 +182,14 @@ pub fn handle_pkt_out(
                 }
             }
         } else {
-            node.stats.inbound_low_priority_consensus_inc();
+            node.stats.inbound_low_priority_messages.inc();
         }
     } else {
         // high priority message
         if let Err(e) = CALLBACK_QUEUE.send_in_high_priority_message(request) {
             match e.downcast::<TrySendError<QueueMsg<ConsensusMessage>>>()? {
                 TrySendError::Full(_) => {
-                    node.stats.inbound_high_priority_consensus_drops_inc();
+                    node.stats.inbound_high_priority_message_drops.inc();
                     node.bad_events.inc_dropped_high_queue(peer_id);
                 }
                 TrySendError::Disconnected(_) => {
@@ -197,7 +197,7 @@ pub fn handle_pkt_out(
                 }
             }
         } else {
-            node.stats.inbound_high_priority_consensus_inc();
+            node.stats.inbound_high_priority_messages.inc();
         }
     }
 

--- a/concordium-node/src/rpc.rs
+++ b/concordium-node/src/rpc.rs
@@ -431,8 +431,8 @@ impl P2p for RpcServerImpl {
 
         Ok(Response::new(PeerStatsResponse {
             peerstats,
-            avg_bps_in: self.node.stats.get_avg_bps_in(),
-            avg_bps_out: self.node.stats.get_avg_bps_out(),
+            avg_bps_in: self.node.stats.avg_bps_in.get(),
+            avg_bps_out: self.node.stats.avg_bps_out.get(),
         }))
     }
 

--- a/concordium-node/src/stats_export_service.rs
+++ b/concordium-node/src/stats_export_service.rs
@@ -118,49 +118,49 @@ impl StatsExportService {
         registry.register(Box::new(connections_received.clone()))?;
 
         let inbound_high_priority_message_drops = IntCounter::with_opts(Opts::new(
-            "consensus_inbound_high_priority_message_drops_total",
+            "network_inbound_high_priority_message_drops_total",
             "Total inbound high priority consensus messages dropped due to a full queue",
         ))?;
         registry.register(Box::new(inbound_high_priority_message_drops.clone()))?;
 
         let inbound_low_priority_message_drops = IntCounter::with_opts(Opts::new(
-            "consensus_inbound_low_priority_message_drops_total",
+            "network_inbound_low_priority_message_drops_total",
             "Total inbound low priority consensus messages dropped due to a full queue",
         ))?;
         registry.register(Box::new(inbound_low_priority_message_drops.clone()))?;
 
         let inbound_high_priority_messages = IntCounter::with_opts(Opts::new(
-            "consensus_inbound_high_priority_messages_total",
+            "network_inbound_high_priority_messages_total",
             "Total inbound high priority consensus messages received",
         ))?;
         registry.register(Box::new(inbound_high_priority_messages.clone()))?;
 
         let inbound_low_priority_messages = IntCounter::with_opts(Opts::new(
-            "consensus_inbound_low_priority_messages_total",
+            "network_inbound_low_priority_messages_total",
             "Total inbound low priority consensus messages received",
         ))?;
         registry.register(Box::new(inbound_low_priority_messages.clone()))?;
 
         let inbound_high_priority_message_queue_size = IntGauge::with_opts(Opts::new(
-            "consensus_inbound_high_priority_message_queue_size",
+            "network_inbound_high_priority_message_queue_size",
             "Current number of inbound high priority messages in queue",
         ))?;
         registry.register(Box::new(inbound_high_priority_message_queue_size.clone()))?;
 
         let inbound_low_priority_message_queue_size = IntGauge::with_opts(Opts::new(
-            "consensus_inbound_low_priority_message_queue_size",
+            "network_inbound_low_priority_message_queue_size",
             "Current number of inbound low priority messages in queue",
         ))?;
         registry.register(Box::new(inbound_low_priority_message_queue_size.clone()))?;
 
         let outbound_high_priority_message_queue_size = IntGauge::with_opts(Opts::new(
-            "consensus_outbound_high_priority_message_queue_size",
+            "network_outbound_high_priority_message_queue_size",
             "Current number of outbound high priority messages in queue",
         ))?;
         registry.register(Box::new(outbound_high_priority_message_queue_size.clone()))?;
 
         let outbound_low_priority_message_queue_size = IntGauge::with_opts(Opts::new(
-            "consensus_outbound_low_priority_message_queue_size",
+            "network_outbound_low_priority_message_queue_size",
             "Current number of outbound low priority messages in queue",
         ))?;
         registry.register(Box::new(outbound_low_priority_message_queue_size.clone()))?;

--- a/concordium-node/src/stats_export_service.rs
+++ b/concordium-node/src/stats_export_service.rs
@@ -45,246 +45,184 @@ impl PrometheusStateData {
 
 /// Collects statistics pertaining to the node.
 pub struct StatsExportService {
+    /// The Prometheus registry. Every metric which should be exposed via the
+    /// Prometheus exporter should be registered in this registry.
     registry: Registry,
-    pkts_received_counter: IntCounter,
-    pkts_sent_counter: IntCounter,
-    peers_gauge: IntGauge,
-    connections_received: IntCounter,
-    inbound_high_priority_consensus_drops_counter: IntCounter,
-    inbound_low_priority_consensus_drops_counter: IntCounter,
-    inbound_high_priority_consensus_counter: IntCounter,
-    inbound_low_priority_consensus_counter: IntCounter,
-    inbound_high_priority_consensus_size: IntGauge,
-    inbound_low_priority_consensus_size: IntGauge,
-    outbound_high_priority_consensus_size: IntGauge,
-    outbound_low_priority_consensus_size: IntGauge,
-    last_throughput_measurement_timestamp: GenericGauge<AtomicI64>,
-    bytes_received: GenericGauge<AtomicU64>,
-    bytes_sent: GenericGauge<AtomicU64>,
-    avg_bps_in: GenericGauge<AtomicU64>,
-    avg_bps_out: GenericGauge<AtomicU64>,
+    /// Total number of network packets received.
+    pub packets_received: IntCounter,
+    /// Total number of network packets sent.
+    pub packets_sent: IntCounter,
+    /// Current number of connected peers.
+    pub connected_peers: IntGauge,
+    /// Total number of connections received.
+    pub connections_received: IntCounter,
+    /// Total inbound high priority consensus messages dropped due to a full
+    /// queue.
+    pub inbound_high_priority_message_drops: IntCounter,
+    /// Total inbound low priority consensus messages dropped due to a full
+    /// queue.
+    pub inbound_low_priority_message_drops: IntCounter,
+    /// Total inbound high priority consensus messages received.
+    pub inbound_high_priority_messages: IntCounter,
+    /// Total inbound low priority consensus messages received.
+    pub inbound_low_priority_messages: IntCounter,
+    /// Current number of inbound high priority messages in queue.
+    pub inbound_high_priority_message_queue_size: IntGauge,
+    /// Current number of inbound low priority messages in queue.
+    pub inbound_low_priority_message_queue_size: IntGauge,
+    /// Current number of outbound high priority messages in queue.
+    pub outbound_high_priority_message_queue_size: IntGauge,
+    /// Current number of outbound low priority messages in queue.
+    pub outbound_low_priority_message_queue_size: IntGauge,
+    /// Total number of bytes received.
+    pub received_bytes: GenericGauge<AtomicU64>,
+    /// Total number of bytes sent.
+    pub sent_bytes: GenericGauge<AtomicU64>,
+    /// Timestamp for the last calculation of throughput.
+    pub last_throughput_measurement_timestamp: GenericGauge<AtomicI64>,
+    /// Average bytes per second received between the two last values of
+    /// last_throughput_measurement_timestamp.
+    pub avg_bps_in: GenericGauge<AtomicU64>,
+    /// Average bytes per second sent between the two last values of
+    /// last_throughput_measurement_timestamp.
+    pub avg_bps_out: GenericGauge<AtomicU64>,
 }
 
 impl StatsExportService {
-    /// Creates a new instance of the starts export service object.
+    /// Creates a new instance of the stats export service object.
     pub fn new() -> anyhow::Result<Self> {
         let registry = Registry::new();
 
-        let pg_opts = Opts::new("peer_number", "current peers connected");
-        let pg = IntGauge::with_opts(pg_opts)?;
-        registry.register(Box::new(pg.clone()))?;
+        let packets_received = IntCounter::with_opts(Opts::new(
+            "network_packets_received_total",
+            "Total number of network packets received",
+        ))?;
+        registry.register(Box::new(packets_received.clone()))?;
 
-        let cr_opts = Opts::new("conn_received", "connections received");
-        let cr = IntCounter::with_opts(cr_opts)?;
-        registry.register(Box::new(cr.clone()))?;
+        let packets_sent = IntCounter::with_opts(Opts::new(
+            "network_packets_sent_total",
+            "Total number of network packets sent",
+        ))?;
+        registry.register(Box::new(packets_sent.clone()))?;
 
-        let prc_opts = Opts::new("packets_received", "packets received");
-        let prc = IntCounter::with_opts(prc_opts)?;
-        registry.register(Box::new(prc.clone()))?;
+        let connected_peers = IntGauge::with_opts(Opts::new(
+            "network_connected_peers",
+            "Current number of connected peers",
+        ))?;
+        registry.register(Box::new(connected_peers.clone()))?;
 
-        let psc_opts = Opts::new("packets_sent", "packets sent");
-        let psc = IntCounter::with_opts(psc_opts)?;
-        registry.register(Box::new(psc.clone()))?;
+        let connections_received = IntCounter::with_opts(Opts::new(
+            "network_connections_received_total",
+            "Total number of connections received",
+        ))?;
+        registry.register(Box::new(connections_received.clone()))?;
 
-        let inbound_high_priority_consensus_drops_opts = Opts::new(
-            "inbound_high_priority_consensus_drops",
-            "inbound high priority consensus messages dropped",
-        );
-        let inbound_high_priority_consensus_drops_counter =
-            IntCounter::with_opts(inbound_high_priority_consensus_drops_opts)?;
-        registry.register(Box::new(inbound_high_priority_consensus_drops_counter.clone()))?;
+        let inbound_high_priority_message_drops = IntCounter::with_opts(Opts::new(
+            "consensus_inbound_high_priority_message_drops_total",
+            "Total inbound high priority consensus messages dropped due to a full queue",
+        ))?;
+        registry.register(Box::new(inbound_high_priority_message_drops.clone()))?;
 
-        let inbound_low_priority_consensus_drops_opts = Opts::new(
-            "inbound_low_priority_consensus_drops",
-            "inbound low priority consensus messages dropped",
-        );
-        let inbound_low_priority_consensus_drops_counter =
-            IntCounter::with_opts(inbound_low_priority_consensus_drops_opts)?;
-        registry.register(Box::new(inbound_low_priority_consensus_drops_counter.clone()))?;
+        let inbound_low_priority_message_drops = IntCounter::with_opts(Opts::new(
+            "consensus_inbound_low_priority_message_drops_total",
+            "Total inbound low priority consensus messages dropped due to a full queue",
+        ))?;
+        registry.register(Box::new(inbound_low_priority_message_drops.clone()))?;
 
-        let inbound_high_priority_consensus_counter_opts = Opts::new(
-            "inbound_high_priority_consensus_counter",
-            "inbound high priority consensus messages received",
-        );
-        let inbound_high_priority_consensus_counter =
-            IntCounter::with_opts(inbound_high_priority_consensus_counter_opts)?;
-        registry.register(Box::new(inbound_high_priority_consensus_counter.clone()))?;
+        let inbound_high_priority_messages = IntCounter::with_opts(Opts::new(
+            "consensus_inbound_high_priority_messages_total",
+            "Total inbound high priority consensus messages received",
+        ))?;
+        registry.register(Box::new(inbound_high_priority_messages.clone()))?;
 
-        let inbound_low_priority_consensus_counter_opts = Opts::new(
-            "inbound_low_priority_consensus_counter",
-            "inbound low priority consensus messages received",
-        );
-        let inbound_low_priority_consensus_counter =
-            IntCounter::with_opts(inbound_low_priority_consensus_counter_opts)?;
-        registry.register(Box::new(inbound_low_priority_consensus_counter.clone()))?;
+        let inbound_low_priority_messages = IntCounter::with_opts(Opts::new(
+            "consensus_inbound_low_priority_messages_total",
+            "Total inbound low priority consensus messages received",
+        ))?;
+        registry.register(Box::new(inbound_low_priority_messages.clone()))?;
 
-        let inbound_high_priority_consensus_size_opts = Opts::new(
-            "inbound_high_priority_consensus_size",
-            "inbound high priority consensus queue size",
-        );
-        let inbound_high_priority_consensus_size =
-            IntGauge::with_opts(inbound_high_priority_consensus_size_opts)?;
-        registry.register(Box::new(inbound_high_priority_consensus_size.clone()))?;
+        let inbound_high_priority_message_queue_size = IntGauge::with_opts(Opts::new(
+            "consensus_inbound_high_priority_message_queue_size",
+            "Current number of inbound high priority messages in queue",
+        ))?;
+        registry.register(Box::new(inbound_high_priority_message_queue_size.clone()))?;
 
-        let inbound_low_priority_consensus_size_opts = Opts::new(
-            "inbound_low_priority_consensus_size",
-            "inbound low priority consensus queue size",
-        );
-        let inbound_low_priority_consensus_size =
-            IntGauge::with_opts(inbound_low_priority_consensus_size_opts)?;
-        registry.register(Box::new(inbound_low_priority_consensus_size.clone()))?;
+        let inbound_low_priority_message_queue_size = IntGauge::with_opts(Opts::new(
+            "consensus_inbound_low_priority_message_queue_size",
+            "Current number of inbound low priority messages in queue",
+        ))?;
+        registry.register(Box::new(inbound_low_priority_message_queue_size.clone()))?;
 
-        let outbound_high_priority_consensus_size_opts = Opts::new(
-            "outbound_high_priority_consensus_size",
-            "outbound high priority consensus queue size",
-        );
-        let outbound_high_priority_consensus_size =
-            IntGauge::with_opts(outbound_high_priority_consensus_size_opts)?;
-        registry.register(Box::new(outbound_high_priority_consensus_size.clone()))?;
+        let outbound_high_priority_message_queue_size = IntGauge::with_opts(Opts::new(
+            "consensus_outbound_high_priority_message_queue_size",
+            "Current number of outbound high priority messages in queue",
+        ))?;
+        registry.register(Box::new(outbound_high_priority_message_queue_size.clone()))?;
 
-        let outbound_low_priority_consensus_size_opts = Opts::new(
-            "outbound_low_priority_consensus_size",
-            "outbound low priority consensus queue size",
-        );
-        let outbound_low_priority_consensus_size =
-            IntGauge::with_opts(outbound_low_priority_consensus_size_opts)?;
-        registry.register(Box::new(outbound_low_priority_consensus_size.clone()))?;
+        let outbound_low_priority_message_queue_size = IntGauge::with_opts(Opts::new(
+            "consensus_outbound_low_priority_message_queue_size",
+            "Current number of outbound low priority messages in queue",
+        ))?;
+        registry.register(Box::new(outbound_low_priority_message_queue_size.clone()))?;
 
-        let last_throughput_measurement_timestamp_opts = Opts::new(
+        let received_bytes = GenericGauge::with_opts(Opts::new(
+            "network_received_bytes",
+            "Total number of bytes received",
+        ))?;
+        registry.register(Box::new(received_bytes.clone()))?;
+
+        let sent_bytes =
+            GenericGauge::with_opts(Opts::new("network_sent_bytes", "Total number of bytes sent"))?;
+        registry.register(Box::new(sent_bytes.clone()))?;
+
+        // `last_throughput_measurement_timestamp` is not registered in the registry on
+        // purpose, since it should not be exposed in the prometheus exporter, but we
+        // still used the value of the gauge when calculating `avg_bps_in` and
+        // `avg_bps_out`.
+        let last_throughput_measurement_timestamp = GenericGauge::with_opts(Opts::new(
             "last_throughput_measurement_timestamp",
-            "last_throughput_measurement_timestamp",
-        );
-        let ltm = GenericGauge::with_opts(last_throughput_measurement_timestamp_opts)?;
-        registry.register(Box::new(ltm.clone()))?;
+            "Timestamp for the last calculation of throughput",
+        ))?;
 
-        let brc_opts = Opts::new("bytes_received", "bytes received");
-        let brc = GenericGauge::with_opts(brc_opts)?;
-        registry.register(Box::new(brc.clone()))?;
+        // `avg_bps_in` is not registered in the registry on purpose, since it should
+        // not be exposed in the prometheus exporter, but we still exposed the
+        // value of the gauge in the gRPC API.
+        let avg_bps_in = GenericGauge::with_opts(Opts::new(
+            "avg_bps_in",
+            "Average bytes per second received between the two last values of \
+             last_throughput_measurement_timestamp",
+        ))?;
 
-        let bsc_opts = Opts::new("bytes_sent", "bytes sent");
-        let bsc = GenericGauge::with_opts(bsc_opts)?;
-        registry.register(Box::new(bsc.clone()))?;
-
-        let avg_bps_in_opts = Opts::new("avg_bps_in", "average inbound througput");
-        let avg_bps_in = GenericGauge::with_opts(avg_bps_in_opts)?;
-        registry.register(Box::new(avg_bps_in.clone()))?;
-
-        let avg_bps_out_opts = Opts::new("avg_bps_out", "average outbound througput");
-        let avg_bps_out = GenericGauge::with_opts(avg_bps_out_opts)?;
-        registry.register(Box::new(avg_bps_out.clone()))?;
+        // `avg_bps_out` is not registered in the registry on purpose, since it should
+        // not be exposed in the prometheus exporter, but we still exposed the
+        // value of the gauge in the gRPC API.
+        let avg_bps_out = GenericGauge::with_opts(Opts::new(
+            "avg_bps_out",
+            "Average bytes per second sent between the two last values of \
+             last_throughput_measurement_timestamp",
+        ))?;
 
         Ok(StatsExportService {
             registry,
-            pkts_received_counter: prc,
-            pkts_sent_counter: psc,
-            peers_gauge: pg,
-            connections_received: cr,
-            inbound_high_priority_consensus_drops_counter,
-            inbound_low_priority_consensus_drops_counter,
-            inbound_high_priority_consensus_counter,
-            inbound_low_priority_consensus_counter,
-            inbound_high_priority_consensus_size,
-            inbound_low_priority_consensus_size,
-            outbound_high_priority_consensus_size,
-            outbound_low_priority_consensus_size,
-            last_throughput_measurement_timestamp: ltm,
-            bytes_received: brc,
-            bytes_sent: bsc,
+            packets_received,
+            packets_sent,
+            connected_peers,
+            connections_received,
+            inbound_high_priority_message_drops,
+            inbound_low_priority_message_drops,
+            inbound_high_priority_messages,
+            inbound_low_priority_messages,
+            inbound_high_priority_message_queue_size,
+            inbound_low_priority_message_queue_size,
+            outbound_high_priority_message_queue_size,
+            outbound_low_priority_message_queue_size,
+            last_throughput_measurement_timestamp,
+            received_bytes,
+            sent_bytes,
             avg_bps_in,
             avg_bps_out,
         })
     }
-
-    /// Increases the peer count.
-    pub fn peers_inc(&self) { self.peers_gauge.inc(); }
-
-    /// Decreases the peer count.
-    pub fn peers_dec(&self) { self.peers_gauge.dec(); }
-
-    /// Increases the number of received packets.
-    pub fn pkt_received_inc(&self) { self.pkts_received_counter.inc(); }
-
-    /// Increases the number of sent packets.
-    pub fn pkt_sent_inc(&self) { self.pkts_sent_counter.inc(); }
-
-    /// Increases the number of received connections.
-    pub fn conn_received_inc(&self) { self.connections_received.inc(); }
-
-    /// Increases the number of high priority consensus messages dropped due to
-    /// the queue being full.
-    pub fn inbound_high_priority_consensus_drops_inc(&self) {
-        self.inbound_high_priority_consensus_drops_counter.inc();
-    }
-
-    /// Increases the number of low priority consensus messages dropped due to
-    /// the queue being full.
-    pub fn inbound_low_priority_consensus_drops_inc(&self) {
-        self.inbound_low_priority_consensus_drops_counter.inc();
-    }
-
-    /// Increases the number of received high priority consensus messages.
-    pub fn inbound_high_priority_consensus_inc(&self) {
-        self.inbound_high_priority_consensus_counter.inc();
-    }
-
-    /// Increases the number of received low priority consensus messages.
-    pub fn inbound_low_priority_consensus_inc(&self) {
-        self.inbound_low_priority_consensus_counter.inc();
-    }
-
-    /// Sets the size value of the high priority inbound consensus queue.
-    pub fn set_inbound_high_priority_consensus_size(&self, value: i64) {
-        self.inbound_high_priority_consensus_size.set(value);
-    }
-
-    /// Sets the size value of the low priority inbound consensus queue.
-    pub fn set_inbound_low_priority_consensus_size(&self, value: i64) {
-        self.inbound_low_priority_consensus_size.set(value);
-    }
-
-    /// Sets the size value of the high priority outbound consensus queue.
-    pub fn set_outbound_high_priority_consensus_size(&self, value: i64) {
-        self.outbound_high_priority_consensus_size.set(value);
-    }
-
-    /// Sets the size value of the low priority outbound consensus queue.
-    pub fn set_outbound_low_priority_consensus_size(&self, value: i64) {
-        self.outbound_low_priority_consensus_size.set(value);
-    }
-
-    /// Gets the timestamp for the last throughput check.
-    pub fn get_last_throughput_measurement_timestamp(&self) -> i64 {
-        self.last_throughput_measurement_timestamp.get()
-    }
-
-    /// Sets the value of throughput timestamp.
-    pub fn set_last_throughput_measurement_timestamp(&self, value: i64) {
-        self.last_throughput_measurement_timestamp.set(value);
-    }
-
-    /// Gets the count of received bytes.
-    pub fn get_bytes_received(&self) -> u64 { self.bytes_received.get() }
-
-    /// Gets the count of sent bytes.
-    pub fn get_bytes_sent(&self) -> u64 { self.bytes_sent.get() }
-
-    /// Sets the value of received bytes.
-    pub fn set_bytes_received(&self, value: u64) { self.bytes_received.set(value); }
-
-    /// Sets the value of sent bytes.
-    pub fn set_bytes_sent(&self, value: u64) { self.bytes_sent.set(value); }
-
-    /// Gets the value of average inbound throughput.
-    pub fn get_avg_bps_in(&self) -> u64 { self.avg_bps_in.get() }
-
-    /// Gets the value of average outbound throughput.
-    pub fn get_avg_bps_out(&self) -> u64 { self.avg_bps_out.get() }
-
-    /// Sets the value of average inbound throughput.
-    pub fn set_avg_bps_in(&self, value: u64) { self.avg_bps_in.set(value); }
-
-    /// Sets the value of average outbound throughput.
-    pub fn set_avg_bps_out(&self, value: u64) { self.avg_bps_out.set(value); }
 
     fn metrics(state: State) -> (State, String) {
         let state_data = PrometheusStateData::borrow_from(&state);

--- a/docs/prometheus-exporter.md
+++ b/docs/prometheus-exporter.md
@@ -81,14 +81,22 @@ Total inbound low priority messages received. This is incremented when a consens
 
 Current number of consensus messages in the inbound high priority queue. Start dropping messages when larger than 16 * 1024.
 
+The value of this metric should average around 0. There can be spikes, but generally large numbers mean the node is strugling to keep up.
+
 ### `network_inbound_low_priority_message_queue_size`
 
 Current number of consensus messages in the inbound low priority queue. Start dropping messages when larger than 32 * 1024.
+
+The value of this metric should average around 0. There can be spikes, but generally large numbers mean the node is strugling to keep up.
 
 ### `network_outbound_high_priority_message_queue_size`
 
 Current number of consensus messages in the outbound high priority queue. Start dropping messages when larger than 8 * 1024.
 
+The value of this metric should average around 0. There can be spikes, but generally large numbers mean the node is strugling to keep up.
+
 ### `network_outbound_low_priority_message_queue_size`
 
 Current number of consensus messages in the outbound low priority queue. Start dropping messages when larger than 16 * 1024.
+
+The value of this metric should average around 0. There can be spikes, but generally large numbers mean the node is strugling to keep up.

--- a/docs/prometheus-exporter.md
+++ b/docs/prometheus-exporter.md
@@ -29,17 +29,66 @@ The following options are available for configuring the pushing of metrics:
 
 ## Metrics
 
-- `network_received_bytes` Total number of bytes received.
-- `network_sent_bytes` Total number of bytes sent.
-- `network_packets_received_total` Total number of network packets received.
-- `network_packets_sent_total` Total number of network packets sent.
-- `network_connected_peers` Current number of connected peers.
-- `network_connections_received_total` Total number of connections received.
-- `consensus_inbound_high_priority_message_drops_total` Total inbound high priority consensus messages dropped due to a full queue.
-- `consensus_inbound_low_priority_message_drops_total` Total inbound low priority consensus messages dropped due to a full queue.
-- `consensus_inbound_high_priority_messages_total` Total inbound high priority consensus messages received.
-- `consensus_inbound_low_priority_messages_total` Total inbound low priority consensus messages received.
-- `consensus_inbound_high_priority_message_queue_size` Current number of inbound high priority messages in queue.
-- `consensus_inbound_low_priority_message_queue_size` Current number of inbound low priority messages in queue.
-- `consensus_outbound_high_priority_message_queue_size` Current number of outbound high priority messages in queue.
-- `consensus_outbound_low_priority_message_queue_size` Current number of outbound low priority messages in queue.
+All of the following accumulated metrics are relative to the startup of the node, in other words, restarting the node resets the metrics.
+
+### `network_received_bytes`
+
+Total number of bytes received over the network. Only network message received from connected peers are accounted.
+
+Note: This metric is updated during "housekeeping", meaning the update frequency depends on the node configuration `--housekeeping-interval` (`CONCORDIUM_NODE_CONNECTION_HOUSEKEEPING_INTERVAL`) which is one every 30 seconds by default.
+
+### `network_sent_bytes`
+
+Total number of bytes sent over the network. Only network message sent to connected peers are accounted.
+
+Note: This metric is updated during "housekeeping", meaning the update frequency depends on the node configuration `--housekeeping-interval` (`CONCORDIUM_NODE_CONNECTION_HOUSEKEEPING_INTERVAL`) which is one every 30 seconds by default.
+
+### `network_packets_received_total`
+
+Total number of network packets received from peers. This is accounted before the any form of deduplication.
+
+### `network_packets_sent_total`
+
+Total number of network packets sent to peers.
+
+### `network_connected_peers`
+
+Current number of connected peers. This is incremented when a peer completes a handshake and decremented again when the connection is dropped.
+
+###  `network_connections_received_total`
+
+Total number of connections received. Incremented everytime someone tries to establish a new connection, meaning even the failed connections are accounted, such as when the address is banned, duplicate connection or the node is at its limit on number of connections.
+
+### `network_inbound_high_priority_message_drops_total`
+
+Total inbound high priority messages dropped due to the queue for high priority messages being full.
+See `network_inbound_high_priority_message_queue_size` for the current size of the queue.
+
+### `network_inbound_low_priority_message_drops_total`
+
+Total inbound low priority messages dropped due to the queue for low priority messages being full.
+See `network_inbound_low_priority_message_queue_size` for the current size of the queue.
+
+### `network_inbound_high_priority_messages_total`
+
+Total inbound high priority messages received. This is incremented when a consensus message is enqueue in the high priority queue. Note: Does not include the dropped messages, see `network_inbound_high_priority_message_drops_total`.
+
+### `network_inbound_low_priority_messages_total`
+
+Total inbound low priority messages received. This is incremented when a consensus message is enqueue in the low priority queue. Note: Does not include the dropped messages, see `network_inbound_low_priority_message_drops_total`.
+
+### `network_inbound_high_priority_message_queue_size`
+
+Current number of consensus messages in the inbound high priority queue. Start dropping messages when larger than 16 * 1024.
+
+### `network_inbound_low_priority_message_queue_size`
+
+Current number of consensus messages in the inbound low priority queue. Start dropping messages when larger than 32 * 1024.
+
+### `network_outbound_high_priority_message_queue_size`
+
+Current number of consensus messages in the outbound high priority queue. Start dropping messages when larger than 8 * 1024.
+
+### `network_outbound_low_priority_message_queue_size`
+
+Current number of consensus messages in the outbound low priority queue. Start dropping messages when larger than 16 * 1024.

--- a/docs/prometheus-exporter.md
+++ b/docs/prometheus-exporter.md
@@ -26,3 +26,20 @@ The following options are available for configuring the pushing of metrics:
   Password to use for push gateway, both username or password must be provided to enable authentication.
 - `--prometheus-push-gateway-username` (`CONCORDIUM_NODE_PROMETHEUS_PUSH_GATEWAY_USERNAME`)
   Username to use for push gateway, both username or password must be provided to enable authentication.
+
+## Metrics
+
+- `network_received_bytes` Total number of bytes received.
+- `network_sent_bytes` Total number of bytes sent.
+- `network_packets_received_total` Total number of network packets received.
+- `network_packets_sent_total` Total number of network packets sent.
+- `network_connected_peers` Current number of connected peers.
+- `network_connections_received_total` Total number of connections received.
+- `consensus_inbound_high_priority_message_drops_total` Total inbound high priority consensus messages dropped due to a full queue.
+- `consensus_inbound_low_priority_message_drops_total` Total inbound low priority consensus messages dropped due to a full queue.
+- `consensus_inbound_high_priority_messages_total` Total inbound high priority consensus messages received.
+- `consensus_inbound_low_priority_messages_total` Total inbound low priority consensus messages received.
+- `consensus_inbound_high_priority_message_queue_size` Current number of inbound high priority messages in queue.
+- `consensus_inbound_low_priority_message_queue_size` Current number of inbound low priority messages in queue.
+- `consensus_outbound_high_priority_message_queue_size` Current number of outbound high priority messages in queue.
+- `consensus_outbound_low_priority_message_queue_size` Current number of outbound low priority messages in queue.

--- a/docs/prometheus-exporter.md
+++ b/docs/prometheus-exporter.md
@@ -81,22 +81,22 @@ Total inbound low priority messages received. This is incremented when a consens
 
 Current number of consensus messages in the inbound high priority queue. Start dropping messages when larger than 16 * 1024.
 
-The value of this metric should average around 0. There can be spikes, but generally large numbers mean the node is strugling to keep up.
+The value of this metric should average around 0. There can be spikes, but generally large numbers over extended periods mean the node is struggling to keep up.
 
 ### `network_inbound_low_priority_message_queue_size`
 
 Current number of consensus messages in the inbound low priority queue. Start dropping messages when larger than 32 * 1024.
 
-The value of this metric should average around 0. There can be spikes, but generally large numbers mean the node is strugling to keep up.
+The value of this metric should average around 0. There can be spikes, but generally large numbers over extended periods mean the node is struggling to keep up.
 
 ### `network_outbound_high_priority_message_queue_size`
 
 Current number of consensus messages in the outbound high priority queue. Start dropping messages when larger than 8 * 1024.
 
-The value of this metric should average around 0. There can be spikes, but generally large numbers mean the node is strugling to keep up.
+The value of this metric should average around 0. There can be spikes, but generally large numbers over extended periods mean the node is struggling to keep up.
 
 ### `network_outbound_low_priority_message_queue_size`
 
 Current number of consensus messages in the outbound low priority queue. Start dropping messages when larger than 16 * 1024.
 
-The value of this metric should average around 0. There can be spikes, but generally large numbers mean the node is strugling to keep up.
+The value of this metric should average around 0. There can be spikes, but generally large numbers over extended periods mean the node is struggling to keep up.


### PR DESCRIPTION
## Purpose

Related to #709 

## Changes

- Use more consistent naming scheme for metrics as according to [Prometheus documentation](https://prometheus.io/docs/practices/naming/).
- Reduce some boilerplate for metrics by making fields public, avoiding getters and setters for each metric.
- Update our documentation with description of metrics.
- Hide `last_throughput_measurement_timestamp`, `avg_bps_in` and `avg_bps_out` metrics from the exporter, instead the recommendation is to calculate an average using the query language with the metrics `network_received_bytes` and `network_sent_bytes` withing the Prometheus server.
- Remove unused feature "gen" from `prometheus` dependency.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
