### PR TITLE
Update Rust fmt to `2023-04-01`

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -108,11 +108,11 @@ jobs:
 
     - name: Run rustfmt
       run: |
-        cargo fmt --manifest-path concordium-node/Cargo.toml --all -- --check
-        cargo fmt --manifest-path collector-backend/Cargo.toml --all -- --check
-        cargo fmt --manifest-path collector/Cargo.toml --all -- --check
-        cargo fmt --manifest-path service/windows/Cargo.toml --all -- --check
-        cargo fmt --manifest-path service/windows/installer/custom-actions/Cargo.toml --all -- --check
+        cargo fmt --manifest-path concordium-node/Cargo.toml -- --check
+        cargo fmt --manifest-path collector-backend/Cargo.toml -- --check
+        cargo fmt --manifest-path collector/Cargo.toml -- --check
+        cargo fmt --manifest-path service/windows/Cargo.toml -- --check
+        cargo fmt --manifest-path service/windows/installer/custom-actions/Cargo.toml -- --check
 
   build:
     needs: [fourmolu, rustfmt]

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -89,7 +89,7 @@ jobs:
     strategy:
       matrix:
         plan:
-        - rust: "nightly-2022-06-09-x86_64-unknown-linux-gnu"
+        - rust: "nightly-2023-04-01-x86_64-unknown-linux-gnu"
 
     steps:
     - name: Checkout

--- a/collector-backend/src/bin/node-collector-backend.rs
+++ b/collector-backend/src/bin/node-collector-backend.rs
@@ -78,7 +78,7 @@ struct ConfigCli {
     pub trace:                  bool,
     #[structopt(long = "info", help = "Info mode", env = "COLLECTOR_BACKEND_LOG_LEVEL_INFO")]
     #[allow(dead_code)] // for backwards compatibility
-    pub info:                   bool,
+    pub info: bool,
     #[structopt(
         long = "no-log-timestamp",
         help = "Do not output timestamp in log output",

--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -61,7 +61,7 @@ struct ConfigCli {
     pub trace:                  bool,
     #[structopt(long = "info", help = "Info mode", env = "CONCORDIUM_NODE_COLLECTOR_INFO")]
     #[allow(dead_code)] // allow for backwards compatibility.
-    pub info:                   bool,
+    pub info: bool,
     #[structopt(
         long = "no-log-timestamp",
         help = "Do not output timestamp in log output",

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "5.3.1"
+version = "6.0.0"
 dependencies = [
  "bs58",
  "chrono",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common-derive"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-smart-contract-engine"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-wasm"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "concordium-contracts-common",
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "aes",
  "anyhow",


### PR DESCRIPTION
## Purpose

Update Rust fmt to `2023-04-01` to match other Rust repos.

Depends on: https://github.com/Concordium/concordium-base/pull/369

## Changes

- Update version in CI jobs
- Update base dependency
- Fix formatting

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.