### PR TITLE
Extend metrics with indicator for unsupported pending protocol updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased changes
 
-- Extend Prometheus exporter with metrics: `grpc_request_duration_seconds`, `grpc_in_flight_requests`, `consensus_baking_committee`, `consensus_finalization_committee`, `consensus_baking_lottery_power`, `consensus_baked_blocks_total`, `consensus_finalized_baked_blocks_total`, `network_soft_banned_peers_total` and `consensus_non_finalized_transactions` see [docs/prometheus-exporter.md](https://github.com/Concordium/concordium-node/blob/main/docs/prometheus-exporter.md) for more details.
+- Extend Prometheus exporter with metrics: `grpc_request_duration_seconds`, `grpc_in_flight_requests`, `consensus_baking_committee`, `consensus_finalization_committee`, `consensus_baking_lottery_power`, `consensus_baked_blocks_total`, `consensus_finalized_baked_blocks_total`, `network_soft_banned_peers_total`, `consensus_non_finalized_transactions` and `consensus_unsupported_pending_protocol_version` see [docs/prometheus-exporter.md](https://github.com/Concordium/concordium-node/blob/main/docs/prometheus-exporter.md) for more details.
 
 ## 5.2.4
 

--- a/concordium-consensus/src/Concordium/External.hs
+++ b/concordium-consensus/src/Concordium/External.hs
@@ -405,9 +405,9 @@ startConsensus ::
     Ptr NotifyContext ->
     -- |The callback used to invoke upon new block arrival, and new finalized blocks.
     FunPtr NotifyCallback ->
-    -- |Context for when signalling a unsupported protocol update is pending or effective.
+    -- |Context for when signalling a unsupported protocol update is pending.
     Ptr NotifyUnsupportedUpdatesContext ->
-    -- |The callback used to signal a unsupported protocol update is pending or effective.
+    -- |The callback used to signal a unsupported protocol update is pending.
     FunPtr NotifyUnsupportedUpdatesCallback ->
     -- |Handler for generated messages
     FunPtr BroadcastCallback ->

--- a/concordium-consensus/src/Concordium/External.hs
+++ b/concordium-consensus/src/Concordium/External.hs
@@ -372,7 +372,8 @@ foreign import ccall "dynamic"
         FunPtr NotifyUnsupportedUpdatesCallback ->
         NotifyUnsupportedUpdatesCallback
 
--- |Serialize effective timestamp of unsupported protocol update, to milliseconds since unix epoch.
+-- |Call FFI callback with effective timestamp of unsupported protocol update, as milliseconds since
+-- unix epoch.
 mkNotifyUnsupportedUpdates :: (Word64 -> IO ()) -> Timestamp -> IO ()
 mkNotifyUnsupportedUpdates f unsupportedUpdateEffectiveTime =
     f (tsMillis unsupportedUpdateEffectiveTime)

--- a/concordium-consensus/src/Concordium/External.hs
+++ b/concordium-consensus/src/Concordium/External.hs
@@ -356,10 +356,10 @@ mkNotifyBlockFinalized f = \bh height isHomeBaked -> do
     BS.unsafeUseAsCStringLen (Proto.encodeMessage msg) $ \(cPtr, len) -> do
         f 1 (castPtr cPtr) (fromIntegral len) (fromIntegral height) isHomeBakedByte
 
--- |Context for when signalling a unsupported protocol update is pending or effective.
+-- |Context for when signalling a unsupported protocol update is pending.
 data NotifyUnsupportedUpdatesContext
 
--- |The callback used to signal a unsupported protocol update is pending or effective.
+-- |The callback used to signal a unsupported protocol update is pending.
 type NotifyUnsupportedUpdatesCallback =
     -- |Handle to the context.
     Ptr NotifyUnsupportedUpdatesContext ->
@@ -375,7 +375,7 @@ foreign import ccall "dynamic"
 -- |Serialize effective timestamp of unsupported protocol update, to milliseconds since unix epoch.
 mkNotifyUnsupportedUpdates :: (Word64 -> IO ()) -> Timestamp -> IO ()
 mkNotifyUnsupportedUpdates f unsupportedUpdateEffectiveTime =
-  f (tsMillis unsupportedUpdateEffectiveTime)
+    f (tsMillis unsupportedUpdateEffectiveTime)
 
 -- |Start up an instance of Skov without starting the baker thread.
 -- If an error occurs starting Skov, the error will be logged and
@@ -558,9 +558,9 @@ startConsensusPassive ::
     Ptr NotifyContext ->
     -- |The callback used to invoke upon new block arrival, and new finalized blocks.
     FunPtr NotifyCallback ->
-    -- |Context for when signalling a unsupported protocol update is pending or effective.
+    -- |Context for when signalling a unsupported protocol update is pending.
     Ptr NotifyUnsupportedUpdatesContext ->
-    -- |The callback used to signal a unsupported protocol update is pending or effective.
+    -- |The callback used to signal a unsupported protocol update is pending.
     FunPtr NotifyUnsupportedUpdatesCallback ->
     -- |Handler for sending catch-up status to peers
     FunPtr CatchUpStatusCallback ->
@@ -1441,9 +1441,9 @@ foreign export ccall
         Int64 ->
         Ptr NotifyContext ->
         FunPtr NotifyCallback ->
-        -- |Context for when signalling a unsupported protocol update is pending or effective.
+        -- |Context for when signalling a unsupported protocol update is pending.
         Ptr NotifyUnsupportedUpdatesContext ->
-        -- |The callback used to signal a unsupported protocol update is pending or effective.
+        -- |The callback used to signal a unsupported protocol update is pending.
         FunPtr NotifyUnsupportedUpdatesCallback ->
         -- |Handler for generated messages
         FunPtr BroadcastCallback ->
@@ -1487,9 +1487,9 @@ foreign export ccall
         Int64 ->
         Ptr NotifyContext ->
         FunPtr NotifyCallback ->
-        -- |Context for when signalling a unsupported protocol update is pending or effective.
+        -- |Context for when signalling a unsupported protocol update is pending.
         Ptr NotifyUnsupportedUpdatesContext ->
-        -- |The callback used to signal a unsupported protocol update is pending or effective.
+        -- |The callback used to signal a unsupported protocol update is pending.
         FunPtr NotifyUnsupportedUpdatesCallback ->
         -- |Handler for sending catch-up status to peers
         FunPtr CatchUpStatusCallback ->

--- a/concordium-consensus/src/Concordium/MultiVersion.hs
+++ b/concordium-consensus/src/Concordium/MultiVersion.hs
@@ -124,6 +124,12 @@ instance
     -- The information is used to count the number of finalized baked blocks exposed by a prometheus
     -- metric.
     handleFinalize _ lfbp bps = liftSkov $ do
+        -- Check for protocol update.
+        result <- checkForProtocolUpdate
+        let haveUnsupportedUpdate = case result of
+                CFPURUnsupportedPending -> True
+                _ -> False
+        -- Trigger callback notifying Rust of a finalized block.
         lift (asks (notifyBlockFinalized . mvCallbacks)) >>= \case
             Nothing -> return ()
             Just notifyCallback -> do
@@ -139,14 +145,12 @@ instance
                     let isHomeBaked = case nodeBakerIdMaybe of
                             Nothing -> False
                             Just nodeBakerId -> Just nodeBakerId == (blockBaker <$> blockFields (_bpBlock bp))
-                    liftIO (notifyCallback (bpHash bp) height isHomeBaked)
+                    liftIO (notifyCallback (bpHash bp) height isHomeBaked haveUnsupportedUpdate)
                 let height = localToAbsoluteBlockHeight latestEraGenesisHeight (bpHeight lfbp)
                 let isHomeBaked = case nodeBakerIdMaybe of
                         Nothing -> False
                         Just myBakerId -> Just myBakerId == (blockBaker <$> blockFields (_bpBlock lfbp))
-                liftIO (notifyCallback (bpHash lfbp) height isHomeBaked)
-        -- And then check for protocol update.
-        checkForProtocolUpdate
+                liftIO (notifyCallback (bpHash lfbp) height isHomeBaked haveUnsupportedUpdate)
 
 -- |Configuration for the global state that uses disk storage
 -- for both tree state and block state.
@@ -203,8 +207,9 @@ data Callbacks = Callbacks
       -- the hash of the block, its absolute height and whether the block was produced by the baker id configured for this node.
       notifyBlockArrived :: Maybe (BlockHash -> AbsoluteBlockHeight -> Bool -> IO ()),
       -- |Notify a block was finalized. The arguments are the hash of the block,
-      -- its absolute height and whether the block was produced by the baker id configured for this node.
-      notifyBlockFinalized :: Maybe (BlockHash -> AbsoluteBlockHeight -> Bool -> IO ())
+      -- its absolute height, whether the block was produced by the baker id configured for this
+      -- node and whether any unsupported protocol updates are pending.
+      notifyBlockFinalized :: Maybe (BlockHash -> AbsoluteBlockHeight -> Bool -> Bool -> IO ())
     }
 
 -- |Baker identity and baking thread 'MVar'.
@@ -454,6 +459,19 @@ newGenesis (PVGenesisData (gd :: GenesisData pv)) vcGenesisHeight = case consens
                     notifyRegenesis (Just (genesisBlockHash gd))
     ConsensusV1 -> error "New consensus version not implemented yet." -- TODO: implement
 
+-- |Outcome for checking for protocol update.
+data CheckForProtocolUpdateResult
+    = -- | No protocol update are either pending or effective at this time.
+      CFPURNone
+    | -- | A protocol update is effective at this time, but is unsupported by this node version.
+      CFPURUnsupportedEffective
+    | -- | A protocol update is effective at this time and is unsupported by this node version.
+      CFPURSupportedEffective
+    | -- | A protocol update is pending at this time, but is unsupported by this node version.
+      CFPURUnsupportedPending
+    | -- | A protocol update is pending at this time and is unsupported by this node version.
+      CFPURSupportedPending
+
 -- |Determine if a protocol update has occurred, and handle it.
 -- When a protocol update first becomes pending, this logs the update that will occur (if it is
 -- of a known type) or logs an error message (if it is unknown).
@@ -469,18 +487,18 @@ checkForProtocolUpdate ::
       MultiVersion fc,
       Skov.SkovConfiguration fc UpdateHandler
     ) =>
