### PR TITLE
Fix catchup message labelling

### DIFF
--- a/concordium-node/src/consensus_ffi/helpers.rs
+++ b/concordium-node/src/consensus_ffi/helpers.rs
@@ -265,11 +265,9 @@ impl ConsensusFfiResponse {
     /// Get the label. This is used when updating metrics of the prometheus
     /// exporter.
     pub fn label(&self) -> &str {
-        if self.is_successful() {
+        if self.is_successful() || matches!(self, Self::ContinueCatchUp) {
             "valid"
-        } else if let ConsensusFfiResponse::ContinueCatchUp = self {
-            "valid"
-        } else if let ConsensusFfiResponse::DuplicateEntry = self {
+        } else if let Self::DuplicateEntry = self {
             "duplicate"
         } else {
             "invalid"

--- a/concordium-node/src/consensus_ffi/helpers.rs
+++ b/concordium-node/src/consensus_ffi/helpers.rs
@@ -267,6 +267,8 @@ impl ConsensusFfiResponse {
     pub fn label(&self) -> &str {
         if self.is_successful() {
             "valid"
+        } else if let ConsensusFfiResponse::ContinueCatchUp = self {
+            "valid"
         } else if let ConsensusFfiResponse::DuplicateEntry = self {
             "duplicate"
         } else {


### PR DESCRIPTION
## Purpose

Fixes https://github.com/Concordium/concordium-node/issues/764

## Changes

Label consensus ffi responses ContinueCatchUp as a valid message in prometheus metrics.

