### PR TITLE
Advance epoch

### DIFF
--- a/concordium-consensus/src/Concordium/KonsensusV1/Consensus.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Consensus.hs
@@ -10,6 +10,7 @@ import qualified Data.Vector as Vector
 
 import Lens.Micro.Platform
 
+import qualified Concordium.KonsensusV1.TreeState.LowLevel as LowLevel
 import Concordium.KonsensusV1.TreeState.Implementation
 import Concordium.KonsensusV1.TreeState.Types
 import Concordium.KonsensusV1.Types
@@ -97,3 +98,16 @@ advanceRound newRound timedOut = do
                     then -- If we're a finalizer for the current epoch then we reset the timer
                         resetTimer currentTimeout
                     else return ()
+
+-- |Advance the 'Epoch' of the current 'RoundStatus'.
+--
+-- Advancing epochs in particular carries out the following:
+-- * Updates the 'rsCurrentEpoch' to the provided 'Epoch' for the current 'RoundStatus'.
+-- * Computes the new 'LeadershipElectionNonce' and updates the current 'RoundStatus'.
+-- * Updates the 'rsLatestEpochFinEntry' of the current 'RoundStatus' to @Present finalizationEntry@.
+advanceEpoch :: (MonadState (SkovData (MPV m)) m,
+               LowLevel.MonadTreeStateStore m) => Epoch -> FinalizationEntry ->  m ()
+advanceEpoch newEpoch finalizationEntry = do
+    currentRoundStatus <- use roundStatus
+    
+    return ()

--- a/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Types.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Types.hs
@@ -241,6 +241,32 @@ advanceRoundStatus toRound mTcQc RoundStatus{..} =
         Nothing -> Absent
         Just (tc, qc) -> Present (tc, qc)
 
+-- |Advance the proived 'RoundStatus' to the provided 'Epoch'.
+-- In particular this does the following to the provided 'RoundStatus'
+--
+-- * Set the 'rsCurrentEpoch' to the provied 'Epoch'
+-- * Set the 'rsLatestEpochFinEntry' to the provided 'FinalizationEntry'.
+-- * Set the 'rsLeadershipElectionNonce' to the provided 'LeadershipElectionNonce'.
+advanceRoundStatusEpoch ::
+    -- |The 'Epoch' we advance to.
+    Epoch ->
+    -- |The 'FinalizationEntry' that witnesses the
+    -- new 'Epoch'.
+    FinalizationEntry ->
+    -- |The new leader election nonce.
+    LeadershipElectionNonce ->
+    -- |The 'RoundStatus' we're progressing from.
+    RoundStatus ->
+    -- |The new 'RoundStatus'.
+    RoundStatus
+advanceRoundStatusEpoch toEpoch latestFinalizationEntry newLeadershipElectionNonce RoundStatus{..} =
+    RoundStatus
+        { rsCurrentEpoch = toEpoch,
+          rsLatestEpochFinEntry = Present latestFinalizationEntry,
+          rsLeadershipElectionNonce = newLeadershipElectionNonce,
+          ..
+        }
+
 instance Serialize RoundStatus where
     put RoundStatus{..} = do
         put rsCurrentEpoch

--- a/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Types.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Types.hs
@@ -248,7 +248,7 @@ advanceRoundStatus toRound (Right qc) RoundStatus{..} =
 -- |Advance the proived 'RoundStatus' to the provided 'Epoch'.
 -- In particular this does the following to the provided 'RoundStatus'
 --
--- * Set the 'rsCurrentEpoch' to the provied 'Epoch'
+-- * Set the 'rsCurrentEpoch' to the provided 'Epoch'
 -- * Set the 'rsLatestEpochFinEntry' to the provided 'FinalizationEntry'.
 -- * Set the 'rsLeadershipElectionNonce' to the provided 'LeadershipElectionNonce'.
 advanceRoundStatusEpoch ::

