### PR TITLE
Refactor statistics handling.

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/Statistics.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Statistics.hs
@@ -2,8 +2,12 @@
 
 module Concordium.GlobalState.Statistics where
 
+import Data.Maybe
 import Data.Time
+import Data.Time.Clock.POSIX
 import Lens.Micro.Platform
+
+import Concordium.Utils
 
 -- |Weight factor to use in computing exponentially-weighted moving averages.
 emaWeight :: Double
@@ -74,3 +78,151 @@ initialConsensusStatistics =
           _finalizationPeriodEMA = Nothing,
           _finalizationPeriodEMVar = Nothing
         }
+
+-- |Update the statistics when a block becomes fully validated (arrives).
+updateStatsOnArrive ::
+    -- |Nominal block time.
+    UTCTime ->
+    -- |Block arrival time.
+    UTCTime ->
+    -- |Number of transactions in the block.
+    Int ->
+    ConsensusStatistics ->
+    ConsensusStatistics
+updateStatsOnArrive nominalTime arrivalTime transactionCount =
+    updateTransactionsPerBlock . updatePeriod . updateLatency . (blocksVerifiedCount +~ 1)
+  where
+    updateLatency s =
+        s
+            & (blockArriveLatencyEMA .~ oldEMA + emaWeight * delta)
+            & (blockArriveLatencyEMVar %~ \oldEMVar -> (1 - emaWeight) * (oldEMVar + emaWeight * delta * delta))
+      where
+        oldEMA = s ^. blockArriveLatencyEMA
+        delta = realToFrac (diffUTCTime arrivalTime nominalTime) - oldEMA
+
+    updatePeriod s =
+        case s ^. blockLastArrive of
+            Nothing -> s & blockLastArrive ?~! arrivalTime
+            Just lastBTime ->
+                s
+                    & (blockLastArrive ?~! arrivalTime)
+                    & (blockArrivePeriodEMA ?~! oldEMA + emaWeight * delta)
+                    & (blockArrivePeriodEMVar ?~! (1 - emaWeight) * (oldEMVar + emaWeight * delta * delta))
+              where
+                blockTime = realToFrac (diffUTCTime arrivalTime lastBTime)
+                oldEMA = fromMaybe blockTime (s ^. blockArrivePeriodEMA)
+                delta = blockTime - oldEMA
+                oldEMVar = fromMaybe 0 (s ^. blockArrivePeriodEMVar)
+
+    updateTransactionsPerBlock s =
+        s
+            & (transactionsPerBlockEMA .~ oldEMA + emaWeight * delta)
+            & (transactionsPerBlockEMVar %~ \oldEMVar -> (1 - emaWeight) * (oldEMVar + emaWeight * delta * delta))
+      where
+        oldEMA = s ^. transactionsPerBlockEMA
+        delta = fromIntegral transactionCount - oldEMA
+
+-- |Render the statistics relating to block arrivals as a string.
+showArriveStatistics :: ConsensusStatistics -> String
+showArriveStatistics s =
+    "Arrive statistics:"
+        ++ " blocksVerifiedCount="
+        ++ show (s ^. blocksVerifiedCount)
+        ++ " blockLastArrive="
+        ++ show (maybe (0 :: Double) (realToFrac . utcTimeToPOSIXSeconds) $ s ^. blockLastArrive)
+        ++ " blockArriveLatencyEMA="
+        ++ show (s ^. blockArriveLatencyEMA)
+        ++ " blockArriveLatencyEMSD="
+        ++ show (sqrt $ s ^. blockArriveLatencyEMVar)
+        ++ " blockArrivePeriodEMA="
+        ++ show (s ^. blockArrivePeriodEMA)
+        ++ " blockArrivePeriodEMSD="
+        ++ show (sqrt <$> s ^. blockArrivePeriodEMVar)
+        ++ " transactionsPerBlockEMA="
+        ++ show (s ^. transactionsPerBlockEMA)
+        ++ " transactionsPerBlockEMSD="
+        ++ show (sqrt $ s ^. transactionsPerBlockEMVar)
+
+-- |Update the statistics when a block is received by the consensus.
+updateStatsOnReceive ::
+    -- |Nominal block time.
+    UTCTime ->
+    -- |Block receive time.
+    UTCTime ->
+    ConsensusStatistics ->
+    ConsensusStatistics
+updateStatsOnReceive nominalTime receiveTime =
+    updatePeriod . updateLatency . (blocksReceivedCount +~ 1)
+  where
+    updateLatency s =
+        s
+            & (blockReceiveLatencyEMA .~ oldEMA + emaWeight * delta)
+            & (blockReceiveLatencyEMVar %~ \oldEMVar -> (1 - emaWeight) * (oldEMVar + emaWeight * delta * delta))
+      where
+        oldEMA = s ^. blockReceiveLatencyEMA
+        delta = realToFrac (diffUTCTime receiveTime nominalTime) - oldEMA
+    updatePeriod s =
+        case s ^. blockLastReceived of
+            Nothing -> s & blockLastReceived ?~! receiveTime
+            Just lastBTime ->
+                s
+                    & (blockLastReceived ?~! receiveTime)
+                    & (blockReceivePeriodEMA ?~! oldEMA + emaWeight * delta)
+                    & (blockReceivePeriodEMVar ?~! (1 - emaWeight) * (oldEMVar + emaWeight * delta * delta))
+              where
+                blockTime = realToFrac (diffUTCTime receiveTime lastBTime)
+                oldEMA = fromMaybe blockTime (s ^. blockReceivePeriodEMA)
+                delta = blockTime - oldEMA
+                oldEMVar = fromMaybe 0 (s ^. blockReceivePeriodEMVar)
+
+-- |Render the statistics related to receiving blocks as a string.
+showReceiveStatistics :: ConsensusStatistics -> String
+showReceiveStatistics s =
+    "Receive statistics:"
+        ++ " blocksReceivedCount="
+        ++ show (s ^. blocksReceivedCount)
+        ++ " blockLastReceived="
+        ++ show (maybe (0 :: Double) (realToFrac . utcTimeToPOSIXSeconds) $ s ^. blockLastReceived)
+        ++ " blockReceiveLatencyEMA="
+        ++ show (s ^. blockReceiveLatencyEMA)
+        ++ " blockReceiveLatencyEMSD="
+        ++ show (sqrt $ s ^. blockReceiveLatencyEMVar)
+        ++ " blockReceivePeriodEMA="
+        ++ show (s ^. blockReceivePeriodEMA)
+        ++ " blockReceivePeriodEMSD="
+        ++ show (sqrt <$> s ^. blockReceivePeriodEMVar)
+
+-- |Update the statistics when a block becomes (explicitly) finalized.
+updateStatsOnFinalize ::
+    -- |Current time
+    UTCTime ->
+    ConsensusStatistics ->
+    ConsensusStatistics
+updateStatsOnFinalize curTime =
+    (lastFinalizedTime ?~! curTime) . updatePeriod . (finalizationCount +~ 1)
+  where
+    updatePeriod s
+        | Just lastFinTime <- s ^. lastFinalizedTime =
+            let
+                finTime = realToFrac (diffUTCTime curTime lastFinTime)
+                oldEMA = fromMaybe finTime (s ^. finalizationPeriodEMA)
+                delta = finTime - oldEMA
+                oldEMVar = fromMaybe 0 (s ^. finalizationPeriodEMVar)
+            in
+                s
+                    & (finalizationPeriodEMA ?~! oldEMA + emaWeight * delta)
+                    & (finalizationPeriodEMVar ?~! (1 - emaWeight) * (oldEMVar + emaWeight * delta * delta))
+        | otherwise = s
+
+-- |Render the statistics related to finalization.
+showFinalizationStatistics :: ConsensusStatistics -> String
+showFinalizationStatistics s =
+    "Finalization statistics:"
+        ++ " finalizationCount="
+        ++ show (s ^. finalizationCount)
+        ++ " lastFinalizedTime="
+        ++ show (maybe (0 :: Double) (realToFrac . utcTimeToPOSIXSeconds) $ s ^. lastFinalizedTime)
+        ++ " finalizationPeriodEMA="
+        ++ show (s ^. finalizationPeriodEMA)
+        ++ " finalizationPeriodEMSD="
+        ++ show (sqrt <$> s ^. finalizationPeriodEMVar)