-    VersionedSkovM fc lastpv ()
+    VersionedSkovM fc lastpv CheckForProtocolUpdateResult
 checkForProtocolUpdate = liftSkov body
   where
     body ::
         ( Skov.SkovMonad (VersionedSkovM fc lastpv),
           TreeStateMonad (VersionedSkovM fc lastpv)
         ) =>
-        VersionedSkovM fc lastpv ()
+        VersionedSkovM fc lastpv CheckForProtocolUpdateResult
     body =
         check >>= \case
-            Nothing -> return ()
-            Just (PVInit{pvInitGenesis = nextGenesis :: Regenesis newpv, ..}) ->
+            Right result -> return result
+            Left (PVInit{pvInitGenesis = nextGenesis :: Regenesis newpv, ..}) ->
                 case consensusVersionFor (protocolVersion @newpv) of
                     ConsensusV0 -> do
                         MultiVersionRunner{..} <- lift ask
@@ -528,7 +546,7 @@ checkForProtocolUpdate = liftSkov body
                             -- Notify the network layer we have a new genesis.
                             let Callbacks{..} = mvCallbacks
                             liftIO $ notifyRegenesis (Just (regenesisBlockHash nextGenesis))
-                            return ()
+                            return CFPURSupportedEffective
                     ConsensusV1 -> error "New consensus version not implemented yet." -- TODO: implement
     showPU ProtocolUpdate{..} =
         Text.unpack puMessage
