### PR TITLE
Fix GRPC dummy values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,16 @@
   restake earnings. Other chains (including mainnet and testnet) are not affected.
 - Support the new ConcordiumBFT consensus.
 - Changes to the `GetConsensusStatus` endpoint:
-  * Slot duration only returned in consensus version 1.
+  * Slot duration only returned in protocol versions 0-5.
   * Endpoint extended to return current timeout duration, current round, current epoch and trigger
-    block time in consensus version 1.
+    block time in protocol version 6.
 - Changes to the `GetBlockInfo` endpoint:
-  * Block slot only returned in consensus version 0.
-  * Endpoint extended to return block round and epoch.
+  * Block slot only returned in protocol versions 0-5.
+  * In protocol version 6, the returned finalized block is the last finalized block until itself
+    is finalized. Then it is itself.
+  * Endpoint extended to return block round and epoch in protocol version 6.
 - Changes to the `ElectionInfo` endpoint:
-  * Election difficulty only returned in consensus version 0.
+  * Election difficulty only returned in protocol versions 0-5.
 
 ## 5.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@
   compatibility with chains started with P5 genesis data, where some genesis bakers are not set to
   restake earnings. Other chains (including mainnet and testnet) are not affected.
 - Support the new ConcordiumBFT consensus.
+- Changes to the `GetConsensusStatus` endpoint:
+  * Slot duration only returned in consensus version 1.
+  * Endpoint extended to return current timeout duration, current round, current epoch and trigger
+    block time in consensus version 1.
+- Changes to the `GetBlockInfo` endpoint:
+  * Block slot only returned in consensus version 0.
+  * Endpoint extended to return block round and epoch.
+- Changes to the `ElectionInfo` endpoint:
+  * Election difficulty only returned in consensus version 0.
 
 ## 5.4.2
 

--- a/concordium-consensus/src/Concordium/GlobalState/TransactionTable.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/TransactionTable.hs
@@ -14,7 +14,6 @@ import qualified Data.PQueue.Prio.Min as MinPQ
 import Data.Word
 import Lens.Micro.Platform
 
-import Concordium.KonsensusV1.Types
 import qualified Concordium.TransactionVerification as TVer
 import Concordium.Types
 import Concordium.Types.Execution

--- a/concordium-consensus/src/Concordium/KonsensusV1/LeaderElection.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/LeaderElection.hs
@@ -23,7 +23,6 @@ import Concordium.Types.SeedState
 
 import Concordium.Crypto.VRF (proofToHash)
 import Concordium.GlobalState.BakerInfo
-import Concordium.KonsensusV1.Types
 
 -- |Compute the leader for a given round, given the set of bakers and leadership election nonce
 -- for the epoch. The leader is computed as follows:

--- a/concordium-consensus/src/Concordium/KonsensusV1/Types.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Types.hs
@@ -33,10 +33,6 @@ import Concordium.Types.Transactions
 import Concordium.Utils.BinarySearch
 import Concordium.Utils.Serialization
 
--- |A round number for consensus.
-newtype Round = Round {theRound :: Word64}
-    deriving (Eq, Ord, Show, Serialize, Num, Integral, Real, Enum, Bounded)
-
 -- |A strict version of 'Maybe'.
 data Option a
     = Absent

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -483,7 +483,7 @@ getConsensusStatus = MVR $ \mvr -> do
             csFinalizationPeriodEMA = stats ^. finalizationPeriodEMA
             csFinalizationPeriodEMSD = sqrt <$> stats ^. finalizationPeriodEMVar
         csCurrentTimeoutDuration <- Just <$> use (SkovV1.roundStatus . SkovV1.rsCurrentTimeout)
-        csCurrentRound <- Just . SkovV1.theRound <$> use (SkovV1.roundStatus . SkovV1.rsCurrentRound)
+        csCurrentRound <- Just <$> use (SkovV1.roundStatus . SkovV1.rsCurrentRound)
         csCurrentEpoch <- Just <$> use (SkovV1.roundStatus . SkovV1.rsCurrentEpoch)
         ss <- BS.getSeedState (SkovV1.bpState lfb)
         let csTriggerBlockTime = Just $ ss ^. triggerBlockTime
