### PR TITLE
Fix mac build script

### DIFF
--- a/scripts/distribution/macOS-package/build.sh
+++ b/scripts/distribution/macOS-package/build.sh
@@ -248,6 +248,10 @@ function collectDylibs() {
         local fileToFix=${1:?"Missing file to fix with dylibbundler"};
         cd "$payloadDir/Library/Concordium Node"
         # Paths to search for dylibs are added with the '-s' flag.
+        # We use `--create-dir` to ensure that the `./libs` folder exists.
+        # But we should not use `--overwrite-dir` even though it implies `--create-dir`
+        # because it will delete the libs folder if it already exists, which would delete 
+        # the results of previous calls to `collectDylibsFor`.
         "$macdylibbundlerDir/dylibbundler" --fix-file "$fileToFix" --bundle-deps --dest-dir "./libs" --install-path "@executable_path/libs/" --create-dir \
             -s "$concordiumDylibDir" \
             -s "$stackSnapshotDir" \

--- a/scripts/distribution/macOS-package/build.sh
+++ b/scripts/distribution/macOS-package/build.sh
@@ -24,7 +24,7 @@ readonly collectorDir="$macPackageDir/../../../collector"
 readonly consensusDir="$macPackageDir/../../../concordium-consensus"
 
 readonly toolsDir="$macPackageDir/tools"
-readonly macdylibbundlerDir="$toolsDir/macdylibbundler-1.0.0"
+readonly macdylibbundlerDir="$toolsDir/macdylibbundler-1.0.5"
 
 readonly buildDir="$macPackageDir/build"
 readonly payloadDir="$buildDir/payload"
@@ -226,7 +226,7 @@ function getDylibbundler() {
         logInfo " -- Downloading..."
         mkdir "$toolsDir"
         cd "$macPackageDir"
-        curl -sSL "https://github.com/auriamg/macdylibbundler/archive/refs/tags/1.0.0.zip" > "$toolsDir/dylibbundler.zip" \
+        curl -sSL "https://github.com/auriamg/macdylibbundler/archive/refs/tags/1.0.5.zip" > "$toolsDir/dylibbundler.zip" \
                     && logInfo " -- Unzipping..." \
                     && cd "$toolsDir" \
                     && unzip "dylibbundler.zip" \
@@ -248,7 +248,7 @@ function collectDylibs() {
         local fileToFix=${1:?"Missing file to fix with dylibbundler"};
         cd "$payloadDir/Library/Concordium Node"
         # Paths to search for dylibs are added with the '-s' flag.
-        "$macdylibbundlerDir/dylibbundler" --fix-file "$fileToFix" --bundle-deps --dest-dir "./libs" --install-path "@executable_path/libs/" --overwrite-dir \
+        "$macdylibbundlerDir/dylibbundler" --fix-file "$fileToFix" --bundle-deps --dest-dir "./libs" --install-path "@executable_path/libs/" --create-dir \
             -s "$concordiumDylibDir" \
             -s "$stackSnapshotDir" \
             $stackLibDirs # Unquoted on purpose to use as arguments correctly


### PR DESCRIPTION
## Purpose

Fix the mac build script, so that the dylibs are included in the build.
Closes https://github.com/Concordium/concordium-node/issues/820

This issue was caused by a few things:
- We separated out the node collector in a previous PR.
- The macdylibbundler tool v1.0.0 did not quote all paths, which was fine for our previous node setup, but it became an issue with the new node collector (because some of our folder names have spaces in them).
- Version 1.0.5 of macdylibbundler fixes the issue with quoting paths (https://github.com/auriamg/macdylibbundler/commits/master).
- The last issue was that the second invocation of `collectDylibsFor` would overwrite the `libs` folder. I am not sure why this wasn't an issue before. Perhaps the tool doesn't overwrite the dir if the binary doesn't have any dependencies that need to be moved. But this was fixed by changing `--overwrite-dir` to `--create-dir`, which just ensures that the dir is created instead of overwriting it.

## Changes

- Update to macdylibbundler 1.0.5
- Change `--overwrite-dir` to `--create-dir`

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
