### PR TITLE
Fix config parsing for grpc2 certificate options.

### DIFF
--- a/concordium-node/src/configuration.rs
+++ b/concordium-node/src/configuration.rs
@@ -359,6 +359,7 @@ pub struct GRPC2Config {
     )]
     pub listen_port:                Option<u16>,
     #[structopt(
+        name = "grpc2-x509-cert",
         long = "grpc2-x509-cert",
         help = "Certificate used to enable TLS support for the GRPC V2 server.",
         env = "CONCORDIUM_NODE_GRPC2_X509_CERT",
@@ -367,6 +368,7 @@ pub struct GRPC2Config {
     )]
     pub x509_cert:                  Option<PathBuf>,
     #[structopt(
+        name = "grpc2-cert-private-key",
         long = "grpc2-cert-private-key",
         help = "Private key corresponding to the certificate",
         env = "CONCORDIUM_NODE_GRPC2_CERT_PRIVATE_KEY",


### PR DESCRIPTION
## Purpose

Fix parsing of certificate options.

The name was not set, which combined with `requires` leads to problems.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
