### PR TITLE
Extend metrics with committee status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased changes
 
-- Extend Prometheus exporter with metrics: `grpc_request_duration_seconds`, `grpc_in_flight_requests` and `consensus_baking_committee` see [docs/prometheus-exporter.md](https://github.com/Concordium/concordium-node/blob/main/docs/prometheus-exporter.md) for more details.
+- Extend Prometheus exporter with metrics: `grpc_request_duration_seconds`, `grpc_in_flight_requests`, `consensus_baking_committee` and `consensus_finalization_committee` see [docs/prometheus-exporter.md](https://github.com/Concordium/concordium-node/blob/main/docs/prometheus-exporter.md) for more details.
 
 ## 5.2.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased changes
 
-- Extend Prometheus exporter with metrics: `grpc_request_duration_seconds` and `grpc_in_flight_requests` see [docs/prometheus-exporter.md](https://github.com/Concordium/concordium-node/blob/main/docs/prometheus-exporter.md) for more details.
+- Extend Prometheus exporter with metrics: `grpc_request_duration_seconds`, `grpc_in_flight_requests` and `consensus_baking_committee` see [docs/prometheus-exporter.md](https://github.com/Concordium/concordium-node/blob/main/docs/prometheus-exporter.md) for more details.
 
 ## 5.2.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased changes
 
-- Extend Prometheus exporter with metrics: `grpc_request_duration_seconds`, `grpc_in_flight_requests`, `consensus_baking_committee` and `consensus_finalization_committee` see [docs/prometheus-exporter.md](https://github.com/Concordium/concordium-node/blob/main/docs/prometheus-exporter.md) for more details.
+- Extend Prometheus exporter with metrics: `grpc_request_duration_seconds`, `grpc_in_flight_requests`, `consensus_baking_committee`, `consensus_finalization_committee` and `network_soft_banned_peers_total` see [docs/prometheus-exporter.md](https://github.com/Concordium/concordium-node/blob/main/docs/prometheus-exporter.md) for more details.
 
 ## 5.2.4
 

--- a/concordium-node/src/consensus_ffi/helpers.rs
+++ b/concordium-node/src/consensus_ffi/helpers.rs
@@ -336,36 +336,10 @@ impl TryFrom<i64> for ConsensusFfiResponse {
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum ConsensusIsInBakingCommitteeResponse {
-    ActiveInCommittee,
+    ActiveInCommittee = 0,
     NotInCommittee,
     AddedButNotActiveInCommittee,
     AddedButWrongKeys,
-}
-
-impl ConsensusIsInBakingCommitteeResponse {
-    /// Get the label. This is used when updating metrics of the prometheus
-    /// exporter.
-    pub fn label(&self) -> &'static str {
-        use ConsensusIsInBakingCommitteeResponse::*;
-        match self {
-            ActiveInCommittee => "active_in_committee",
-            NotInCommittee => "not_in_committee",
-            AddedButNotActiveInCommittee => "added_but_not_active_in_committee",
-            AddedButWrongKeys => "added_but_wrong_keys",
-        }
-    }
-
-    /// Get all possible labels. This is used to reset when updating metrics of
-    /// the prometheus exporter.
-    pub fn labels() -> [&'static str; 4] {
-        use ConsensusIsInBakingCommitteeResponse::*;
-        [
-            ActiveInCommittee.label(),
-            NotInCommittee.label(),
-            AddedButNotActiveInCommittee.label(),
-            AddedButWrongKeys.label(),
-        ]
-    }
 }
 
 impl TryFrom<u8> for ConsensusIsInBakingCommitteeResponse {

--- a/concordium-node/src/consensus_ffi/helpers.rs
+++ b/concordium-node/src/consensus_ffi/helpers.rs
@@ -345,7 +345,7 @@ pub enum ConsensusIsInBakingCommitteeResponse {
 impl ConsensusIsInBakingCommitteeResponse {
     /// Get the label. This is used when updating metrics of the prometheus
     /// exporter.
-    pub fn label(&self) -> &str {
+    pub fn label(&self) -> &'static str {
         use ConsensusIsInBakingCommitteeResponse::*;
         match self {
             ActiveInCommittee => "active_in_committee",
@@ -357,12 +357,13 @@ impl ConsensusIsInBakingCommitteeResponse {
 
     /// Get all possible labels. This is used to reset when updating metrics of
     /// the prometheus exporter.
-    pub const fn labels() -> &'static [&'static str] {
-        &[
-            "active_in_committee",
-            "not_in_committee",
-            "added_but_not_active_in_committee",
-            "added_but_wrong_keys",
+    pub fn labels() -> [&'static str; 4] {
+        use ConsensusIsInBakingCommitteeResponse::*;
+        [
+            ActiveInCommittee.label(),
+            NotInCommittee.label(),
+            AddedButNotActiveInCommittee.label(),
+            AddedButWrongKeys.label(),
         ]
     }
 }

--- a/concordium-node/src/consensus_ffi/helpers.rs
+++ b/concordium-node/src/consensus_ffi/helpers.rs
@@ -342,6 +342,31 @@ pub enum ConsensusIsInBakingCommitteeResponse {
     AddedButWrongKeys,
 }
 
+impl ConsensusIsInBakingCommitteeResponse {
+    /// Get the label. This is used when updating metrics of the prometheus
+    /// exporter.
+    pub fn label(&self) -> &str {
+        use ConsensusIsInBakingCommitteeResponse::*;
+        match self {
+            ActiveInCommittee => "active_in_committee",
+            NotInCommittee => "not_in_committee",
+            AddedButNotActiveInCommittee => "added_but_not_active_in_committee",
+            AddedButWrongKeys => "added_but_wrong_keys",
+        }
+    }
+
+    /// Get all possible labels. This is used to reset when updating metrics of
+    /// the prometheus exporter.
+    pub const fn labels() -> &'static [&'static str] {
+        &[
+            "active_in_committee",
+            "not_in_committee",
+            "added_but_not_active_in_committee",
+            "added_but_wrong_keys",
+        ]
+    }
+}
+
 impl TryFrom<u8> for ConsensusIsInBakingCommitteeResponse {
     type Error = anyhow::Error;
 

--- a/concordium-node/src/p2p/connectivity.rs
+++ b/concordium-node/src/p2p/connectivity.rs
@@ -527,6 +527,7 @@ pub fn connect(
                     Instant::now() + Duration::from_secs(config::UNREACHABLE_EXPIRATION_SECS),
                 );
                 node.stats.soft_banned_peers.inc();
+                node.stats.soft_banned_peers_total.inc();
             }
             bail!(e)
         }

--- a/concordium-node/src/p2p/maintenance.rs
+++ b/concordium-node/src/p2p/maintenance.rs
@@ -839,6 +839,7 @@ fn process_conn_change(node: &Arc<P2PNode>, conn_change: ConnChange) {
                     Instant::now() + Duration::from_secs(config::SOFT_BAN_DURATION_SECS),
                 );
                 node.stats.soft_banned_peers.inc();
+                node.stats.soft_banned_peers_total.inc();
             }
         }
         ConnChange::RemovalByToken(token) => {

--- a/concordium-node/src/stats_export_service.rs
+++ b/concordium-node/src/stats_export_service.rs
@@ -86,7 +86,9 @@ impl StatsConsensusCollector {
         let baking_committee = IntGaugeVec::new(
             Opts::new(
                 "consensus_baking_committee",
-                "The baking commmittee status of the node for the current best block",
+                "The baking commmittee status of the node for the current best block, labelled \
+                 with the status where the only metric with value of 1 represents the current \
+                 status",
             )
             .variable_label("status"),
             &["status"],

--- a/concordium-node/src/stats_export_service.rs
+++ b/concordium-node/src/stats_export_service.rs
@@ -80,7 +80,7 @@ pub struct StatsConsensusCollector {
     /// The baking committee status of the node for the current best block.
     baking_committee:       IntGaugeVec,
     /// Whether the node is a member of the finalization committee for the
-    /// current best block.
+    /// current finalization round.
     finalization_committee: IntGauge,
 }
 
@@ -99,8 +99,8 @@ impl StatsConsensusCollector {
 
         let finalization_committee = IntGauge::with_opts(Opts::new(
             "consensus_finalization_committee",
-            "The finalization commmittee status of the node for the current best block. The \
-             metric will have a value of 1 when member of the finalization committee",
+            "The finalization commmittee status of the node for the current finalization round. \
+             The metric will have a value of 1 when member of the finalization committee",
         ))?;
 
         Ok(Self {

--- a/concordium-node/src/stats_export_service.rs
+++ b/concordium-node/src/stats_export_service.rs
@@ -206,6 +206,8 @@ pub struct StatsExportService {
     pub sent_consensus_messages: IntCounterVec,
     /// Current number of soft banned peers.
     pub soft_banned_peers: IntGauge,
+    /// The total number of soft banned peers since startup.
+    pub soft_banned_peers_total: IntCounter,
     /// Total number of peers connected since startup.
     pub total_peers: IntCounter,
     /// Information of the node software. Contains a label `version` with the
@@ -368,6 +370,12 @@ impl StatsExportService {
         ))?;
         registry.register(Box::new(soft_banned_peers.clone()))?;
 
+        let soft_banned_peers_total = IntCounter::with_opts(Opts::new(
+            "network_soft_banned_peers_total",
+            "Total number of soft banned peers since startup",
+        ))?;
+        registry.register(Box::new(soft_banned_peers_total.clone()))?;
+
         let total_peers = IntCounter::with_opts(Opts::new(
             "network_peers_total",
             "Total number of peers since startup",
@@ -441,6 +449,7 @@ impl StatsExportService {
             received_consensus_messages,
             sent_consensus_messages,
             soft_banned_peers,
+            soft_banned_peers_total,
             total_peers,
             node_info,
             node_startup_timestamp,

--- a/docs/prometheus-exporter.md
+++ b/docs/prometheus-exporter.md
@@ -192,14 +192,13 @@ Streaming gRPC methods are counted as in flight until the response stream is clo
 
 ### `consensus_baking_committee`
 
-The baking committee status of the node at the current best block.
-Provides the status using a label (`status=<status>`) with the value of 1 for the status matching the current state and 0 for all other states.
+The baking committee status of the node for the current best block.
 
-Possible values of `status` are:
-- `"active_in_committee"` The node is in the baking committee and is actively baking.
-- `"not_in_committee"` The node is not in the baking committee.
-- `"added_but_not_active_in_committee"` The node is added to the upcoming the baking committee, and is not baking actively yet.
-- `"added_but_wrong_keys"` The node is setup with baker keys not matching the keys currently registered in the baking committee.
+The value is mapped to a status:
+- `0` The node is in the baking committee and is actively baking.
+- `1` The node is not in the baking committee.
+- `2` The node is added to the upcoming the baking committee, and is not baking actively yet.
+- `3` The node is setup with baker keys not matching the keys currently registered in the baking committee.
 
 ### `consensus_finalization_committee`
 

--- a/docs/prometheus-exporter.md
+++ b/docs/prometheus-exporter.md
@@ -203,4 +203,4 @@ Possible values of `status` are:
 
 ### `consensus_finalization_committee`
 
-The finalization committee status of the node for the current best block. The metric will have a value of 1 if and only if the node is a member of the finalization committee.
+The finalization committee status of the node for the current finalization round. The metric will have a value of 1 if and only if the node is a member of the finalization committee.

--- a/docs/prometheus-exporter.md
+++ b/docs/prometheus-exporter.md
@@ -185,3 +185,14 @@ Possible values of `status` are:
 
 Current number of gRPC requests being handled by the node.
 Streaming gRPC methods are counted as in flight until the response stream is closed.
+
+### `consensus_baking_committee`
+
+The baking committee status of the node at the current best block.
+Provides the status using a label (`status=<status>`) with the value of 1 for the status matching the current state and 0 for all other states.
+
+Possible values of `status` are:
+- `"active_in_committee"` The node is in the baking committee and is actively baking.
+- `"not_in_committee"` The node is not in the baking committee.
+- `"added_but_not_active_in_committee"` The node is added to the upcoming the baking committee, and is not baking actively yet.
+- `"added_but_wrong_keys"` The node is setup with baker keys not matching the keys currently registered in the baking committee.

--- a/docs/prometheus-exporter.md
+++ b/docs/prometheus-exporter.md
@@ -137,6 +137,10 @@ Possible values of `message` are:
 
 Current number of soft banned peers. The node temporarily bans peers if they fail to follow the protocol.
 
+### `network_soft_banned_peers_total`
+
+The total number of soft banned peers since startup. The node temporarily bans peers if they fail to follow the protocol.
+
 ### `network_peers_total`
 
 Total number of peers connected since startup.

--- a/docs/prometheus-exporter.md
+++ b/docs/prometheus-exporter.md
@@ -196,3 +196,7 @@ Possible values of `status` are:
 - `"not_in_committee"` The node is not in the baking committee.
 - `"added_but_not_active_in_committee"` The node is added to the upcoming the baking committee, and is not baking actively yet.
 - `"added_but_wrong_keys"` The node is setup with baker keys not matching the keys currently registered in the baking committee.
+
+### `consensus_finalization_committee`
+
+The finalization committee status of the node for the current best block. The metric will have a value of 1 if and only if the node is a member of the finalization committee.


### PR DESCRIPTION
## Purpose

Related to https://github.com/Concordium/concordium-node/issues/755.

## Changes

- Extend Prometheus exporter with metrics exposing the current baking, finalization committee status and the total number of soft-banned peers. 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