--- a/concordium-consensus/src/Concordium/Skov/Statistics.hs
+++ b/concordium-consensus/src/Concordium/Skov/Statistics.hs
@@ -1,12 +1,5 @@
 module Concordium.Skov.Statistics where
 
-import Data.Maybe
-import Data.Time
-import Data.Time.Clock.POSIX
-import Lens.Micro.Platform
-
-import Concordium.Utils
-
 import Concordium.GlobalState.BlockPointer (bpArriveTime, bpTransactionCount)
 import Concordium.GlobalState.Statistics
 import Concordium.GlobalState.TreeState
@@ -18,138 +11,25 @@ import Concordium.TimeMonad
 -- | Called when a block is fully validated (arrives) to update the statistics.
 updateArriveStatistics :: (MonadLogger m, TreeStateMonad m, SkovQueryMonad m) => BlockPointerType m -> m ()
 updateArriveStatistics bp = do
-    s0 <- getConsensusStatistics
-    let s1 = s0 & blocksVerifiedCount +~ 1
-    s2 <- updateLatency s1
-    let s3 = updatePeriod s2
-    let s = updateTransactionsPerBlock s3
+    nominalTime <- getSlotTime (blockSlot bp)
+    s <-
+        updateStatsOnArrive nominalTime (bpArriveTime bp) (bpTransactionCount bp)
+            <$> getConsensusStatistics
     putConsensusStatistics s
