### PR TITLE
Export consensusv1 database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased changes
 
+- Add support for out-of-band export files.
 - Fix a bug which caused the first epoch of the new protocol to be shorter than expected.
 - Fix a bug that caused an incorrect reporting of total stake in the first
   payday just after genesis when the node started from genesis at protocols 4 or 5.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased changes
 
-- Add support for out-of-band export files.
+- Add support for out-of-band export files for ConcordiumBFT (protocol version 6).
 - Fix a network layer bug where initial messages after the handshake could be
   dropped in some circumstances.
 - Fix a bug which caused the first epoch of the new protocol to be shorter than expected.

--- a/concordium-consensus/src/Concordium/ImportExport.hs
+++ b/concordium-consensus/src/Concordium/ImportExport.hs
@@ -773,12 +773,16 @@ exportBlocksToChunk hdl firstHeight chunkSize lastFinalizationRecordIndex getBlo
                 liftIO $ do
                     BS.hPut hdl $ runPut $ putWord64be len
                     BS.hPut hdl serializedBlock
+                -- For 'ConsensusV0' this will yield a result (as we are looking up finalized blocks),
+                -- while for 'ConsensusV1' this will always return @Nothing@, and as such
+                -- the @lastFinRecIdx@ will remain zero throughout the export.
                 let lastFinRecIdx' = fromMaybe lastFinRecIdx finalizationRecordIndexM
                 if count < chunkSize
                     then ebtc (height + 1) (count + 1) lastFinRecIdx'
                     else return (count, lastFinRecIdx')
 
 -- |Export all finalization records with indices above `dbsLastFinIndex` to a chunk
+-- Note. For 'ConsensusV0' this function will not write anything to the file.
 exportFinRecsToChunk ::
     MonadIO m =>
     -- |Handle to export to

--- a/concordium-consensus/src/Concordium/ImportExport.hs
+++ b/concordium-consensus/src/Concordium/ImportExport.hs
@@ -615,6 +615,10 @@ exportSections dbDir outDir chunkSize genIndex startHeight blockIndex lastWritte
 -- |Action for getting a block (and possibly a finalization index) at a particular height.
 -- Note that for 'ConsensusV1' (>P5) the finalization index is simply @Nothing@ as they do not
 -- exist on this version.
+--
+-- Note. This is a slightly hacky abstraction for retrieving blocks, (and their associated @FinalizationIndex@
+-- for protocols <P5), but this is a way of abstracting over the two consensus versions and reusing
+-- as much functionality for the actual file writing as possible.
 type GetBlockAt m = BlockHeight -> m (Maybe (BS.ByteString, Maybe FinalizationIndex))
 
 -- |Action for getting a finalization record at a particular index.

--- a/concordium-consensus/src/Concordium/ImportExport.hs
+++ b/concordium-consensus/src/Concordium/ImportExport.hs
@@ -613,12 +613,12 @@ exportSections dbDir outDir chunkSize genIndex startHeight blockIndex lastWritte
             return (False, Empty)
 
 -- |Action for getting a block (and possibly a finalization index) at a particular height.
--- Note that for consensus v1 the finalization index is simply @Nothing@ as they do not
+-- Note that for 'ConsensusV1' (>P5) the finalization index is simply @Nothing@ as they do not
 -- exist on this version.
 type GetBlockAt m = BlockHeight -> m (Maybe (BS.ByteString, Maybe FinalizationIndex))
 
 -- |Action for getting a finalization record at a particular index.
--- Note that for ConsensusV1 this always returns @Nothing@.
+-- Note that for 'ConsensusV1' (>P5) this always returns @Nothing@.
 type GetFinalizationRecordAt m = FinalizationIndex -> m (Maybe BS.ByteString)
 
 -- |Write a database section as a collection of chunks in the specified directory. The last exported

--- a/concordium-consensus/src/Concordium/ImportExport.hs
+++ b/concordium-consensus/src/Concordium/ImportExport.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -403,7 +402,8 @@ exportConsensusV1Blocks ::
     ( IsProtocolVersion pv,
       MonadIO m,
       KonsensusV1.MonadTreeStateStore m,
-      MonadLogger m
+      MonadLogger m,
+      MPV m ~ pv
     ) =>
     -- |Export path.
     FilePath ->

--- a/concordium-consensus/src/Concordium/ImportExport.hs
+++ b/concordium-consensus/src/Concordium/ImportExport.hs
@@ -641,7 +641,7 @@ data GetFinalizationRecordAt (cv :: ConsensusParametersVersion) (m :: Type -> Ty
           gfaV0 :: FinalizationIndex -> m (Maybe BS.ByteString)
         } ->
         GetFinalizationRecordAt 'ConsensusParametersVersion0 m
-    -- |'ConsensusV1' does not use the concept of finalization indecies,
+    -- |'ConsensusV1' does not use the concept of finalization indices,
     -- so this is a noop.
     GetFinalizationRecordAtV1 :: GetFinalizationRecordAt 'ConsensusParametersVersion0 m
 

--- a/concordium-consensus/src/Concordium/ImportExport.hs
+++ b/concordium-consensus/src/Concordium/ImportExport.hs
@@ -40,6 +40,7 @@
 -- genesis block, and all finalization records that are not already included in blocks.
 module Concordium.ImportExport where
 
+import Data.Maybe (fromMaybe)
 import Control.Monad
 import Control.Monad.Catch
 import Control.Monad.IO.Class
@@ -98,7 +99,7 @@ data SectionHeader = SectionHeader
       sectionBlockCount :: !Word64,
       sectionBlocksLength :: !Word64,
       sectionFinalizationCount :: !Word64
-    }
+    } deriving (Eq, Show)
 
 instance Serialize SectionHeader where
     put SectionHeader{..} = do
