### PR TITLE
Extend reporter metrics with recently connected peer counts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased changes
 - Fix a bug where the prometheus interface was not exposed in the
   bootstrapper when `CONCORDIUM_NODE_PROMETHEUS_LISTEN_PORT` was set.
-- Extend Prometheus exporter with metric `recent_peers`, see
+- Extend Prometheus exporter with metric `peer_bucket_size`, see
   [docs/prometheus-exporter.md](https://github.com/Concordium/concordium-node/blob/main/docs/prometheus-exporter.md) for more details.
 
 ## 5.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Changelog
 
 ## Unreleased changes
-- Fix a bug where the prometheus interface was not exposed in the
-  bootstrapper when `CONCORDIUM_NODE_PROMETHEUS_LISTEN_PORT` was set.
 - Extend Prometheus exporter with metric `peer_bucket_size`, see
   [docs/prometheus-exporter.md](https://github.com/Concordium/concordium-node/blob/main/docs/prometheus-exporter.md) for more details.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Unreleased changes
+- Fix a bug where the prometheus interface was not exposed in the
+  bootstrapper when `CONCORDIUM_NODE_PROMETHEUS_LISTEN_PORT` was set.
+- Extend Prometheus exporter with metric `recent_peers`, see
+  [docs/prometheus-exporter.md](https://github.com/Concordium/concordium-node/blob/main/docs/prometheus-exporter.md) for more details.
 
 ## 5.3.1
 

--- a/concordium-node/src/bin/bootstrapper.rs
+++ b/concordium-node/src/bin/bootstrapper.rs
@@ -54,6 +54,7 @@ async fn main() -> anyhow::Result<()> {
     start_push_gateway(&conf.prometheus, &node.stats, node.id());
 
     if let Some(plp) = conf.prometheus.prometheus_listen_port {
+        // We ignore the receiver since we do not care about graceful shutdown here.
         let (sender, _) = tokio::sync::broadcast::channel(1);
         tokio::spawn(async move {
             stats_export_service

--- a/concordium-node/src/connection/mod.rs
+++ b/concordium-node/src/connection/mod.rs
@@ -586,8 +586,16 @@ impl Connection {
     pub fn populate_remote_end_networks(&mut self, peer: RemotePeer, networks: &Networks) {
         self.remote_end_networks.extend(networks.iter());
 
+        let increment_bucket = |a: u64| {
+            self.handler.stats.recent_peers.with_label_values(&[a.to_string().as_str()]).inc();
+        };
+
         if self.remote_peer.peer_type != PeerType::Bootstrapper {
-            write_or_die!(self.handler.buckets()).insert_into_bucket(peer, networks.to_owned());
+            write_or_die!(self.handler.buckets()).insert_into_bucket(
+                peer,
+                networks.to_owned(),
+                increment_bucket,
+            );
         }
     }
 

--- a/concordium-node/src/connection/mod.rs
+++ b/concordium-node/src/connection/mod.rs
@@ -586,15 +586,11 @@ impl Connection {
     pub fn populate_remote_end_networks(&mut self, peer: RemotePeer, networks: &Networks) {
         self.remote_end_networks.extend(networks.iter());
 
-        let increment_bucket = |a: u64| {
-            self.handler.stats.recent_peers.with_label_values(&[a.to_string().as_str()]).inc();
-        };
-
         if self.remote_peer.peer_type != PeerType::Bootstrapper {
             write_or_die!(self.handler.buckets()).insert_into_bucket(
                 peer,
                 networks.to_owned(),
-                increment_bucket,
+                &self.handler.stats.peer_bucket_size,
             );
         }
     }

--- a/concordium-node/src/network/buckets.rs
+++ b/concordium-node/src/network/buckets.rs
@@ -121,7 +121,8 @@ impl Buckets {
     ) {
         let clean_before = get_current_stamp() - timeout_bucket_entry_period;
         self.buckets[0].retain(|entry| entry.last_seen >= clean_before);
-        bucket_size_gauge.with_label_values(&["0"]).set(self.buckets[0].len().try_into().unwrap());
+        let new_bucket_size = self.buckets[0].len();
+        bucket_size_gauge.with_label_values(&["0"]).set(new_bucket_size.try_into().unwrap());
     }
 }
 

--- a/concordium-node/src/network/buckets.rs
+++ b/concordium-node/src/network/buckets.rs
@@ -158,8 +158,7 @@ mod tests {
         };
 
         // and check that only one is inserted
-        let dummy_gauge =
-            IntGaugeVec::new(Opts::new("dummy", "").variable_label("bucket"), &["bucket"]);
+        let dummy_gauge = register_int_gauge_vec!("bucket_dummy_gauge", "help", &["bucket"]);
         if let Ok(bucket_size_gauge_dummy) = dummy_gauge {
             buckets.insert_into_bucket(p2p_peer, Default::default(), &bucket_size_gauge_dummy);
             buckets.insert_into_bucket(

--- a/concordium-node/src/network/buckets.rs
+++ b/concordium-node/src/network/buckets.rs
@@ -130,7 +130,7 @@ impl Buckets {
 mod tests {
     use super::*;
     use crate::common::P2PNodeId;
-    use prometheus::{core::GenericGaugeVec, Opts};
+    use prometheus::{core::GenericGaugeVec, register_int_gauge_vec, Opts};
     use rand::Rng;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
@@ -158,7 +158,8 @@ mod tests {
         };
 
         // and check that only one is inserted
-        let dummy_gauge = GenericGaugeVec::new(Opts::new("", ""), &[""]);
+        let dummy_gauge =
+            register_int_gauge_vec!(Opts::new("bucket_opts", "bucket_desc"), &["bucket"]);
         if let Ok(bucket_size_gauge_dummy) = dummy_gauge {
             buckets.insert_into_bucket(p2p_peer, Default::default(), &bucket_size_gauge_dummy);
             buckets.insert_into_bucket(

--- a/concordium-node/src/network/buckets.rs
+++ b/concordium-node/src/network/buckets.rs
@@ -52,7 +52,7 @@ impl Buckets {
         &mut self,
         peer: RemotePeer,
         networks: Networks,
-        on_insert_in_bucket: impl Fn(u64),
+        on_insert_success: impl Fn(u64),
     ) {
         let bucket = &mut self.buckets[0];
 
@@ -61,7 +61,7 @@ impl Buckets {
             networks,
             last_seen: get_current_stamp(),
         }) {
-            on_insert_in_bucket(0);
+            on_insert_success(0);
         }
     }
 
@@ -112,15 +112,11 @@ impl Buckets {
     }
 
     /// Removes the bucket nodes older than then specified amount of time.
-    pub fn clean_buckets(
-        &mut self,
-        timeout_bucket_entry_period: u64,
-        on_remove_from_bucket: impl Fn(u64),
-    ) {
+    pub fn clean_buckets(&mut self, timeout_bucket_entry_period: u64, on_removal: impl Fn(u64)) {
         let clean_before = get_current_stamp() - timeout_bucket_entry_period;
         self.buckets[0].retain(|entry| {
             if entry.last_seen < clean_before {
-                on_remove_from_bucket(0);
+                on_removal(0);
             }
             entry.last_seen >= clean_before
         });

--- a/concordium-node/src/network/buckets.rs
+++ b/concordium-node/src/network/buckets.rs
@@ -56,7 +56,6 @@ impl Buckets {
         bucket_size_gauge: &IntGaugeVec,
     ) {
         let bucket = &mut self.buckets[0];
-
         if bucket.insert(Node {
             peer,
             networks,
@@ -119,8 +118,9 @@ impl Buckets {
         bucket_size_gauge: &IntGaugeVec,
     ) {
         let clean_before = get_current_stamp() - timeout_bucket_entry_period;
-        self.buckets[0].retain(|entry| entry.last_seen >= clean_before);
-        let new_bucket_size = self.buckets[0].len();
+        let bucket = &mut self.buckets[0];
+        bucket.retain(|entry| entry.last_seen >= clean_before);
+        let new_bucket_size = bucket.len();
         bucket_size_gauge.with_label_values(&["0"]).set(new_bucket_size as i64);
     }
 }

--- a/concordium-node/src/network/buckets.rs
+++ b/concordium-node/src/network/buckets.rs
@@ -159,7 +159,7 @@ mod tests {
 
         // and check that only one is inserted
         let dummy_gauge =
-            register_int_gauge_vec!(Opts::new("bucket_opts", "bucket_desc"), &["bucket"]);
+            IntGaugeVec::new(Opts::new("dummy", "").variable_label("bucket"), &["bucket"]);
         if let Ok(bucket_size_gauge_dummy) = dummy_gauge {
             buckets.insert_into_bucket(p2p_peer, Default::default(), &bucket_size_gauge_dummy);
             buckets.insert_into_bucket(

--- a/concordium-node/src/p2p/maintenance.rs
+++ b/concordium-node/src/p2p/maintenance.rs
@@ -739,11 +739,10 @@ pub fn spawn(
                 && Instant::now().duration_since(last_buckets_cleaned)
                     >= Duration::from_millis(node.config.bucket_cleanup_interval)
             {
-                let decrement_bucket = |a: u64| {
-                    node.stats.recent_peers.with_label_values(&[a.to_string().as_str()]).dec();
-                };
-                write_or_die!(node.buckets())
-                    .clean_buckets(node.config.timeout_bucket_entry_period, decrement_bucket);
+                write_or_die!(node.buckets()).clean_buckets(
+                    node.config.timeout_bucket_entry_period,
+                    &node.stats.peer_bucket_size,
+                );
                 last_buckets_cleaned = Instant::now();
             }
         }

--- a/concordium-node/src/p2p/maintenance.rs
+++ b/concordium-node/src/p2p/maintenance.rs
@@ -739,8 +739,11 @@ pub fn spawn(
                 && Instant::now().duration_since(last_buckets_cleaned)
                     >= Duration::from_millis(node.config.bucket_cleanup_interval)
             {
+                let decrement_bucket = |a: u64| {
+                    node.stats.recent_peers.with_label_values(&[a.to_string().as_str()]).dec();
+                };
                 write_or_die!(node.buckets())
-                    .clean_buckets(node.config.timeout_bucket_entry_period);
+                    .clean_buckets(node.config.timeout_bucket_entry_period, decrement_bucket);
                 last_buckets_cleaned = Instant::now();
             }
         }

--- a/concordium-node/src/stats_export_service.rs
+++ b/concordium-node/src/stats_export_service.rs
@@ -272,8 +272,8 @@ pub struct StatsExportService {
     /// This is not exposed in the prometheus exporter, but is exposed by the
     /// gRPC API.
     pub avg_bps_out: AtomicU64,
-    /// The number of peers that recently connected to the bootstrapper labelled
-    /// by the bucket in which they are contained.
+    /// The number of peers that recently connected to the node labelled by the
+    /// bucket in which they are contained.
     pub peer_bucket_size: IntGaugeVec,
 }
 
@@ -473,8 +473,8 @@ impl StatsExportService {
         let peer_bucket_size = IntGaugeVec::new(
             Opts::new(
                 "peer_bucket_size",
-                "The number of peers that recently connected to the bootstrapper labelled by the \
-                 number of the bucket in which they are contained",
+                "The number of peers that recently connected to the node labelled by the number \
+                 of the bucket in which they are contained",
             )
             .variable_label("bucket"),
             &["bucket"],

--- a/concordium-node/src/stats_export_service.rs
+++ b/concordium-node/src/stats_export_service.rs
@@ -18,8 +18,8 @@ use hyper::Body;
 use prometheus::{
     self,
     core::{Atomic, AtomicI64, AtomicU64, GenericGauge},
-    Encoder, Gauge, HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGauge, Opts,
-    Registry, TextEncoder,
+    Encoder, Gauge, HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
+    Opts, Registry, TextEncoder,
 };
 use std::{
     net::SocketAddr,
@@ -272,6 +272,9 @@ pub struct StatsExportService {
     /// This is not exposed in the prometheus exporter, but is exposed by the
     /// gRPC API.
     pub avg_bps_out: AtomicU64,
+    /// The number of peers that recently connected to the bootstrapper labelled
+    /// by the bucket in which they are contained.
+    pub recent_peers: IntGaugeVec,
 }
 
 impl StatsExportService {
@@ -467,6 +470,16 @@ impl StatsExportService {
         let last_throughput_measurement_received_bytes = AtomicU64::new(0);
         let avg_bps_in = AtomicU64::new(0);
         let avg_bps_out = AtomicU64::new(0);
+        let recent_peers = IntGaugeVec::new(
+            Opts::new(
+                "recent_peers",
+                "The number of peers that recently connected to the bootstrapper labelled by the \
+                 number of the bucket in which they are contained",
+            )
+            .variable_label("bucket"),
+            &["bucket"],
+        )?;
+        registry.register(Box::new(recent_peers.clone()))?;
 
         Ok(StatsExportService {
             registry,
@@ -501,6 +514,7 @@ impl StatsExportService {
             last_throughput_measurement_received_bytes,
             avg_bps_in,
             avg_bps_out,
+            recent_peers,
         })
     }
 

--- a/concordium-node/src/stats_export_service.rs
+++ b/concordium-node/src/stats_export_service.rs
@@ -274,7 +274,7 @@ pub struct StatsExportService {
     pub avg_bps_out: AtomicU64,
     /// The number of peers that recently connected to the bootstrapper labelled
     /// by the bucket in which they are contained.
-    pub recent_peers: IntGaugeVec,
+    pub peer_bucket_size: IntGaugeVec,
 }
 
 impl StatsExportService {
@@ -470,16 +470,16 @@ impl StatsExportService {
         let last_throughput_measurement_received_bytes = AtomicU64::new(0);
         let avg_bps_in = AtomicU64::new(0);
         let avg_bps_out = AtomicU64::new(0);
-        let recent_peers = IntGaugeVec::new(
+        let peer_bucket_size = IntGaugeVec::new(
             Opts::new(
-                "recent_peers",
+                "peer_bucket_size",
                 "The number of peers that recently connected to the bootstrapper labelled by the \
                  number of the bucket in which they are contained",
             )
             .variable_label("bucket"),
             &["bucket"],
         )?;
-        registry.register(Box::new(recent_peers.clone()))?;
+        registry.register(Box::new(peer_bucket_size.clone()))?;
 
         Ok(StatsExportService {
             registry,
@@ -514,7 +514,7 @@ impl StatsExportService {
             last_throughput_measurement_received_bytes,
             avg_bps_in,
             avg_bps_out,
-            recent_peers,
+            peer_bucket_size,
         })
     }
 

--- a/docs/prometheus-exporter.md
+++ b/docs/prometheus-exporter.md
@@ -235,4 +235,4 @@ This metric is intended for setting up alerts to catch outdated nodes.
 
 ### `peer_bucket_size`
 
-The number of recently connected peers used to generate the peer list included in handshake responses of the bootstrapper. Labelled by the number of the bucket in which the peer is maintained (`bucket=<number>`).
+The number of recently connected peers used to generate the peer list included in handshake responses of the node. Labelled by the number of the bucket in which the peer is maintained (`bucket=<number>`).

--- a/docs/prometheus-exporter.md
+++ b/docs/prometheus-exporter.md
@@ -233,6 +233,6 @@ Indicator for unsupported pending protocol updates where a non-zero value indica
 
 This metric is intended for setting up alerts to catch outdated nodes.
 
-### `recent_peers`
+### `peer_bucket_size`
 
 The size of the set of recently connected peers used to generate the peer list included in handshake responses of the bootstrapper. Labelled by the number of the bucket in which the peer is maintained (`bucket=<number>`).

--- a/docs/prometheus-exporter.md
+++ b/docs/prometheus-exporter.md
@@ -235,4 +235,4 @@ This metric is intended for setting up alerts to catch outdated nodes.
 
 ### `peer_bucket_size`
 
-The size of the set of recently connected peers used to generate the peer list included in handshake responses of the bootstrapper. Labelled by the number of the bucket in which the peer is maintained (`bucket=<number>`).
+The number of recently connected peers used to generate the peer list included in handshake responses of the bootstrapper. Labelled by the number of the bucket in which the peer is maintained (`bucket=<number>`).

--- a/docs/prometheus-exporter.md
+++ b/docs/prometheus-exporter.md
@@ -232,3 +232,7 @@ Finalized blocks received as part of catchup are also counted, when the block wa
 Indicator for unsupported pending protocol updates where a non-zero value indicates the effective time (Unix time in milliseconds) of a pending unsupported protocol update.
 
 This metric is intended for setting up alerts to catch outdated nodes.
+
+### `recent_peers`
+
+The size of the set of recently connected peers used to generate the peer list included in handshake responses of the bootstrapper. Labelled by the number of the bucket in which the peer is maintained (`bucket=<number>`).


### PR DESCRIPTION
## Purpose

Extends the prometheus reporter interface by adding a metric of recently connected peer counts, labelled by the bucket in which the peer is maintained. The following is an example of the relevant snippet of the `/metrics`-endpoint after these changes:

```
...
# HELP peer_bucket_size The number of peers that recently connected to the bootstrapper labelled by the number of the bucket in which they are contained
# TYPE peer_bucket_size gauge
peer_bucket_size{bucket="0"} 2
...
```

## Changes

Extend reporter and update metrics when elements are added to and removed from buckets.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.