-    logEvent Skov LLInfo $
-        "Arrive statistics:"
-            ++ " blocksVerifiedCount="
-            ++ show (s ^. blocksVerifiedCount)
-            ++ " blockLastArrive="
-            ++ show (maybe (0 :: Double) (realToFrac . utcTimeToPOSIXSeconds) $ s ^. blockLastArrive)
-            ++ " blockArriveLatencyEMA="
-            ++ show (s ^. blockArriveLatencyEMA)
-            ++ " blockArriveLatencyEMSD="
-            ++ show (sqrt $ s ^. blockArriveLatencyEMVar)
-            ++ " blockArrivePeriodEMA="
-            ++ show (s ^. blockArrivePeriodEMA)
-            ++ " blockArrivePeriodEMSD="
-            ++ show (sqrt <$> s ^. blockArrivePeriodEMVar)
-            ++ " transactionsPerBlockEMA="
-            ++ show (s ^. transactionsPerBlockEMA)
-            ++ " transactionsPerBlockEMSD="
-            ++ show (sqrt $ s ^. transactionsPerBlockEMVar)
-  where
-    curTime = bpArriveTime bp
-    updateLatency s = do
-        slotTime <- getSlotTime (blockSlot bp)
-        let
-            oldEMA = s ^. blockArriveLatencyEMA
-            delta = realToFrac (diffUTCTime curTime slotTime) - oldEMA
-        return $
-            s
-                & (blockArriveLatencyEMA .~ oldEMA + emaWeight * delta)
-                & (blockArriveLatencyEMVar %~ \oldEMVar -> (1 - emaWeight) * (oldEMVar + emaWeight * delta * delta))
-    updatePeriod s =
-        case s ^. blockLastArrive of
-            Nothing -> s & blockLastArrive ?~! curTime
-            Just lastBTime ->
-                let
-                    blockTime = realToFrac (diffUTCTime curTime lastBTime)
-                    oldEMA = fromMaybe blockTime (s ^. blockArrivePeriodEMA)
-                    delta = blockTime - oldEMA
-                    oldEMVar = fromMaybe 0 (s ^. blockArrivePeriodEMVar)
-                in
-                    s
-                        & (blockLastArrive ?~! curTime)
-                        & (blockArrivePeriodEMA ?~! oldEMA + emaWeight * delta)
-                        & (blockArrivePeriodEMVar ?~! (1 - emaWeight) * (oldEMVar + emaWeight * delta * delta))
-    updateTransactionsPerBlock s =
-        let
-            oldEMA = s ^. transactionsPerBlockEMA
-            delta = fromIntegral (bpTransactionCount bp) - oldEMA
-        in
-            s
-                & (transactionsPerBlockEMA .~ oldEMA + emaWeight * delta)
-                & (transactionsPerBlockEMVar %~ \oldEMVar -> (1 - emaWeight) * (oldEMVar + emaWeight * delta * delta))
+    logEvent Skov LLInfo $ showArriveStatistics s
 
 -- | Called when a block is received to update the statistics.
 updateReceiveStatistics :: (TreeStateMonad m, MonadLogger m, SkovQueryMonad m) => PendingBlock -> m ()
 updateReceiveStatistics pb = do
-    s0 <- getConsensusStatistics
-    let s1 = s0 & blocksReceivedCount +~ 1
-    s2 <- updateLatency s1
-    let s = updatePeriod s2
+    nominalTime <- getSlotTime (blockSlot pb)
+    s <- updateStatsOnReceive nominalTime (blockReceiveTime pb) <$> getConsensusStatistics
     putConsensusStatistics s
