### PR TITLE
Bump base to reduce use of unsafe code, bump version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+## 5.4.0
+
 - Support using block height as block identifiers in gRPC v2 API.
 - Extend gRPC v2 API call `GetBlockInfo` with the protocol version of the block.
 - Do not use peer buckets when running as a normal node (not as a bootstrapper).

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -644,7 +644,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_node"
-version = "5.3.2"
+version = "5.4.0"
 dependencies = [
  "anyhow",
  "app_dirs2",

--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium_node"
-version = "5.3.2" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
+version = "5.4.0" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
 description = "Concordium Node"
 authors = ["Concordium <developers@concordium.com>"]
 exclude = [".gitignore", ".gitlab-ci.yml", "test/**/*","**/**/.gitignore","**/**/.gitlab-ci.yml"]

--- a/service/windows/installer/Node.wxs
+++ b/service/windows/installer/Node.wxs
@@ -2,9 +2,9 @@
 <!-- When updating the product version, the Product Id should be refreshed, otherwise it will not be
     possible to upgrade an existing installation.
 -->
-<?define VersionNumber="5.3.2" ?>
+<?define VersionNumber="5.4.0" ?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:Util="http://schemas.microsoft.com/wix/UtilExtension">
-    <Product Name="Concordium Node" Manufacturer="Concordium Software" Id="af24341f-3557-421a-b055-bd41775f3f11" UpgradeCode="297295b4-c716-4d33-8170-0f6136663bfd" Language="1033" Codepage="1252" Version="$(var.VersionNumber)">
+    <Product Name="Concordium Node" Manufacturer="Concordium Software" Id="8a8385b8-4ef3-4ed5-a44b-71db14fd5492" UpgradeCode="297295b4-c716-4d33-8170-0f6136663bfd" Language="1033" Codepage="1252" Version="$(var.VersionNumber)">
         <Package Id="*" Keywords="Concordium Installer" Description="Concordium Node $(var.VersionNumber) Installer" Manufacturer="Concordium Software" InstallerVersion="500" Languages="1033" Compressed="yes" InstallScope="perMachine" />
         <MajorUpgrade Schedule="afterInstallValidate" DowngradeErrorMessage="The currently-installed version of [ProductName] is newer than the version you are trying to install. The installation cannot continue. If you wish to install this version, please remove the newer version first." />
         <Media Id="1" Cabinet="Node.cab" EmbedCab="yes" />


### PR DESCRIPTION
## Purpose

Bump base to bring in https://github.com/Concordium/concordium-base/pull/376

Bump version to 5.4.0 for upcoming release.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