@@ -544,7 +562,7 @@ checkForProtocolUpdate = liftSkov body
         ( Skov.SkovMonad (VersionedSkovM fc lastpv),
           TreeStateMonad (VersionedSkovM fc lastpv)
         ) =>
-        VersionedSkovM fc lastpv (Maybe (PVInit (VersionedSkovM fc lastpv)))
+        VersionedSkovM fc lastpv (Either (PVInit (VersionedSkovM fc lastpv)) CheckForProtocolUpdateResult)
     check =
         Skov.getProtocolUpdateStatus >>= \case
             ProtocolUpdated pu -> case checkUpdate @lastpv pu of
@@ -557,12 +575,12 @@ checkForProtocolUpdate = liftSkov body
                     lift $ do
                         callbacks <- asks mvCallbacks
                         liftIO (notifyRegenesis callbacks Nothing)
-                        return Nothing
+                        return $ Right CFPURUnsupportedEffective
                 Right upd -> do
                     logEvent Kontrol LLInfo $ "Starting protocol update."
                     initData <- updateRegenesis upd
-                    return (Just initData)
-            PendingProtocolUpdates [] -> return Nothing
+                    return (Left initData)
+            PendingProtocolUpdates [] -> return $ Right CFPURNone
             PendingProtocolUpdates ((ts, pu) : _) -> do
                 -- There is a queued protocol update, but only log about it
                 -- if we have not done so already.
@@ -573,24 +591,27 @@ checkForProtocolUpdate = liftSkov body
                                 then (True, s)
                                 else (False, s{Skov.ssHandlerState = AlreadyNotified ts pu})
                         )
-                unless alreadyNotified $ case checkUpdate @lastpv pu of
-                    Left err ->
-                        logEvent Kontrol LLError $
-                            "An unsupported protocol update ("
-                                ++ err
-                                ++ ") will take effect at "
-                                ++ show (timestampToUTCTime $ transactionTimeToTimestamp ts)
-                                ++ ": "
-                                ++ showPU pu
-                    Right upd ->
-                        logEvent Kontrol LLInfo $
-                            "A protocol update will take effect at "
-                                ++ show (timestampToUTCTime $ transactionTimeToTimestamp ts)
-                                ++ ": "
-                                ++ showPU pu
-                                ++ "\n"
-                                ++ show upd
-                return Nothing
+                case checkUpdate @lastpv pu of
+                    Left err -> do
+                        unless alreadyNotified $
+                            logEvent Kontrol LLError $
+                                "An unsupported protocol update ("
+                                    ++ err
+                                    ++ ") will take effect at "
+                                    ++ show (timestampToUTCTime $ transactionTimeToTimestamp ts)
+                                    ++ ": "
+                                    ++ showPU pu
+                        return $ Right CFPURUnsupportedPending
+                    Right upd -> do
+                        unless alreadyNotified $
+                            logEvent Kontrol LLInfo $
+                                "A protocol update will take effect at "
+                                    ++ show (timestampToUTCTime $ transactionTimeToTimestamp ts)
+                                    ++ ": "
+                                    ++ showPU pu
+                                    ++ "\n"
+                                    ++ show upd
+                        return $ Right CFPURSupportedPending
 
 -- |Make a 'MultiVersionRunner' for a given configuration.
 makeMultiVersionRunner ::
