### PR TITLE
Revise core genesis parameters for new consensus protocol.

### DIFF
--- a/concordium-consensus/src/Concordium/Birk/Bake.hs
+++ b/concordium-consensus/src/Concordium/Birk/Bake.hs
@@ -39,7 +39,7 @@ import Concordium.GlobalState.Parameters
 import Concordium.GlobalState.TransactionTable
 import Concordium.GlobalState.TreeState as TS
 import Concordium.Types.HashableTo
-import Concordium.Types.SeedState hiding (getSeedState)
+import Concordium.Types.SeedState
 import Concordium.Types.Transactions
 import Concordium.Types.Updates
 

--- a/concordium-consensus/src/Concordium/Birk/Bake.hs
+++ b/concordium-consensus/src/Concordium/Birk/Bake.hs
@@ -39,7 +39,7 @@ import Concordium.GlobalState.Parameters
 import Concordium.GlobalState.TransactionTable
 import Concordium.GlobalState.TreeState as TS
 import Concordium.Types.HashableTo
-import Concordium.Types.SeedState
+import Concordium.Types.SeedState hiding (getSeedState)
 import Concordium.Types.Transactions
 import Concordium.Types.Updates
 
@@ -91,7 +91,7 @@ processTransactions ::
       SkovMonad m
     ) =>
     Slot ->
-    SeedState ->
+    SeedState (SeedStateVersionFor (MPV m)) ->
     BlockPointerType m ->
     Maybe FinalizerInfo ->
     BakerId ->

--- a/concordium-consensus/src/Concordium/GlobalState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState.hs
@@ -96,7 +96,7 @@ initialiseExistingGlobalState _ GlobalStateConfig{..} = do
 -- but future protocol updates might need to do some migration of these as
 -- well.
 migrateExistingState ::
-    (IsProtocolVersion pv, IsProtocolVersion oldpv) =>
+    (IsProtocolVersion pv, IsProtocolVersion oldpv, IsConsensusV0 pv) =>
     -- |The configuration.
     GlobalStateConfig ->
     -- |Global state context for the state we are migrating from.
@@ -138,7 +138,7 @@ migrateExistingState GlobalStateConfig{..} oldPbsc oldState migration genData = 
 -- |Initialise new global state with the given genesis. If the state already
 -- exists this will raise an exception. It is not necessary to call 'activateGlobalState'
 -- on the generated state, as this will establish the necessary invariants.
-initialiseNewGlobalState :: IsProtocolVersion pv => GenesisData pv -> GlobalStateConfig -> LogIO (GSContext pv, GSState pv)
+initialiseNewGlobalState :: (IsProtocolVersion pv, IsConsensusV0 pv) => GenesisData pv -> GlobalStateConfig -> LogIO (GSContext pv, GSState pv)
 initialiseNewGlobalState genData GlobalStateConfig{..} = do
     pbscBlobStore <- liftIO $ createBlobStore dtdbBlockStateFile
     pbscAccountCache <- liftIO $ newAccountCache (rpAccountsCacheSize dtdbRuntimeParameters)
@@ -160,7 +160,7 @@ initialiseNewGlobalState genData GlobalStateConfig{..} = do
     return (pbsc, isd)
 
 -- |Either initialise an existing state, or if it does not exist, initialise a new one with the given genesis.
-initialiseGlobalState :: forall pv. IsProtocolVersion pv => GenesisData pv -> GlobalStateConfig -> LogIO (GSContext pv, GSState pv)
+initialiseGlobalState :: forall pv. (IsProtocolVersion pv, IsConsensusV0 pv) => GenesisData pv -> GlobalStateConfig -> LogIO (GSContext pv, GSState pv)
 initialiseGlobalState gd cfg =
     initialiseExistingGlobalState (protocolVersion @pv) cfg >>= \case
         Nothing -> initialiseNewGlobalState gd cfg

--- a/concordium-consensus/src/Concordium/GlobalState/Parameters.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Parameters.hs
@@ -73,7 +73,7 @@ getExactVersionedCryptographicParameters bs = do
     return (vValue v)
 
 -- |Implementation-defined parameters, such as block size. They are not
