### PR TITLE
Update metrics for bytes sent and received on message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
   - `bytes_received` is now `network_received_bytes`.
   - `bytes_sent` is now `network_sent_bytes`.
 - Remove `last_throughput_measurement_timestamp`, `avg_bps_in` and `avg_bps_out` metrics exposed by the Prometheus exporter.
-- Prometheus metrics `network_sent_bytes` and `network_received_bytes` updates on every message instead of during "housekeeping".
+- Prometheus metrics `network_sent_bytes` and `network_received_bytes` update on every message instead of during "housekeeping".
 
 ## 5.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
   - `bytes_received` is now `network_received_bytes`.
   - `bytes_sent` is now `network_sent_bytes`.
 - Remove `last_throughput_measurement_timestamp`, `avg_bps_in` and `avg_bps_out` metrics exposed by the Prometheus exporter.
-- Prometheus metrics `network_sent_bytes` and `network_received_bytes` update on every message instead of during "housekeeping".
+- Change behavior of Prometheus metrics `network_sent_bytes` and `network_received_bytes`. Before this change these metrics were calculated as a sum of all the bytes sent/received to peers, which causes the metrics to drop when a peer is dropped. They were only updated during the scheduled "housekeeping" (every 30 secons by default). The new behavior is to update the metric every time a message is sent/received to a peer.
 
 ## 5.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   - `bytes_received` is now `network_received_bytes`.
   - `bytes_sent` is now `network_sent_bytes`.
 - Remove `last_throughput_measurement_timestamp`, `avg_bps_in` and `avg_bps_out` metrics exposed by the Prometheus exporter.
+- Prometheus metrics `network_sent_bytes` and `network_received_bytes` updates on every message instead of during "housekeeping".
 
 ## 5.2.1
 

