### PR TITLE
Support block height as block identifier in gRPC v2 block queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Support using block height as block identifiers in gRPC v2 API.
+- Extend gRPC v2 API call `GetBlockInfo` with the protocol version of the block.
 - Enable CORS support in grpc-web. This only applies when grpc-web is enabled.
 
 ## 5.3.2

--- a/concordium-consensus/src/Concordium/External.hs
+++ b/concordium-consensus/src/Concordium/External.hs
@@ -1113,7 +1113,7 @@ getBlockInfo :: StablePtr ConsensusRunner -> CString -> IO CString
 getBlockInfo cptr blockcstr =
     decodeBlockHash blockcstr >>= \case
         Nothing -> jsonCString AE.Null
-        Just bh -> jsonQuery cptr (snd <$> Q.getBlockInfo (Queries.Given bh))
+        Just bh -> jsonQuery cptr (Q.responseToMaybe <$> Q.getBlockInfo (Queries.Given bh))
 
 -- |Get the list of transactions in a block with short summaries of their effects.
 -- Returns a null-terminated string encoding a JSON value.
@@ -1133,7 +1133,7 @@ getRewardStatus :: StablePtr ConsensusRunner -> CString -> IO CString
 getRewardStatus cptr blockcstr =
     decodeBlockHash blockcstr >>= \case
         Nothing -> jsonCString AE.Null
-        Just bh -> jsonQuery cptr (snd <$> Q.getRewardStatus (Queries.Given bh))
+        Just bh -> jsonQuery cptr (Q.responseToMaybe <$> Q.getRewardStatus (Queries.Given bh))
 
 -- |Get birk parameters for the given block. The block must be given as a
 -- null-terminated base16 encoding of the block hash.
@@ -1143,7 +1143,7 @@ getBirkParameters :: StablePtr ConsensusRunner -> CString -> IO CString
 getBirkParameters cptr blockcstr =
     decodeBlockHash blockcstr >>= \case
         Nothing -> jsonCString AE.Null
-        Just bh -> jsonQuery cptr (snd <$> Q.getBlockBirkParameters (Queries.Given bh))
+        Just bh -> jsonQuery cptr (Q.responseToMaybe <$> Q.getBlockBirkParameters (Queries.Given bh))
 
 -- |Get the cryptographic parameters in a given block. The block must be given as a
 -- null-terminated base16 encoding of the block hash.
@@ -1153,7 +1153,7 @@ getCryptographicParameters :: StablePtr ConsensusRunner -> CString -> IO CString
 getCryptographicParameters cptr blockcstr =
     decodeBlockHash blockcstr >>= \case
         Nothing -> jsonCString AE.Null
-        Just bh -> jsonQuery cptr $ Versioned 0 . snd <$> Q.getCryptographicParameters (Queries.Given bh)
+        Just bh -> jsonQuery cptr $ Versioned 0 . Q.responseToMaybe <$> Q.getCryptographicParameters (Queries.Given bh)
 
 -- |Get all of the identity providers registered in the system as of a given block.
 -- The block must be given as a null-terminated base16 encoding of the block hash.
@@ -1163,7 +1163,7 @@ getAllIdentityProviders :: StablePtr ConsensusRunner -> CString -> IO CString
 getAllIdentityProviders cptr blockcstr =
     decodeBlockHash blockcstr >>= \case
         Nothing -> jsonCString AE.Null
-        Just bh -> jsonQuery cptr (snd <$> Q.getAllIdentityProviders (Queries.Given bh))
+        Just bh -> jsonQuery cptr (Q.responseToMaybe <$> Q.getAllIdentityProviders (Queries.Given bh))
 
 -- |Get all of the identity providers registered in the system as of a given block.
 -- The block must be given as a null-terminated base16 encoding of the block hash.
@@ -1173,7 +1173,7 @@ getAllAnonymityRevokers :: StablePtr ConsensusRunner -> CString -> IO CString
 getAllAnonymityRevokers cptr blockcstr =
     decodeBlockHash blockcstr >>= \case
         Nothing -> jsonCString AE.Null