--- a/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Types.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Types.hs
@@ -245,7 +245,7 @@ advanceRoundStatus toRound (Right qc) RoundStatus{..} =
           ..
         }
 
--- |Advance the proived 'RoundStatus' to the provided 'Epoch'.
+-- |Advance the provided 'RoundStatus' to the provided 'Epoch'.
 -- In particular this does the following to the provided 'RoundStatus'
 --
 -- * Set the 'rsCurrentEpoch' to the provided 'Epoch'

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Types.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Types.hs
@@ -188,6 +188,10 @@ genTimeoutSignatureMessages = do
     msgs <- vectorOf (fromIntegral numMessages) genTimeoutSignatureMessage
     return $! SignatureMessages $! foldl' (\acc msg -> Map.insert (FinalizerIndex . fromIntegral $ Map.size acc) msg acc) Map.empty msgs
 
+-- |Generate an arbitrary 'LeadershipElectionNonce'
+genLeadershipElectionNonce :: Gen LeadershipElectionNonce
+genLeadershipElectionNonce = Hash.Hash . FBS.pack <$> vector 32
+
 -- |Generate a 'RoundStatus' suitable for testing serialization.
 genRoundStatus :: Gen RoundStatus
 genRoundStatus = do
@@ -199,7 +203,7 @@ genRoundStatus = do
     rsCurrentTimeoutSignatureMessages <- genTimeoutSignatureMessages
     rsCurrentTimeout <- Duration <$> arbitrary
     rsHighestQC <- coinFlip =<< genQuorumCertificate
-    rsLeadershipElectionNonce <- Hash.Hash . FBS.pack <$> vector 32
+    rsLeadershipElectionNonce <- genLeadershipElectionNonce
     rsLatestEpochFinEntry <- coinFlip =<< genFinalizationEntry
     tc <- genTimeoutCertificate
     qc <- genQuorumCertificate
@@ -473,6 +477,26 @@ propAdvanceRoundStatusFromTCRound =
                         emptySignatureMessages
                         (rsCurrentQuorumSignatureMessages newRoundStatus)
 
+propAdvanceRoundStatusEpoch :: Property
+propAdvanceRoundStatusEpoch =
+    forAll genRoundStatus $ \fromRoundStatus ->
+        forAll genEpoch $ \toEpoch ->
+            forAll genFinalizationEntry $ \finalizationEntry ->
+                forAll genLeadershipElectionNonce $ \newLeadershipElectionNonce -> do
+                    let newRoundStatus = advanceRoundStatusEpoch toEpoch finalizationEntry newLeadershipElectionNonce fromRoundStatus
+                    assertEqual
+                        "RoundStatus should have advanced epoch"
+                        toEpoch
+                        (rsCurrentEpoch newRoundStatus)
+                    assertEqual
+                        "RoundStatus should have a present finalization entry"
+                        (Present finalizationEntry)
+                        (rsLatestEpochFinEntry newRoundStatus)
+                    assertEqual
+                        "RoundStatus should have updated the leadership election nonce"
+                        newLeadershipElectionNonce
+                        (rsLeadershipElectionNonce newRoundStatus)
+
 tests :: Spec
 tests = describe "KonsensusV1.Types" $ do
     it "FinalizerSet serialization" propSerializeFinalizerSet
@@ -498,3 +522,4 @@ tests = describe "KonsensusV1.Types" $ do
     it "SignedBlock signature fails with different key" propSignBakedBlockDiffKey
     it "RoundStatus advances from quorum round" propAdvanceRoundStatusFromQuorumRound
     it "RoundStatus advances from timed out round" propAdvanceRoundStatusFromTCRound
+    it "RoundStatus advances epoch" propAdvanceRoundStatusEpoch


### PR DESCRIPTION
## Purpose

Implementation of the `advanceEpoch` protocol from the blue paper. 

Note that computing the new leadership election nonce is left as a todo as it is already implemented on this branch: https://github.com/Concordium/concordium-node/tree/block-verification

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