--- protocol-level parameters hence do not fit into 'GenesisParameters'.
+-- protocol-level parameters hence do not fit into 'GenesisParametersV2'.
 data RuntimeParameters = RuntimeParameters
     { -- |Maximum block size produced by the baker (in bytes). Note that this only
       -- applies to the blocks produced by this baker, we will still accept blocks

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -119,6 +119,8 @@ data PersistentBirkParameters (pv :: ProtocolVersion) = PersistentBirkParameters
 makeLenses ''PersistentBirkParameters
 
 -- |Migrate a 'SeedState' between protocol versions.
+-- For migrations in consensus version 0, changes to the seed state are handled prior to state
+-- migration. For consensus version 1, they should be handled here.
 migrateSeedState :: StateMigrationParameters oldpv pv -> SeedState (SeedStateVersionFor oldpv) -> SeedState (SeedStateVersionFor pv)
 migrateSeedState StateMigrationParametersTrivial{} ss = ss
 migrateSeedState StateMigrationParametersP1P2{} ss = ss

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -104,19 +104,27 @@ import Lens.Micro.Platform
 
 -- * Birk parameters
 
-data PersistentBirkParameters (av :: AccountVersion) = PersistentBirkParameters
+data PersistentBirkParameters (pv :: ProtocolVersion) = PersistentBirkParameters
     { -- |The currently-registered bakers.
-      _birkActiveBakers :: !(BufferedRef (PersistentActiveBakers av)),
+      _birkActiveBakers :: !(BufferedRef (PersistentActiveBakers (AccountVersionFor pv))),
       -- |The bakers that will be used for the next epoch.
-      _birkNextEpochBakers :: !(HashedBufferedRef (PersistentEpochBakers av)),
+      _birkNextEpochBakers :: !(HashedBufferedRef (PersistentEpochBakers (AccountVersionFor pv))),
       -- |The bakers for the current epoch.
-      _birkCurrentEpochBakers :: !(HashedBufferedRef (PersistentEpochBakers av)),
+      _birkCurrentEpochBakers :: !(HashedBufferedRef (PersistentEpochBakers (AccountVersionFor pv))),
       -- |The seed state used to derive the leadership election nonce.
-      _birkSeedState :: !SeedState
+      _birkSeedState :: !(SeedState (SeedStateVersionFor pv))
     }
     deriving (Show)
 
 makeLenses ''PersistentBirkParameters
+
+-- |Migrate a 'SeedState' between protocol versions.
+migrateSeedState :: StateMigrationParameters oldpv pv -> SeedState (SeedStateVersionFor oldpv) -> SeedState (SeedStateVersionFor pv)
+migrateSeedState StateMigrationParametersTrivial{} ss = ss
+migrateSeedState StateMigrationParametersP1P2{} ss = ss
+migrateSeedState StateMigrationParametersP2P3{} ss = ss
+migrateSeedState StateMigrationParametersP3ToP4{} ss = ss
+migrateSeedState StateMigrationParametersP4ToP5{} ss = ss
 
 -- |See documentation of @migratePersistentBlockState@.
 --
@@ -130,8 +138,8 @@ migratePersistentBirkParameters ::
     ) =>
     StateMigrationParameters oldpv pv ->
     Accounts.Accounts pv ->
-    PersistentBirkParameters (AccountVersionFor oldpv) ->
-    t m (PersistentBirkParameters (AccountVersionFor pv))
+    PersistentBirkParameters oldpv ->
+    t m (PersistentBirkParameters pv)
 migratePersistentBirkParameters migration accounts PersistentBirkParameters{..} = do
     newActiveBakers <- migrateReference (migratePersistentActiveBakers migration accounts) _birkActiveBakers
     newNextEpochBakers <- migrateHashedBufferedRef (migratePersistentEpochBakers migration) _birkNextEpochBakers
@@ -141,7 +149,7 @@ migratePersistentBirkParameters migration accounts PersistentBirkParameters{..} 
             { _birkActiveBakers = newActiveBakers,
               _birkNextEpochBakers = newNextEpochBakers,
               _birkCurrentEpochBakers = newCurrentEpochBakers,
-              _birkSeedState = _birkSeedState
+              _birkSeedState = migrateSeedState migration _birkSeedState
             }
 
 -- |Accumulated state when iterating accounts, meant for constructing PersistentBirkParameters.
@@ -194,13 +202,13 @@ emptyIBPCollectedDelegators =
 
 -- |Generate initial birk parameters from accounts and seed state.
 initialBirkParameters ::
-    forall av m.
-    (MonadBlobStore m, IsAccountVersion av) =>
+    forall pv av m.
+    (MonadBlobStore m, IsProtocolVersion pv, av ~ AccountVersionFor pv) =>
     -- |The accounts in ascending order of the account index.
     [PersistentAccount av] ->
     -- |The seed state
-    SeedState ->
-    m (PersistentBirkParameters av)
+    SeedState (SeedStateVersionFor pv) ->
+    m (PersistentBirkParameters pv)
 initialBirkParameters accounts seedState = do
     -- Iterate accounts and collect delegators.
     IBPCollectedDelegators{..} <- case delegationSupport @av of
@@ -305,22 +313,22 @@ freezeContractState cs = case Wasm.getWasmVersion @v of
         return (hsh, Instances.InstanceStateV1 persistent)
 
 -- |Serialize 'PersistentBirkParameters' in V0 format.
