### PR TITLE
Disable broadcast callbacks when performing out-of-band-catchup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Extend the node health check so that if the node is configured with baker
   credentials then it is required to be in the baking committee for it to be
   considered healthy.
+- Fix a bug that could cause the node to hang indefinitely during the out-of-
+  band-catchup when the node is a finalizer.
 
 ## 5.3.0
 

--- a/concordium-consensus/src/Concordium/MultiVersion.hs
+++ b/concordium-consensus/src/Concordium/MultiVersion.hs
@@ -1270,8 +1270,8 @@ importBlocks importFile = do
         -- Check if the import should be stopped.
         if shouldStop
             then return $ fixResult Skov.ResultConsensusShutDown
-            -- Disable broadcast callbacks as the network layer is not started for out-of-band-catchup.
-            else local disableBroadcastCallbacks $ fixResult <$> receiveExecuteBlock gi bs
+            else -- Disable broadcast callbacks as the network layer is not started for out-of-band-catchup.
+                local disableBroadcastCallbacks $ fixResult <$> receiveExecuteBlock gi bs
     doImport (ImportFinalizationRecord _ gi bs) = fixResult <$> receiveFinalizationRecord gi bs
     fixResult Skov.ResultSuccess = Right ()
     fixResult Skov.ResultDuplicate = Right ()
@@ -1279,10 +1279,11 @@ importBlocks importFile = do
     fixResult e = Left (ImportOtherError e)
     -- Sets broadcast callbacks to do-nothing functions.
     disableBroadcastCallbacks mvr@MultiVersionRunner{..} = do
-        mvr {
-          mvCallbacks = mvCallbacks {
-                broadcastBlock = const . const $ return (),
-                broadcastFinalizationMessage = const . const $ return (),
-                broadcastFinalizationRecord = const . const $ return ()
+        mvr
+            { mvCallbacks =
+                mvCallbacks
+                    { broadcastBlock = const . const $ return (),
+                      broadcastFinalizationMessage = const . const $ return (),
+                      broadcastFinalizationRecord = const . const $ return ()
+                    }
             }
-        }

--- a/concordium-consensus/src/Concordium/MultiVersion.hs
+++ b/concordium-consensus/src/Concordium/MultiVersion.hs
@@ -1281,8 +1281,8 @@ importBlocks importFile = do
         mvr
             { mvCallbacks =
                 mvCallbacks
-                    { broadcastBlock = const . const $ return (),
-                      broadcastFinalizationMessage = const . const $ return (),
-                      broadcastFinalizationRecord = const . const $ return ()
+                    { broadcastBlock = \_ _ -> return (),
+                      broadcastFinalizationMessage = \_ _ -> return (),
+                      broadcastFinalizationRecord = \_ _ -> return ()
                     }
             }

--- a/concordium-consensus/src/Concordium/MultiVersion.hs
+++ b/concordium-consensus/src/Concordium/MultiVersion.hs
@@ -1270,14 +1270,13 @@ importBlocks importFile = do
         -- Check if the import should be stopped.
         if shouldStop
             then return $ fixResult Skov.ResultConsensusShutDown
-            else -- Disable broadcast callbacks as the network layer is not started for out-of-band-catchup.
-                local disableBroadcastCallbacks $ fixResult <$> receiveExecuteBlock gi bs
-    doImport (ImportFinalizationRecord _ gi bs) = fixResult <$> receiveFinalizationRecord gi bs
+            else local disableBroadcastCallbacks $ fixResult <$> receiveExecuteBlock gi bs
+    doImport (ImportFinalizationRecord _ gi bs) = local disableBroadcastCallbacks $ fixResult <$> receiveFinalizationRecord gi bs
     fixResult Skov.ResultSuccess = Right ()
     fixResult Skov.ResultDuplicate = Right ()
     fixResult Skov.ResultConsensusShutDown = Right ()
     fixResult e = Left (ImportOtherError e)
-    -- Sets broadcast callbacks to do-nothing functions.
+    -- Disable broadcast callbacks as the network layer is not started at the point of the out-of-band-catchup.
     disableBroadcastCallbacks mvr@MultiVersionRunner{..} = do
         mvr
             { mvCallbacks =

--- a/concordium-node/src/consensus_ffi/consensus.rs
+++ b/concordium-node/src/consensus_ffi/consensus.rs
@@ -39,7 +39,7 @@ impl TryFrom<u8> for ConsensusLogLevel {
     }
 }
 
-pub const CONSENSUS_QUEUE_DEPTH_OUT_HI: usize = 10;
+pub const CONSENSUS_QUEUE_DEPTH_OUT_HI: usize = 8 * 1024;
 pub const CONSENSUS_QUEUE_DEPTH_OUT_LO: usize = 16 * 1024;
 pub const CONSENSUS_QUEUE_DEPTH_IN_HI: usize = 16 * 1024;
 pub const CONSENSUS_QUEUE_DEPTH_IN_LO: usize = 32 * 1024;

--- a/concordium-node/src/consensus_ffi/consensus.rs
+++ b/concordium-node/src/consensus_ffi/consensus.rs
@@ -39,7 +39,7 @@ impl TryFrom<u8> for ConsensusLogLevel {
     }
 }
 
-pub const CONSENSUS_QUEUE_DEPTH_OUT_HI: usize = 8 * 1024;
+pub const CONSENSUS_QUEUE_DEPTH_OUT_HI: usize = 10;
 pub const CONSENSUS_QUEUE_DEPTH_OUT_LO: usize = 16 * 1024;
 pub const CONSENSUS_QUEUE_DEPTH_IN_HI: usize = 16 * 1024;
 pub const CONSENSUS_QUEUE_DEPTH_IN_LO: usize = 32 * 1024;


### PR DESCRIPTION
## Purpose

Fixes https://github.com/Concordium/concordium-node/issues/761

## Changes

Disable broadcast callbacks in `importBlocks` which is used iff. when importing blocks during the out-of-band-catchup.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.