@@ -729,7 +750,8 @@ startupSkov genesis = do
                         case nextPV of
                             Nothing -> do
                                 mvrLogIO $ activateConfiguration newEConfig
-                                liftSkovUpdate newEConfig' checkForProtocolUpdate
+                                _ <- liftSkovUpdate newEConfig' checkForProtocolUpdate
+                                return ()
                             Just nextSPV -> loop nextSPV (Just newEConfig) (vcIndex + 1) (fromIntegral lastFinalizedHeight + 1)
                     -- We failed to load anything in the first iteration of the
                     -- loop. Decode the provided genesis and attempt to start the
@@ -747,7 +769,8 @@ startupSkov genesis = do
                     -- last one we loaded.
                     Right (Just config@(EVersionedConfiguration newEConfig')) -> do
                         mvrLogIO $ activateConfiguration config
-                        liftSkovUpdate newEConfig' checkForProtocolUpdate
+                        _ <- liftSkovUpdate newEConfig' checkForProtocolUpdate
+                        return ()
             ConsensusV1 -> error "New consensus not implemented yet." -- TODO: implement
     loop initProtocolVersion Nothing 0 0
 

--- a/concordium-consensus/src/Concordium/MultiVersion.hs
+++ b/concordium-consensus/src/Concordium/MultiVersion.hs
@@ -577,29 +577,27 @@ checkForProtocolUpdate = liftSkov body
                                 then (True, s)
                                 else (False, s{Skov.ssHandlerState = AlreadyNotified ts pu})
                         )
-                case checkUpdate @lastpv pu of
+                unless alreadyNotified $ case checkUpdate @lastpv pu of
                     Left err -> do
-                        unless alreadyNotified $
-                            logEvent Kontrol LLError $
-                                "An unsupported protocol update ("
-                                    ++ err
-                                    ++ ") will take effect at "
-                                    ++ show (timestampToUTCTime $ transactionTimeToTimestamp ts)
-                                    ++ ": "
-                                    ++ showPU pu
+                        logEvent Kontrol LLError $
+                            "An unsupported protocol update ("
+                                ++ err
+                                ++ ") will take effect at "
+                                ++ show (timestampToUTCTime $ transactionTimeToTimestamp ts)
+                                ++ ": "
+                                ++ showPU pu
                         callbacks <- lift $ asks mvCallbacks
                         case notifyUnsupportedProtocolUpdate callbacks of
                             Just notifyCallback -> liftIO $ notifyCallback $ transactionTimeToTimestamp ts
                             Nothing -> return ()
                     Right upd -> do
-                        unless alreadyNotified $
-                            logEvent Kontrol LLInfo $
-                                "A protocol update will take effect at "
-                                    ++ show (timestampToUTCTime $ transactionTimeToTimestamp ts)
-                                    ++ ": "
-                                    ++ showPU pu
-                                    ++ "\n"
-                                    ++ show upd
+                        logEvent Kontrol LLInfo $
+                            "A protocol update will take effect at "
+                                ++ show (timestampToUTCTime $ transactionTimeToTimestamp ts)
+                                ++ ": "
+                                ++ showPU pu
+                                ++ "\n"
+                                ++ show upd
                 return Nothing
 
 -- |Make a 'MultiVersionRunner' for a given configuration.

--- a/concordium-consensus/src/Concordium/MultiVersion.hs
+++ b/concordium-consensus/src/Concordium/MultiVersion.hs
@@ -204,11 +204,10 @@ data Callbacks = Callbacks
       -- the hash of the block, its absolute height and whether the block was produced by the baker id configured for this node.
       notifyBlockArrived :: Maybe (BlockHash -> AbsoluteBlockHeight -> Bool -> IO ()),
       -- |Notify a block was finalized. The arguments are the hash of the block,
-      -- its absolute height and whether the block was produced by the baker id configured for this
-      -- node.
+      -- its absolute height and whether the block was produced by the baker id configured for this node.
       notifyBlockFinalized :: Maybe (BlockHash -> AbsoluteBlockHeight -> Bool -> IO ()),
-      -- |Notify unsupported protocol updates are pending.
-      -- Takes the effective time as argument in the case of an unsupported protocol update.
+      -- |Notify unsupported protocol update is pending when called.
+      -- Takes the effective time of the update as argument.
       notifyUnsupportedProtocolUpdate :: Maybe (Timestamp -> IO ())
     }
 
@@ -590,8 +589,8 @@ checkForProtocolUpdate = liftSkov body
                                     ++ showPU pu
                         callbacks <- lift $ asks mvCallbacks
                         case notifyUnsupportedProtocolUpdate callbacks of