-    logEvent Skov LLInfo $
-        "Receive statistics:"
-            ++ " blocksReceivedCount="
-            ++ show (s ^. blocksReceivedCount)
-            ++ " blockLastReceived="
-            ++ show (maybe (0 :: Double) (realToFrac . utcTimeToPOSIXSeconds) $ s ^. blockLastReceived)
-            ++ " blockReceiveLatencyEMA="
-            ++ show (s ^. blockReceiveLatencyEMA)
-            ++ " blockReceiveLatencyEMSD="
-            ++ show (sqrt $ s ^. blockReceiveLatencyEMVar)
-            ++ " blockReceivePeriodEMA="
-            ++ show (s ^. blockReceivePeriodEMA)
-            ++ " blockReceivePeriodEMSD="
-            ++ show (sqrt <$> s ^. blockReceivePeriodEMVar)
-  where
-    updateLatency s = do
-        slotTime <- getSlotTime (blockSlot pb)
-        let
-            oldEMA = s ^. blockReceiveLatencyEMA
-            delta = realToFrac (diffUTCTime (blockReceiveTime pb) slotTime) - oldEMA
-        return $
-            s
-                & (blockReceiveLatencyEMA .~ oldEMA + emaWeight * delta)
-                & (blockReceiveLatencyEMVar %~ \oldEMVar -> (1 - emaWeight) * (oldEMVar + emaWeight * delta * delta))
-    updatePeriod s =
-        case s ^. blockLastReceived of
-            Nothing -> s & blockLastReceived ?~! blockReceiveTime pb
-            Just lastBTime ->
-                let
-                    blockTime = realToFrac (diffUTCTime (blockReceiveTime pb) lastBTime)
-                    oldEMA = fromMaybe blockTime (s ^. blockReceivePeriodEMA)
-                    delta = blockTime - oldEMA
-                    oldEMVar = fromMaybe 0 (s ^. blockReceivePeriodEMVar)
-                in
-                    s
-                        & (blockLastReceived ?~! blockReceiveTime pb)
-                        & (blockReceivePeriodEMA ?~! oldEMA + emaWeight * delta)
-                        & (blockReceivePeriodEMVar ?~! (1 - emaWeight) * (oldEMVar + emaWeight * delta * delta))
+    logEvent Skov LLInfo $ showReceiveStatistics s
 
 -- | Called when a block has been finalized to update the statistics.
 updateFinalizationStatistics :: (TreeStateMonad m, MonadLogger m, TimeMonad m) => m ()
 updateFinalizationStatistics = do
-    s0 <- getConsensusStatistics
-    let s1 = s0 & finalizationCount +~ 1
     curTime <- currentTime
-    let s = case s1 ^. lastFinalizedTime of
-            Nothing -> s1 & lastFinalizedTime ?~! curTime
-            Just lastFinTime ->
-                let
-                    finTime = realToFrac (diffUTCTime curTime lastFinTime)
-                    oldEMA = fromMaybe finTime (s1 ^. finalizationPeriodEMA)
-                    delta = finTime - oldEMA
-                    oldEMVar = fromMaybe 0 (s1 ^. finalizationPeriodEMVar)
-                in
-                    s1
-                        & (lastFinalizedTime ?~! curTime)
-                        & (finalizationPeriodEMA ?~! oldEMA + emaWeight * delta)
-                        & (finalizationPeriodEMVar ?~! (1 - emaWeight) * (oldEMVar + emaWeight * delta * delta))
+    s <- updateStatsOnFinalize curTime <$> getConsensusStatistics
     putConsensusStatistics s
-    logEvent Skov LLInfo $
-        "Finalization statistics:"
-            ++ " finalizationCount="
-            ++ show (s ^. finalizationCount)
-            ++ " lastFinalizedTime="
-            ++ show (maybe (0 :: Double) (realToFrac . utcTimeToPOSIXSeconds) $ s ^. lastFinalizedTime)
-            ++ " finalizationPeriodEMA="
-            ++ show (s ^. finalizationPeriodEMA)
-            ++ " finalizationPeriodEMSD="
-            ++ show (sqrt <$> s ^. finalizationPeriodEMVar)
+    logEvent Skov LLInfo $ showFinalizationStatistics s


### PR DESCRIPTION
## Purpose

This refactors the handling of block receive/arrive/finalize statistics to simplify reuse in the new consensus.

## Changes

- `updateArriveStatistics` (`Concordium.Skov.Statistics`) is refactored into `updateStatsOnArrive` and `showArriveStatistics` (`Concordium.GlobalState.Statistics`).

- `updateReceiveStatistics` (`Concordium.Skov.Statistics`) is refactored into `updateStatsOnReceive` and `showReceiveStatistics` (`Concordium.GlobalState.Statistics`).

- `updateFinalizationStatistics` (`Concordium.Skov.Statistics`) is refactored into `updateStatsOnFinalize` and `showFinalizationStatistics` (`Concordium.GlobalState.Statistics`).

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
