### PR TITLE
Change docker/Ubuntu build scripts to use default genesis from library function

### DIFF
--- a/jenkinsfiles/distribution-image.Jenkinsfile
+++ b/jenkinsfiles/distribution-image.Jenkinsfile
@@ -26,6 +26,12 @@ pipeline {
         }
 
         stage('build') {
+            environment {
+                // Overrides the parameter 'genesis_path'
+                // Use default genesis path for each environment, if the GENESIS_PATH param has not been set.
+                // Uses library function defined here: https://gitlab.com/Concordium/infra/jenkins-library/-/blob/master/vars/defaultGenesis.groovy
+                genesis_path = defaultGenesis(environment, genesis_path)
+            }
             steps {
                 sh 'printenv'
                 sshagent (credentials: ['jenkins-gitlab-ssh']) {

--- a/jenkinsfiles/distribution-image.Jenkinsfile
+++ b/jenkinsfiles/distribution-image.Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
         stage('build') {
             environment {
                 // Overrides the parameter 'genesis_path'
-                // Use default genesis path for each environment, if the GENESIS_PATH param has not been set.
+                // Use default genesis path for each environment, if the genesis_path param has not been set.
                 // Uses library function defined here: https://gitlab.com/Concordium/infra/jenkins-library/-/blob/master/vars/defaultGenesis.groovy
                 genesis_path = defaultGenesis(environment, genesis_path)
             }

--- a/jenkinsfiles/ubuntu.Jenkinsfile
+++ b/jenkinsfiles/ubuntu.Jenkinsfile
@@ -46,8 +46,8 @@ pipeline {
         DOMAIN = concordiumDomain(ENVIRONMENT)
         BUILD_FILE = "concordium-${ENVIRONMENT}-node_${CODE_VERSION}_amd64.deb"
         OUTFILE = "s3://distribution.${DOMAIN}/deb/concordium-${ENVIRONMENT}-node_${OUT_VERSION}_amd64.deb"
-        GENESIS_HASH_PATH = "${GENESIS_FULL_PATH}/genesis_hash"
-        GENESIS_DAT_FILE = "${GENESIS_FULL_PATH}/genesis.dat"
+        GENESIS_HASH_PATH = "genesis/${GENESIS_FULL_PATH}/genesis_hash"
+        GENESIS_DAT_FILE = "genesis/${GENESIS_FULL_PATH}/genesis.dat"
         ENVIRONMENT_CAP = environment.capitalize()
         DATA_DIR = "./scripts/distribution/ubuntu-packages/template/data/"
         RPC_PORT = "${rpc_port[environment]}"

--- a/jenkinsfiles/ubuntu.Jenkinsfile
+++ b/jenkinsfiles/ubuntu.Jenkinsfile
@@ -25,12 +25,6 @@ Map listen_port = [
     stagenet: "9500"
 ]
 
-Map genesis_path = [
-    mainnet: "mainnet/2021-06-09",
-    testnet: "testnet/2022-06-13/genesis_data",
-    stagenet: "stagenet/2022-11-11/genesis_data"
-]
-
 pipeline {
     // Use jenkins-worker, as it has the keys for pushing to AWS.
     agent { label 'jenkins-worker' }
@@ -45,11 +39,10 @@ pipeline {
                 returnStdout: true,
                 script: "[[ -z '${VERSION}' ]] && echo '${CODE_VERSION}' || echo '${VERSION}'"
             )}""".trim()
-        // Ude default genesis path for each environment, if the GENESIS_PATH param has not been set.
-        GENESIS_FULL_PATH = """${sh(
-                returnStdout: true,
-                script: "[[ -z '${GENESIS_PATH}' ]] && echo 'genesis/${genesis_path[ENVIRONMENT]}' || echo 'genesis/${GENESIS_PATH}'"
-            )}""".trim()
+        
+        // Use default genesis path for each environment, if the GENESIS_PATH param has not been set.
+        // Uses library function defined here: https://gitlab.com/Concordium/infra/jenkins-library/-/blob/master/vars/defaultGenesis.groovy
+        GENESIS_FULL_PATH = defaultGenesis(ENVIRONMENT, GENESIS_PATH)
         DOMAIN = concordiumDomain(ENVIRONMENT)
         BUILD_FILE = "concordium-${ENVIRONMENT}-node_${CODE_VERSION}_amd64.deb"
         OUTFILE = "s3://distribution.${DOMAIN}/deb/concordium-${ENVIRONMENT}-node_${OUT_VERSION}_amd64.deb"


### PR DESCRIPTION
## Purpose

Let the Ubuntu and docker build scripts use a default genesis path defined in a Jenkins library function, when the path has not been defined as a parameter of the build job.

## Changes

Added a call to a Jenkins library function, that returns the path parameter if it is defined, and if the path parameter is not defined returns a default path.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