-        Just bh -> jsonQuery cptr (snd <$> Q.getAllAnonymityRevokers (Queries.Given bh))
+        Just bh -> jsonQuery cptr (Q.responseToMaybe <$> Q.getAllAnonymityRevokers (Queries.Given bh))
 
 -- |Given a null-terminated string that represents a block hash (base 16), and a number of blocks,
 -- returns a null-terminated string containing a JSON list of the ancestors of the node (up to the
@@ -1183,7 +1183,7 @@ getAncestors :: StablePtr ConsensusRunner -> CString -> Word64 -> IO CString
 getAncestors cptr blockcstr depth =
     decodeBlockHash blockcstr >>= \case
         Nothing -> jsonCString AE.Null
-        Just bh -> jsonQuery cptr (snd <$> Q.getAncestors (Queries.Given bh) (BlockHeight depth))
+        Just bh -> jsonQuery cptr (Q.responseToMaybe <$> Q.getAncestors (Queries.Given bh) (BlockHeight depth))
 
 -- |Get the list of account addresses in the given block. The block must be
 -- given as a null-terminated base16 encoding of the block hash. The return
@@ -1193,7 +1193,7 @@ getAccountList :: StablePtr ConsensusRunner -> CString -> IO CString
 getAccountList cptr blockcstr =
     decodeBlockHash blockcstr >>= \case
         Nothing -> jsonCString AE.Null
-        Just bh -> jsonQuery cptr (snd <$> Q.getAccountList (Queries.Given bh))
+        Just bh -> jsonQuery cptr (Q.responseToMaybe <$> Q.getAccountList (Queries.Given bh))
 
 -- |Get the list of contract instances (their addresses) in the given block. The
 -- block must be given as a null-terminated base16 encoding of the block hash.
@@ -1203,7 +1203,7 @@ getInstances :: StablePtr ConsensusRunner -> CString -> IO CString
 getInstances cptr blockcstr =
     decodeBlockHash blockcstr >>= \case
         Nothing -> jsonCString AE.Null
-        Just bh -> jsonQuery cptr (snd <$> Q.getInstanceList (Queries.Given bh))
+        Just bh -> jsonQuery cptr (Q.responseToMaybe <$> Q.getInstanceList (Queries.Given bh))
 
 -- |Get the list of modules in the given block. The block must be given as a
 -- null-terminated base16 encoding of the block hash.
@@ -1213,7 +1213,7 @@ getModuleList :: StablePtr ConsensusRunner -> CString -> IO CString
 getModuleList cptr blockcstr = do
     decodeBlockHash blockcstr >>= \case
         Nothing -> jsonCString AE.Null
-        Just bh -> jsonQuery cptr (snd <$> Q.getModuleList (Queries.Given bh))
+        Just bh -> jsonQuery cptr (Q.responseToMaybe <$> Q.getModuleList (Queries.Given bh))
 
 -- |Get account information for the given block and identifier. The block must be
 -- given as a null-terminated base16 encoding of the block hash and the account
@@ -1228,7 +1228,7 @@ getAccountInfo cptr blockcstr acctcstr = do
     acctbs <- BS.packCString acctcstr
     let account = decodeAccountIdentifier acctbs
     case (mblock, account) of
-        (Just bh, Just acct) -> jsonQuery cptr (snd <$> Q.getAccountInfo (Queries.Given bh) acct)
+        (Just bh, Just acct) -> jsonQuery cptr (Q.responseToMaybe <$> Q.getAccountInfo (Queries.Given bh) acct)
         _ -> jsonCString AE.Null
 
 -- |Get instance information the given block and instance. The block must be
@@ -1242,7 +1242,7 @@ getInstanceInfo cptr blockcstr instcstr = do
     mblock <- decodeBlockHash blockcstr
     minst <- decodeInstanceAddress instcstr
     case (mblock, minst) of
-        (Just bh, Just inst) -> jsonQuery cptr (snd <$> Q.getInstanceInfo (Queries.Given bh) inst)
+        (Just bh, Just inst) -> jsonQuery cptr (Q.responseToMaybe <$> Q.getInstanceInfo (Queries.Given bh) inst)
         _ -> jsonCString AE.Null
 
 -- |Run the smart contract entrypoint in a given context and in the state at the
@@ -1262,7 +1262,7 @@ invokeContract cptr blockcstr ctxcstr maxInvokeEnergy = do
         (Just bh, Just ctx) -> do
             -- Make sure the max allowed energy is respected.
             let effectiveCtx = ctx{InvokeContract.ccEnergy = min (InvokeContract.ccEnergy ctx) (fromIntegral maxInvokeEnergy)}
-            jsonQuery cptr (snd <$> Q.invokeContract (Queries.Given bh) effectiveCtx)
+            jsonQuery cptr (Q.responseToMaybe <$> Q.invokeContract (Queries.Given bh) effectiveCtx)
         _ -> jsonCString AE.Null
 
 -- |Get the source code of a module as deployed on the chain at a particular block.
@@ -1280,7 +1280,7 @@ getModuleSource cptr blockcstr modcstr = do
     mmod <- decodeModuleRef modcstr
     case (mblock, mmod) of
         (Just bh, Just modref) -> do
-            msrc <- runMVR (snd <$> Q.getModuleSource (Queries.Given bh) modref) mvr
+            msrc <- runMVR (Q.responseToMaybe <$> Q.getModuleSource (Queries.Given bh) modref) mvr
             byteStringToCString $ maybe BS.empty S.encode msrc
         _ -> byteStringToCString BS.empty
 
@@ -1293,7 +1293,7 @@ getBakerList :: StablePtr ConsensusRunner -> CString -> IO CString
 getBakerList cptr blockcstr = do
     decodeBlockHash blockcstr >>= \case
         Nothing -> jsonCString AE.Null
-        Just bh -> jsonQuery cptr (snd <$> Q.getRegisteredBakers (Queries.Given bh))
+        Just bh -> jsonQuery cptr (Q.responseToMaybe <$> Q.getRegisteredBakers (Queries.Given bh))
 
 -- |Get the status of a baker pool or the passive delegators with respect to a particular block.
 -- The block must be given as a null-terminated base16 encoding of the block hash.
@@ -1316,7 +1316,7 @@ getPoolStatus ::
 getPoolStatus cptr blockcstr passive bid = do
     decodeBlockHash blockcstr >>= \case
         Nothing -> jsonCString AE.Null
-        Just bh -> jsonQuery cptr (snd <$> Q.getPoolStatus (Queries.Given bh) mbid)
+        Just bh -> jsonQuery cptr (Q.responseToMaybe <$> Q.getPoolStatus (Queries.Given bh) mbid)
   where
     mbid = if passive /= 0 then Nothing else Just (BakerId (AccountIndex bid))
 

--- a/concordium-consensus/src/Concordium/External.hs
+++ b/concordium-consensus/src/Concordium/External.hs
@@ -1083,10 +1083,11 @@ getBlocksAtHeight ::
     IO CString
 getBlocksAtHeight cptr height genIndex restrict =
     jsonQuery cptr $
-        Q.getBlocksAtHeight
-            (BlockHeight height)
-            (GenesisIndex genIndex)
-            (restrict /= 0)
+        fmap fst
+            <$> Q.getBlocksAtHeight
+                (BlockHeight height)
+                (GenesisIndex genIndex)
+                (restrict /= 0)
 
 -- | Retrieve the last finalized block height relative to the most recent genesis index. Used for
 -- resuming out-of-band catchup.

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -160,10 +160,34 @@ liftSkovQueryBlock a bh =
                 (\vc -> liftSkovQuery mvr vc (mapM a =<< resolveBlock bh))
                 mvr
 
+-- | Response for queries needing to resolve a BlockHashInput first.
+data BHIQueryResponse a
+    = -- | No block found for the provided identifier.
+      BQRNoBlock
+    | -- | Block and value found for the provided identifier.
+      BQRBlock
+        { -- | Hash of the block which the identifier was resolved to.
+          bhiqrHash :: BlockHash,
+          -- | Resulting value computed from the given block.
+          bhiqrValue :: a
+        }
+    deriving (Show)
+
+instance Functor BHIQueryResponse where
+    fmap fn response = case response of
+        BQRNoBlock -> BQRNoBlock
+        BQRBlock bh a -> BQRBlock bh (fn a)
+
+-- | Convert BHIQueryResponse to a Maybe.
+responseToMaybe :: BHIQueryResponse a -> Maybe a
+responseToMaybe response = case response of
+    BQRNoBlock -> Nothing
+    BQRBlock _ v -> Just v
+
 -- |Try a 'BlockHashInput' based query on the latest skov version. If a specific
 -- block hash is given we work backwards through consensus versions until we
 -- find the specified block or run out of versions.
--- The return value is the hash used for the query, and a result if it was found.
+-- The return value contains the block hash used for the query and result, if it was able to resolve the BlockHashInput.
 liftSkovQueryBHI ::
     ( forall (pv :: ProtocolVersion).
       ( SkovMonad (VersionedSkovM finconf pv),
@@ -174,35 +198,13 @@ liftSkovQueryBHI ::
       VersionedSkovM finconf pv a
     ) ->
     BlockHashInput ->
-    MVR finconf (Maybe BlockHash, Maybe a)
-liftSkovQueryBHI a bhi = do
-    case bhi of
-        Given bh ->
-            MVR $ \mvr ->
-                (Just bh,) . fmap fst
-                    <$> atLatestSuccessfulVersion
-                        (\vc -> liftSkovQuery mvr vc (mapM a =<< resolveBlock bh))
-                        mvr
-        AtHeight heightInput -> do
-            blocks <- case heightInput of
-                Absolute abh -> Concordium.Queries.getBlocksAtHeight (fromIntegral abh) 0 False
-                Relative{..} -> Concordium.Queries.getBlocksAtHeight rBlockHeight rGenesisIndex rRestrict
-            case blocks of
-                (Just ([bh], evc)) ->
-                    MVR $ \mvr ->
-                        (Just bh,)
-                            <$> liftSkovQuery mvr evc (mapM a =<< resolveBlock bh)
-                _ -> return (Nothing, Nothing)
-        other -> liftSkovQueryLatest $ do
-            bp <- case other of
-                Best -> bestBlock
-                LastFinal -> lastFinalizedBlock
-            (Just (bpHash bp),) . Just <$> a bp
+    MVR finconf (BHIQueryResponse a)
+liftSkovQueryBHI a = liftSkovQueryBHIAndVersion (const a)
 
--- |Try a 'BlockHashInput' based query on the latest skov version. If a specific
--- block hash is given we work backwards through consensus versions until we
+-- |Try a 'BlockHashInput' based query on the latest skov version and provided with the configuration.
+-- If a specific block hash is given we work backwards through consensus versions until we
 -- find the specified block or run out of versions.
--- The return value is the hash used for the query, and a result if it was found.
+-- The return value contains the block hash used for the query and result, if it was able to resolve the BlockHashInput.
 liftSkovQueryBHIAndVersion ::
     ( forall (pv :: ProtocolVersion).
       ( SkovMonad (VersionedSkovM finconf pv),
@@ -213,25 +215,31 @@ liftSkovQueryBHIAndVersion ::
       VersionedSkovM finconf pv a
     ) ->
     BlockHashInput ->
-    MVR finconf (Maybe BlockHash, Maybe a)
+    MVR finconf (BHIQueryResponse a)
 liftSkovQueryBHIAndVersion query bhi = do
     case bhi of
         Given bh ->
-            MVR $ \mvr ->
-                (Just bh,) . fmap fst
-                    <$> atLatestSuccessfulVersion
-                        (\evc -> liftSkovQuery mvr evc (mapM (query evc) =<< resolveBlock bh))
-                        mvr
+            MVR $ \mvr -> do
+                maybeValue <-
+                    fmap fst
+                        <$> atLatestSuccessfulVersion
+                            (\evc -> liftSkovQuery mvr evc (mapM (query evc) =<< resolveBlock bh))
+                            mvr
+                return $ case maybeValue of
+                    Just v -> BQRBlock bh v
+                    Nothing -> BQRNoBlock
         AtHeight heightInput -> do
             blocks <- case heightInput of
                 Absolute abh -> Concordium.Queries.getBlocksAtHeight (fromIntegral abh) 0 False
                 Relative{..} -> Concordium.Queries.getBlocksAtHeight rBlockHeight rGenesisIndex rRestrict
             case blocks of
                 (Just ([bh], evc)) ->
-                    MVR $ \mvr ->
-                        (Just bh,)
-                            <$> liftSkovQuery mvr evc (mapM (query evc) =<< resolveBlock bh)
-                _ -> return (Nothing, Nothing)
+                    MVR $ \mvr -> do
+                        maybeValue <- liftSkovQuery mvr evc (mapM (query evc) =<< resolveBlock bh)
+                        return $ case maybeValue of
+                            Just v -> BQRBlock bh v
+                            Nothing -> BQRNoBlock
+                _ -> return BQRNoBlock
         other -> do
             versions <- liftIO . readIORef =<< asks mvVersions
             let evc = Vec.last versions
@@ -239,7 +247,7 @@ liftSkovQueryBHIAndVersion query bhi = do
                 bp <- case other of
                     Best -> bestBlock
                     LastFinal -> lastFinalizedBlock
-                (Just (bpHash bp),) . Just <$> query evc bp
+                BQRBlock (bpHash bp) <$> query evc bp
 
 -- |Try a block based query on the latest skov version, working
 -- backwards until we find the specified block or run out of
@@ -355,7 +363,7 @@ getBranches = liftSkovQueryLatest $ do
             )
             Map.empty
 
--- |Get a list of block hashes at a particular absolute height.
+-- |Get a list of block hashes and configuration at a particular absolute height.
 -- This traverses versions from the latest to the earliest, which is probably
 -- fine for most practical cases.
 getBlocksAtHeight ::
@@ -418,7 +426,7 @@ getNextAccountNonce accountAddress = liftSkovQueryLatest $ do
 -- ** Block indexed
 
 -- |Get the basic info about a particular block.
-getBlockInfo :: BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe BlockInfo)
+getBlockInfo :: BlockHashInput -> MVR finconf (BHIQueryResponse BlockInfo)
 getBlockInfo =
     liftSkovQueryBHIAndVersion
         ( \(EVersionedConfiguration vc) (bp :: BlockPointerType (VersionedSkovM finconf pv)) -> do
@@ -495,19 +503,19 @@ getBlockSummary = liftSkovQueryBlock getBlockSummarySkovM
         return BlockSummary{..}
 
 -- |Get the block items of a block.
-getBlockItems :: forall finconf. BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe [BlockItem])
+getBlockItems :: forall finconf. BlockHashInput -> MVR finconf (BHIQueryResponse [BlockItem])
 getBlockItems = liftSkovQueryBHI (return . blockTransactions)
 
 -- |Get the transaction outcomes in the block.
-getBlockTransactionSummaries :: forall finconf. BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe (Vec.Vector TransactionSummary))
+getBlockTransactionSummaries :: forall finconf. BlockHashInput -> MVR finconf (BHIQueryResponse (Vec.Vector TransactionSummary))
 getBlockTransactionSummaries = liftSkovQueryBHI $ BS.getOutcomes <=< blockState
 
 -- |Get the transaction outcomes in the block.
-getBlockSpecialEvents :: forall finconf. BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe (Seq.Seq SpecialTransactionOutcome))
+getBlockSpecialEvents :: forall finconf. BlockHashInput -> MVR finconf (BHIQueryResponse (Seq.Seq SpecialTransactionOutcome))
 getBlockSpecialEvents = liftSkovQueryBHI $ BS.getSpecialOutcomes <=< blockState
 
 -- |Get the pending updates at the end of a given block.
-getBlockPendingUpdates :: forall finconf. BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe [(TransactionTime, PendingUpdateEffect)])
+getBlockPendingUpdates :: forall finconf. BlockHashInput -> MVR finconf (BHIQueryResponse [(TransactionTime, PendingUpdateEffect)])
 getBlockPendingUpdates = liftSkovQueryBHI query
   where
     query ::
@@ -603,7 +611,7 @@ getBlockPendingUpdates = liftSkovQueryBHI query
 
 -- |Get the chain parameters valid at the end of a given block, as well as the address of the foundation account.
 -- The chain parameters contain only the account index of the foundation account.
-getBlockChainParameters :: forall finconf. BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe (AccountAddress, EChainParametersAndKeys))
+getBlockChainParameters :: forall finconf. BlockHashInput -> MVR finconf (BHIQueryResponse (AccountAddress, EChainParametersAndKeys))
 getBlockChainParameters = liftSkovQueryBHI query
   where
     query ::