@@ -715,7 +715,7 @@ getBlockInfo =
             let biTransactionsSize = fromIntegral $ SkovV1.blockTransactionsSize bp
             let biBlockStateHash = SkovV1.blockStateHash bp
             let biProtocolVersion = evcProtocolVersion evc
-            let biRound = Just . SkovV1.theRound $ SkovV1.blockRound bp
+            let biRound = Just $ SkovV1.blockRound bp
             let biEpoch = Just $ SkovV1.blockEpoch bp
             return BlockInfo{..}
         )

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -243,9 +243,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "3f1e31e207a6b8fb791a38ea3105e6cb541f55e4d029902d3039a4ad07cc4105"
 
 [[package]]
 name = "base64ct"
@@ -379,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.2"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6ed94e98ecff0c12dd1b04c15ec0d7d9458ca8fe806cea6f12954efe74c63b"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "bytecheck"
@@ -472,6 +472,7 @@ dependencies = [
  "js-sys",
  "num-integer",
  "num-traits 0.2.15",
+ "serde 1.0.163",
  "time 0.1.45",
  "wasm-bindgen",
  "winapi 0.3.9",
@@ -532,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "6.0.0"
+version = "6.1.0"
 dependencies = [
  "bs58",
  "chrono",
@@ -615,6 +616,7 @@ dependencies = [
  "itertools",
  "leb128",
  "libc",
+ "nom",
  "num",
  "num-bigint 0.4.3",
  "num-traits 0.2.15",
@@ -948,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common",
@@ -1501,7 +1503,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1798,9 +1800,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lmdb-rkv"
@@ -1925,6 +1927,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2019,6 +2027,16 @@ dependencies = [
  "hex",
  "rand 0.6.5",
  "zeroize",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2315,7 +2333,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
  "hmac",
  "password-hash",
  "sha2 0.10.6",
@@ -2481,9 +2499,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ec6d5fe0b140acb27c9a0444118cf55bfbb4e0b259739429abb4521dd67c16"
+checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
 dependencies = [
  "unicode-ident",
 ]
@@ -2848,9 +2866,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+checksum = "d1a59b5d8e97dee33696bf13c5ba8ab85341c002922fba050069326b9c498974"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2859,9 +2877,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "rend"
@@ -2874,11 +2892,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.17"
+version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13293b639a097af28fc8a90f22add145a9c954e49d77da06263d58cf44d5fb91"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3068,7 +3086,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.1",
 ]
 
 [[package]]
@@ -3163,9 +3181,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2855b3715770894e67cbfa3df957790aa0c9edc3bf06efa1a84d77fa0839d1"
+checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -3337,7 +3355,7 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3346,7 +3364,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -3519,9 +3537,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
@@ -3799,15 +3817,15 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.8"
+version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -3823,7 +3841,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.21.0",
+ "base64 0.21.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3877,7 +3895,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b00ec4842256d1fe0a46176e2ef5bc357664c66e7d91aff5a7d43d83a65f47"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.1",
  "bytes",
  "futures-core",
  "http",


### PR DESCRIPTION
## Purpose

https://github.com/Concordium/concordium-node/issues/870 and https://github.com/Concordium/concordium-node/issues/871

## Changes

Changes to `getConsensusStatus`:
* Best block is now the block with the highest QC (in consensus version 1)
* Slot duration is now only returned in consensus version 0
* In consensus version 1, current timeout duration, current round, current epoch and the trigger block time of the seedstate of the last finalized block are now returned

Changes to `getBlockInfo`:
* Block slot is now only returned in consensus version 0
* In consensus version 1, the returned last finalized block is now the last finalized block until itself is finalized (then it is itself)
* In consensus version 1, the block round and epoch are now returned

Changes to `getBlockBirkParameters`:
* The election difficulty are now only returned in consensus verison 0

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