-putBirkParametersV0 :: forall m av. (IsAccountVersion av, MonadBlobStore m, MonadPut m) => PersistentBirkParameters av -> m ()
-putBirkParametersV0 PersistentBirkParameters{..} = do
+putBirkParametersV0 :: forall m pv. (IsProtocolVersion pv, MonadBlobStore m, MonadPut m) => PersistentBirkParameters pv -> m ()
+putBirkParametersV0 PersistentBirkParameters{..} = withIsSeedStateVersionFor (protocolVersion @pv) $ do
     sPut _birkSeedState
     putEpochBakers =<< refLoad _birkNextEpochBakers
     putEpochBakers =<< refLoad _birkCurrentEpochBakers
 
-instance (IsAccountVersion av, MonadBlobStore m) => MHashableTo m H.Hash (PersistentBirkParameters av) where
-    getHashM PersistentBirkParameters{..} = do
+instance (IsProtocolVersion pv, MonadBlobStore m) => MHashableTo m H.Hash (PersistentBirkParameters pv) where
+    getHashM PersistentBirkParameters{..} = withIsSeedStateVersionFor (protocolVersion @pv) $ do
         nextHash <- getHashM _birkNextEpochBakers
         currentHash <- getHashM _birkCurrentEpochBakers
         let bpH0 = H.hash $ "SeedState" <> encode _birkSeedState
             bpH1 = H.hashOfHashes nextHash currentHash
         return $ H.hashOfHashes bpH0 bpH1
 
-instance (MonadBlobStore m, IsAccountVersion av) => BlobStorable m (PersistentBirkParameters av) where
-    storeUpdate bps@PersistentBirkParameters{..} = do
+instance (MonadBlobStore m, IsProtocolVersion pv) => BlobStorable m (PersistentBirkParameters pv) where
+    storeUpdate bps@PersistentBirkParameters{..} = withIsSeedStateVersionFor (protocolVersion @pv) $ do
         (pabs, actBakers) <- storeUpdate _birkActiveBakers
         (pnebs, nextBakers) <- storeUpdate _birkNextEpochBakers
         (pcebs, currentBakers) <- storeUpdate _birkCurrentEpochBakers
@@ -337,7 +345,7 @@ instance (MonadBlobStore m, IsAccountVersion av) => BlobStorable m (PersistentBi
                   _birkCurrentEpochBakers = currentBakers
                 }
             )
-    load = do
+    load = withIsSeedStateVersionFor (protocolVersion @pv) $ do
         mabs <- label "Active bakers" load
         mnebs <- label "Next epoch bakers" load
         mcebs <- label "Current epoch bakers" load
@@ -348,7 +356,7 @@ instance (MonadBlobStore m, IsAccountVersion av) => BlobStorable m (PersistentBi
             _birkCurrentEpochBakers <- mcebs
             return PersistentBirkParameters{..}
 
-instance (MonadBlobStore m, IsAccountVersion av) => Cacheable m (PersistentBirkParameters av) where
+instance (MonadBlobStore m, IsProtocolVersion pv) => Cacheable m (PersistentBirkParameters pv) where
     cache PersistentBirkParameters{..} = do
         activeBaks <- cache _birkActiveBakers
         next <- cache _birkNextEpochBakers
@@ -671,7 +679,7 @@ data BlockStatePointers (pv :: ProtocolVersion) = BlockStatePointers
       bspBank :: !(Hashed Rewards.BankStatus),
       bspIdentityProviders :: !(HashedBufferedRef IPS.IdentityProviders),
       bspAnonymityRevokers :: !(HashedBufferedRef ARS.AnonymityRevokers),
-      bspBirkParameters :: !(PersistentBirkParameters (AccountVersionFor pv)),
+      bspBirkParameters :: !(PersistentBirkParameters pv),
       bspCryptographicParameters :: !(HashedBufferedRef CryptographicParameters),
       bspUpdates :: !(BufferedRef (Updates pv)),
       bspReleaseSchedule :: !(ReleaseSchedule pv),
@@ -682,7 +690,7 @@ data BlockStatePointers (pv :: ProtocolVersion) = BlockStatePointers
     }
 
 -- |Lens for accessing the birk parameters of a 'BlockStatePointers' structure.
-birkParameters :: Lens' (BlockStatePointers pv) (PersistentBirkParameters (AccountVersionFor pv))
+birkParameters :: Lens' (BlockStatePointers pv) (PersistentBirkParameters pv)
 birkParameters = lens bspBirkParameters (\bsp bp -> bsp{bspBirkParameters = bp})
 
 -- |A hashed version of 'PersistingBlockState'.  This is used when the block state