-                          Just notifyCallback -> liftIO $ notifyCallback $ transactionTimeToTimestamp ts
-                          Nothing -> return ()
+                            Just notifyCallback -> liftIO $ notifyCallback $ transactionTimeToTimestamp ts
+                            Nothing -> return ()
                     Right upd -> do
                         unless alreadyNotified $
                             logEvent Kontrol LLInfo $

--- a/concordium-consensus/test-runners/app/Main.hs
+++ b/concordium-consensus/test-runners/app/Main.hs
@@ -294,6 +294,7 @@ callbacks myPeerId peersRef monitorChan = Callbacks{..}
     notifyRegenesis Nothing = return ()
     notifyBlockArrived = Nothing
     notifyBlockFinalized = Nothing
+    notifyUnsupportedProtocolUpdate = Nothing
 
 -- |Construct a 'MultiVersionConfiguration' to use for each baker node.
 config :: FilePath -> BakerIdentity -> MultiVersionConfiguration (BufferedFinalization ThreadTimer)

--- a/concordium-consensus/test-runners/catchup/Main.hs
+++ b/concordium-consensus/test-runners/catchup/Main.hs
@@ -310,6 +310,7 @@ callbacks myPeerId peersRef monitorChan = Callbacks{..}
     notifyRegenesis Nothing = return ()
     notifyBlockArrived = Nothing
     notifyBlockFinalized = Nothing
+    notifyUnsupportedProtocolUpdate = Nothing
 
 -- |Construct a 'MultiVersionConfiguration' to use for each baker node.
 config :: FilePath -> BakerIdentity -> MultiVersionConfiguration (BufferedFinalization ThreadTimer)

--- a/concordium-consensus/test-runners/execute-chain/Main.hs
+++ b/concordium-consensus/test-runners/execute-chain/Main.hs
@@ -52,6 +52,7 @@ main = do
                   broadcastFinalizationRecord = \_ _ -> return (),
                   notifyBlockArrived = Nothing,
                   notifyBlockFinalized = Nothing,
+                  notifyUnsupportedProtocolUpdate = Nothing,
                   notifyCatchUpStatus = \_ _ -> return (),
                   notifyRegenesis = \_ -> return ()
                 }

--- a/concordium-node/src/bin/cli.rs
+++ b/concordium-node/src/bin/cli.rs
@@ -18,7 +18,7 @@ use concordium_node::{
             ConsensusContainer, ConsensusLogLevel, Regenesis, CALLBACK_QUEUE,
             CONSENSUS_QUEUE_DEPTH_IN_HI, CONSENSUS_QUEUE_DEPTH_OUT_HI,
         },
-        ffi::{self, StartConsensusConfig},
+        ffi,
         helpers::QueueMsg,
         messaging::ConsensusMessage,
     },