@@ -622,7 +630,7 @@ getBlockChainParameters = liftSkovQueryBHI query
                 return (foundationAddr, EChainParametersAndKeys params (_unhashed (UQ._currentKeyCollection updates)))
 
 -- |Get the finalization record contained in the given block, if any.
-getBlockFinalizationSummary :: forall finconf. BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe BlockFinalizationSummary)
+getBlockFinalizationSummary :: forall finconf. BlockHashInput -> MVR finconf (BHIQueryResponse BlockFinalizationSummary)
 getBlockFinalizationSummary = liftSkovQueryBHI getFinSummarySkovM
   where
     getFinSummarySkovM ::
@@ -654,7 +662,7 @@ getBlockFinalizationSummary = liftSkovQueryBHI getFinSummarySkovM
             _ -> return NoSummary
 
 -- |Get next update sequences numbers at the end of a given block.
-getNextUpdateSequenceNumbers :: forall finconf. BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe NextUpdateSequenceNumbers)
+getNextUpdateSequenceNumbers :: forall finconf. BlockHashInput -> MVR finconf (BHIQueryResponse NextUpdateSequenceNumbers)
 getNextUpdateSequenceNumbers = liftSkovQueryBHI query
   where
     query ::
@@ -668,7 +676,7 @@ getNextUpdateSequenceNumbers = liftSkovQueryBHI query
         return $ updateQueuesNextSequenceNumbers $ UQ._pendingUpdates updates
 
 -- |Get the total amount of GTU in existence and status of the reward accounts.
-getRewardStatus :: BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe RewardStatus)
+getRewardStatus :: BlockHashInput -> MVR finconf (BHIQueryResponse RewardStatus)
 getRewardStatus = liftSkovQueryBHI $ \bp -> do
     reward <- BS.getRewardStatus =<< blockState bp
     gd <- getGenesisData
@@ -678,7 +686,7 @@ getRewardStatus = liftSkovQueryBHI $ \bp -> do
     return $ epochToUTC <$> reward
 
 -- |Get the birk parameters that applied when a given block was baked.
-getBlockBirkParameters :: BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe BlockBirkParameters)
+getBlockBirkParameters :: BlockHashInput -> MVR finconf (BHIQueryResponse BlockBirkParameters)
 getBlockBirkParameters = liftSkovQueryBHI $ \bp -> do
     bs <- blockState bp
     bbpElectionDifficulty <- BS.getCurrentElectionDifficulty bs
@@ -695,22 +703,22 @@ getBlockBirkParameters = liftSkovQueryBHI $ \bp -> do
     return BlockBirkParameters{..}
 
 -- |Get the cryptographic parameters of the chain at a given block.
-getCryptographicParameters :: BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe CryptographicParameters)
+getCryptographicParameters :: BlockHashInput -> MVR finconf (BHIQueryResponse CryptographicParameters)
 getCryptographicParameters = liftSkovQueryBHI $ \bp -> do
     bs <- blockState bp
     BS.getCryptographicParameters bs
 
 -- |Get all of the identity providers registered in the system as of a given block.
-getAllIdentityProviders :: BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe [IpInfo])
+getAllIdentityProviders :: BlockHashInput -> MVR finconf (BHIQueryResponse [IpInfo])
 getAllIdentityProviders = liftSkovQueryBHI $ BS.getAllIdentityProviders <=< blockState
 
 -- |Get all of the anonymity revokers registered in the system as of a given block.
-getAllAnonymityRevokers :: BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe [ArInfo])
+getAllAnonymityRevokers :: BlockHashInput -> MVR finconf (BHIQueryResponse [ArInfo])
 getAllAnonymityRevokers = liftSkovQueryBHI $ BS.getAllAnonymityRevokers <=< blockState
 
 -- |Get the ancestors of a block (including itself) up to a maximum
 -- length.
-getAncestors :: BlockHashInput -> BlockHeight -> MVR finconf (Maybe BlockHash, Maybe [BlockHash])
+getAncestors :: BlockHashInput -> BlockHeight -> MVR finconf (BHIQueryResponse [BlockHash])
 getAncestors bhi count =
     liftSkovQueryBHI
         ( \bp -> do
@@ -728,17 +736,17 @@ getAncestors bhi count =
                 go (a : acc) (n - 1) a'
 
 -- |Get a list of all accounts in the block state.
-getAccountList :: BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe [AccountAddress])
+getAccountList :: BlockHashInput -> MVR finconf (BHIQueryResponse [AccountAddress])
 getAccountList = liftSkovQueryBHI (BS.getAccountList <=< blockState)
 
 -- |Get a list of all smart contract instances in the block state.
-getInstanceList :: BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe [ContractAddress])
+getInstanceList :: BlockHashInput -> MVR finconf (BHIQueryResponse [ContractAddress])
 getInstanceList =
     liftSkovQueryBHI $
         BS.getContractInstanceList <=< blockState
 
 -- |Get the list of modules present as of a given block.
-getModuleList :: BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe [ModuleRef])
+getModuleList :: BlockHashInput -> MVR finconf (BHIQueryResponse [ModuleRef])
 getModuleList = liftSkovQueryBHI $ BS.getModuleList <=< blockState
 
 -- |Get the details of an account in the block state.
@@ -748,48 +756,44 @@ getModuleList = liftSkovQueryBHI $ BS.getModuleList <=< blockState
 getAccountInfo ::
     BlockHashInput ->
     AccountIdentifier ->
-    MVR finconf (Maybe BlockHash, Maybe AccountInfo)
-getAccountInfo blockHashInput acct = do
-    (bh, mmai) <-
-        liftSkovQueryBHI
-            ( \bp -> do
-                bs <- blockState bp
-                macc <- case acct of
-                    AccAddress addr -> BS.getAccount bs addr
-                    AccIndex idx -> BS.getAccountByIndex bs idx
-                    CredRegID crid -> BS.getAccountByCredId bs crid
-                forM macc $ \(aiAccountIndex, acc) -> do
-                    aiAccountNonce <- BS.getAccountNonce acc
-                    aiAccountAmount <- BS.getAccountAmount acc
-                    aiAccountReleaseSchedule <- BS.getAccountReleaseSummary acc
-                    aiAccountCredentials <- fmap (Versioned 0) <$> BS.getAccountCredentials acc
-                    aiAccountThreshold <- aiThreshold <$> BS.getAccountVerificationKeys acc
-                    aiAccountEncryptedAmount <- BS.getAccountEncryptedAmount acc
-                    aiAccountEncryptionKey <- BS.getAccountEncryptionKey acc
-                    gd <- getGenesisData
-                    let convEpoch e =
-                            timestampToUTCTime $
-                                addDuration
-                                    (gdGenesisTime gd)
-                                    (fromIntegral e * fromIntegral (gdEpochLength gd) * gdSlotDuration gd)
-                    aiStakingInfo <- toAccountStakingInfo convEpoch <$> BS.getAccountStake acc
-                    aiAccountAddress <- BS.getAccountCanonicalAddress acc
-                    return AccountInfo{..}
-            )
-            blockHashInput
-    return (bh, join mmai)
+    MVR finconf (BHIQueryResponse (Maybe AccountInfo))
+getAccountInfo blockHashInput acct =
+    liftSkovQueryBHI
+        ( \bp -> do
+            bs <- blockState bp
+            macc <- case acct of
+                AccAddress addr -> BS.getAccount bs addr
+                AccIndex idx -> BS.getAccountByIndex bs idx
+                CredRegID crid -> BS.getAccountByCredId bs crid
+            forM macc $ \(aiAccountIndex, acc) -> do
+                aiAccountNonce <- BS.getAccountNonce acc
+                aiAccountAmount <- BS.getAccountAmount acc
+                aiAccountReleaseSchedule <- BS.getAccountReleaseSummary acc
+                aiAccountCredentials <- fmap (Versioned 0) <$> BS.getAccountCredentials acc
+                aiAccountThreshold <- aiThreshold <$> BS.getAccountVerificationKeys acc
+                aiAccountEncryptedAmount <- BS.getAccountEncryptedAmount acc
+                aiAccountEncryptionKey <- BS.getAccountEncryptionKey acc
+                gd <- getGenesisData
+                let convEpoch e =
+                        timestampToUTCTime $
+                            addDuration
+                                (gdGenesisTime gd)
+                                (fromIntegral e * fromIntegral (gdEpochLength gd) * gdSlotDuration gd)
+                aiStakingInfo <- toAccountStakingInfo convEpoch <$> BS.getAccountStake acc
+                aiAccountAddress <- BS.getAccountCanonicalAddress acc
+                return AccountInfo{..}
+        )
+        blockHashInput
 
 -- |Get the details of a smart contract instance in the block state.
-getInstanceInfo :: BlockHashInput -> ContractAddress -> MVR finconf (Maybe BlockHash, Maybe Wasm.InstanceInfo)
-getInstanceInfo bhi caddr = do
-    (bh, ii) <-
-        liftSkovQueryBHI
-            ( \bp -> do
-                bs <- blockState bp
-                mkII =<< BS.getContractInstance bs caddr
-            )
-            bhi
-    return (bh, join ii)
+getInstanceInfo :: BlockHashInput -> ContractAddress -> MVR finconf (BHIQueryResponse (Maybe Wasm.InstanceInfo))
+getInstanceInfo bhi caddr =
+    liftSkovQueryBHI
+        ( \bp -> do
+            bs <- blockState bp
+            mkII =<< BS.getContractInstance bs caddr
+        )
+        bhi
   where
     mkII Nothing = return Nothing
     mkII (Just (BS.InstanceInfoV0 BS.InstanceInfoV{..})) = do
@@ -824,16 +828,14 @@ getInstanceInfo bhi caddr = do
 -- requested block does not exist, or the instance does not exist in that
 -- block), @Just . Left@ if the instance is a V0 instance, and @Just . Right@ if
 -- the instance is a V1 instance.
