### PR TITLE
Start events after genesis.

### DIFF
--- a/concordium-consensus/src/Concordium/KonsensusV1.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1.hs
@@ -8,7 +8,9 @@ import Control.Monad.Catch
 import Control.Monad.IO.Class
 import Control.Monad.Reader.Class
 import Control.Monad.State.Class
+import Lens.Micro.Platform
 
+import qualified Concordium.Genesis.Data.BaseV1 as BaseV1
 import Concordium.GlobalState.BlockState
 import Concordium.GlobalState.Persistent.BlockState
 import qualified Concordium.GlobalState.Transactions as Transactions
@@ -106,5 +108,7 @@ startEvents ::
     ) =>
     m ()
 startEvents = do
-    resetTimerWithCurrentTimeout
-    makeBlock
+    genesisTime <- timestampToUTCTime . BaseV1.genesisTime . gmParameters <$> use genesisMetadata
+    doAfter genesisTime $ do
+        resetTimerWithCurrentTimeout
+        makeBlock


### PR DESCRIPTION
## Purpose
Closes https://github.com/Concordium/concordium-node/issues/868.

## Changes

The `startEvents` function now waits until the genesis time before it calls `resetTimerWithCurrentTimeout` and `makeBlock`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
