### PR TITLE
Fix leftover renaming of metric in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 
 ## 5.3.0
 
-- Extend Prometheus exporter with metrics: `grpc_request_duration_seconds`, `grpc_in_flight_requests`, `consensus_baking_committee`, `consensus_finalization_committee`, `consensus_baking_lottery_power`, `consensus_baked_blocks_total`, `consensus_finalized_baked_blocks_total`, `network_soft_banned_peers_total`, `consensus_non_finalized_transactions` and `consensus_unsupported_pending_protocol_version` see [docs/prometheus-exporter.md](https://github.com/Concordium/concordium-node/blob/main/docs/prometheus-exporter.md) for more details.
+- Extend Prometheus exporter with metrics: `grpc_request_response_time_seconds`, `grpc_in_flight_requests`, `consensus_baking_committee`, `consensus_finalization_committee`, `consensus_baking_lottery_power`, `consensus_baked_blocks_total`, `consensus_finalized_baked_blocks_total`, `network_soft_banned_peers_total`, `consensus_non_finalized_transactions` and `consensus_unsupported_pending_protocol_version` see [docs/prometheus-exporter.md](https://github.com/Concordium/concordium-node/blob/main/docs/prometheus-exporter.md) for more details.
 
 ## 5.2.4
 


### PR DESCRIPTION
## Purpose

Forgot to update the metric name in changelog when renaming `grpc_request_duration_seconds` to `grpc_request_response_time_seconds`