### PR TITLE
Extend metrics with baking lottery power

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased changes
 
-- Extend Prometheus exporter with metrics: `grpc_request_duration_seconds`, `grpc_in_flight_requests`, `consensus_baking_committee`, `consensus_finalization_committee` and `network_soft_banned_peers_total` see [docs/prometheus-exporter.md](https://github.com/Concordium/concordium-node/blob/main/docs/prometheus-exporter.md) for more details.
+- Extend Prometheus exporter with metrics: `grpc_request_duration_seconds`, `grpc_in_flight_requests`, `consensus_baking_committee`, `consensus_finalization_committee`, `consensus_baking_lottery_power` and `network_soft_banned_peers_total` see [docs/prometheus-exporter.md](https://github.com/Concordium/concordium-node/blob/main/docs/prometheus-exporter.md) for more details.
 
 ## 5.2.4
 

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -1021,35 +1021,40 @@ data BakerStatus
       AddedButWrongKeys
     deriving (Eq, Ord, Show)
 
--- |Determine the status of the baker with respect to the current best block.
-getBakerStatusBestBlock :: MVR finconf (BakerStatus, Maybe BakerId)
+-- |Determine the status and lottery power of the baker with respect to the current best block.
+getBakerStatusBestBlock :: MVR finconf (BakerStatus, Maybe BakerId, Maybe Double)
 getBakerStatusBestBlock =
     asks mvBaker >>= \case
-        Nothing -> return (NotInCommittee, Nothing)
+        Nothing -> return (NotInCommittee, Nothing, Nothing)
         Just Baker{bakerIdentity = bakerIdent} -> liftSkovQueryLatest $ do
             bb <- bestBlock
             bs <- queryBlockState bb
             bakers <- BS.getCurrentEpochBakers bs
-            bakerStatus <- case fullBaker bakers (bakerId bakerIdent) of
-                Just fbinfo
-                    -- Current baker with valid keys
-                    | validateBakerKeys (fbinfo ^. bakerInfo) bakerIdent ->
-                        return ActiveInComittee
-                    -- Current baker, but invalid keys
-                    | otherwise -> return AddedButWrongKeys
-                Nothing ->
+            (bakerStatus, bakerLotteryPower) <- case fullBaker bakers (bakerId bakerIdent) of
+                Just fbinfo -> do
+                    let status =
+                            if validateBakerKeys (fbinfo ^. bakerInfo) bakerIdent
+                                then -- Current baker with valid keys
+                                    ActiveInComittee
+                                else -- Current baker, but invalid keys
+                                    AddedButWrongKeys
+                    let bakerLotteryPower = fromIntegral (fbinfo ^. bakerStake) / fromIntegral (bakerTotalStake bakers)
+                    return (status, Just bakerLotteryPower)
+                Nothing -> do
                     -- Not a current baker
-                    BS.getBakerAccount bs (bakerId bakerIdent) >>= \case
-                        Just acc ->
-                            -- Account is valid
-                            BS.getAccountBaker acc >>= \case
-                                -- Account has no registered baker
-                                Nothing -> return NotInCommittee
-                                Just ab
-                                    -- Registered baker with valid keys
-                                    | validateBakerKeys (ab ^. accountBakerInfo . bakerInfo) bakerIdent ->
-                                        return AddedButNotActiveInCommittee
-                                    -- Registered baker with invalid keys
-                                    | otherwise -> return AddedButWrongKeys
-                        Nothing -> return NotInCommittee
-            return (bakerStatus, Just $ bakerId bakerIdent)
+                    status <-
+                        BS.getBakerAccount bs (bakerId bakerIdent) >>= \case
+                            Just acc ->
+                                -- Account is valid
+                                BS.getAccountBaker acc >>= \case
+                                    -- Account has no registered baker
+                                    Nothing -> return NotInCommittee
+                                    Just ab
+                                        -- Registered baker with valid keys
+                                        | validateBakerKeys (ab ^. accountBakerInfo . bakerInfo) bakerIdent ->
+                                            return AddedButNotActiveInCommittee
+                                        -- Registered baker with invalid keys
+                                        | otherwise -> return AddedButWrongKeys
+                            Nothing -> return NotInCommittee
+                    return (status, Nothing)
+            return (bakerStatus, Just $ bakerId bakerIdent, bakerLotteryPower)

--- a/concordium-node/src/grpc2.rs
+++ b/concordium-node/src/grpc2.rs
@@ -2078,7 +2078,7 @@ pub mod server {
                         // protocol on the chain.
                         types::node_info::node::ConsensusStatus::NotRunning(types::Empty {})
                     } else if matches!(self.consensus.consensus_type, ConsensusType::Active) {
-                        let (in_baking_committee, _, bid) = self.consensus.in_baking_committee();
+                        let (in_baking_committee, _, bid, _) = self.consensus.in_baking_committee();
                         let baker_id = types::BakerId {
                             value: bid,
                         };

--- a/concordium-node/src/rpc.rs
+++ b/concordium-node/src/rpc.rs
@@ -485,7 +485,7 @@ impl P2p for RpcServerImpl {
             SystemTime::now().duration_since(UNIX_EPOCH).expect("Time went backwards").as_secs();
         Ok(Response::new(match self.consensus {
             Some(ref consensus) => {
-                let (consensus_baking_committee_status, has_baker_id, pre_baker_id) =
+                let (consensus_baking_committee_status, has_baker_id, pre_baker_id, _) =
                     consensus.in_baking_committee();
                 let consensus_baker_id = if has_baker_id {
                     Some(pre_baker_id)

--- a/concordium-node/src/stats_export_service.rs
+++ b/concordium-node/src/stats_export_service.rs
@@ -80,7 +80,7 @@ pub struct StatsConsensusCollector {
     /// Whether the node is a member of the finalization committee for the
     /// current finalization round.
     finalization_committee: IntGauge,
-    /// Current active lottery power. Is only be non-zero when active member of
+    /// Current active lottery power. Is only non-zero when active member of
     /// the baking committee.
     baking_lottery_power:   Gauge,
 }
@@ -101,8 +101,8 @@ impl StatsConsensusCollector {
 
         let baking_lottery_power = Gauge::with_opts(Opts::new(
             "consensus_baking_lottery_power",
-            "Baking lottery power for the current epoch of the best block. Is only be non-zero \
-             when active member of the baking committee.",
+            "Baking lottery power for the current epoch of the best block. Is only non-zero when \
+             active member of the baking committee.",
         ))?;
 
         Ok(Self {

--- a/docs/prometheus-exporter.md
+++ b/docs/prometheus-exporter.md
@@ -203,3 +203,9 @@ The value is mapped to a status:
 ### `consensus_finalization_committee`
 
 The finalization committee status of the node for the current finalization round. The metric will have a value of 1 if and only if the node is a member of the finalization committee.
+
+### `consensus_baking_lottery_power`
+
+Baking lottery power for the current epoch of the best block.
+The value is a number between 0 and 1, and is representing the fraction of baking stake (combined stake of the baker and delegators) to the total baking stake of the baking committee.
+Is only non-zero when active member of the baking committee.


### PR DESCRIPTION
## Purpose

Related to https://github.com/Concordium/concordium-node/issues/755.

## Changes

- Add metric showing the current lottery power of the node. (Is 0 when not baking).

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