-getInstanceState :: BlockHashInput -> ContractAddress -> MVR finconf (Maybe BlockHash, Maybe (Either Wasm.ContractState (StateV1.PersistentState, StateV1.LoadCallback)))
-getInstanceState bhi caddr = do
-    (bh, ii) <-
-        liftSkovQueryBHI
-            ( \bp -> do
-                bs <- blockState bp
-                mkII =<< BS.getContractInstance bs caddr
-            )
-            bhi
-    return (bh, join ii)
+getInstanceState :: BlockHashInput -> ContractAddress -> MVR finconf (BHIQueryResponse (Maybe (Either Wasm.ContractState (StateV1.PersistentState, StateV1.LoadCallback))))
+getInstanceState bhi caddr =
+    liftSkovQueryBHI
+        ( \bp -> do
+            bs <- blockState bp
+            mkII =<< BS.getContractInstance bs caddr
+        )
+        bhi
   where
     mkII Nothing = return Nothing
     mkII (Just (BS.InstanceInfoV0 BS.InstanceInfoV{..})) =
@@ -844,22 +846,19 @@ getInstanceState bhi caddr = do
         return . Just . Right $! (state, callback)
 
 -- |Get the source of a module as it was deployed to the chain.
-getModuleSource :: BlockHashInput -> ModuleRef -> MVR finconf (Maybe BlockHash, Maybe Wasm.WasmModule)
-getModuleSource bhi modRef = do
-    (bh, res) <-
-        liftSkovQueryBHI
-            ( \bp -> do
-                bs <- blockState bp
-                BS.getModule bs modRef
-            )
-            bhi
-    return (bh, join res)
+getModuleSource :: BlockHashInput -> ModuleRef -> MVR finconf (BHIQueryResponse (Maybe Wasm.WasmModule))
+getModuleSource bhi modRef =
+    liftSkovQueryBHI
+        ( \bp -> do
+            bs <- blockState bp
+            BS.getModule bs modRef
+        )
+        bhi
 
 -- |Get the status of a particular delegation pool.
-getPoolStatus :: forall finconf. BlockHashInput -> Maybe BakerId -> MVR finconf (Maybe BlockHash, Maybe PoolStatus)
-getPoolStatus blockHashInput mbid = do
-    (bh, res) <- liftSkovQueryBHI poolStatus blockHashInput
-    return (bh, join res)
+getPoolStatus :: forall finconf. BlockHashInput -> Maybe BakerId -> MVR finconf (BHIQueryResponse (Maybe PoolStatus))
+getPoolStatus blockHashInput mbid =
+    liftSkovQueryBHI poolStatus blockHashInput
   where
     poolStatus ::
         forall pv.
@@ -874,7 +873,7 @@ getPoolStatus blockHashInput mbid = do
             BS.getPoolStatus bs mbid
 
 -- |Get a list of all registered baker IDs in the specified block.
-getRegisteredBakers :: forall finconf. BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe [BakerId])
+getRegisteredBakers :: forall finconf. BlockHashInput -> MVR finconf (BHIQueryResponse [BakerId])
 getRegisteredBakers = liftSkovQueryBHI (BS.getActiveBakers <=< blockState)
 
 -- | Error type for querying delegators for some block.
@@ -883,16 +882,12 @@ data GetDelegatorsError
       GDEUnsupportedProtocolVersion
     | -- | No pool found for the provided baker ID.
       GDEPoolNotFound
-    | -- | No block found for the provided block input.
-      GDEBlockNotFound
 
 -- |Get the list of registered delegators for a given block.
 -- Changes to delegation is reflected immediately in this list.
 -- If a BakerId is provided it will return the delegators for the corresponding pool otherwise it returns the passive delegators.
-getDelegators :: forall finconf. BlockHashInput -> Maybe BakerId -> MVR finconf (Maybe BlockHash, Either GetDelegatorsError [DelegatorInfo])
-getDelegators bhi maybeBakerId = do
-    (bh, res) <- liftSkovQueryBHI getter bhi
-    return (bh, fromMaybe (Left GDEBlockNotFound) res)
+getDelegators :: forall finconf. BlockHashInput -> Maybe BakerId -> MVR finconf (BHIQueryResponse (Either GetDelegatorsError [DelegatorInfo]))
+getDelegators bhi maybeBakerId = liftSkovQueryBHI getter bhi
   where
     getter ::
         forall pv.
@@ -915,10 +910,8 @@ getDelegators bhi maybeBakerId = do
 
 -- |Get the fixed list of delegators contributing stake in the reward period for a given block.
 -- If a BakerId is provided it will return the delegators for the corresponding pool otherwise it returns the passive delegators.
-getDelegatorsRewardPeriod :: forall finconf. BlockHashInput -> Maybe BakerId -> MVR finconf (Maybe BlockHash, Either GetDelegatorsError [DelegatorRewardPeriodInfo])
-getDelegatorsRewardPeriod bhi maybeBakerId = do
-    (bh, res) <- liftSkovQueryBHI getter bhi
-    return (bh, fromMaybe (Left GDEBlockNotFound) res)
+getDelegatorsRewardPeriod :: forall finconf. BlockHashInput -> Maybe BakerId -> MVR finconf (BHIQueryResponse (Either GetDelegatorsError [DelegatorRewardPeriodInfo]))
+getDelegatorsRewardPeriod bhi maybeBakerId = liftSkovQueryBHI getter bhi
   where
     getter ::
         forall pv.
@@ -1003,7 +996,7 @@ getTransactionStatusInBlock trHash blockHash =
             )
 
 -- * Smart contract invocations
-invokeContract :: BlockHashInput -> InvokeContract.ContractContext -> MVR finconf (Maybe BlockHash, Maybe InvokeContract.InvokeContractResult)
+invokeContract :: BlockHashInput -> InvokeContract.ContractContext -> MVR finconf (BHIQueryResponse InvokeContract.InvokeContractResult)
 invokeContract bhi cctx =
     liftSkovQueryBHI
         ( \bp -> do

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -113,15 +113,16 @@ liftSkovQueryAtGenesisIndex genIndex a = MVR $ \mvr -> do
 atLatestSuccessfulVersion ::
     (EVersionedConfiguration finconf -> IO (Maybe a)) ->
     MultiVersionRunner finconf ->
-    IO (Maybe a)
+    IO (Maybe (a, EVersionedConfiguration finconf))
 atLatestSuccessfulVersion a mvr = do
     versions <- readIORef (mvVersions mvr)
     let tryAt (i :: Int)
             | i < 0 = return Nothing
             | otherwise = do
-                r <- a (versions Vec.! i)
+                let version = versions Vec.! i
+                r <- a version
                 case r of
-                    Just _ -> return r
+                    Just x -> return (Just (x, version))
                     Nothing -> tryAt (i - 1)
     tryAt (Vec.length versions - 1)
 
@@ -137,7 +138,7 @@ liftSkovQueryLatestResult ::
     ) ->
     MVR finconf (Maybe a)
 liftSkovQueryLatestResult a = MVR $ \mvr ->
-    atLatestSuccessfulVersion (\vc -> liftSkovQuery mvr vc a) mvr
+    fmap fst <$> atLatestSuccessfulVersion (\vc -> liftSkovQuery mvr vc a) mvr
 
 -- |Try a block based query on the latest skov version, working
 -- backwards until we find the specified block or run out of
@@ -154,9 +155,10 @@ liftSkovQueryBlock ::
     MVR finconf (Maybe a)
 liftSkovQueryBlock a bh =
     MVR $ \mvr ->
-        atLatestSuccessfulVersion
-            (\vc -> liftSkovQuery mvr vc (mapM a =<< resolveBlock bh))
-            mvr
+        fmap fst
+            <$> atLatestSuccessfulVersion
+                (\vc -> liftSkovQuery mvr vc (mapM a =<< resolveBlock bh))
+                mvr
 
 -- |Try a 'BlockHashInput' based query on the latest skov version. If a specific
 -- block hash is given we work backwards through consensus versions until we
@@ -172,20 +174,30 @@ liftSkovQueryBHI ::
       VersionedSkovM finconf pv a
     ) ->
     BlockHashInput ->
-    MVR finconf (BlockHash, Maybe a)
+    MVR finconf (Maybe BlockHash, Maybe a)
 liftSkovQueryBHI a bhi = do
     case bhi of
         Given bh ->
             MVR $ \mvr ->
-                (bh,)
+                (Just bh,) . fmap fst
                     <$> atLatestSuccessfulVersion
                         (\vc -> liftSkovQuery mvr vc (mapM a =<< resolveBlock bh))
                         mvr
+        AtHeight heightInput -> do
+            blocks <- case heightInput of
+                Absolute abh -> Concordium.Queries.getBlocksAtHeight (fromIntegral abh) 0 False
+                Relative{..} -> Concordium.Queries.getBlocksAtHeight rBlockHeight rGenesisIndex rRestrict
+            case blocks of
+                (Just ([bh], evc)) ->
+                    MVR $ \mvr ->
+                        (Just bh,)
+                            <$> liftSkovQuery mvr evc (mapM a =<< resolveBlock bh)
+                _ -> return (Nothing, Nothing)
         other -> liftSkovQueryLatest $ do
             bp <- case other of
                 Best -> bestBlock
                 LastFinal -> lastFinalizedBlock
-            (bpHash bp,) . Just <$> a bp
+            (Just (bpHash bp),) . Just <$> a bp
 
 -- |Try a 'BlockHashInput' based query on the latest skov version. If a specific
 -- block hash is given we work backwards through consensus versions until we
@@ -201,15 +213,25 @@ liftSkovQueryBHIAndVersion ::
       VersionedSkovM finconf pv a
     ) ->
     BlockHashInput ->
-    MVR finconf (BlockHash, Maybe a)
+    MVR finconf (Maybe BlockHash, Maybe a)
 liftSkovQueryBHIAndVersion query bhi = do
     case bhi of
         Given bh ->
             MVR $ \mvr ->
-                (bh,)
+                (Just bh,) . fmap fst
                     <$> atLatestSuccessfulVersion
                         (\evc -> liftSkovQuery mvr evc (mapM (query evc) =<< resolveBlock bh))
                         mvr
+        AtHeight heightInput -> do
+            blocks <- case heightInput of
+                Absolute abh -> Concordium.Queries.getBlocksAtHeight (fromIntegral abh) 0 False
+                Relative{..} -> Concordium.Queries.getBlocksAtHeight rBlockHeight rGenesisIndex rRestrict
+            case blocks of
+                (Just ([bh], evc)) ->
+                    MVR $ \mvr ->
+                        (Just bh,)
+                            <$> liftSkovQuery mvr evc (mapM (query evc) =<< resolveBlock bh)
+                _ -> return (Nothing, Nothing)
         other -> do
             versions <- liftIO . readIORef =<< asks mvVersions
             let evc = Vec.last versions
