### PR TITLE
Correctly set genesis baker restaking.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased changes
 
+- Fix a bug that causes bakers in genesis to restake their earnings when they should not. This
+  affects genesis data at protocol version P5; P1-P4 genesis data are not affected. This breaks
+  compatibility with chains started with P5 genesis data, where some genesis bakers are not set to
+  restake earnings. Other chains (including mainnet and testnet) are not affected.
+
 ## 5.4.0
 
 - Support using block height as block identifiers in gRPC v2 API.

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
@@ -1286,7 +1286,7 @@ makeFromGenesisAccount spv cryptoParams chainParameters GenesisAccount{..} = do
             paseBakerInfo <- refMakeFlushed $ genesisBakerInfoEx spv chainParameters baker
             let enduringBaker =
                     PersistentAccountStakeEnduringBaker
-                        { paseBakerRestakeEarnings = True,
+                        { paseBakerRestakeEarnings = gbRestakeEarnings baker,
                           paseBakerPendingChange = NoChange,
                           ..
                         }


### PR DESCRIPTION
## Purpose

Fixes #859

This fixes a bug where bakers in genesis from protocol version P5 are set to restake their earnings, regardless of whether the genesis data indicates that they should do so.

## Changes

- Use the restaking flag from genesis data to determine whether genesis bakers restake their earnings.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