@@ -743,7 +744,7 @@ exportBlocksToChunk hdl firstHeight chunkSize lastFinalizationRecordIndex getBlo
                 liftIO $ do
                     BS.hPut hdl $ runPut $ putWord64be len
                     BS.hPut hdl serializedBlock
-                let lastFinRecIdx' = maybe 0 (+ 1) finalizationRecordIndexM
+                let lastFinRecIdx' = fromMaybe lastFinRecIdx finalizationRecordIndexM
                 if count < chunkSize
                     then ebtc (height + 1) (count + 1) lastFinRecIdx'
                     else return (count, lastFinRecIdx')

--- a/concordium-consensus/src/Concordium/ImportExport.hs
+++ b/concordium-consensus/src/Concordium/ImportExport.hs
@@ -2,8 +2,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE UndecidableInstances #-}
 
 -- |Functionality for importing and exporting the block database.
 --
@@ -41,16 +39,11 @@
 -- genesis block, and all finalization records that are not already included in blocks.
 module Concordium.ImportExport where
 
-import Control.Monad.Reader
-import Control.Monad.Trans.Identity
-import Data.Kind (Type)
 import Control.Monad.Trans.Reader
 import Control.Monad
-import Control.Monad.Trans (lift)
 import Control.Monad.Catch
 import Control.Monad.IO.Class
-import Control.Monad.State.Strict (MonadState, evalStateT)
-import qualified Control.Monad.State.Strict as State
+import Control.Monad.State (MonadState, evalStateT)
 import Control.Monad.Trans.Except
 import qualified Data.Attoparsec.Text as AP
 import Data.Bits
@@ -69,7 +62,6 @@ import System.Directory
 import System.FilePath
 import System.IO
 
-import Concordium.Types.HashableTo
 import Concordium.Common.Version
 import Concordium.GlobalState.Block
 import Concordium.GlobalState.BlockPointer
@@ -81,105 +73,18 @@ import Concordium.Utils.Serialization.Put
 import Lens.Micro.Platform
 import qualified Concordium.KonsensusV1.TreeState.LowLevel.LMDB as KonsensusV1
 import qualified Concordium.KonsensusV1.TreeState.LowLevel as KonsensusV1
-import qualified Concordium.KonsensusV1.Types as KonsensusV1
+import Concordium.KonsensusV1.TreeState.LowLevel (MonadTreeStateStore(lookupLastBlock))
 
--- |FIXME: document this
-data DBState pv
-    = DBStateV0
-        { _dbsV0FinIndex :: !FinalizationIndex,
-          _dbsV0Handlers :: !(DatabaseHandlers pv ())
-        }
-   | DBStateV1
-       { _dbsV1Handlers :: !(KonsensusV1.DatabaseHandlers pv)}
+-- |State used for exporting the database.
+data DBState pv = DBState
+    { _dbsHandlers :: DatabaseHandlers pv (),
+      _dbsLastFinIndex :: FinalizationIndex
+    }
+
 makeLenses ''DBState
 
--- |FIXME: document this
-class (MonadIO m, MonadState s m) => MonadExporter s m where
-    -- |Read a block from the database at the provided 'BlockHeight'.
-    -- Returns something if a block could be retrieved, and otherwise
-    -- nothing is returned.
-    readBlockAt :: BlockHeight -> m (Maybe (BS.ByteString, FinalizationIndex))
-    -- |Read a finalization record from the databae at the provided 'FinalizationIndex'
-    -- Returns something if one exists, otherwise returns nothing.
-    readFinalizationRecordAt :: FinalizationIndex -> m (Maybe BS.ByteString)
-    -- |Read the genesis hash of the database.
-    -- Returns nothing if it was not possible to read from the database.
-    -- TODO: make Either
-    readGenesisHash :: m (Maybe BlockHash)
-    -- |Check whether it is possible to read the "last" block of the database.
-    -- If this fails rerturns @False@ otherwise @True@.
-    -- TODO: Make Either
-    canRead :: m Bool
-
-instance forall pv m. (MonadCatch m, MonadIO m, IsProtocolVersion pv, MonadState (DBState pv) m) => MonadExporter (DBState pv) m where
-    readBlockAt height = case demoteProtocolVersion (protocolVersion @pv) of
-        -- Protocols [p1;p5] uses v0 lmdb while p6 uses v1.
-        P6 -> readV1Block
-        _ -> readV0Block        
-      where
-        readV0Block = do
-            handles <- use dbsV0Handlers
-            liftIO $ resizeOnResized $ getFinalizedBlockAtHeight handles height >>= \case
-                Nothing -> return Nothing
-                Just sb | NormalBlock normalBlock <- sbBlock sb -> do
-                    let serializedBlock = runPut $ putVersionedBlock (protocolVersion @pv) normalBlock
-                        finIndex = sbFinalizationIndex sb
-                    return $ Just (serializedBlock, finIndex)
-                _ -> return Nothing -- Do not export genesis blocks.
-        readV1Block = do
-            KonsensusV1.resizeOnResized $ KonsensusV1.lookupBlockByHeight height >>= \case
-                Nothing -> return Nothing
-                Just storedB | KonsensusV1.NormalBlock signedB <- KonsensusV1.stbBlock storedB -> do
-                    let serializedBlock = runPut $ KonsensusV1.putSignedBlock signedB
-                    return $ Just (serializedBlock, 0) -- The finalization index is never used here, so just return 0.
-                _ -> return Nothing -- Do not export genesis blocks.
-                
-    readFinalizationRecordAt finRecIndex = case demoteProtocolVersion (protocolVersion @pv) of
-        P6 -> readV1FinalizationRecord
-        _ -> readV0FinalizationRecord
-      where
-        readV0FinalizationRecord = resizeOnResized $ readFinalizationRecord finRecIndex >>= \case
-            Nothing -> return Nothing
-            Just fr -> do
-                return $ Just $ runPut $ putVersionedFinalizationRecordV0 fr
-        readV1FinalizationRecord = return Nothing
-
-    readGenesisHash = case demoteProtocolVersion (protocolVersion @pv) of
-        P6 -> readV1GenesisHash
-        _ -> readV0GenesisHash
-      where
-        readV0GenesisHash = do
-            resizeOnResized $ readFinalizationRecord 0 >>= \case
-                Nothing -> return Nothing
-                Just genFinRec -> return $ Just $! finalizationBlockPointer genFinRec
-        readV1GenesisHash = do
-            dbh <- use dbsV1Handlers
-            runSilentLogger $ runReaderT (KonsensusV1.runDiskLLDBM $ do
-                KonsensusV1.resizeOnResized $ KonsensusV1.lookupFirstBlock >>= \case
-                    Nothing -> return Nothing
-                    Just sb -> return $ Just $ getHash sb
-                ) dbh
-    canRead = case demoteProtocolVersion (protocolVersion @pv) of
-        P6 -> canReadV1
-        _ -> liftIO canReadV0
-      where
-        canReadV0 = do
-            dbh <- use dbsV0Handlers
-            getLastBlock dbh >>= \case
-                Left _ -> return False
-                Right _ -> return True
-        canReadV1 = do
-            dbh <- use dbsV1Handlers
-            runSilentLogger $ runReaderT (KonsensusV1.runDiskLLDBM $ do
-                KonsensusV1.lookupLastBlock >>= \case
-                    Nothing -> return False
-                    Just _ -> return True
-                ) dbh
-
--- |FIXME: document this
-newtype ExporterMonad (m :: Type -> Type) (a :: Type) = ExporterMonad {runExporterMonad :: m a}
-    deriving (Functor, Applicative, Monad, MonadIO, MonadState s)
-    deriving MonadTrans via IdentityT
+instance HasDatabaseHandlers pv () (DBState pv) where
+    dbHandlers = dbsHandlers
 
 -- |A section header of an exported block database
 data SectionHeader = SectionHeader
@@ -466,13 +371,24 @@ exportDatabaseV3 dbDir outDir chunkSize = do
             return exportError
         Nothing -> return exportError
 
+exportConsensusV1Blocks ::
+  (
+    MonadLogger m,
+    KonsensusV1.MonadTreeStateStore m
+  ) =>
+  m (Bool, BlockIndex)
+exportConsensusV1Blocks = do
+    lookupLastBlock >>= \case
+        Nothing -> return (True, Empty)
+        Just sb -> undefined
+
 -- |Export database sections corresponding to blocks with genesis indices >= genIndex
 -- and of height >= startHeight.
 -- Returns a @Bool@ and a @BlockIndex@ where the former indicates whether an error occurred,
 -- and the latter contains information about the sections that were succesfully written to the
 -- file-system. If a section could not be exported or if any errors occurred this will be logged
 -- to `stdout` in this function.
-exportSections :: (MonadState (DBState pv) m, MonadIO m) =>
+exportSections ::
     -- |Database directory
     FilePath ->
     -- |Export directory
@@ -487,14 +403,14 @@ exportSections :: (MonadState (DBState pv) m, MonadIO m) =>
     BlockIndex ->
     -- |Filename of last chunk in previous export
     Maybe String ->
-    m (Bool, BlockIndex)
+    IO (Bool, BlockIndex)
 exportSections dbDir outDir chunkSize genIndex startHeight blockIndex lastWrittenChunkM = do
     let treeStateDir = dbDir </> "treestate-" ++ show genIndex
     -- Check if the database exists for this genesis index.
-    dbEx <- liftIO $ doesPathExist $ treeStateDir </> "data.mdb"
+    dbEx <- doesPathExist $ treeStateDir </> "data.mdb"
     if dbEx
         then
-            liftIO $ openReadOnlyDatabase treeStateDir >>= \case
+            openReadOnlyDatabase treeStateDir >>= \case
                 Nothing -> do
                     -- If we cannot open the database as a 'ConsensusV0', then
                     -- we try open up the 'ConsensusV1' database.
@@ -504,11 +420,7 @@ exportSections dbDir outDir chunkSize genIndex startHeight blockIndex lastWritte
                             putStrLn "Tree state database could not be opened"
                             return (True, Empty)
                         Just (KonsensusV1.VersionDatabaseHandlers (dbh :: KonsensusV1.DatabaseHandlers pv)) -> 
-                            runSilentLogger $ runReaderT (KonsensusV1.runDiskLLDBM $ do
-                                                             KonsensusV1.lookupLastBlock >>= \case
-                                                                 Nothing -> return (True, Empty)
-                                                                 Just sb -> return (True, Empty)
-                                                         ) dbh
+                            runSilentLogger $ runReaderT (KonsensusV1.runDiskLLDBM @pv exportConsensusV1Blocks) dbh
                 Just (VersionDatabaseHandlers (dbh :: DatabaseHandlers pv ())) -> do
                     (exportError, sectionData) <-
                         liftIO $
@@ -519,7 +431,7 @@ exportSections dbDir outDir chunkSize genIndex startHeight blockIndex lastWritte
                                 Right (_, sb) -> do
                                     evalStateT
                                         ( do
-                                            mgenFinRec <- readFinalizationRecord 0
+                                            mgenFinRec <- resizeOnResized $ readFinalizationRecord 0
                                             case mgenFinRec of
                                                 Nothing -> liftIO $ do
                                                     putStrLn "No finalization record found in database for finalization index 0."
@@ -556,7 +468,7 @@ exportSections dbDir outDir chunkSize genIndex startHeight blockIndex lastWritte
                                                                     lastWrittenChunkM
                                                             return (False, singleton (genHash, chunks))
                                         )
-                                        (DBStateV0 0)
+                                        (DBState dbh 0)
                     closeDatabase dbh
                     -- if an error occurred, return sections
                     -- that were succesfully written to the
@@ -579,7 +491,7 @@ exportSections dbDir outDir chunkSize genIndex startHeight blockIndex lastWritte
         else do
             -- this is not an error condition, but rather
             -- the condition for terminating the export.
-            liftIO . putStrLn $ "The tree state database does not exist at " ++ treeStateDir
+            putStrLn $ "The tree state database does not exist at " ++ treeStateDir
             return (False, Empty)
   where
     -- Return the last exported genesis hash or the provided one.
@@ -603,7 +515,7 @@ exportSections dbDir outDir chunkSize genIndex startHeight blockIndex lastWritte
 -- The @Maybe @ parameter contains the filename to be used for the first chunk to be written, if so
 -- provided, and if the file already exists, a version number is added and used instead.
 writeChunks ::
-    (MonadCatch m, MonadState (DBState pv) m, MonadIO m) =>
+    (IsProtocolVersion pv, MonadIO m, MonadState (DBState pv) m, MonadCatch m) =>
     -- |Genesis index
     GenesisIndex ->
     -- |Protocol version
@@ -706,7 +618,8 @@ writeChunks
 -- finalization record, the 'dbsLastFinIndex' field of the state is updated with its finalization
 -- index.
 exportBlocksToChunk ::
-    (MonadIO m, IsProtocolVersion pv, MonadState (DBState pv) m, MonadCatch m) =>
+    forall pv m.
+    (IsProtocolVersion pv, MonadIO m, MonadState (DBState pv) m, MonadCatch m) =>
     -- |Handle to export to
     Handle ->
     -- |Height of next block to export
@@ -718,41 +631,43 @@ exportBlocksToChunk ::
 exportBlocksToChunk hdl firstHeight chunkSize = ebtc firstHeight 0
   where
     ebtc height count =
-        readBlockAt height >>= \case
+        resizeOnResized (readFinalizedBlockAtHeight height) >>= \case
             Nothing -> return count
-            Just (serializedBlock, finIndex) -> do
-                let len = fromIntegral $ BS.length serializedBlock
+            Just sb | NormalBlock normalBlock <- sbBlock sb -> do
+                let serializedBlock =
+                        runPut $ putVersionedBlock (protocolVersion @pv) normalBlock
+                    len = fromIntegral $ BS.length serializedBlock
                 liftIO $ do
                     BS.hPut hdl $ runPut $ putWord64be len
                     BS.hPut hdl serializedBlock
-                s <- State.get
-                case s of
-                    DBStateV0{} -> dbsV0FinIndex .= finIndex
-                    DBStateV1{} -> return ()
+                forM_ (blockFields (sbBlock sb)) $ \bf ->
+                    case blockFinalizationData bf of
+                        BlockFinalizationData fr ->
+                            dbsLastFinIndex .= finalizationIndex fr
+                        NoFinalizationData -> return ()
                 if count < chunkSize
                     then ebtc (height + 1) (count + 1)
                     else return count
+            Just _ -> return count -- this branch should never be reachable, genesis blocks are not exported.
 
 -- |Export all finalization records with indices above `dbsLastFinIndex` to a chunk
 exportFinRecsToChunk ::
-    (IsProtocolVersion pv, MonadIO m, MonadState (DBState pv) m, MonadCatch m) =>
+    forall pv m.
+    (MonadIO m, MonadState (DBState pv) m, MonadCatch m) =>
     -- |Handle to export to
     Handle ->
     -- |Number of exported finalization records
     m Word64
-exportFinRecsToChunk hdl = do
-      s <- State.get
-      case s of
-        DBStateV0{..} -> exportFinRecsFrom 0 $ _dbsV0FinIndex + 1
-        DBStateV1{} -> return 0
+exportFinRecsToChunk hdl = exportFinRecsFrom 0 . (+ 1) =<< use dbsLastFinIndex
   where
     exportFinRecsFrom count finRecIndex =
-        readFinalizationRecordAt finRecIndex >>= \case
+        resizeOnResized (readFinalizationRecord finRecIndex) >>= \case
             -- if there's no finalization record with an index after the last exported one,
             -- there are no more finalization records to export
             Nothing -> return count
-            Just serializedFr -> do
-                let len = fromIntegral $ BS.length serializedFr
+            Just fr -> do
+                let serializedFr = runPut $ putVersionedFinalizationRecordV0 fr
+                    len = fromIntegral $ BS.length serializedFr
                 liftIO $ do
                     BS.hPut hdl $ runPut $ putWord64be len
                     BS.hPut hdl serializedFr

--- a/concordium-consensus/src/Concordium/KonsensusV1/TreeState/LowLevel/LMDB.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TreeState/LowLevel/LMDB.hs
@@ -546,6 +546,7 @@ instance
 
 -- |Initialise the low-level database by writing out the genesis block and initial round status.
 initialiseLowLevelDB ::
+    forall pv r m.
     (MonadIO m, MonadReader r m, HasDatabaseHandlers r pv, MonadLogger m, IsProtocolVersion pv) =>
     -- |Genesis block.
     StoredBlock pv ->
@@ -556,3 +557,9 @@ initialiseLowLevelDB genesisBlock roundStatus = asWriteTransaction $ \dbh txn ->
     storeReplaceRecord txn (dbh ^. blockStore) 0 genesisBlock
     storeReplaceRecord txn (dbh ^. blockHashIndex) (getHash genesisBlock) 0
     storeReplaceRecord txn (dbh ^. roundStatusStore) CSKRoundStatus roundStatus
+    let metadata =
+            VersionMetadata
+                { vmDatabaseVersion = 1,
+                  vmProtocolVersion = demoteProtocolVersion (protocolVersion @pv)
+                }
+    storeReplaceRecord txn (dbh ^. metadataStore) versionMetadata $ S.encode metadata

--- a/concordium-consensus/tools/database-exporter/Main.hs
+++ b/concordium-consensus/tools/database-exporter/Main.hs
@@ -13,12 +13,18 @@ import System.Exit
 import Concordium.GlobalState.Block
 import Concordium.GlobalState.Finalization
 import Concordium.ImportExport
+import qualified Concordium.KonsensusV1.TreeState.Types as SkovV1
+import qualified Concordium.KonsensusV1.Types as KonsensusV1
 import Concordium.Logger
 import Concordium.Types
+import Concordium.Types.HashableTo
+import Concordium.Types.Parameters
 
 import DatabaseExporter.CommandLineParser
 
 -- |Check an exported block file.
+-- Note that for 'ConsensusV1' we only check the blocks since
+-- that is the only thing being exported.
 checkDatabase :: FilePath -> IO ()
 checkDatabase filepath = do
     logm External LLInfo $ "Checking database: " ++ filepath
@@ -29,12 +35,19 @@ checkDatabase filepath = do
         Right _ -> putStrLn "Done."
   where
     logm _ lvl s = putStrLn $ show lvl ++ ": " ++ s
+    handleImport :: MonadLogger m => UTCTime -> ImportData -> m (ImportResult a ())
     handleImport t (ImportBlock pv gi bs) = case promoteProtocolVersion pv of
-        SomeProtocolVersion spv -> case deserializeExactVersionedPendingBlock spv bs t of
-            Left _ -> return $ Left ImportSerializationFail
-            Right pb -> do
-                logEvent External LLInfo $ "GenesisIndex: " ++ show gi ++ " block: " ++ show (pbHash pb) ++ " slot: " ++ show (blockSlot pb)
-                return $ Right ()
+        SomeProtocolVersion spv -> case consensusVersionFor spv of
+            ConsensusV0 -> case deserializeExactVersionedPendingBlock spv bs t of
+                Left _ -> return $ Left ImportSerializationFail
+                Right pb -> do
+                    logEvent External LLInfo $ "GenesisIndex: " ++ show gi ++ " block: " ++ show (pbHash pb) ++ " slot: " ++ show (blockSlot pb)
+                    return $ Right ()
+            ConsensusV1 -> case SkovV1.deserializeExactVersionedPendingBlock spv bs t of
+                Left _ -> return $ Left ImportSerializationFail
+                Right pb -> do
+                    logEvent External LLInfo $ "GenesisIndex: " ++ show gi ++ " block: " ++ show (getHash pb :: BlockHash) ++ " round: " ++ show (KonsensusV1.blockRound pb)
+                    return $ Right ()
     handleImport _ (ImportFinalizationRecord _ gi bs) =
         case runGet getExactVersionedFinalizationRecord bs of
             Left _ -> return $ Left ImportSerializationFail

--- a/concordium-consensus/tools/database-exporter/Main.hs
+++ b/concordium-consensus/tools/database-exporter/Main.hs
@@ -62,7 +62,7 @@ main = do
     case conf of
         Check file -> checkDatabase file
         Export db filepath n | n > 0 -> do
-            exportError <- exportDatabaseV3 db filepath n
+            exportError <- runLoggerT (exportDatabaseV3 db filepath n) logm
             when exportError $ exitWith $ ExitFailure 1
         Export{} -> do
             putStrLn "Chunk size should be larger than 0"
@@ -74,3 +74,4 @@ main = do
             ( fullDesc
                 <> progDesc "Export the database of a consensus node"
             )
+    logm _ lvl s = putStrLn $ show lvl ++ ": " ++ s

--- a/concordium-consensus/tools/database-exporter/Main.hs
+++ b/concordium-consensus/tools/database-exporter/Main.hs
@@ -46,7 +46,7 @@ checkDatabase filepath = do
             ConsensusV1 -> case SkovV1.deserializeExactVersionedPendingBlock spv bs t of
                 Left _ -> return $ Left ImportSerializationFail
                 Right pb -> do
-                    logEvent External LLInfo $ "GenesisIndex: " ++ show gi ++ " block: " ++ show (getHash pb :: BlockHash) ++ " round: " ++ show (KonsensusV1.blockRound pb)
+                    logEvent External LLInfo $ "GenesisIndex: " ++ show gi ++ " block: " ++ show ((blockHash . getHash) pb) ++ " round: " ++ show (KonsensusV1.blockRound pb)
                     return $ Right ()
     handleImport _ (ImportFinalizationRecord _ gi bs) =
         case runGet getExactVersionedFinalizationRecord bs of


### PR DESCRIPTION
## Purpose

https://github.com/Concordium/concordium-node/issues/869

## Changes

- Expanded checkDatabase such that it also handles blocks for the new consensus protocol.
- Expand the exporting functionality such that it also exports a v1 low level database.
- Populate the metadata store when inititalizing consensusv1 database.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
