### PR TITLE
Extend prometheus exporter with grpc_in_flight_requests metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased changes
 
-- Extend Prometheus exporter with metrics: `grpc_request_duration_seconds` see [docs/prometheus-exporter.md](https://github.com/Concordium/concordium-node/blob/main/docs/prometheus-exporter.md) for more details.
+- Extend Prometheus exporter with metrics: `grpc_request_duration_seconds` and `grpc_pending_requests` see [docs/prometheus-exporter.md](https://github.com/Concordium/concordium-node/blob/main/docs/prometheus-exporter.md) for more details.
 
 ## 5.2.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased changes
 
-- Extend Prometheus exporter with metrics: `grpc_request_duration_seconds` and `grpc_pending_requests` see [docs/prometheus-exporter.md](https://github.com/Concordium/concordium-node/blob/main/docs/prometheus-exporter.md) for more details.
+- Extend Prometheus exporter with metrics: `grpc_request_duration_seconds` and `grpc_in_flight_requests` see [docs/prometheus-exporter.md](https://github.com/Concordium/concordium-node/blob/main/docs/prometheus-exporter.md) for more details.
 
 ## 5.2.4
 

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -4241,6 +4241,7 @@ dependencies = [
  "http-body",
  "http-range-header",
  "pin-project-lite",
+ "tokio",
  "tower",
  "tower-layer",
  "tower-service",

--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -78,7 +78,7 @@ hyper = { version = "0.14" }
 # gRPC dependencies
 tonic = { version = "0.8", features = ["tls"] }
 tonic-reflection = "0.5"
-tower-http = { version = "0.4", features = ["trace"] }
+tower-http = { version = "0.4", features = ["trace", "metrics"] }
 tower = "0.4"
 tonic-web = "0.4"
 prost = "0.11"

--- a/concordium-node/src/grpc2.rs
+++ b/concordium-node/src/grpc2.rs
@@ -948,8 +948,13 @@ pub mod server {
                 let stats_layer = StatsLayer {
                     stats: node.stats.clone(),
                 };
-                let mut builder =
-                    tonic::transport::Server::builder().layer(log_layer).layer(stats_layer);
+                let in_flight_request_layer = tower_http::metrics::InFlightRequestsLayer::new(
+                    node.stats.grpc_pending_requests_counter.clone(),
+                );
+                let mut builder = tonic::transport::Server::builder()
+                    .layer(log_layer)
+                    .layer(in_flight_request_layer)
+                    .layer(stats_layer);
                 if let Some(identity) = identity {
                     builder = builder
                         .tls_config(ServerTlsConfig::new().identity(identity))

--- a/concordium-node/src/grpc2.rs
+++ b/concordium-node/src/grpc2.rs
@@ -949,7 +949,7 @@ pub mod server {
                     stats: node.stats.clone(),
                 };
                 let in_flight_request_layer = tower_http::metrics::InFlightRequestsLayer::new(
-                    node.stats.grpc_pending_requests_counter.clone(),
+                    node.stats.grpc_in_flight_requests_counter.clone(),
                 );
                 let mut builder = tonic::transport::Server::builder()
                     .layer(log_layer)

--- a/concordium-node/src/stats_export_service.rs
+++ b/concordium-node/src/stats_export_service.rs
@@ -19,6 +19,7 @@ use prometheus::{
     TextEncoder,
 };
 use std::{net::SocketAddr, sync::RwLock, thread, time};
+use tower_http::metrics::in_flight_requests::InFlightRequestsCounter;
 
 use crate::configuration;
 use std::sync::Arc;
@@ -41,6 +42,27 @@ impl PrometheusStateData {
         Self {
             registry: Arc::new(RwLock::new(registry)),
         }
+    }
+}
+
+/// Wrapper for implementing the prometheus::Collector trait for
+/// InFlightRequestsCounter, which syncs the prometheus gauge with the counter
+/// on scrape.
+struct GrpcInFlightRequestsCollector {
+    /// The prometheus gauge exposed.
+    pub gauge:   IntGauge,
+    /// Counter used to track in flight requests by
+    /// `tower_http::metrics::InFlightRequestsLayer`.
+    pub counter: InFlightRequestsCounter,
+}
+
+impl prometheus::core::Collector for GrpcInFlightRequestsCollector {
+    fn desc(&self) -> Vec<&prometheus::core::Desc> { self.gauge.desc() }
+
+    fn collect(&self) -> Vec<prometheus::proto::MetricFamily> {
+        let in_flight_requests = self.counter.get();
+        self.gauge.set(in_flight_requests as i64);
+        self.gauge.collect()
     }
 }
 
@@ -116,6 +138,11 @@ pub struct StatsExportService {
     /// gRPC method name (`method=<name>`) and the gRPC response status
     /// (`status=<status>`).
     pub grpc_request_response_time: HistogramVec,
+    /// Counter for tracking inflight requests.
+    /// This is passed to the Tower layer `InFlightRequestLayer` provided by
+    /// `tower_http::metrics` and then synced with the prometheus gauge on each
+    /// scrape.
+    pub grpc_pending_requests_counter: InFlightRequestsCounter,
     /// Total number of bytes received at the point of last
     /// throughput_measurement.
     ///
@@ -299,6 +326,17 @@ impl StatsExportService {
         )?;
         registry.register(Box::new(grpc_request_response_time.clone()))?;
 
+        let grpc_pending_requests_gauge = IntGauge::with_opts(Opts::new(
+            "grpc_pending_requests",
+            "Current number of gRPC requests being handled by the node",
+        ))?;
+        let grpc_pending_requests_counter = InFlightRequestsCounter::new();
+        let grpc_pending_requests = GrpcInFlightRequestsCollector {
+            gauge:   grpc_pending_requests_gauge,
+            counter: grpc_pending_requests_counter.clone(),
+        };
+        registry.register(Box::new(grpc_pending_requests))?;
+
         let last_throughput_measurement_timestamp = AtomicI64::new(0);
         let last_throughput_measurement_sent_bytes = AtomicU64::new(0);
         let last_throughput_measurement_received_bytes = AtomicU64::new(0);
@@ -328,6 +366,7 @@ impl StatsExportService {
             node_info,
             node_startup_timestamp,
             grpc_request_response_time,
+            grpc_pending_requests_counter,
             last_throughput_measurement_timestamp,
             last_throughput_measurement_sent_bytes,
             last_throughput_measurement_received_bytes,

--- a/concordium-node/src/stats_export_service.rs
+++ b/concordium-node/src/stats_export_service.rs
@@ -51,10 +51,10 @@ impl PrometheusStateData {
 /// on scrape.
 struct GrpcInFlightRequestsCollector {
     /// The prometheus gauge exposed.
-    pub gauge:   IntGauge,
+    gauge:   IntGauge,
     /// Counter used to track in flight requests by
     /// `tower_http::metrics::InFlightRequestsLayer`.
-    pub counter: InFlightRequestsCounter,
+    counter: InFlightRequestsCounter,
 }
 
 impl prometheus::core::Collector for GrpcInFlightRequestsCollector {

--- a/concordium-node/src/stats_export_service.rs
+++ b/concordium-node/src/stats_export_service.rs
@@ -1,6 +1,6 @@
 //! Node's statistics and their exposure.
 
-use crate::{common::p2p_node_id::P2PNodeId, read_or_die, spawn_or_die};
+use crate::{common::p2p_node_id::P2PNodeId, configuration, read_or_die, spawn_or_die};
 use anyhow::Context;
 use gotham::{
     handler::IntoResponse,
@@ -18,11 +18,12 @@ use prometheus::{
     Encoder, HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGauge, Opts, Registry,
     TextEncoder,
 };
-use std::{net::SocketAddr, sync::RwLock, thread, time};
+use std::{
+    net::SocketAddr,
+    sync::{Arc, RwLock},
+    thread, time,
+};
 use tower_http::metrics::in_flight_requests::InFlightRequestsCounter;
-
-use crate::configuration;
-use std::sync::Arc;
 
 struct HTMLStringResponse(pub String);
 

--- a/concordium-node/src/stats_export_service.rs
+++ b/concordium-node/src/stats_export_service.rs
@@ -142,7 +142,7 @@ pub struct StatsExportService {
     /// This is passed to the Tower layer `InFlightRequestLayer` provided by
     /// `tower_http::metrics` and then synced with the prometheus gauge on each
     /// scrape.
-    pub grpc_pending_requests_counter: InFlightRequestsCounter,
+    pub grpc_in_flight_requests_counter: InFlightRequestsCounter,
     /// Total number of bytes received at the point of last
     /// throughput_measurement.
     ///
@@ -326,16 +326,16 @@ impl StatsExportService {
         )?;
         registry.register(Box::new(grpc_request_response_time.clone()))?;
 
-        let grpc_pending_requests_gauge = IntGauge::with_opts(Opts::new(
-            "grpc_pending_requests",
+        let grpc_in_flight_requests_gauge = IntGauge::with_opts(Opts::new(
+            "grpc_in_flight_requests",
             "Current number of gRPC requests being handled by the node",
         ))?;
-        let grpc_pending_requests_counter = InFlightRequestsCounter::new();
-        let grpc_pending_requests = GrpcInFlightRequestsCollector {
-            gauge:   grpc_pending_requests_gauge,
-            counter: grpc_pending_requests_counter.clone(),
+        let grpc_in_flight_requests_counter = InFlightRequestsCounter::new();
+        let grpc_in_flight_requests = GrpcInFlightRequestsCollector {
+            gauge:   grpc_in_flight_requests_gauge,
+            counter: grpc_in_flight_requests_counter.clone(),
         };
-        registry.register(Box::new(grpc_pending_requests))?;
+        registry.register(Box::new(grpc_in_flight_requests))?;
 
         let last_throughput_measurement_timestamp = AtomicI64::new(0);
         let last_throughput_measurement_sent_bytes = AtomicU64::new(0);
@@ -366,7 +366,7 @@ impl StatsExportService {
             node_info,
             node_startup_timestamp,
             grpc_request_response_time,
-            grpc_pending_requests_counter,
+            grpc_in_flight_requests_counter,
             last_throughput_measurement_timestamp,
             last_throughput_measurement_sent_bytes,
             last_throughput_measurement_received_bytes,

--- a/docs/prometheus-exporter.md
+++ b/docs/prometheus-exporter.md
@@ -181,7 +181,7 @@ Possible values of `status` are:
 - `"data loss"` Unrecoverable data loss or corruption.
 - `"unauthenticated"` The request does not have valid authentication credentials.
 
-### `grpc_pending_requests`
+### `grpc_in_flight_requests`
 
 Current number of gRPC requests being handled by the node.
-Streaming gRPC methods are counted as pending until the response stream is closed.
+Streaming gRPC methods are counted as in flight until the response stream is closed.

--- a/docs/prometheus-exporter.md
+++ b/docs/prometheus-exporter.md
@@ -180,3 +180,8 @@ Possible values of `status` are:
 - `"unavailable"` The service is currently unavailable.
 - `"data loss"` Unrecoverable data loss or corruption.
 - `"unauthenticated"` The request does not have valid authentication credentials.
+
+### `grpc_pending_requests`
+
+Current number of gRPC requests being handled by the node.
+Streaming gRPC methods are counted as pending until the response stream is closed.


### PR DESCRIPTION
## Purpose

Related to #755.

## Changes

- Extend Prometheus exporter with `grpc_in_flight_requests` metric.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