@@ -217,7 +239,7 @@ liftSkovQueryBHIAndVersion query bhi = do
                 bp <- case other of
                     Best -> bestBlock
                     LastFinal -> lastFinalizedBlock
-                (bpHash bp,) . Just <$> query evc bp
+                (Just (bpHash bp),) . Just <$> query evc bp
 
 -- |Try a block based query on the latest skov version, working
 -- backwards until we find the specified block or run out of
@@ -235,19 +257,20 @@ liftSkovQueryBlockAndVersion ::
     BlockHash ->
     MVR finconf (Maybe a)
 liftSkovQueryBlockAndVersion a bh = MVR $ \mvr ->
-    atLatestSuccessfulVersion
-        ( \(EVersionedConfiguration vc) -> do
-            st <- readIORef (vcState vc)
-            runMVR
-                ( evalSkovT
-                    (mapM (a vc) =<< resolveBlock bh)
-                    (mvrSkovHandlers vc mvr)
-                    (vcContext vc)
-                    st
-                )
-                mvr
-        )
-        mvr
+    fmap fst
+        <$> atLatestSuccessfulVersion
+            ( \(EVersionedConfiguration vc) -> do
+                st <- readIORef (vcState vc)
+                runMVR
+                    ( evalSkovT
+                        (mapM (a vc) =<< resolveBlock bh)
+                        (mvrSkovHandlers vc mvr)
+                        (vcContext vc)
+                        st
+                    )
+                    mvr
+            )
+            mvr
 
 -- |Retrieve the consensus status.
 getConsensusStatus :: MVR finconf ConsensusStatus
@@ -342,7 +365,7 @@ getBlocksAtHeight ::
     GenesisIndex ->
     -- |Whether to restrict to the specified genesis index
     Bool ->
-    MVR finconf [BlockHash]
+    MVR finconf (Maybe ([BlockHash], EVersionedConfiguration finconf))
 getBlocksAtHeight basedHeight baseGI False = MVR $ \mvr -> do
     baseGenHeight <-
         if baseGI == 0
@@ -353,23 +376,22 @@ getBlocksAtHeight basedHeight baseGI False = MVR $ \mvr -> do
                     (\(EVersionedConfiguration vc) -> vcGenesisHeight vc)
                         <$> (versions Vec.!? fromIntegral baseGI)
     case baseGenHeight of
-        Nothing -> return [] -- This occurs if the genesis index is invalid
+        Nothing -> return Nothing -- This occurs if the genesis index is invalid
         Just genHeight -> do
             let height = localToAbsoluteBlockHeight genHeight basedHeight
             -- The default case should never be needed, since 'absoluteToLocalBlockHeight' won't fail
             -- at a genesis block height of 0, which should be the case for the initial genesis.
-            fromMaybe []
-                <$> atLatestSuccessfulVersion
-                    ( \evc@(EVersionedConfiguration vc) ->
-                        forM (absoluteToLocalBlockHeight (vcGenesisHeight vc) height) $ \localHeight ->
-                            liftSkovQuery mvr evc (map getHash <$> Skov.getBlocksAtHeight localHeight)
-                    )
-                    mvr
+            atLatestSuccessfulVersion
+                ( \evc@(EVersionedConfiguration vc) ->
+                    forM (absoluteToLocalBlockHeight (vcGenesisHeight vc) height) $ \localHeight ->
+                        liftSkovQuery mvr evc (map getHash <$> Skov.getBlocksAtHeight localHeight)
+                )
+                mvr
 getBlocksAtHeight height baseGI True = MVR $ \mvr -> do
     versions <- readIORef (mvVersions mvr)
     case versions Vec.!? fromIntegral baseGI of
-        Nothing -> return []
-        Just evc -> liftSkovQuery mvr evc (map getHash <$> Skov.getBlocksAtHeight height)
+        Nothing -> return Nothing
+        Just evc -> Just . (,evc) <$> liftSkovQuery mvr evc (map getHash <$> Skov.getBlocksAtHeight height)
 
 -- | Retrieve the last finalized block height relative to the most recent genesis index. Used for
 -- resuming out-of-band catchup.
@@ -396,10 +418,10 @@ getNextAccountNonce accountAddress = liftSkovQueryLatest $ do
 -- ** Block indexed
 
 -- |Get the basic info about a particular block.
-getBlockInfo :: BlockHashInput -> MVR finconf (BlockHash, Maybe BlockInfo)
+getBlockInfo :: BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe BlockInfo)
 getBlockInfo =
     liftSkovQueryBHIAndVersion
-        ( \(EVersionedConfiguration vc) bp -> do
+        ( \(EVersionedConfiguration vc) (bp :: BlockPointerType (VersionedSkovM finconf pv)) -> do
             let biBlockHash = getHash bp
             biBlockParent <-
                 if blockSlot bp == 0 && vcIndex vc /= 0
@@ -427,6 +449,7 @@ getBlockInfo =
             let biTransactionEnergyCost = bpTransactionsEnergyCost bp
             let biTransactionsSize = bpTransactionsSize bp
             let biBlockStateHash = blockStateHash bp
+            let biProtocolVersion = demoteProtocolVersion (protocolVersion @pv)
             return BlockInfo{..}
         )
 
@@ -472,19 +495,19 @@ getBlockSummary = liftSkovQueryBlock getBlockSummarySkovM
         return BlockSummary{..}
 
 -- |Get the block items of a block.
-getBlockItems :: forall finconf. BlockHashInput -> MVR finconf (BlockHash, Maybe [BlockItem])
+getBlockItems :: forall finconf. BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe [BlockItem])
 getBlockItems = liftSkovQueryBHI (return . blockTransactions)
 
 -- |Get the transaction outcomes in the block.
-getBlockTransactionSummaries :: forall finconf. BlockHashInput -> MVR finconf (BlockHash, Maybe (Vec.Vector TransactionSummary))
+getBlockTransactionSummaries :: forall finconf. BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe (Vec.Vector TransactionSummary))
 getBlockTransactionSummaries = liftSkovQueryBHI $ BS.getOutcomes <=< blockState
 
 -- |Get the transaction outcomes in the block.
-getBlockSpecialEvents :: forall finconf. BlockHashInput -> MVR finconf (BlockHash, Maybe (Seq.Seq SpecialTransactionOutcome))
+getBlockSpecialEvents :: forall finconf. BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe (Seq.Seq SpecialTransactionOutcome))
 getBlockSpecialEvents = liftSkovQueryBHI $ BS.getSpecialOutcomes <=< blockState
 
 -- |Get the pending updates at the end of a given block.
-getBlockPendingUpdates :: forall finconf. BlockHashInput -> MVR finconf (BlockHash, Maybe [(TransactionTime, PendingUpdateEffect)])
+getBlockPendingUpdates :: forall finconf. BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe [(TransactionTime, PendingUpdateEffect)])
 getBlockPendingUpdates = liftSkovQueryBHI query
   where
     query ::
@@ -580,7 +603,7 @@ getBlockPendingUpdates = liftSkovQueryBHI query
 
 -- |Get the chain parameters valid at the end of a given block, as well as the address of the foundation account.
 -- The chain parameters contain only the account index of the foundation account.
-getBlockChainParameters :: forall finconf. BlockHashInput -> MVR finconf (BlockHash, Maybe (AccountAddress, EChainParametersAndKeys))
+getBlockChainParameters :: forall finconf. BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe (AccountAddress, EChainParametersAndKeys))
 getBlockChainParameters = liftSkovQueryBHI query
   where
     query ::
@@ -599,7 +622,7 @@ getBlockChainParameters = liftSkovQueryBHI query
                 return (foundationAddr, EChainParametersAndKeys params (_unhashed (UQ._currentKeyCollection updates)))
 
 -- |Get the finalization record contained in the given block, if any.
-getBlockFinalizationSummary :: forall finconf. BlockHashInput -> MVR finconf (BlockHash, Maybe BlockFinalizationSummary)
+getBlockFinalizationSummary :: forall finconf. BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe BlockFinalizationSummary)
 getBlockFinalizationSummary = liftSkovQueryBHI getFinSummarySkovM
   where
     getFinSummarySkovM ::
@@ -631,7 +654,7 @@ getBlockFinalizationSummary = liftSkovQueryBHI getFinSummarySkovM
             _ -> return NoSummary
 
 -- |Get next update sequences numbers at the end of a given block.
-getNextUpdateSequenceNumbers :: forall finconf. BlockHashInput -> MVR finconf (BlockHash, Maybe NextUpdateSequenceNumbers)
+getNextUpdateSequenceNumbers :: forall finconf. BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe NextUpdateSequenceNumbers)
 getNextUpdateSequenceNumbers = liftSkovQueryBHI query
   where
     query ::
@@ -645,7 +668,7 @@ getNextUpdateSequenceNumbers = liftSkovQueryBHI query
         return $ updateQueuesNextSequenceNumbers $ UQ._pendingUpdates updates
 
 -- |Get the total amount of GTU in existence and status of the reward accounts.
-getRewardStatus :: BlockHashInput -> MVR finconf (BlockHash, Maybe RewardStatus)
+getRewardStatus :: BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe RewardStatus)
 getRewardStatus = liftSkovQueryBHI $ \bp -> do
     reward <- BS.getRewardStatus =<< blockState bp
     gd <- getGenesisData
@@ -655,7 +678,7 @@ getRewardStatus = liftSkovQueryBHI $ \bp -> do
     return $ epochToUTC <$> reward
 
 -- |Get the birk parameters that applied when a given block was baked.
-getBlockBirkParameters :: BlockHashInput -> MVR finconf (BlockHash, Maybe BlockBirkParameters)
+getBlockBirkParameters :: BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe BlockBirkParameters)
 getBlockBirkParameters = liftSkovQueryBHI $ \bp -> do
     bs <- blockState bp
     bbpElectionDifficulty <- BS.getCurrentElectionDifficulty bs
@@ -672,22 +695,22 @@ getBlockBirkParameters = liftSkovQueryBHI $ \bp -> do
     return BlockBirkParameters{..}
 
 -- |Get the cryptographic parameters of the chain at a given block.
-getCryptographicParameters :: BlockHashInput -> MVR finconf (BlockHash, Maybe CryptographicParameters)
+getCryptographicParameters :: BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe CryptographicParameters)
 getCryptographicParameters = liftSkovQueryBHI $ \bp -> do
     bs <- blockState bp
     BS.getCryptographicParameters bs
 
 -- |Get all of the identity providers registered in the system as of a given block.
