### PR TITLE
Update readme

### DIFF
--- a/concordium-node/README.md
+++ b/concordium-node/README.md
@@ -97,7 +97,7 @@ Environment variables only apply to the default build. This links with shared Ha
   Once the node is built it can be run as
 
   ```console
-  cargo run -- --config-dir <CONFIG_DIR> --data-dir <DATA_DIR>
+  cargo run -- --config-dir <CONCORDIUM_NODE_CONFIG_DIR> --data-dir <CONCORDIUM_NODE_DATA_DIR>
   ```
 
   or
@@ -105,7 +105,6 @@ Environment variables only apply to the default build. This links with shared Ha
   ```console
   cargo run --release -- --config-dir <CONCORDIUM_NODE_CONFIG_DIR> --data-dir <CONCORDIUM_NODE_DATA_DIR>
   ```
-
 
   to be run in release mode for improved performance. Note that the
   [concordium-consensus](../concordium-consensus/) dependency is the same regardless of how the
@@ -115,7 +114,6 @@ Documentation about what <CONCORDIUM_NODE_CONFIG_DIR> and <CONCORDIUM_NODE_DATA_
 
 - The node built with Haskell library auto-discovery is not suitable for distribution to other
   machines. It is a dynamically linked binary with a large number of shared library dependencies.
-
 
 ### MacOS Specific
 

--- a/concordium-node/README.md
+++ b/concordium-node/README.md
@@ -110,7 +110,7 @@ Environment variables only apply to the default build. This links with shared Ha
   [concordium-consensus](../concordium-consensus/) dependency is the same regardless of how the
   node itself is built, the `--release` only applies to the optimization of the rust node xcomponents.
   
-Documentation about what <CONCORDIUM_NODE_CONFIG_DIR> and <CONCORDIUM_NODE_DATA_DIR> is seen at https://github.com/Concordium/concordium-node/blob/main/scripts/distribution/ubuntu-packages/README.md.
+Documentation about what <CONCORDIUM_NODE_CONFIG_DIR> and <CONCORDIUM_NODE_DATA_DIR> is seen at https://github.com/Concordium/concordium-node/blob/main/VARIABLES.md#common
 
 - The node built with Haskell library auto-discovery is not suitable for distribution to other
   machines. It is a dynamically linked binary with a large number of shared library dependencies.

--- a/concordium-node/README.md
+++ b/concordium-node/README.md
@@ -103,7 +103,7 @@ Environment variables only apply to the default build. This links with shared Ha
   or
 
   ```console
-  cargo run --release -- --config-dir <CONFIG_DIR> --data-dir <DATA_DIR>
+  cargo run --release -- --config-dir <CONCORDIUM_NODE_CONFIG_DIR> --data-dir <CONCORDIUM_NODE_DATA_DIR>
   ```
 
 
@@ -111,7 +111,7 @@ Environment variables only apply to the default build. This links with shared Ha
   [concordium-consensus](../concordium-consensus/) dependency is the same regardless of how the
   node itself is built, the `--release` only applies to the optimization of the rust node xcomponents.
   
-Documentation about what <CONFIG_DIR> and <DATA_DIR> is seen at https://github.com/Concordium/concordium-node/blob/main/scripts/distribution/ubuntu-packages/README.md.
+Documentation about what <CONCORDIUM_NODE_CONFIG_DIR> and <CONCORDIUM_NODE_DATA_DIR> is seen at https://github.com/Concordium/concordium-node/blob/main/scripts/distribution/ubuntu-packages/README.md.
 
 - The node built with Haskell library auto-discovery is not suitable for distribution to other
   machines. It is a dynamically linked binary with a large number of shared library dependencies.

--- a/concordium-node/README.md
+++ b/concordium-node/README.md
@@ -127,7 +127,7 @@ extra-include-dirs:
 - /opt/homebrew/include/
 ```
 
-### Apple silicon specific
+### Apple silicon + MacOS specific
 
 You may need to add the following entry to your `~/.stack/config.yaml` for the `libffi` include:
 

--- a/concordium-node/README.md
+++ b/concordium-node/README.md
@@ -108,7 +108,7 @@ Environment variables only apply to the default build. This links with shared Ha
 
   to be run in release mode for improved performance. Note that the
   [concordium-consensus](../concordium-consensus/) dependency is the same regardless of how the
-  node itself is built, the `--release` only applies to the optimization of the rust node xcomponents.
+  node itself is built, the `--release` only applies to the optimization of the rust node components.
   
 Documentation about what <CONCORDIUM_NODE_CONFIG_DIR> and <CONCORDIUM_NODE_DATA_DIR> is seen at https://github.com/Concordium/concordium-node/blob/main/VARIABLES.md#common
 

--- a/concordium-node/README.md
+++ b/concordium-node/README.md
@@ -127,7 +127,7 @@ extra-include-dirs:
 - /opt/homebrew/include/
 ```
 
-### Apple silicon + MacOS specific
+### M1 and M2 MacOS specific
 
 You may need to add the following entry to your `~/.stack/config.yaml` for the `libffi` include:
 

--- a/concordium-node/README.md
+++ b/concordium-node/README.md
@@ -97,21 +97,25 @@ Environment variables only apply to the default build. This links with shared Ha
   Once the node is built it can be run as
 
   ```console
-  cargo run --
+  cargo run -- --config-dir <CONFIG_DIR> --data-dir <DATA_DIR>
   ```
 
   or
 
   ```console
-  cargo run --release --
+  cargo run --release -- --config-dir <CONFIG_DIR> --data-dir <DATA_DIR>
   ```
+
 
   to be run in release mode for improved performance. Note that the
   [concordium-consensus](../concordium-consensus/) dependency is the same regardless of how the
-  node itself is built, the `--release` only applies to the optimization of the Rust node xcomponents.
+  node itself is built, the `--release` only applies to the optimization of the rust node xcomponents.
+  
+Documentation about what <CONFIG_DIR> and <DATA_DIR> is seen at https://github.com/Concordium/concordium-node/blob/main/scripts/distribution/ubuntu-packages/README.md.
 
 - The node built with Haskell library auto-discovery is not suitable for distribution to other
   machines. It is a dynamically linked binary with a large number of shared library dependencies.
+
 
 ### MacOS Specific
 
@@ -125,7 +129,7 @@ extra-include-dirs:
 - /opt/homebrew/include/
 ```
 
-### M1 MacOS Specific
+### Apple silicon specific
 
 You may need to add the following entry to your `~/.stack/config.yaml` for the `libffi` include:
 


### PR DESCRIPTION
## Purpose

Currently the documentation does not correlate with the product, if one is to plainly follow the guide. Meaning it is not explicitly stated that certain variables has to be set in order to execute `cargo run --`.

## Changes

Add documentation about required variables which has to be set in order to start the node