--- a/concordium-node/src/connection/mod.rs
+++ b/concordium-node/src/connection/mod.rs
@@ -520,6 +520,7 @@ impl Connection {
         self.stats.bytes_received.fetch_add(bytes.len() as u64, Ordering::Relaxed);
         self.handler.connection_handler.total_received.fetch_add(1, Ordering::Relaxed);
         self.handler.stats.packets_received.inc();
+        self.handler.stats.received_bytes.inc_by(bytes.len() as u64);
 
         #[cfg(feature = "network_dump")]
         {
@@ -726,6 +727,7 @@ impl Connection {
 
             self.handler.connection_handler.total_sent.fetch_add(1, Ordering::Relaxed);
             self.handler.stats.packets_sent.inc();
+            self.handler.stats.sent_bytes.inc_by(msg.len() as u64);
             self.stats.messages_sent.fetch_add(1, Ordering::Relaxed);
             self.stats.bytes_sent.fetch_add(msg.len() as u64, Ordering::Relaxed);
 

--- a/concordium-node/src/grpc2.rs
+++ b/concordium-node/src/grpc2.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use prometheus::core::Atomic;
 use prost::bytes::BufMut;
 use std::{
     convert::{TryFrom, TryInto},

--- a/concordium-node/src/p2p/maintenance.rs
+++ b/concordium-node/src/p2p/maintenance.rs
@@ -724,7 +724,7 @@ pub fn spawn(
 
                     let peer_stat_list = node.get_peer_stats(None);
                     check_peers(&node, &peer_stat_list, attempted_bootstrap);
-                    if let Err(e) = node.measure_throughput(&peer_stat_list) {
+                    if let Err(e) = node.measure_throughput() {
                         error!("Could not measure throughput: {}", e);
                     }
 

--- a/concordium-node/src/p2p/peers.rs
+++ b/concordium-node/src/p2p/peers.rs
@@ -54,15 +54,12 @@ impl P2PNode {
 
     /// Measures the node's average byte throughput as bps i.e., bytes per
     /// second.
-    pub fn measure_throughput(&self, peer_stats: &[PeerStats]) -> anyhow::Result<()> {
+    pub fn measure_throughput(&self) -> anyhow::Result<()> {
         let prev_bytes_received = self.stats.last_throughput_measurement_received_bytes.get();
         let prev_bytes_sent = self.stats.last_throughput_measurement_sent_bytes.get();
 
-        let (bytes_received, bytes_sent) = peer_stats
-            .iter()
-            .filter(|ps| ps.peer_type == PeerType::Node)
-            .map(|ps| (ps.bytes_received, ps.bytes_sent))
-            .fold((0, 0), |(acc_i, acc_o), (i, o)| (acc_i + i, acc_o + o));
+        let bytes_received = self.stats.received_bytes.get();
+        let bytes_sent = self.stats.sent_bytes.get();
 
         self.stats.last_throughput_measurement_received_bytes.set(bytes_received);
         self.stats.last_throughput_measurement_sent_bytes.set(bytes_sent);
@@ -166,16 +163,7 @@ fn calculate_average_throughput(
     );
     let delta: u64 = (now_millis - before_millis) as u64; // as is safe since we checked the difference is positive.
 
-    ensure!(
-        bytes_recv >= prev_bytes_recv,
-        "Received bytes were lost. Refusing to calculate average throughput."
-    );
     let avg_bps_in = (milliseconds_to_second * (bytes_recv - prev_bytes_recv)) / delta;
-
-    ensure!(
-        bytes_sent >= prev_bytes_sent,
-        "Sent bytes were lost. Refusing to calculate average throughput."
-    );
     let avg_bps_out = (milliseconds_to_second * (bytes_sent - prev_bytes_sent)) / delta;
 
     Ok((avg_bps_in, avg_bps_out))
@@ -203,16 +191,6 @@ mod tests {
         assert!(
             calculate_average_throughput(2, 1, 1, 2, 1, 2).is_err(),
             "Calculation should fail since time difference is negative."
-        );
-
-        assert!(
-            calculate_average_throughput(1, 1001, 1002, 1001, 1001, 1002).is_err(),
-            "Received bytes were lost. Refusing to calculate average throughput."
-        );
-
-        assert!(
-            calculate_average_throughput(1, 1001, 1001, 1002, 1001, 1000).is_err(),
-            "Sent bytes were lost. Refusing to calculate average throughput."
         );
     }
 }

--- a/concordium-node/src/rpc.rs
+++ b/concordium-node/src/rpc.rs
@@ -17,6 +17,7 @@ use crate::{
 use byteorder::WriteBytesExt;
 use futures::future::Future;
 use p2p_server::*;
+use prometheus::core::Atomic;
 use std::{
     convert::TryInto,
     io::Write,

--- a/docs/prometheus-exporter.md
+++ b/docs/prometheus-exporter.md
@@ -35,13 +35,9 @@ All of the following accumulated metrics are relative to the startup of the node
 
 Total number of bytes received over the network. Only network message received from connected peers are accounted.
 
-Note: This metric is updated during "housekeeping", meaning the update frequency depends on the node configuration `--housekeeping-interval` (`CONCORDIUM_NODE_CONNECTION_HOUSEKEEPING_INTERVAL`) which is one every 30 seconds by default.
-
 ### `network_sent_bytes`
 
 Total number of bytes sent over the network. Only network message sent to connected peers are accounted.
-
-Note: This metric is updated during "housekeeping", meaning the update frequency depends on the node configuration `--housekeeping-interval` (`CONCORDIUM_NODE_CONNECTION_HOUSEKEEPING_INTERVAL`) which is one every 30 seconds by default.
 
 ### `network_packets_received_total`
 


### PR DESCRIPTION
## Purpose

Currently, the metrics for received bytes and sent bytes are calculated during "housekeeping" which is every 30 second by default. The metrics are calculated as a sum of all the bytes sent/received to peers, which causes the metrics to drop when a peer is dropped.
This PR changes these two metrics to be updated on every message sent/received instead.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