-getAllIdentityProviders :: BlockHashInput -> MVR finconf (BlockHash, Maybe [IpInfo])
+getAllIdentityProviders :: BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe [IpInfo])
 getAllIdentityProviders = liftSkovQueryBHI $ BS.getAllIdentityProviders <=< blockState
 
 -- |Get all of the anonymity revokers registered in the system as of a given block.
-getAllAnonymityRevokers :: BlockHashInput -> MVR finconf (BlockHash, Maybe [ArInfo])
+getAllAnonymityRevokers :: BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe [ArInfo])
 getAllAnonymityRevokers = liftSkovQueryBHI $ BS.getAllAnonymityRevokers <=< blockState
 
 -- |Get the ancestors of a block (including itself) up to a maximum
 -- length.
-getAncestors :: BlockHashInput -> BlockHeight -> MVR finconf (BlockHash, Maybe [BlockHash])
+getAncestors :: BlockHashInput -> BlockHeight -> MVR finconf (Maybe BlockHash, Maybe [BlockHash])
 getAncestors bhi count =
     liftSkovQueryBHI
         ( \bp -> do
@@ -705,17 +728,17 @@ getAncestors bhi count =
                 go (a : acc) (n - 1) a'
 
 -- |Get a list of all accounts in the block state.
-getAccountList :: BlockHashInput -> MVR finconf (BlockHash, Maybe [AccountAddress])
+getAccountList :: BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe [AccountAddress])
 getAccountList = liftSkovQueryBHI (BS.getAccountList <=< blockState)
 
 -- |Get a list of all smart contract instances in the block state.
-getInstanceList :: BlockHashInput -> MVR finconf (BlockHash, Maybe [ContractAddress])
+getInstanceList :: BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe [ContractAddress])
 getInstanceList =
     liftSkovQueryBHI $
         BS.getContractInstanceList <=< blockState
 
 -- |Get the list of modules present as of a given block.
-getModuleList :: BlockHashInput -> MVR finconf (BlockHash, Maybe [ModuleRef])
+getModuleList :: BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe [ModuleRef])
 getModuleList = liftSkovQueryBHI $ BS.getModuleList <=< blockState
 
 -- |Get the details of an account in the block state.
@@ -725,7 +748,7 @@ getModuleList = liftSkovQueryBHI $ BS.getModuleList <=< blockState
 getAccountInfo ::
     BlockHashInput ->
     AccountIdentifier ->
-    MVR finconf (BlockHash, Maybe AccountInfo)
+    MVR finconf (Maybe BlockHash, Maybe AccountInfo)
 getAccountInfo blockHashInput acct = do
     (bh, mmai) <-
         liftSkovQueryBHI
@@ -757,7 +780,7 @@ getAccountInfo blockHashInput acct = do
     return (bh, join mmai)
 
 -- |Get the details of a smart contract instance in the block state.
-getInstanceInfo :: BlockHashInput -> ContractAddress -> MVR finconf (BlockHash, Maybe Wasm.InstanceInfo)
+getInstanceInfo :: BlockHashInput -> ContractAddress -> MVR finconf (Maybe BlockHash, Maybe Wasm.InstanceInfo)
 getInstanceInfo bhi caddr = do
     (bh, ii) <-
         liftSkovQueryBHI
@@ -801,7 +824,7 @@ getInstanceInfo bhi caddr = do
 -- requested block does not exist, or the instance does not exist in that
 -- block), @Just . Left@ if the instance is a V0 instance, and @Just . Right@ if
 -- the instance is a V1 instance.
-getInstanceState :: BlockHashInput -> ContractAddress -> MVR finconf (BlockHash, Maybe (Either Wasm.ContractState (StateV1.PersistentState, StateV1.LoadCallback)))
+getInstanceState :: BlockHashInput -> ContractAddress -> MVR finconf (Maybe BlockHash, Maybe (Either Wasm.ContractState (StateV1.PersistentState, StateV1.LoadCallback)))
 getInstanceState bhi caddr = do
     (bh, ii) <-
         liftSkovQueryBHI
@@ -821,7 +844,7 @@ getInstanceState bhi caddr = do
         return . Just . Right $! (state, callback)
 
 -- |Get the source of a module as it was deployed to the chain.
-getModuleSource :: BlockHashInput -> ModuleRef -> MVR finconf (BlockHash, Maybe Wasm.WasmModule)
+getModuleSource :: BlockHashInput -> ModuleRef -> MVR finconf (Maybe BlockHash, Maybe Wasm.WasmModule)
 getModuleSource bhi modRef = do
     (bh, res) <-
         liftSkovQueryBHI
@@ -833,7 +856,7 @@ getModuleSource bhi modRef = do
     return (bh, join res)
 
 -- |Get the status of a particular delegation pool.
-getPoolStatus :: forall finconf. BlockHashInput -> Maybe BakerId -> MVR finconf (BlockHash, Maybe PoolStatus)
+getPoolStatus :: forall finconf. BlockHashInput -> Maybe BakerId -> MVR finconf (Maybe BlockHash, Maybe PoolStatus)
 getPoolStatus blockHashInput mbid = do
     (bh, res) <- liftSkovQueryBHI poolStatus blockHashInput
     return (bh, join res)
@@ -851,7 +874,7 @@ getPoolStatus blockHashInput mbid = do
             BS.getPoolStatus bs mbid
 
 -- |Get a list of all registered baker IDs in the specified block.
-getRegisteredBakers :: forall finconf. BlockHashInput -> MVR finconf (BlockHash, Maybe [BakerId])
+getRegisteredBakers :: forall finconf. BlockHashInput -> MVR finconf (Maybe BlockHash, Maybe [BakerId])
 getRegisteredBakers = liftSkovQueryBHI (BS.getActiveBakers <=< blockState)
 
 -- | Error type for querying delegators for some block.
@@ -866,7 +889,7 @@ data GetDelegatorsError
 -- |Get the list of registered delegators for a given block.
 -- Changes to delegation is reflected immediately in this list.
 -- If a BakerId is provided it will return the delegators for the corresponding pool otherwise it returns the passive delegators.
-getDelegators :: forall finconf. BlockHashInput -> Maybe BakerId -> MVR finconf (BlockHash, Either GetDelegatorsError [DelegatorInfo])
+getDelegators :: forall finconf. BlockHashInput -> Maybe BakerId -> MVR finconf (Maybe BlockHash, Either GetDelegatorsError [DelegatorInfo])
 getDelegators bhi maybeBakerId = do
     (bh, res) <- liftSkovQueryBHI getter bhi
     return (bh, fromMaybe (Left GDEBlockNotFound) res)
@@ -892,7 +915,7 @@ getDelegators bhi maybeBakerId = do
 
 -- |Get the fixed list of delegators contributing stake in the reward period for a given block.
 -- If a BakerId is provided it will return the delegators for the corresponding pool otherwise it returns the passive delegators.
-getDelegatorsRewardPeriod :: forall finconf. BlockHashInput -> Maybe BakerId -> MVR finconf (BlockHash, Either GetDelegatorsError [DelegatorRewardPeriodInfo])
+getDelegatorsRewardPeriod :: forall finconf. BlockHashInput -> Maybe BakerId -> MVR finconf (Maybe BlockHash, Either GetDelegatorsError [DelegatorRewardPeriodInfo])
 getDelegatorsRewardPeriod bhi maybeBakerId = do
     (bh, res) <- liftSkovQueryBHI getter bhi
     return (bh, fromMaybe (Left GDEBlockNotFound) res)
@@ -980,7 +1003,7 @@ getTransactionStatusInBlock trHash blockHash =
             )
 
 -- * Smart contract invocations