@@ -795,7 +803,7 @@ bspPoolRewards bsp = case bspRewardDetails bsp of
 -- |An initial 'HashedPersistentBlockState', which may be used for testing purposes.
 initialPersistentState ::
     (SupportsPersistentState pv m) =>
-    SeedState ->
+    SeedState (SeedStateVersionFor pv) ->
     CryptographicParameters ->
     [PersistentAccount (AccountVersionFor pv)] ->
     IPS.IdentityProviders ->
@@ -839,7 +847,7 @@ initialPersistentState seedState cryptoParams accounts ips ars keysCollection ch
 emptyBlockState ::
     forall pv m.
     (SupportsPersistentState pv m) =>
-    PersistentBirkParameters (AccountVersionFor pv) ->
+    PersistentBirkParameters pv ->
     CryptographicParameters ->
     UpdateKeysCollection (AuthorizationsVersionForPV pv) ->
     ChainParameters pv ->
@@ -1006,10 +1014,17 @@ doPutNewModule pbs (pmInterface, pmSource) = do
             modules <- refMake mods'
             (True,) <$> storePBS pbs (bsp{bspModules = modules})
 
-doGetSeedState :: (SupportsPersistentState pv m) => PersistentBlockState pv -> m SeedState
+doGetSeedState ::
+    (SupportsPersistentState pv m) =>
+    PersistentBlockState pv ->
+    m (SeedState (SeedStateVersionFor pv))
 doGetSeedState pbs = _birkSeedState . bspBirkParameters <$> loadPBS pbs
 
-doSetSeedState :: (SupportsPersistentState pv m) => PersistentBlockState pv -> SeedState -> m (PersistentBlockState pv)
+doSetSeedState ::
+    (SupportsPersistentState pv m) =>
+    PersistentBlockState pv ->
+    SeedState (SeedStateVersionFor pv) ->
+    m (PersistentBlockState pv)
 doSetSeedState pbs ss = do
     bsp <- loadPBS pbs
     storePBS pbs bsp{bspBirkParameters = (bspBirkParameters bsp){_birkSeedState = ss}}
@@ -1032,12 +1047,19 @@ doGetNextEpochBakers pbs = do
     bsp <- loadPBS pbs
     epochToFullBakers =<< refLoad (bspBirkParameters bsp ^. birkNextEpochBakers)
 
