### PR TITLE
Add metric for total received messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@
   - `bytes_sent` is now `network_sent_bytes`.
 - Remove `last_throughput_measurement_timestamp`, `avg_bps_in` and `avg_bps_out` metrics exposed by the Prometheus exporter.
 - Change behavior of Prometheus metrics `network_sent_bytes` and `network_received_bytes`. Before this change these metrics were calculated as a sum of all the bytes sent/received to peers, which causes the metrics to drop when a peer is dropped. They were only updated during the scheduled "housekeeping" (every 30 secons by default). The new behavior is to update the metric every time a message is sent/received to a peer.
-- Extend Prometheus exporter with metrics: `consensus_last_finalized_block_height`, `consensus_last_finalized_block_timestamp`, `consensus_last_arrived_block_height`, `consensus_last_arrived_block_timestamp` see [docs/prometheus-exporter.md](https://github.com/Concordium/concordium-node/blob/main/docs/prometheus-exporter.md) for more details.
+- Extend Prometheus exporter with metrics: `consensus_last_finalized_block_height`, `consensus_last_finalized_block_timestamp`, `consensus_last_arrived_block_height`, `consensus_last_arrived_block_timestamp`, `consensus_received_messages_total` see [docs/prometheus-exporter.md](https://github.com/Concordium/concordium-node/blob/main/docs/prometheus-exporter.md) for more details.
+- Remove metrics `network_inbound_high_priority_message_drops_total`, `network_inbound_low_priority_message_drops_total`, `network_inbound_high_priority_messages_total` and `network_inbound_high_priority_messages_total` as they can be derived using the labels of `consensus_received_messages_total`.
 
 ## 5.2.1
 

--- a/concordium-node/src/consensus_ffi/helpers.rs
+++ b/concordium-node/src/consensus_ffi/helpers.rs
@@ -107,6 +107,18 @@ impl PacketType {
             PacketType::CatchUpStatus => false,
         }
     }
+
+    /// Get the label. This is used when updating metrics of the prometheus
+    /// exporter.
+    pub fn as_label(&self) -> &str {
+        match self {
+            PacketType::Block => "block",
+            PacketType::Transaction => "transaction",
+            PacketType::FinalizationRecord => "finalization record",
+            PacketType::FinalizationMessage => "finalization message",
+            PacketType::CatchUpStatus => "catch-up status message",
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Error)]
@@ -247,6 +259,16 @@ impl ConsensusFfiResponse {
             | ContinueCatchUp => false,
             PendingBlock => packet_type != PacketType::Block,
             Success | PendingFinalization | Asynchronous => true,
+        }
+    }
+
+    /// Get the label. This is used when updating metrics of the prometheus
+    /// exporter.
+    pub fn as_label(&self) -> &str {
+        match self {
+            ConsensusFfiResponse::Success => "valid",
+            ConsensusFfiResponse::DuplicateEntry => "duplicate",
+            _ => "invalid",
         }
     }
 }