-invokeContract :: BlockHashInput -> InvokeContract.ContractContext -> MVR finconf (BlockHash, Maybe InvokeContract.InvokeContractResult)
+invokeContract :: BlockHashInput -> InvokeContract.ContractContext -> MVR finconf (Maybe BlockHash, Maybe InvokeContract.InvokeContractResult)
 invokeContract bhi cctx =
     liftSkovQueryBHI
         ( \bp -> do

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -453,9 +453,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
  "js-sys",

--- a/concordium-node/src/consensus_ffi/ffi.rs
+++ b/concordium-node/src/consensus_ffi/ffi.rs
@@ -1971,8 +1971,8 @@ impl ConsensusContainer {
         account_identifier: &crate::grpc2::types::AccountIdentifierInput,
     ) -> Result<([u8; 32], Vec<u8>), tonic::Status> {
         use crate::grpc2::Require;
-        let (block_id_type, block_hash) =
-            crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
+        let (block_id_type, block_hash) = bhi.to_ptr();
         let (acc_type, acc_id) =
             crate::grpc2::types::account_identifier_to_ffi(account_identifier).require()?;
         let consensus = self.consensus.load(Ordering::SeqCst);
@@ -1982,7 +1982,7 @@ impl ConsensusContainer {
             getAccountInfoV2(
                 consensus,
                 block_id_type,
-                block_hash,
+                block_hash.as_ptr(),
                 acc_type,
                 acc_id,
                 out_hash.as_mut_ptr(),
@@ -2038,8 +2038,8 @@ impl ConsensusContainer {
         block_hash: &crate::grpc2::types::BlockHashInput,
     ) -> Result<([u8; 32], crate::grpc2::types::CryptographicParameters), tonic::Status> {
         use crate::grpc2::Require;
-        let (block_id_type, block_hash) =
-            crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
+        let (block_id_type, block_hash) = bhi.to_ptr();
         let consensus = self.consensus.load(Ordering::SeqCst);
         let mut out_hash = [0u8; 32];
         let mut crypto_parameter_ptr: Option<CryptographicParameters> = None;
@@ -2047,7 +2047,7 @@ impl ConsensusContainer {
             getCryptographicParametersV2(
                 consensus,
                 block_id_type,
-                block_hash,
+                block_hash.as_ptr(),
                 out_hash.as_mut_ptr(),
                 &mut crypto_parameter_ptr,
                 copy_cryptographic_parameters_callback,
@@ -2084,15 +2084,15 @@ impl ConsensusContainer {
         let sender = Box::new(sender);
         let consensus = self.consensus.load(Ordering::SeqCst);
         let mut buf = [0u8; 32];
-        let (block_id_type, block_hash) =
-            crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
+        let (block_id_type, block_hash) = bhi.to_ptr();
         let sender_ptr = Box::into_raw(sender);
         let response: ConsensusQueryResponse = unsafe {
             getAccountListV2(
                 consensus,
                 sender_ptr,
                 block_id_type,
-                block_hash,
+                block_hash.as_ptr(),
                 buf.as_mut_ptr(),
                 enqueue_bytearray_callback,
             )
@@ -2119,14 +2119,14 @@ impl ConsensusContainer {
         let sender = Box::new(sender);
         let consensus = self.consensus.load(Ordering::SeqCst);
         let mut buf = [0u8; 32];
-        let (block_id_type, block_hash) =
-            crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
+        let (block_id_type, block_hash) = bhi.to_ptr();
         let response: ConsensusQueryResponse = unsafe {
             getModuleListV2(
                 consensus,
                 Box::into_raw(sender),
                 block_id_type,
-                block_hash,
+                block_hash.as_ptr(),
                 buf.as_mut_ptr(),
                 enqueue_bytearray_callback,
             )
@@ -2146,14 +2146,14 @@ impl ConsensusContainer {
         let consensus = self.consensus.load(Ordering::SeqCst);
         let mut out_data: Vec<u8> = Vec::new();
         let mut out_hash = [0u8; 32];
-        let (block_id_type, block_id) =
-            crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
+        let (block_id_type, block_id) = bhi.to_ptr();
         let module_ref_ptr = crate::grpc2::types::module_reference_to_ffi(module_ref).require()?;
         let response: ConsensusQueryResponse = unsafe {
             getModuleSourceV2(
                 consensus,
                 block_id_type,
-                block_id,
+                block_id.as_ptr(),
                 module_ref_ptr,
                 out_hash.as_mut_ptr(),
                 &mut out_data,
@@ -2177,14 +2177,14 @@ impl ConsensusContainer {
         let sender = Box::new(sender);
         let consensus = self.consensus.load(Ordering::SeqCst);
         let mut buf = [0u8; 32];
-        let (block_id_type, block_hash) =
-            crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
+        let (block_id_type, block_hash) = bhi.to_ptr();
         let response: ConsensusQueryResponse = unsafe {
             getInstanceListV2(
                 consensus,
                 Box::into_raw(sender),
                 block_id_type,
-                block_hash,
+                block_hash.as_ptr(),
                 buf.as_mut_ptr(),
                 enqueue_bytearray_callback,
             )
@@ -2201,8 +2201,8 @@ impl ConsensusContainer {
         address: &crate::grpc2::types::ContractAddress,
     ) -> Result<([u8; 32], Vec<u8>), tonic::Status> {
         use crate::grpc2::Require;
-        let (block_id_type, block_hash) =
-            crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
+        let (block_id_type, block_hash) = bhi.to_ptr();
         let addr_index = address.index;
         let addr_subindex = address.subindex;
         let consensus = self.consensus.load(Ordering::SeqCst);
@@ -2212,7 +2212,7 @@ impl ConsensusContainer {
             getInstanceInfoV2(
                 consensus,
                 block_id_type,
-                block_hash,
+                block_hash.as_ptr(),
                 addr_index,
                 addr_subindex,
                 out_hash.as_mut_ptr(),
@@ -2232,8 +2232,8 @@ impl ConsensusContainer {
         address: &crate::grpc2::types::ContractAddress,
     ) -> Result<([u8; 32], ContractStateResponse), tonic::Status> {
         use crate::grpc2::Require;
-        let (block_id_type, block_hash) =
-            crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
+        let (block_id_type, block_hash) = bhi.to_ptr();
         let addr_index = address.index;
         let addr_subindex = address.subindex;
         let consensus = self.consensus.load(Ordering::SeqCst);
@@ -2244,7 +2244,7 @@ impl ConsensusContainer {
             getInstanceStateV2(
                 consensus,
                 block_id_type,
-                block_hash,
+                block_hash.as_ptr(),
                 addr_index,
                 addr_subindex,
                 out_hash.as_mut_ptr(),
@@ -2278,14 +2278,14 @@ impl ConsensusContainer {
         let sender = Box::new(sender);
         let consensus = self.consensus.load(Ordering::SeqCst);
         let mut buf = [0u8; 32];
-        let (block_id_type, block_hash) =
-            crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
+        let (block_id_type, block_hash) = bhi.to_ptr();
         let response: ConsensusQueryResponse = unsafe {
             getAncestorsV2(
                 consensus,
                 Box::into_raw(sender),
                 block_id_type,
-                block_hash,
+                block_hash.as_ptr(),
                 amount,
                 buf.as_mut_ptr(),
                 enqueue_bytearray_callback,
@@ -2330,9 +2330,10 @@ impl ConsensusContainer {
         let consensus = self.consensus.load(Ordering::SeqCst);
         let mut out_data: Vec<u8> = Vec::new();
         let mut out_hash = [0u8; 32];
-        let (block_id_type, block_id) =
+        let bhi =
             crate::grpc2::types::block_hash_input_to_ffi(request.block_hash.as_ref().require()?)
                 .require()?;
+        let (block_id_type, block_id) = bhi.to_ptr();
 
         // Optional Address to ffi
         let (
@@ -2378,7 +2379,7 @@ impl ConsensusContainer {
             invokeInstanceV2(
                 consensus,
                 block_id_type,
-                block_id,
+                block_id.as_ptr(),
                 contract.index,
                 contract.subindex,
                 invoker_address_type,
@@ -2411,13 +2412,13 @@ impl ConsensusContainer {
         let consensus = self.consensus.load(Ordering::SeqCst);
         let mut out_data: Vec<u8> = Vec::new();
         let mut out_hash = [0u8; 32];
-        let (block_id_type, block_id) =
-            crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
+        let (block_id_type, block_id) = bhi.to_ptr();
         let response: ConsensusQueryResponse = unsafe {
             getBlockInfoV2(
                 consensus,
                 block_id_type,
-                block_id,
+                block_id.as_ptr(),
                 out_hash.as_mut_ptr(),
                 &mut out_data,
                 copy_to_vec_callback,
@@ -2439,14 +2440,14 @@ impl ConsensusContainer {
         let sender = Box::new(sender);
         let consensus = self.consensus.load(Ordering::SeqCst);
         let mut buf = [0u8; 32];
-        let (block_id_type, block_hash) =
-            crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
+        let (block_id_type, block_hash) = bhi.to_ptr();
         let response: ConsensusQueryResponse = unsafe {
             getBakerListV2(
                 consensus,
                 Box::into_raw(sender),
                 block_id_type,
-                block_hash,
+                block_hash.as_ptr(),
                 buf.as_mut_ptr(),
                 enqueue_bytearray_callback,
             )
@@ -2465,16 +2466,18 @@ impl ConsensusContainer {
         let consensus = self.consensus.load(Ordering::SeqCst);
         let mut out_data: Vec<u8> = Vec::new();
         let mut out_hash = [0u8; 32];
-        let (block_id_type, block_id) =
+        let bhi =
             crate::grpc2::types::block_hash_input_to_ffi(request.block_hash.as_ref().require()?)
                 .require()?;
+
+        let (block_id_type, block_id) = bhi.to_ptr();
         let baker_id = crate::grpc2::types::baker_id_to_ffi(request.baker.as_ref().require()?);
 
         let response: ConsensusQueryResponse = unsafe {
             getPoolInfoV2(
                 consensus,
                 block_id_type,
-                block_id,
+                block_id.as_ptr(),
                 baker_id,
                 out_hash.as_mut_ptr(),
                 &mut out_data,
@@ -2496,13 +2499,13 @@ impl ConsensusContainer {
         let consensus = self.consensus.load(Ordering::SeqCst);
         let mut out_data: Vec<u8> = Vec::new();
         let mut out_hash = [0u8; 32];
-        let (block_id_type, block_id) =
-            crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
+        let (block_id_type, block_id) = bhi.to_ptr();
         let response: ConsensusQueryResponse = unsafe {
             getPassiveDelegationInfoV2(
                 consensus,
                 block_id_type,
-                block_id,
+                block_id.as_ptr(),
                 out_hash.as_mut_ptr(),
                 &mut out_data,
                 copy_to_vec_callback,
@@ -2549,13 +2552,13 @@ impl ConsensusContainer {
         let consensus = self.consensus.load(Ordering::SeqCst);
         let mut out_data: Vec<u8> = Vec::new();
         let mut out_hash = [0u8; 32];
-        let (block_id_type, block_id) =
-            crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
+        let (block_id_type, block_id) = bhi.to_ptr();
         let response: ConsensusQueryResponse = unsafe {
             getTokenomicsInfoV2(
                 consensus,
                 block_id_type,
-                block_id,
+                block_id.as_ptr(),
                 out_hash.as_mut_ptr(),
                 &mut out_data,
                 copy_to_vec_callback,
@@ -2577,16 +2580,17 @@ impl ConsensusContainer {
         let sender = Box::new(sender);
         let consensus = self.consensus.load(Ordering::SeqCst);
         let mut buf = [0u8; 32];
-        let (block_id_type, block_hash) =
+        let bhi =
             crate::grpc2::types::block_hash_input_to_ffi(request.block_hash.as_ref().require()?)
                 .require()?;
+        let (block_id_type, block_hash) = bhi.to_ptr();
         let baker_id = crate::grpc2::types::baker_id_to_ffi(request.baker.as_ref().require()?);
         let response: ConsensusQueryResponse = unsafe {
             getPoolDelegatorsV2(
                 consensus,
                 Box::into_raw(sender),
                 block_id_type,
-                block_hash,
+                block_hash.as_ptr(),
                 baker_id,
                 buf.as_mut_ptr(),
                 enqueue_bytearray_callback,
@@ -2609,16 +2613,17 @@ impl ConsensusContainer {
         let sender = Box::new(sender);
         let consensus = self.consensus.load(Ordering::SeqCst);
         let mut buf = [0u8; 32];
-        let (block_id_type, block_hash) =
+        let bhi =
             crate::grpc2::types::block_hash_input_to_ffi(request.block_hash.as_ref().require()?)
                 .require()?;
+        let (block_id_type, block_hash) = bhi.to_ptr();
         let baker_id = crate::grpc2::types::baker_id_to_ffi(request.baker.as_ref().require()?);
         let response: ConsensusQueryResponse = unsafe {
             getPoolDelegatorsRewardPeriodV2(
                 consensus,
                 Box::into_raw(sender),
                 block_id_type,
-                block_hash,
+                block_hash.as_ptr(),
                 baker_id,
                 buf.as_mut_ptr(),
                 enqueue_bytearray_callback,
@@ -2640,14 +2645,14 @@ impl ConsensusContainer {
         let sender = Box::new(sender);
         let consensus = self.consensus.load(Ordering::SeqCst);
         let mut buf = [0u8; 32];
-        let (block_id_type, block_hash) =
-            crate::grpc2::types::block_hash_input_to_ffi(request).require()?;
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(request).require()?;
+        let (block_id_type, block_hash) = bhi.to_ptr();
         let response: ConsensusQueryResponse = unsafe {
             getPassiveDelegatorsV2(
                 consensus,
                 Box::into_raw(sender),
                 block_id_type,
-                block_hash,
+                block_hash.as_ptr(),
                 buf.as_mut_ptr(),
                 enqueue_bytearray_callback,
             )
@@ -2669,14 +2674,14 @@ impl ConsensusContainer {
         let sender = Box::new(sender);
         let consensus = self.consensus.load(Ordering::SeqCst);
         let mut buf = [0u8; 32];
-        let (block_id_type, block_hash) =
-            crate::grpc2::types::block_hash_input_to_ffi(request).require()?;
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(request).require()?;
+        let (block_id_type, block_hash) = bhi.to_ptr();
         let response: ConsensusQueryResponse = unsafe {
             getPassiveDelegatorsRewardPeriodV2(
                 consensus,
                 Box::into_raw(sender),
                 block_id_type,
-                block_hash,
+                block_hash.as_ptr(),
                 buf.as_mut_ptr(),
                 enqueue_bytearray_callback,
             )
@@ -2705,14 +2710,14 @@ impl ConsensusContainer {
         let consensus = self.consensus.load(Ordering::SeqCst);
         let mut out_data: Vec<u8> = Vec::new();
         let mut out_hash = [0u8; 32];
-        let (block_id_type, block_id) =
-            crate::grpc2::types::block_hash_input_to_ffi(request).require()?;
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(request).require()?;
+        let (block_id_type, block_id) = bhi.to_ptr();
 
         let response: ConsensusQueryResponse = unsafe {
             getElectionInfoV2(
                 consensus,
                 block_id_type,
-                block_id,
+                block_id.as_ptr(),
                 out_hash.as_mut_ptr(),
                 &mut out_data,
                 copy_to_vec_callback,
@@ -2734,14 +2739,15 @@ impl ConsensusContainer {
         let sender = Box::new(sender);
         let consensus = self.consensus.load(Ordering::SeqCst);
         let mut buf = [0u8; 32];
-        let (block_id_type, block_hash) =
-            crate::grpc2::types::block_hash_input_to_ffi(request).require()?;
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(request).require()?;
+        let (block_id_type, block_hash) = bhi.to_ptr();
+
         let response: ConsensusQueryResponse = unsafe {
             getIdentityProvidersV2(
                 consensus,
                 Box::into_raw(sender),
                 block_id_type,
-                block_hash,
+                block_hash.as_ptr(),
                 buf.as_mut_ptr(),
                 enqueue_bytearray_callback,
             )
@@ -2762,14 +2768,15 @@ impl ConsensusContainer {
         let sender = Box::new(sender);
         let consensus = self.consensus.load(Ordering::SeqCst);
         let mut buf = [0u8; 32];
-        let (block_id_type, block_hash) =
-            crate::grpc2::types::block_hash_input_to_ffi(request).require()?;
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(request).require()?;
+
+        let (block_id_type, block_hash) = bhi.to_ptr();
         let response: ConsensusQueryResponse = unsafe {
             getAnonymityRevokersV2(
                 consensus,
                 Box::into_raw(sender),
                 block_id_type,
-                block_hash,
+                block_hash.as_ptr(),
                 buf.as_mut_ptr(),
                 enqueue_bytearray_callback,
             )
@@ -2813,15 +2820,15 @@ impl ConsensusContainer {
         use crate::grpc2::Require;
         let consensus = self.consensus.load(Ordering::SeqCst);
         let sender = Box::new(sender);
-        let (block_id_type, block_hash) =
-            crate::grpc2::types::block_hash_input_to_ffi(request).require()?;
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(request).require()?;
+        let (block_id_type, block_hash) = bhi.to_ptr();
         let mut buf = [0u8; 32];
         let response: ConsensusQueryResponse = unsafe {
             getBlockItemsV2(
                 consensus,
                 Box::into_raw(sender),
                 block_id_type,
-                block_hash,
+                block_hash.as_ptr(),
                 buf.as_mut_ptr(),
                 enqueue_bytearray_callback,
             )
@@ -2843,14 +2850,14 @@ impl ConsensusContainer {
         let sender = Box::new(sender);
         let consensus = self.consensus.load(Ordering::SeqCst);
         let mut buf = [0u8; 32];
-        let (block_id_type, block_hash) =
-            crate::grpc2::types::block_hash_input_to_ffi(request).require()?;
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(request).require()?;
+        let (block_id_type, block_hash) = bhi.to_ptr();
         let response: ConsensusQueryResponse = unsafe {
             getBlockTransactionEventsV2(
                 consensus,
                 Box::into_raw(sender),
                 block_id_type,
-                block_hash,
+                block_hash.as_ptr(),
                 buf.as_mut_ptr(),
                 enqueue_bytearray_callback,
             )
@@ -2872,14 +2879,14 @@ impl ConsensusContainer {
         let sender = Box::new(sender);
         let consensus = self.consensus.load(Ordering::SeqCst);
         let mut buf = [0u8; 32];
-        let (block_id_type, block_hash) =
-            crate::grpc2::types::block_hash_input_to_ffi(request).require()?;
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(request).require()?;
+        let (block_id_type, block_hash) = bhi.to_ptr();
         let response: ConsensusQueryResponse = unsafe {
             getBlockSpecialEventsV2(
                 consensus,
                 Box::into_raw(sender),
                 block_id_type,
-                block_hash,
+                block_hash.as_ptr(),
                 buf.as_mut_ptr(),
                 enqueue_bytearray_callback,
             )
@@ -2901,14 +2908,14 @@ impl ConsensusContainer {
         let sender = Box::new(sender);
         let consensus = self.consensus.load(Ordering::SeqCst);
         let mut buf = [0u8; 32];
-        let (block_id_type, block_hash) =
-            crate::grpc2::types::block_hash_input_to_ffi(request).require()?;
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(request).require()?;
+        let (block_id_type, block_hash) = bhi.to_ptr();
         let response: ConsensusQueryResponse = unsafe {
             getBlockPendingUpdatesV2(
                 consensus,
                 Box::into_raw(sender),
                 block_id_type,
-                block_hash,
+                block_hash.as_ptr(),
                 buf.as_mut_ptr(),
                 enqueue_bytearray_callback,
             )
@@ -2928,14 +2935,13 @@ impl ConsensusContainer {
         let consensus = self.consensus.load(Ordering::SeqCst);
         let mut out_data: Vec<u8> = Vec::new();
         let mut out_hash = [0u8; 32];
-        let (block_id_type, block_id) =
-            crate::grpc2::types::block_hash_input_to_ffi(request).require()?;
-
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(request).require()?;
+        let (block_id_type, block_id) = bhi.to_ptr();
         let response: ConsensusQueryResponse = unsafe {
             getNextUpdateSequenceNumbersV2(
                 consensus,
                 block_id_type,
-                block_id,
+                block_id.as_ptr(),
                 out_hash.as_mut_ptr(),
                 &mut out_data,
                 copy_to_vec_callback,
@@ -2955,14 +2961,13 @@ impl ConsensusContainer {
         let consensus = self.consensus.load(Ordering::SeqCst);
         let mut out_data: Vec<u8> = Vec::new();
         let mut out_hash = [0u8; 32];
-        let (block_id_type, block_id) =
-            crate::grpc2::types::block_hash_input_to_ffi(request).require()?;
-
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(request).require()?;
+        let (block_id_type, block_id) = bhi.to_ptr();
         let response: ConsensusQueryResponse = unsafe {
             getBlockChainParametersV2(
                 consensus,
                 block_id_type,
-                block_id,
+                block_id.as_ptr(),
                 out_hash.as_mut_ptr(),
                 &mut out_data,
                 copy_to_vec_callback,
@@ -2982,14 +2987,13 @@ impl ConsensusContainer {
         let consensus = self.consensus.load(Ordering::SeqCst);
         let mut out_data: Vec<u8> = Vec::new();
         let mut out_hash = [0u8; 32];
-        let (block_id_type, block_id) =
-            crate::grpc2::types::block_hash_input_to_ffi(request).require()?;
-
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(request).require()?;
+        let (block_id_type, block_id) = bhi.to_ptr();
         let response: ConsensusQueryResponse = unsafe {
             getBlockFinalizationSummaryV2(
                 consensus,
                 block_id_type,
-                block_id,
+                block_id.as_ptr(),
                 out_hash.as_mut_ptr(),
                 &mut out_data,
                 copy_to_vec_callback,

--- a/concordium-node/src/grpc2.rs
+++ b/concordium-node/src/grpc2.rs
@@ -81,8 +81,8 @@ pub mod types {
 
     /// Convert the [`BlockHashInput`] to a pair of a tag and pointer to the
     /// content. The tag is 0 for "Best" block, 1 for "LastFinal" block,
-    /// 2 for a specific block given by a hash, 3 for block given by absolute height, and 4 for
-    /// block given by relative height.
+    /// 2 for a specific block given by a hash, 3 for block given by absolute
+    /// height, and 4 for block given by relative height.
     pub(crate) fn block_hash_input_to_ffi(bhi: &BlockHashInput) -> Option<BlockHashInputFFI> {
         use block_hash_input::BlockHashInput::*;
         match bhi.block_hash_input.as_ref()? {


### PR DESCRIPTION
## Purpose

Closes https://github.com/Concordium/concordium-node/issues/837.
Should be merged with https://github.com/Concordium/concordium-grpc-api/pull/36 and https://github.com/Concordium/concordium-base/pull/374.

## Changes

- Support using block height as block identifiers in gRPC v2 API.
- Extend gRPC v2 API call `GetBlockInfo` with the protocol version of the block.