-doGetSlotBakersP1 :: (AccountVersionFor pv ~ 'AccountV0, SupportsPersistentState pv m) => PersistentBlockState pv -> Slot -> m FullBakers
+doGetSlotBakersP1 ::
+    ( AccountVersionFor pv ~ 'AccountV0,
+      SeedStateVersionFor pv ~ 'SeedStateVersion0,
+      SupportsPersistentState pv m
+    ) =>
+    PersistentBlockState pv ->
+    Slot ->
+    m FullBakers
 doGetSlotBakersP1 pbs slot = do
     bs <- loadPBS pbs
     let bps = bspBirkParameters bs
         SeedState{..} = bps ^. birkSeedState
-        slotEpoch = fromIntegral $ slot `quot` epochLength
+        slotEpoch = fromIntegral $ slot `quot` (epochLength ^. unconditionally)
     case compare slotEpoch (epoch + 1) of
         LT -> epochToFullBakers =<< refLoad (bps ^. birkCurrentEpochBakers)
         EQ -> epochToFullBakers =<< refLoad (bps ^. birkNextEpochBakers)

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Genesis.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Genesis.hs
@@ -75,6 +75,7 @@ genesisState gd = MTL.runExceptT $ case Types.protocolVersion @pv of
 
 -------- Types -----------
 
+-- |A GADT that wraps the core genesis parameters for each consensus version.
 data VersionedCoreGenesisParameters (pv :: Types.ProtocolVersion) where
     CGPV0 :: (Types.IsConsensusV0 pv) => GenesisData.CoreGenesisParameters -> VersionedCoreGenesisParameters pv
     CGPV1 :: (Types.IsConsensusV1 pv) => GDBaseV1.CoreGenesisParametersV1 -> VersionedCoreGenesisParameters pv

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Genesis.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Genesis.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -8,6 +10,7 @@
 module Concordium.GlobalState.Persistent.Genesis (genesisState) where
 
 import qualified Concordium.Genesis.Data as GenesisData
+import qualified Concordium.Genesis.Data.BaseV1 as GDBaseV1
 import qualified Concordium.Genesis.Data.P1 as P1
 import qualified Concordium.Genesis.Data.P2 as P2
 import qualified Concordium.Genesis.Data.P3 as P3
@@ -53,24 +56,28 @@ genesisState ::
 genesisState gd = MTL.runExceptT $ case Types.protocolVersion @pv of
     Types.SP1 -> case gd of
         GenesisData.GDP1 P1.GDP1Initial{..} ->
-            buildGenesisBlockState genesisCore genesisInitialState
+            buildGenesisBlockState (CGPV0 genesisCore) genesisInitialState
     Types.SP2 -> case gd of
         GenesisData.GDP2 P2.GDP2Initial{..} ->
-            buildGenesisBlockState genesisCore genesisInitialState
+            buildGenesisBlockState (CGPV0 genesisCore) genesisInitialState
     Types.SP3 -> case gd of
         GenesisData.GDP3 P3.GDP3Initial{..} ->
-            buildGenesisBlockState genesisCore genesisInitialState
+            buildGenesisBlockState (CGPV0 genesisCore) genesisInitialState
     Types.SP4 -> case gd of
         GenesisData.GDP4 P4.GDP4Initial{..} ->
-            buildGenesisBlockState genesisCore genesisInitialState
+            buildGenesisBlockState (CGPV0 genesisCore) genesisInitialState
     Types.SP5 -> case gd of
         GenesisData.GDP5 P5.GDP5Initial{..} ->
-            buildGenesisBlockState genesisCore genesisInitialState
+            buildGenesisBlockState (CGPV0 genesisCore) genesisInitialState
     Types.SP6 -> case gd of
         GenesisData.GDP6 P6.GDP6Initial{..} ->
-            buildGenesisBlockState genesisCore genesisInitialState
+            buildGenesisBlockState (CGPV1 genesisCore) genesisInitialState
 
 -------- Types -----------
+
+data VersionedCoreGenesisParameters (pv :: Types.ProtocolVersion) where
+    CGPV0 :: (Types.IsConsensusV0 pv) => GenesisData.CoreGenesisParameters -> VersionedCoreGenesisParameters pv
+    CGPV1 :: (Types.IsConsensusV1 pv) => GDBaseV1.CoreGenesisParametersV1 -> VersionedCoreGenesisParameters pv
 
 -- |State being accumulated while iterating the accounts in genesis data.
 -- It is then used to construct the initial block state from genesis.
@@ -118,15 +125,15 @@ initialAccumGenesisState =
 buildGenesisBlockState ::
     forall pv av m.
     (BS.SupportsPersistentState pv m, Types.AccountVersionFor pv ~ av) =>
-    GenesisData.CoreGenesisParameters ->
+    VersionedCoreGenesisParameters pv ->
     GenesisData.GenesisState pv ->
     MTL.ExceptT String m (BS.HashedPersistentBlockState pv, TransactionTable.TransactionTable)
-buildGenesisBlockState GenesisData.CoreGenesisParameters{..} GenesisData.GenesisState{..} = do
+buildGenesisBlockState vcgp GenesisData.GenesisState{..} = do
     -- Iterate the accounts in genesis once and accumulate all relevant information.
     AccumGenesisState{..} <- Vec.ifoldM' accumStateFromGenesisAccounts initialAccumGenesisState genesisAccounts
 
     -- Birk parameters
-    persistentBirkParameters :: BS.PersistentBirkParameters av <- do
+    persistentBirkParameters :: BS.PersistentBirkParameters pv <- do
         _birkActiveBakers <-
             Blob.refMakeFlushed $
                 Bakers.PersistentActiveBakers
@@ -144,10 +151,13 @@ buildGenesisBlockState GenesisData.CoreGenesisParameters{..} GenesisData.Genesis
                 _bakerStakes <- Blob.refMakeFlushed $ Bakers.BakerStakes agsBakerStakes
                 return Bakers.PersistentEpochBakers{_bakerTotalStake = agsStakedTotal, ..}
 
+        let _birkSeedState = case vcgp of
+                CGPV0 GenesisData.CoreGenesisParameters{..} -> Types.initialSeedStateV0 genesisLeadershipElectionNonce genesisEpochLength
+                CGPV1 _ -> Types.initialSeedStateV1 genesisLeadershipElectionNonce
+
         return $
             BS.PersistentBirkParameters
                 { _birkCurrentEpochBakers = _birkNextEpochBakers,
-                  _birkSeedState = Types.initialSeedState genesisLeadershipElectionNonce genesisEpochLength,
                   ..
                 }
 

--- a/concordium-consensus/src/Concordium/Kontrol/Bakers.hs
+++ b/concordium-consensus/src/Concordium/Kontrol/Bakers.hs
@@ -18,7 +18,8 @@ import Lens.Micro.Platform
 
 import Concordium.Types
 import Concordium.Types.Accounts
-import Concordium.Types.SeedState
+import Concordium.Types.Parameters
+import Concordium.Types.SeedState hiding (getSeedState)
 import Concordium.Types.UpdateQueues
 
 import Concordium.GlobalState.BakerInfo
@@ -311,7 +312,8 @@ getSlotBakersP4 ::
     forall m.
     ( BlockStateQuery m,
       PVSupportsDelegation (MPV m),
-      ChainParametersVersionFor (MPV m) ~ 'ChainParametersV1
+      ChainParametersVersionFor (MPV m) ~ 'ChainParametersV1,
+      SeedStateVersionFor (MPV m) ~ 'SeedStateVersion0
     ) =>
     GenesisConfiguration ->
     BlockState m ->
@@ -320,7 +322,7 @@ getSlotBakersP4 ::
 getSlotBakersP4 genData bs slot = do
     SeedState{epochLength, epoch = blockEpoch} <- getSeedState bs
     let epochToSlot :: Epoch -> Slot
-        epochToSlot e = fromIntegral e * epochLength
+        epochToSlot e = fromIntegral e * (epochLength ^. unconditionally)
     nextPayday <- getPaydayEpoch bs
     let nextPaydaySlot = epochToSlot nextPayday
 
@@ -417,14 +419,15 @@ getSlotBakers genData = case protocolVersion @(MPV m) of
 getDefiniteSlotBakersP1 ::
     forall m.
     ( BlockStateQuery m,
-      AccountVersionFor (MPV m) ~ 'AccountV0
+      AccountVersionFor (MPV m) ~ 'AccountV0,
+      SeedStateVersionFor (MPV m) ~ 'SeedStateVersion0
     ) =>
     BlockState m ->
     Slot ->
     m (Maybe FullBakers)
 getDefiniteSlotBakersP1 bs slot = do
     SeedState{..} <- getSeedState bs
-    let slotEpoch = fromIntegral $ slot `quot` epochLength
+    let slotEpoch = fromIntegral $ slot `quot` (epochLength ^. unconditionally)
     if slotEpoch <= epoch + 1
         then Just <$> getSlotBakersP1 bs slot
         else return Nothing
@@ -446,7 +449,8 @@ getDefiniteSlotBakersP4 ::
     forall m.
     ( BlockStateQuery m,
       PVSupportsDelegation (MPV m),
-      ChainParametersVersionFor (MPV m) ~ 'ChainParametersV1
+      ChainParametersVersionFor (MPV m) ~ 'ChainParametersV1,
+      SeedStateVersionFor (MPV m) ~ 'SeedStateVersion0
     ) =>
     GenesisConfiguration ->
     BlockState m ->
@@ -455,7 +459,7 @@ getDefiniteSlotBakersP4 ::
 getDefiniteSlotBakersP4 genData bs slot = do
     SeedState{epochLength, epoch = blockEpoch} <- getSeedState bs
     let epochToSlot :: Epoch -> Slot
-        epochToSlot e = fromIntegral e * epochLength
+        epochToSlot e = fromIntegral e * (epochLength ^. unconditionally)
     nextPayday <- getPaydayEpoch bs
     let nextPaydaySlot = epochToSlot nextPayday
 

--- a/concordium-consensus/src/Concordium/Kontrol/Bakers.hs
+++ b/concordium-consensus/src/Concordium/Kontrol/Bakers.hs
@@ -19,7 +19,7 @@ import Lens.Micro.Platform
 import Concordium.Types
 import Concordium.Types.Accounts
 import Concordium.Types.Parameters
-import Concordium.Types.SeedState hiding (getSeedState)
+import Concordium.Types.SeedState
 import Concordium.Types.UpdateQueues
 
 import Concordium.GlobalState.BakerInfo

--- a/concordium-consensus/src/Concordium/ProtocolUpdate/P1/ProtocolP2.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/P1/ProtocolP2.hs
@@ -97,7 +97,7 @@ updateRegenesis = do
     oldSeedState <- bsoGetSeedState s0
     s1 <-
         bsoSetSeedState s0
-            $ initialSeedState
+            $ initialSeedStateV0
                 (SHA256.hash $ "Regenesis" <> encode (updatedNonce oldSeedState))
             $ gdEpochLength gd
     -- Clear the protocol update.

--- a/concordium-consensus/src/Concordium/ProtocolUpdate/P1/Reboot.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/P1/Reboot.hs
@@ -137,7 +137,7 @@ updateRegenesis UpdateData{..} = do
     oldSeedState <- bsoGetSeedState s0
     s1 <-
         bsoSetSeedState s0 $
-            initialSeedState
+            initialSeedStateV0
                 (SHA256.hash $ "Regenesis" <> encode (updatedNonce oldSeedState))
                 updateEpochLength
     -- Overwrite the election difficulty.

--- a/concordium-consensus/src/Concordium/ProtocolUpdate/P2/ProtocolP3.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/P2/ProtocolP3.hs
@@ -99,7 +99,7 @@ updateRegenesis = do
     oldSeedState <- bsoGetSeedState s0
     s1 <-
         bsoSetSeedState s0
-            $ initialSeedState
+            $ initialSeedStateV0
                 (SHA256.hash $ "Regenesis" <> encode (updatedNonce oldSeedState))
             $ gdEpochLength gd
     -- Clear the protocol update.

--- a/concordium-consensus/src/Concordium/ProtocolUpdate/P3/ProtocolP4.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/P3/ProtocolP4.hs
@@ -105,7 +105,7 @@ updateRegenesis updateData = do
     oldSeedState <- bsoGetSeedState s0
     s1 <-
         bsoSetSeedState s0
-            $ initialSeedState
+            $ initialSeedStateV0
                 (SHA256.hash $ "Regenesis" <> encode (updatedNonce oldSeedState))
             $ gdEpochLength gd
     -- Clear the protocol update.

--- a/concordium-consensus/src/Concordium/ProtocolUpdate/P4/ProtocolP5.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/P4/ProtocolP5.hs
@@ -102,7 +102,7 @@ updateRegenesis = do
     oldSeedState <- bsoGetSeedState s0
     s1 <-
         bsoSetSeedState s0
-            $ initialSeedState
+            $ initialSeedStateV0
                 (SHA256.hash $ "Regenesis" <> encode (updatedNonce oldSeedState))
             $ gdEpochLength gd
     -- Clear the protocol update.

--- a/concordium-consensus/src/Concordium/Skov/Monad.hs
+++ b/concordium-consensus/src/Concordium/Skov/Monad.hs
@@ -136,9 +136,6 @@ transactionVerificationResultToUpdateResult (TV.NotOk (TV.NormalTransactionDupli
 transactionVerificationResultToUpdateResult (TV.NotOk TV.Expired) = ResultStale
 transactionVerificationResultToUpdateResult (TV.NotOk TV.InvalidPayloadSize) = ResultSerializationFail
 
-type IsConsensusV0 (pv :: ProtocolVersion) =
-    ConsensusParametersVersionFor (ChainParametersVersionFor pv) ~ 'ConsensusParametersVersion0
-
 class
     ( Monad m,
       Eq (BlockPointerType m),
@@ -450,7 +447,7 @@ deriving via (MGSTrans SkovQueryMonadT m) instance TimeMonad m => TimeMonad (Sko
 instance
     ( TS.TreeStateMonad m,
       TimeMonad m,
-      ConsensusParametersVersionFor (ChainParametersVersionFor (MPV m)) ~ 'ConsensusParametersVersion0
+      IsConsensusV0 (MPV m)
     ) =>
     SkovQueryMonad (SkovQueryMonadT m)
     where

--- a/concordium-consensus/src/Concordium/Skov/MonadImplementations.hs
+++ b/concordium-consensus/src/Concordium/Skov/MonadImplementations.hs
@@ -23,6 +23,7 @@ import Lens.Micro.Platform
 
 import Concordium.Genesis.Data
 import Concordium.Types
+import Concordium.Types.Parameters
 
 import Concordium.Afgjort.Buffer
 import Concordium.Afgjort.FinalizationQueue

--- a/concordium-consensus/test-runners/app/Main.hs
+++ b/concordium-consensus/test-runners/app/Main.hs
@@ -342,7 +342,7 @@ main = do
                         }
                 }
     let (genesisData, bakerIdentities, _) =
-            makeGenesisData @PV
+            makeGenesisDataV0 @PV
                 now
                 numberOfBakers
                 2000

--- a/concordium-consensus/test-runners/catchup/Main.hs
+++ b/concordium-consensus/test-runners/catchup/Main.hs
@@ -371,7 +371,7 @@ main = do
                         }
                 }
     let (genesisData, bakerIdentities, _) =
-            makeGenesisData @PV
+            makeGenesisDataV0 @PV
                 now
                 numberOfBakers
                 2000

--- a/concordium-consensus/test-runners/deterministic/Main.hs
+++ b/concordium-consensus/test-runners/deterministic/Main.hs
@@ -296,7 +296,7 @@ initialState numAccts = do
     -- The slot duration is set to 'ticksPerSlot' seconds, since the deterministic time
     -- advances 1 second per tick and baking is set to occur once every 'ticksPerSlot' ticks.
     (genData, bakers, _) =
-        makeGenesisData
+        makeGenesisDataV0
             0 -- Start at time 0, to match time
             (maxBakerId + 1) -- Number of bakers
             (ticksPerSlot * 1000) -- Slot time is 100 seconds, for baking blocks every 100 ticks

--- a/concordium-consensus/tests/consensus/ConcordiumTests/FinalizationRecover.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/FinalizationRecover.hs
@@ -41,7 +41,7 @@ makeGlobalStateConfig tempDir rt = GlobalStateConfig rt tempDir (tempDir </> "da
 
 genesis :: Word -> (GenesisData PV, [(BakerIdentity, FullBakerInfo)], Amount)
 genesis nBakers =
-    makeGenesisData
+    makeGenesisDataV0
         0
         nBakers
         1000

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/AccountReleaseScheduleTest.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/AccountReleaseScheduleTest.hs
@@ -27,7 +27,7 @@ import qualified Concordium.Crypto.SHA256 as Hash
 import Concordium.GlobalState.Persistent.Account (PersistentAccount (..))
 import qualified Concordium.GlobalState.Persistent.Account as BS
 import Concordium.GlobalState.Persistent.Account.StructureV1
-import Concordium.Types.SeedState (initialSeedState)
+import Concordium.Types.SeedState (initialSeedStateV0)
 import Test.HUnit
 import Test.Hspec
 import Test.QuickCheck
@@ -72,7 +72,7 @@ createGS = do
     initState <-
         PBS.hpbsPointers
             <$> PBS.initialPersistentState
-                (initialSeedState (Hash.hash "") 1_000)
+                (initialSeedStateV0 (Hash.hash "") 1_000)
                 dummyCryptographicParameters
                 [acc0, acc1]
                 dummyIdentityProviders

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/Updates.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/Updates.hs
@@ -43,7 +43,7 @@ import qualified Concordium.GlobalState.Persistent.BlockState.Updates as PU
 import Concordium.ID.DummyData
 import Concordium.ID.Parameters
 import Concordium.Types.DummyData
-import Concordium.Types.SeedState (initialSeedState)
+import Concordium.Types.SeedState (initialSeedStateV0)
 import Test.HUnit (assertEqual)
 
 --------------------------------------------------------------------------------
@@ -70,7 +70,7 @@ createGS :: ThisMonadConcrete PV (PBS.PersistentBlockState PV)
 createGS = do
     PBS.hpbsPointers
         <$> PBS.initialPersistentState
-            (initialSeedState (Hash.hash "") 1_000)
+            (initialSeedStateV0 (Hash.hash "") 1_000)
             dummyCryptographicParameters
             []
             dummyIdentityProviders

--- a/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
@@ -32,7 +32,8 @@ import qualified Concordium.Crypto.SHA256 as Hash
 import qualified Concordium.ID.Types as Types
 import qualified Concordium.Types.Accounts as Types
 import qualified Concordium.Types.Accounts.Releases as Types
-import Concordium.Types.SeedState (initialSeedState)
+import qualified Concordium.Types.Parameters as Types
+import Concordium.Types.SeedState (initialSeedStateV0, initialSeedStateV1)
 import qualified Concordium.Wasm as Wasm
 
 import qualified Concordium.Common.Time as Time
@@ -138,7 +139,7 @@ createTestBlockStateWithAccounts ::
     PersistentBSM pv (BS.HashedPersistentBlockState pv)
 createTestBlockStateWithAccounts accounts =
     BS.initialPersistentState
-        (initialSeedState (Hash.hash "") 1_000)
+        seedState
         DummyData.dummyCryptographicParameters
         accounts
         DummyData.dummyIdentityProviders
@@ -147,6 +148,9 @@ createTestBlockStateWithAccounts accounts =
         DummyData.dummyChainParameters
   where
     keys = Types.withIsAuthorizationsVersionForPV (Types.protocolVersion @pv) $ DummyData.dummyKeyCollection
+    seedState = case Types.consensusVersionFor (Types.protocolVersion @pv) of
+        Types.ConsensusV0 -> initialSeedStateV0 (Hash.hash "") 1_000
+        Types.ConsensusV1 -> initialSeedStateV1 (Hash.hash "")
 
 -- |Construct a test block state containing the provided accounts.
 createTestBlockStateWithAccountsM ::

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -566,6 +566,7 @@ version = "0.1.0"
 dependencies = [
  "aggregate_sig",
  "anyhow",
+ "bs58",
  "byteorder",
  "chrono",
  "concordium-contracts-common",
@@ -580,6 +581,7 @@ dependencies = [
  "hex",
  "id",
  "itertools",
+ "leb128",
  "libc",
  "num",
  "num-bigint 0.4.3",


### PR DESCRIPTION
## Purpose

Depends on: https://github.com/Concordium/concordium-base/pull/320
Addresses: https://github.com/Concordium/concordium-node/issues/731

This handles the changes to the core genesis parameters to support the new consensus. In particular, the parametrisation of `SeedState`.

## Changes

- Move `IsConsensusV0` and `IsConsensusV1` into base.
- Operations for handling block state initialisation at genesis and migration are adapted to support the changed core genesis parameters and seed state.
- Operations for updating the seed state, getting slot bakers and minting are constrained to consensus version 0.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