--- a/concordium-node/src/consensus_ffi/helpers.rs
+++ b/concordium-node/src/consensus_ffi/helpers.rs
@@ -110,7 +110,7 @@ impl PacketType {
 
     /// Get the label. This is used when updating metrics of the prometheus
     /// exporter.
-    pub fn as_label(&self) -> &str {
+    pub fn label(&self) -> &str {
         match self {
             PacketType::Block => "block",
             PacketType::Transaction => "transaction",
@@ -264,11 +264,13 @@ impl ConsensusFfiResponse {
 
     /// Get the label. This is used when updating metrics of the prometheus
     /// exporter.
-    pub fn as_label(&self) -> &str {
-        match self {
-            ConsensusFfiResponse::Success => "valid",
-            ConsensusFfiResponse::DuplicateEntry => "duplicate",
-            _ => "invalid",
+    pub fn label(&self) -> &str {
+        if self.is_successful() {
+            "valid"
+        } else if let ConsensusFfiResponse::DuplicateEntry = self {
+            "duplicate"
+        } else {
+            "invalid"
         }
     }
 }

--- a/concordium-node/src/plugins/consensus.rs
+++ b/concordium-node/src/plugins/consensus.rs
@@ -175,8 +175,8 @@ pub fn handle_pkt_out(
             match e.downcast::<TrySendError<QueueMsg<ConsensusMessage>>>()? {
                 TrySendError::Full(_) => {
                     node.stats
-                        .received_messages
-                        .with_label_values(&[packet_type.as_label(), "dropped"])
+                        .received_consensus_messages
+                        .with_label_values(&[packet_type.label(), "dropped"])
                         .inc();
                     node.bad_events.inc_dropped_low_queue(peer_id);
                 }
@@ -191,8 +191,8 @@ pub fn handle_pkt_out(
             match e.downcast::<TrySendError<QueueMsg<ConsensusMessage>>>()? {
                 TrySendError::Full(_) => {
                     node.stats
-                        .received_messages
-                        .with_label_values(&[packet_type.as_label(), "dropped"])
+                        .received_consensus_messages
+                        .with_label_values(&[packet_type.label(), "dropped"])
                         .inc();
 
                     node.bad_events.inc_dropped_high_queue(peer_id);
@@ -266,8 +266,8 @@ pub fn handle_consensus_inbound_msg(
 
     // Update metric tracking received messages.
     node.stats
-        .received_messages
-        .with_label_values(&[request.variant.as_label(), consensus_result.as_label()])
+        .received_consensus_messages
+        .with_label_values(&[request.variant.label(), consensus_result.label()])
         .inc();
 
     // rebroadcast incoming broadcasts if applicable

--- a/docs/prometheus-exporter.md
+++ b/docs/prometheus-exporter.md
@@ -59,7 +59,7 @@ Total number of connections received. Incremented everytime someone tries to est
 
 Current number of consensus messages in the inbound high priority queue. Start dropping messages when larger than 16 * 1024.
 
-High priority messages are blocks, finalizations records, finalization messages and catch-up status messages.
+High priority messages are blocks, finalization messages and catch-up status messages.
 
 The value of this metric should average around 0. There can be spikes, but generally large numbers over extended periods mean the node is struggling to keep up.
 
@@ -75,7 +75,7 @@ The value of this metric should average around 0. There can be spikes, but gener
 
 Current number of consensus messages in the outbound high priority queue. Start dropping messages when larger than 8 * 1024.
 
-High priority messages are blocks, finalizations records, finalization messages and catch-up status messages.
+High priority messages are blocks, finalization messages and catch-up status messages.
 
 The value of this metric should average around 0. There can be spikes, but generally large numbers over extended periods mean the node is struggling to keep up.
 

--- a/docs/prometheus-exporter.md
+++ b/docs/prometheus-exporter.md
@@ -55,27 +55,11 @@ Current number of connected peers. This is incremented when a peer completes a h
 
 Total number of connections received. Incremented everytime someone tries to establish a new connection, meaning even the failed connections are accounted, such as when the address is banned, duplicate connection or the node is at its limit on number of connections.
 
-### `network_inbound_high_priority_message_drops_total`
-
-Total inbound high priority messages dropped due to the queue for high priority messages being full.
-See `network_inbound_high_priority_message_queue_size` for the current size of the queue.
-
-### `network_inbound_low_priority_message_drops_total`
-
-Total inbound low priority messages dropped due to the queue for low priority messages being full.
-See `network_inbound_low_priority_message_queue_size` for the current size of the queue.
-
-### `network_inbound_high_priority_messages_total`
-
-Total inbound high priority messages received. This is incremented when a consensus message is enqueue in the high priority queue. Note: Does not include the dropped messages, see `network_inbound_high_priority_message_drops_total`.
-
-### `network_inbound_low_priority_messages_total`
-
-Total inbound low priority messages received. This is incremented when a consensus message is enqueue in the low priority queue. Note: Does not include the dropped messages, see `network_inbound_low_priority_message_drops_total`.
-
 ### `network_inbound_high_priority_message_queue_size`
 
 Current number of consensus messages in the inbound high priority queue. Start dropping messages when larger than 16 * 1024.
+
+High priority messages are blocks, finalizations records, finalization messages and catch-up status messages.
 
 The value of this metric should average around 0. There can be spikes, but generally large numbers over extended periods mean the node is struggling to keep up.
 
@@ -83,17 +67,23 @@ The value of this metric should average around 0. There can be spikes, but gener
 
 Current number of consensus messages in the inbound low priority queue. Start dropping messages when larger than 32 * 1024.
 
+Low priority messages are transaction messages.
+
 The value of this metric should average around 0. There can be spikes, but generally large numbers over extended periods mean the node is struggling to keep up.
 
 ### `network_outbound_high_priority_message_queue_size`
 
 Current number of consensus messages in the outbound high priority queue. Start dropping messages when larger than 8 * 1024.
 
+High priority messages are blocks, finalizations records, finalization messages and catch-up status messages.
+
 The value of this metric should average around 0. There can be spikes, but generally large numbers over extended periods mean the node is struggling to keep up.
 
 ### `network_outbound_low_priority_message_queue_size`
 
 Current number of consensus messages in the outbound low priority queue. Start dropping messages when larger than 16 * 1024.
+
+Low priority messages are transaction messages.
 
 The value of this metric should average around 0. There can be spikes, but generally large numbers over extended periods mean the node is struggling to keep up.
 
@@ -116,3 +106,20 @@ The block height of the last arrived block.
 Timestamp for the processed last arrived block (as Unix time in milliseconds).
 
 Note that this is the time when the node has last processed a new block. It is **not** the objective timestamp of the block (i.e., slot time).
+
+### `consensus_received_messages_total`
+
+Total number of consensus messages received. Labelled with message type (`message=<type>`) and the outcome (`result=<outcome>`).
+
+Possible values of `message` are:
+- `"block"`
+- `"transaction"`
+- `"finalization record"`
+- `"finalization message"`
+- `"catch-up status message"`
+
+Possible values of `result` are:
+- `"valid"` Successful outcome.
+- `"invalid"` Messages being rejected as invalid.
+- `"dropped"` Messages being dropped due to a full queue. See either `network_inbound_low_priority_message_queue_size` or `network_inbound_high_priority_message_queue_size` for more on this.
+- `"duplicate"` Duplicate consensus messages (this is not including deduplication of the network layer).

--- a/docs/prometheus-exporter.md
+++ b/docs/prometheus-exporter.md
@@ -114,7 +114,6 @@ Total number of consensus messages received. Labelled with message type (`messag
 Possible values of `message` are:
 - `"block"`
 - `"transaction"`
-- `"finalization record"`
 - `"finalization message"`
 - `"catch-up status message"`
 
@@ -122,4 +121,4 @@ Possible values of `result` are:
 - `"valid"` Successful outcome.
 - `"invalid"` Messages being rejected as invalid.
 - `"dropped"` Messages being dropped due to a full queue. See either `network_inbound_low_priority_message_queue_size` or `network_inbound_high_priority_message_queue_size` for more on this.
-- `"duplicate"` Duplicate consensus messages (this is not including deduplication of the network layer).
+- `"duplicate"` Duplicate consensus messages. These are duplicate messages determined so by consensus, **after** the message has already been deduplicated at the network layer.


### PR DESCRIPTION
## Purpose

Related to https://github.com/Concordium/concordium-node/issues/710
Extend Prometheus metrics with metric for total received messages.

## Changes

- Introduce metric `consensus_received_messages_total` with a label for message type and a label for result.
- Removed `network_inbound_high_priority_message_drops_total`, `network_inbound_low_priority_message_drops_total`, `network_inbound_high_priority_messages_total` and `network_inbound_high_priority_messages_total` as they can now be derived from `consensus_received_messages_total`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