@@ -138,7 +138,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     info!("Starting consensus layer");
-    let start_consensus_config = StartConsensusConfig {
+    let start_consensus_config = ffi::StartConsensusConfig {
         genesis_data: gen_data,
         maximum_log_level: if conf.common.no_consensus_logs {
             ConsensusLogLevel::Error

--- a/concordium-node/src/bin/cli.rs
+++ b/concordium-node/src/bin/cli.rs
@@ -104,6 +104,10 @@ async fn main() -> anyhow::Result<()> {
             last_arrived_block_timestamp: node.stats.last_arrived_block_timestamp.clone(),
             baked_blocks: node.stats.baked_blocks.clone(),
             finalized_baked_blocks: node.stats.finalized_baked_blocks.clone(),
+            unsupported_pending_protocol_version: node
+                .stats
+                .unsupported_pending_protocol_version
+                .clone(),
         };
         let notification_handlers = ffi::NotificationHandlers {
             blocks:           receiver_blocks,
@@ -120,6 +124,10 @@ async fn main() -> anyhow::Result<()> {
             last_arrived_block_timestamp: node.stats.last_arrived_block_timestamp.clone(),
             baked_blocks: node.stats.baked_blocks.clone(),
             finalized_baked_blocks: node.stats.finalized_baked_blocks.clone(),
+            unsupported_pending_protocol_version: node
+                .stats
+                .unsupported_pending_protocol_version
+                .clone(),
         };
         (Some(notify_context), None)
     } else {

--- a/concordium-node/src/bin/cli.rs
+++ b/concordium-node/src/bin/cli.rs
@@ -104,10 +104,6 @@ async fn main() -> anyhow::Result<()> {
             last_arrived_block_timestamp: node.stats.last_arrived_block_timestamp.clone(),
             baked_blocks: node.stats.baked_blocks.clone(),
             finalized_baked_blocks: node.stats.finalized_baked_blocks.clone(),
-            unsupported_pending_protocol_version: node
-                .stats
-                .unsupported_pending_protocol_version
-                .clone(),
         };
         let notification_handlers = ffi::NotificationHandlers {
             blocks:           receiver_blocks,
@@ -124,14 +120,21 @@ async fn main() -> anyhow::Result<()> {
             last_arrived_block_timestamp: node.stats.last_arrived_block_timestamp.clone(),
             baked_blocks: node.stats.baked_blocks.clone(),
             finalized_baked_blocks: node.stats.finalized_baked_blocks.clone(),
-            unsupported_pending_protocol_version: node
-                .stats
-                .unsupported_pending_protocol_version
-                .clone(),
         };
         (Some(notify_context), None)
     } else {
         (None, None)
+    };
+
+    let unsupported_update_context = if conf.prometheus.is_enabled() {
+        Some(ffi::NotifyUnsupportedUpdatesContext {
+            unsupported_pending_protocol_version: node
+                .stats
+                .unsupported_pending_protocol_version
+                .clone(),
+        })
+    } else {
+        None
     };
 
     info!("Starting consensus layer");
@@ -151,6 +154,7 @@ async fn main() -> anyhow::Result<()> {
         &database_directory,
         regenesis_arc.clone(),
         notification_context,
+        unsupported_update_context,
     )?;
     info!("Consensus layer started");
 

--- a/concordium-node/src/consensus_ffi/consensus.rs
+++ b/concordium-node/src/consensus_ffi/consensus.rs
@@ -1,7 +1,7 @@
 use crate::consensus_ffi::{
     ffi::{
         consensus_runner, get_consensus_ptr, startBaker, stopBaker, stopConsensus,
-        NotificationContext, NotifyUnsupportedUpdatesContext,
+        StartConsensusConfig,
     },
     helpers::{QueueReceiver, QueueSyncSender, RelayOrStopSenderHelper},
     messaging::ConsensusMessage,
@@ -200,13 +200,9 @@ pub struct ConsensusContainer {
 impl ConsensusContainer {
     pub fn new(
         runtime_parameters: ConsensusRuntimeParameters,
-        genesis_data: Vec<u8>,
+        start_config: StartConsensusConfig,
         private_data: Option<Vec<u8>>,
-        max_log_level: ConsensusLogLevel,
         appdata_dir: &Path,
-        regenesis_arc: Arc<Regenesis>,
-        notification_context: Option<NotificationContext>,
-        unsupported_update_context: Option<NotifyUnsupportedUpdatesContext>,
     ) -> anyhow::Result<Self> {
         info!("Starting up the consensus layer");
 
@@ -215,17 +211,9 @@ impl ConsensusContainer {
         } else {
             ConsensusType::Passive
         };
+        let genesis_data = start_config.genesis_data.clone();
 
-        match get_consensus_ptr(
-            &runtime_parameters,
-            genesis_data.clone(),
-            private_data,
-            max_log_level,
-            appdata_dir,
-            regenesis_arc,
-            notification_context,
-            unsupported_update_context,
-        ) {
+        match get_consensus_ptr(&runtime_parameters, start_config, private_data, appdata_dir) {
             Ok(consensus_ptr) => Ok(Self {
                 runtime_parameters,
                 is_baking: Arc::new(AtomicBool::new(false)),

--- a/concordium-node/src/consensus_ffi/consensus.rs
+++ b/concordium-node/src/consensus_ffi/consensus.rs
@@ -1,5 +1,8 @@
 use crate::consensus_ffi::{
-    ffi::{consensus_runner, get_consensus_ptr, startBaker, stopBaker, stopConsensus},
+    ffi::{
+        consensus_runner, get_consensus_ptr, startBaker, stopBaker, stopConsensus,
+        NotificationContext, NotifyUnsupportedUpdatesContext,
+    },
     helpers::{QueueReceiver, QueueSyncSender, RelayOrStopSenderHelper},
     messaging::ConsensusMessage,
 };
@@ -12,8 +15,6 @@ use std::{
         Arc, Mutex, RwLock,
     },
 };
-
-use super::ffi::NotificationContext;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum ConsensusLogLevel {
@@ -205,6 +206,7 @@ impl ConsensusContainer {
         appdata_dir: &Path,
         regenesis_arc: Arc<Regenesis>,
         notification_context: Option<NotificationContext>,
+        unsupported_update_context: Option<NotifyUnsupportedUpdatesContext>,
     ) -> anyhow::Result<Self> {
         info!("Starting up the consensus layer");
 
@@ -222,6 +224,7 @@ impl ConsensusContainer {
             appdata_dir,
             regenesis_arc,
             notification_context,
+            unsupported_update_context,
         ) {
             Ok(consensus_ptr) => Ok(Self {
                 runtime_parameters,

--- a/concordium-node/src/consensus_ffi/ffi.rs
+++ b/concordium-node/src/consensus_ffi/ffi.rs
@@ -358,7 +358,8 @@ type NotifyUnsupportedUpdatesCallback =
 pub struct NotifyUnsupportedUpdatesContext {
     /// If non-zero the value represents the effective timestamp of unsupported
     /// protocol update as milliseconds since unix epoch.
-    pub unsupported_pending_protocol_version: prometheus::IntGauge,
+    pub unsupported_pending_protocol_version:
+        prometheus::core::GenericGauge<prometheus::core::AtomicU64>,
 }
 
 #[allow(improper_ctypes)]
@@ -1428,7 +1429,7 @@ unsafe extern "C" fn unsupported_update_callback(
     unsupported_update_pending: u64,
 ) {
     let context = &*context_ptr;
-    context.unsupported_pending_protocol_version.set(unsupported_update_pending as i64);
+    context.unsupported_pending_protocol_version.set(unsupported_update_pending);
 }
 
 /// Information needed to start consensus.

--- a/concordium-node/src/plugins/consensus.rs
+++ b/concordium-node/src/plugins/consensus.rs
@@ -11,7 +11,7 @@ use crate::{
         consensus::{
             self, ConsensusContainer, ConsensusRuntimeParameters, Regenesis, CALLBACK_QUEUE,
         },
-        ffi::{self, ExecuteBlockCallback, NotificationContext},
+        ffi::{self, ExecuteBlockCallback, NotificationContext, NotifyUnsupportedUpdatesContext},
         helpers::{
             ConsensusFfiResponse,
             PacketType::{self, *},
@@ -44,6 +44,7 @@ pub fn start_consensus_layer(
     appdata_dir: &Path,
     regenesis_arc: Arc<Regenesis>,
     notification_context: Option<NotificationContext>,
+    unsupported_update_context: Option<NotifyUnsupportedUpdatesContext>,
 ) -> anyhow::Result<ConsensusContainer> {
     info!("Starting up the consensus thread");
 
@@ -78,6 +79,7 @@ pub fn start_consensus_layer(
         appdata_dir,
         regenesis_arc,
         notification_context,
+        unsupported_update_context,
     )
 }
 

--- a/concordium-node/src/plugins/consensus.rs
+++ b/concordium-node/src/plugins/consensus.rs
@@ -8,10 +8,8 @@ use crate::{
     connection::ConnChange,
     consensus_ffi::{
         catch_up::{PeerList, PeerStatus},
-        consensus::{
-            self, ConsensusContainer, ConsensusRuntimeParameters, Regenesis, CALLBACK_QUEUE,
-        },
-        ffi::{self, ExecuteBlockCallback, NotificationContext, NotifyUnsupportedUpdatesContext},
+        consensus::{ConsensusContainer, ConsensusRuntimeParameters, CALLBACK_QUEUE},
+        ffi::{self, ExecuteBlockCallback, StartConsensusConfig},
         helpers::{
             ConsensusFfiResponse,
             PacketType::{self, *},
@@ -38,13 +36,9 @@ use std::{
 /// Initializes the consensus layer with the given setup.
 pub fn start_consensus_layer(
     conf: &configuration::BakerConfig,
-    genesis_data: Vec<u8>,
+    start_config: StartConsensusConfig,
     private_data: Option<Vec<u8>>,
-    max_logging_level: consensus::ConsensusLogLevel,
     appdata_dir: &Path,
-    regenesis_arc: Arc<Regenesis>,
-    notification_context: Option<NotificationContext>,
-    unsupported_update_context: Option<NotifyUnsupportedUpdatesContext>,
 ) -> anyhow::Result<ConsensusContainer> {
     info!("Starting up the consensus thread");
 
@@ -71,16 +65,7 @@ pub fn start_consensus_layer(
         modules_cache_size:         conf.modules_cache_size,
     };
 
-    ConsensusContainer::new(
-        runtime_parameters,
-        genesis_data,
-        private_data,
-        max_logging_level,
-        appdata_dir,
-        regenesis_arc,
-        notification_context,
-        unsupported_update_context,
-    )
+    ConsensusContainer::new(runtime_parameters, start_config, private_data, appdata_dir)
 }
 
 /// Stop consensus container

--- a/concordium-node/src/stats_export_service.rs
+++ b/concordium-node/src/stats_export_service.rs
@@ -242,7 +242,7 @@ pub struct StatsExportService {
     pub grpc_in_flight_requests_counter: InFlightRequestsCounter,
     /// If non-zero the value represents the effective timestamp of unsupported
     /// protocol update as milliseconds since unix epoch.
-    pub unsupported_pending_protocol_version: IntGauge,
+    pub unsupported_pending_protocol_version: GenericGauge<AtomicU64>,
     /// Total number of bytes received at the point of last
     /// throughput_measurement.
     ///
@@ -455,7 +455,7 @@ impl StatsExportService {
         };
         registry.register(Box::new(grpc_in_flight_requests))?;
 
-        let unsupported_pending_protocol_version = IntGauge::with_opts(Opts::new(
+        let unsupported_pending_protocol_version = GenericGauge::with_opts(Opts::new(
             "consensus_unsupported_pending_protocol_version",
             "If non-zero the value represents the effective time of an unsupported protocol \
              update (Unix time in milliseconds)",

--- a/concordium-node/src/stats_export_service.rs
+++ b/concordium-node/src/stats_export_service.rs
@@ -240,8 +240,8 @@ pub struct StatsExportService {
     /// `tower_http::metrics` and then synced with the prometheus gauge on each
     /// scrape.
     pub grpc_in_flight_requests_counter: InFlightRequestsCounter,
-    /// Indicator where a value of 1 indicates an unsupported pending protocol
-    /// update is finalized.
+    /// If non-zero the value represents the effective timestamp of unsupported
+    /// protocol update as milliseconds since unix epoch.
     pub unsupported_pending_protocol_version: IntGauge,
     /// Total number of bytes received at the point of last
     /// throughput_measurement.
@@ -428,7 +428,7 @@ impl StatsExportService {
 
         let node_startup_timestamp = IntGauge::with_opts(Opts::new(
             "node_startup_timestamp",
-            "Timestamp of starting up the node (Unix time in milliseconds).",
+            "Timestamp of starting up the node (Unix time in milliseconds)",
         ))?;
         registry.register(Box::new(node_startup_timestamp.clone()))?;
 
@@ -457,8 +457,8 @@ impl StatsExportService {
 
         let unsupported_pending_protocol_version = IntGauge::with_opts(Opts::new(
             "consensus_unsupported_pending_protocol_version",
-            "Indicator where a value of 1 indicates an unsupported pending protocol update is \
-             finalized",
+            "If non-zero the value represents the effective time of an unsupported protocol \
+             update (Unix time in milliseconds)",
         ))?;
         registry.register(Box::new(unsupported_pending_protocol_version.clone()))?;
 

--- a/concordium-node/src/stats_export_service.rs
+++ b/concordium-node/src/stats_export_service.rs
@@ -240,6 +240,9 @@ pub struct StatsExportService {
     /// `tower_http::metrics` and then synced with the prometheus gauge on each
     /// scrape.
     pub grpc_in_flight_requests_counter: InFlightRequestsCounter,
+    /// Indicator where a value of 1 indicates an unsupported pending protocol
+    /// update is finalized.
+    pub unsupported_pending_protocol_version: IntGauge,
     /// Total number of bytes received at the point of last
     /// throughput_measurement.
     ///
@@ -452,6 +455,13 @@ impl StatsExportService {
         };
         registry.register(Box::new(grpc_in_flight_requests))?;
 
+        let unsupported_pending_protocol_version = IntGauge::with_opts(Opts::new(
+            "consensus_unsupported_pending_protocol_version",
+            "Indicator where a value of 1 indicates an unsupported pending protocol update is \
+             finalized",
+        ))?;
+        registry.register(Box::new(unsupported_pending_protocol_version.clone()))?;
+
         let last_throughput_measurement_timestamp = AtomicI64::new(0);
         let last_throughput_measurement_sent_bytes = AtomicU64::new(0);
         let last_throughput_measurement_received_bytes = AtomicU64::new(0);
@@ -485,6 +495,7 @@ impl StatsExportService {
             node_startup_timestamp,
             grpc_request_response_time,
             grpc_in_flight_requests_counter,
+            unsupported_pending_protocol_version,
             last_throughput_measurement_timestamp,
             last_throughput_measurement_sent_bytes,
             last_throughput_measurement_received_bytes,

--- a/docs/prometheus-exporter.md
+++ b/docs/prometheus-exporter.md
@@ -226,3 +226,9 @@ Blocks received as part of catchup are also counted, when the block was baked by
 Total number of finalized blocks baked by the node since startup.
 
 Finalized blocks received as part of catchup are also counted, when the block was baked by the same baker ID as the node is configured with.
+
+### `consensus_unsupported_pending_protocol_version`
+
+Indicator where a value of 1 indicates an unsupported pending protocol update. If this is ever showing 1 make sure to update your node otherwise it will shutdown itself at the effective time of the protocol update.
+
+This metric is intended for setting up alerts to catch outdated nodes.

--- a/docs/prometheus-exporter.md
+++ b/docs/prometheus-exporter.md
@@ -229,6 +229,6 @@ Finalized blocks received as part of catchup are also counted, when the block wa
 
 ### `consensus_unsupported_pending_protocol_version`
 
-Indicator where a value of 1 indicates an unsupported pending protocol update. If this is ever showing 1 make sure to update your node otherwise it will shutdown itself at the effective time of the protocol update.
+Indicator for unsupported pending protocol updates where a non-zero value indicates the effective time (Unix time in milliseconds) of a pending unsupported protocol update.
 
 This metric is intended for setting up alerts to catch outdated nodes.


### PR DESCRIPTION
## Purpose

Related to https://github.com/Concordium/concordium-node/issues/755.

## Changes

- add new callback to consensus to provide information to the metric, which indicates unsupported pending protocol updates.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
