### PR TITLE
Fix p5-p6 account nonce and sequence number migration bug 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased changes
 
+- Fix a bug which caused account nonces and sequence numbers to not be migrated to P6 correctly.
 - Fix a bug which caused the first epoch of the new protocol to be shorter than expected.
 - Fix a bug that caused an incorrect reporting of total stake in the first
   payday just after genesis when the node started from genesis at protocols 4 or 5.

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
@@ -1014,20 +1014,8 @@ instance
             . ttHashMap
             %=! HM.map
                 ( \(bi, s) -> case s of
-                    -- Mark all @Committed@ transactions as @Received@.
-                    -- Note that we here set the @CommitPoint@ to "0", effectively
-                    -- treating the transaction as just received and it has never been
-                    -- part of a block.
-                    -- This ensures that the transaction gets purged after the protocol
-                    -- update if has expired.
-                    -- If we carried over the @CommitPoint@ then the transaction will
-                    -- not get purged, and the only way it could get evicted from the
-                    -- 'TransactionTable' is, if it becomes part of a new block that gets
-                    -- finalized.
-                    -- However this may never be the case if the transaction has become
-                    -- deprecated as part of the protocol update.
+                    Received{..} -> (bi, Received{_tsCommitPoint = 0, ..})
                     Committed{..} -> (bi, Received{_tsCommitPoint = 0, ..})
-                    _ -> (bi, s)
                 )
 
     clearAfterProtocolUpdate = do

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
@@ -1026,7 +1026,7 @@ instance
                     -- finalized.
                     -- However this may never be the case if the transaction has become
                     -- deprecated as part of the protocol update.
-                    Committed{..} -> (bi, Received{_tsCommitPoint = 0})
+                    Committed{..} -> (bi, Received{_tsCommitPoint = 0, ..})
                     _ -> (bi, s)
                 )
 

--- a/concordium-consensus/src/Concordium/GlobalState/TreeState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/TreeState.hs
@@ -460,7 +460,8 @@ class
     --
     --   - Clear all non-finalized blocks from the block table.
     --   - Remove all blocks from the pending table.
-    --   - Mark all non-finalized but committed transactions
+    --   - Mark all 'Committed' transactions as 'Received'.
+    --   - Reset the 'CommitPoint' on all non finalized transactions.
     clearOnProtocolUpdate :: m ()
 
     -- |Do any cleanup of resources that are no longer needed after the protocol

--- a/concordium-consensus/src/Concordium/KonsensusV1/TestMonad.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TestMonad.hs
@@ -37,6 +37,7 @@ import Concordium.GlobalState.Persistent.BlockState
 import qualified Concordium.GlobalState.Persistent.BlockState.Modules as Module
 import qualified Concordium.GlobalState.Persistent.Cache as Cache
 import Concordium.GlobalState.Persistent.Genesis (genesisState)
+import Concordium.GlobalState.TransactionTable (emptyPendingTransactionTable)
 import Concordium.GlobalState.Types
 import Concordium.KonsensusV1.Consensus
 import Concordium.KonsensusV1.TreeState.Implementation
@@ -184,7 +185,8 @@ runTestMonad _tcBakerContext _tcCurrentTime genData (TestMonad a) =
                     genState
                     genTimeoutBase
                     genEpochBakers
-                    & transactionTable .~ initTT
+                    initTT
+                    emptyPendingTransactionTable
         let genBlockPtr = _tsSkovData ^. lastFinalized
         let genStoredBlock =
                 LowLevel.StoredBlock

--- a/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Implementation.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Implementation.hs
@@ -302,7 +302,7 @@ purgeRoundExistingQCs rnd = roundExistingQCs %=! snd . Map.split (rnd - 1)
 --  * If there are any transactions in the 'TransactionTable' then the corresponding 'PendingTransactionsTable'
 --    must take these transactions into account. Refer to 'PendingTransactionTable' for more details.
 --  * The caller must make sure, that the supplied 'TransactionTable' does NOT contain any @Committed@ transactions
---    and all transactions either 'TT.Received' or 'TT.Committed' must have their 'TT.CommitPoint' set to 0.
+--    and all transactions have their commit point set to 0.
 mkInitialSkovData ::
     -- |The 'RuntimeParameters'
     RuntimeParameters ->

--- a/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Implementation.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Implementation.hs
@@ -294,6 +294,14 @@ purgeRoundExistingQCs rnd = roundExistingQCs %=! snd . Map.split (rnd - 1)
 --
 -- In the case that this is from a genesis, then an empty transaction table
 -- and empty pending transaction table must be provided.
+--
+-- Invariants:
+-- In case that a non-empty transaction table is supplied, then we're migrating
+-- from an existing state, thus the 'TransactionTable' and 'PendingTransactionTable'
+-- passed in must both be from the former state.
+--  * If there are any transactions in the 'TransactionTable' then the corresponding 'PendingTransactionsTable'
+--    must take these transactions into account. Refer to 'PendingTransactionTable' for more details.
+--  * The caller must make sure, that the supplied  'TransactionTable' does NOT contain any @Committed@ transactions.
 mkInitialSkovData ::
     -- |The 'RuntimeParameters'
     RuntimeParameters ->

--- a/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Implementation.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Implementation.hs
@@ -30,7 +30,6 @@ import Control.Monad.Reader
 import Control.Monad.State
 import Data.Foldable
 import Data.IORef
-import Data.Maybe (fromMaybe)
 import Data.Time
 import Data.Typeable
 import GHC.Stack
@@ -292,13 +291,10 @@ purgeRoundExistingQCs rnd = roundExistingQCs %=! snd . Map.split (rnd - 1)
 -- |Create an initial 'SkovData pv'
 -- This constructs a 'SkovData pv' from a genesis block
 -- which is suitable to grow the tree from.
--- Further this function takes a @Maybe TransactionTable@ which if
--- present will be used for populating the account nonces and sequence numbers for
--- the new transaction table.
 --
--- This function should not be called directly, instead either use
--- 'mkInitialSkovData' or 'mkInitialSkovDataWithTT'
-mkInitialSkovData' ::
+-- In the case that this is from a genesis, then an empty transaction table
+-- and
+mkInitialSkovData ::
     -- |The 'RuntimeParameters'
     RuntimeParameters ->
     -- |Genesis metadata. State hash should match the hash of the state.
@@ -309,14 +305,13 @@ mkInitialSkovData' ::
     Duration ->
     -- |Bakers at the genesis block
     EpochBakers ->
-    -- |If present the initial skov data created
-    -- will carry over the account nonces and sequence numbers
-    -- from the provided transaction table.
-    -- This is used for migration.
-    Maybe TransactionTable ->
+    -- |'TransactionTable' to initialize the 'SkovData' with.
+    TransactionTable ->
+    -- |'PendingTransactionTable' to initialize the 'SkovData' with.
+    PendingTransactionTable ->
     -- |The initial 'SkovData'
     SkovData pv
-mkInitialSkovData' rp genMeta genState _currentTimeout _skovEpochBakers maybeTT =
+mkInitialSkovData rp genMeta genState _currentTimeout _skovEpochBakers transactionTable' pendingTransactionTable' =
     let genesisBlock = GenesisBlock genMeta
         genesisTime = timestampToUTCTime $ Base.genesisTime (gmParameters genMeta)
         genesisBlockMetadata =
@@ -335,11 +330,11 @@ mkInitialSkovData' rp genMeta genState _currentTimeout _skovEpochBakers maybeTT 
                 }
         _persistentRoundStatus = initialPersistentRoundStatus
         _roundStatus = initialRoundStatus _currentTimeout genesisBlockPointer
-        _transactionTable = fromMaybe TT.emptyTransactionTable maybeTT
+        _transactionTable = transactionTable'
         _transactionTablePurgeCounter = 0
         _skovPendingTransactions =
             PendingTransactions
-                { _pendingTransactionTable = TT.emptyPendingTransactionTable,
+                { _pendingTransactionTable = pendingTransactionTable',
                   _focusBlock = genesisBlockPointer
                 }
         _runtimeParameters = rp
@@ -355,51 +350,6 @@ mkInitialSkovData' rp genMeta genState _currentTimeout _skovEpochBakers maybeTT 
         _currentTimeoutMessages = Absent
         _currentQuorumMessages = emptyQuorumMessages
     in  SkovData{..}
-
--- |Create an initial 'SkovData pv'
--- This constructs a 'SkovData pv' from a genesis block
--- which is suitable to grow the tree from.
-mkInitialSkovData ::
-    -- |The 'RuntimeParameters'
-    RuntimeParameters ->
-    -- |Genesis metadata. State hash should match the hash of the state.
-    GenesisMetadata ->
-    -- |Genesis statep
-    PBS.HashedPersistentBlockState pv ->
-    -- |The base timeout
-    Duration ->
-    -- |Bakers at the genesis block
-    EpochBakers ->
-    -- |The initial 'SkovData'
-    SkovData pv
-mkInitialSkovData rp genMeta genState _currentTimeout _skovEpochBakers = mkInitialSkovData' rp genMeta genState _currentTimeout _skovEpochBakers Nothing
-
--- |Create an initial 'SkovData pv'.
--- This constructs a 'SkovData pv' from a genesis block and
--- carries over the account nonces and sequence numbers from the supplied
--- transaction table.
-mkInitialSkovDataWithTT ::
-    -- |The 'RuntimeParameters'
-    RuntimeParameters ->
-    -- |Genesis metadata. State hash should match the hash of the state.
-    GenesisMetadata ->
-    -- |Genesis statep
-    PBS.HashedPersistentBlockState pv ->
-    -- |The base timeout
-    Duration ->
-    -- |Bakers at the genesis block
-    EpochBakers ->
-    -- |The transaction table to migrate from.
-    -- This carries over the account nonces and sequence numbers to the
-    -- new transaction table.
-    TransactionTable ->
-    -- |The initial 'SkovData'
-    SkovData pv
-mkInitialSkovDataWithTT rp genMeta genState _currentTimeout _skovEpochBakers tt =
-    let migratedTT = emptyTransactionTableWithSequenceNumbers migratedAccountNonces migratedUpdateSequenceNumbers
-        migratedAccountNonces = map (\(addr, anft) -> (aaeAddress addr, anft ^. anftNextNonce)) (HM.toList $ tt ^. ttNonFinalizedTransactions)
-        migratedUpdateSequenceNumbers = Map.fromList $ map (\(utype, nfcu) -> (utype, nfcu ^. nfcuNextSequenceNumber)) (Map.toList $ tt ^. ttNonFinalizedChainUpdates)
-    in  mkInitialSkovData' rp genMeta genState _currentTimeout _skovEpochBakers $ Just migratedTT
 
 -- * Operations on the block table
 

--- a/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Implementation.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Implementation.hs
@@ -301,7 +301,8 @@ purgeRoundExistingQCs rnd = roundExistingQCs %=! snd . Map.split (rnd - 1)
 -- passed in must both be from the former state.
 --  * If there are any transactions in the 'TransactionTable' then the corresponding 'PendingTransactionsTable'
 --    must take these transactions into account. Refer to 'PendingTransactionTable' for more details.
---  * The caller must make sure, that the supplied  'TransactionTable' does NOT contain any @Committed@ transactions.
+--  * The caller must make sure, that the supplied 'TransactionTable' does NOT contain any @Committed@ transactions
+--    and all transactions either 'TT.Received' or 'TT.Committed' must have their 'TT.CommitPoint' set to 0.
 mkInitialSkovData ::
     -- |The 'RuntimeParameters'
     RuntimeParameters ->

--- a/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Implementation.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Implementation.hs
@@ -1096,7 +1096,19 @@ clearOnProtocolUpdate = do
         . TT.ttHashMap
         %=! HM.map
             ( \case
-                (bi, TT.Committed{..}) -> (bi, TT.Received{..})
+                -- Mark all @Committed@ transactions as @Received@.
+                -- Note that we here set the @CommitPoint@ to "0", effectively
+                -- treating the transaction as just received and it has never been
+                -- part of a block.
+                -- This ensures that the transaction gets purged after the protocol
+                -- update if has expired.
+                -- If we carried over the @CommitPoint@ then the transaction will
+                -- not get purged, and the only way it could get evicted from the
+                -- 'TransactionTable' is, if it becomes part of a new block that gets
+                -- finalized.
+                -- However this may never be the case if the transaction has become
+                -- deprecated as part of the protocol update.
+                (bi, TT.Committed{..}) -> (bi, TT.Received{TT._tsCommitPoint = 0, ..})
                 s -> s
             )
 

--- a/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Implementation.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Implementation.hs
@@ -293,7 +293,7 @@ purgeRoundExistingQCs rnd = roundExistingQCs %=! snd . Map.split (rnd - 1)
 -- which is suitable to grow the tree from.
 --
 -- In the case that this is from a genesis, then an empty transaction table
--- and
+-- and empty pending transaction table must be provided.
 mkInitialSkovData ::
     -- |The 'RuntimeParameters'
     RuntimeParameters ->

--- a/concordium-consensus/src/Concordium/MultiVersion.hs
+++ b/concordium-consensus/src/Concordium/MultiVersion.hs
@@ -52,6 +52,7 @@ import Concordium.GlobalState.Block
 import Concordium.GlobalState.BlockPointer (BlockPointer (..), BlockPointerData (..))
 import Concordium.GlobalState.Finalization
 import Concordium.GlobalState.Parameters
+import qualified Concordium.GlobalState.Persistent.TreeState as SkovV0
 import Concordium.GlobalState.TreeState (PVInit (..), TreeStateMonad (getLastFinalizedHeight))
 import Concordium.ImportExport
 import qualified Concordium.KonsensusV1 as KonsensusV1
@@ -791,6 +792,8 @@ checkForProtocolUpdate = liftSkov body
                         lastFinBlockState <- Skov.queryBlockState =<< Skov.lastFinalizedBlock
                         -- the existing persistent block state context.
                         existingPbsc <- asks $ Skov.scGSContext . Skov.srContext
+                        -- the current transaction table.
+                        oldTT <- Skov.SkovT $ SkovV0._transactionTable . Skov.ssGSState <$> State.get
                         -- Migrate the old state to the new protocol and
                         -- get the new skov context and state.
                         (vc1Context, newState) <-
@@ -813,6 +816,8 @@ checkForProtocolUpdate = liftSkov body
                                         handlers
                                         -- lift SkovV1T
                                         unliftSkov
+                                        -- the current transaction table
+                                        oldTT
                                     )
                                     mvLog
                         -- Shutdown the old skov instance as it is

--- a/concordium-consensus/src/Concordium/MultiVersion.hs
+++ b/concordium-consensus/src/Concordium/MultiVersion.hs
@@ -793,7 +793,9 @@ checkForProtocolUpdate = liftSkov body
                         -- the existing persistent block state context.
                         existingPbsc <- asks $ Skov.scGSContext . Skov.srContext
                         -- the current transaction table.
-                        oldTT <- Skov.SkovT $ SkovV0._transactionTable . Skov.ssGSState <$> State.get
+                        oldGS <- Skov.SkovT $ Skov.ssGSState <$> State.get
+                        let oldTT = SkovV0._transactionTable oldGS
+                            oldPTT = SkovV0._pendingTransactions oldGS
                         -- Migrate the old state to the new protocol and
                         -- get the new skov context and state.
                         (vc1Context, newState) <-
@@ -818,6 +820,8 @@ checkForProtocolUpdate = liftSkov body
                                         unliftSkov
                                         -- the current transaction table
                                         oldTT
+                                        -- the current pending transactions
+                                        oldPTT
                                     )
                                     mvLog
                         -- Shutdown the old skov instance as it is

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/TransactionProcessingTest.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/TransactionProcessingTest.hs
@@ -178,6 +178,8 @@ initialSkovData bs =
         bs
         10_000
         dummyEpochBakers
+        emptyTransactionTable
+        emptyPendingTransactionTable
 
 -- |A block hash for the genesis.
 dummyGenesisBlockHash :: BlockHash

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/TreeStateTest.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/TreeStateTest.hs
@@ -83,6 +83,7 @@ import qualified Concordium.Crypto.SHA256 as Hash
 import qualified Concordium.Crypto.SignatureScheme as SigScheme
 import qualified Concordium.Crypto.VRF as VRF
 import Concordium.Genesis.Data.BaseV1
+import Concordium.GlobalState.TransactionTable (emptyPendingTransactionTable, emptyTransactionTable)
 import Concordium.Scheduler.DummyData
 import Concordium.Types
 import Concordium.Types.Execution
@@ -297,6 +298,8 @@ dummyInitialSkovData =
         dummyBlockState
         10_000
         dummyEpochBakers
+        emptyTransactionTable
+        emptyPendingTransactionTable
 
 -- |A 'LowLevelDB' for testing purposes.
 newtype TestLLDB pv = TestLLDB {theTestLLDB :: IORef (LowLevelDB pv)}

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/TreeStateTest.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/TreeStateTest.hs
@@ -1127,8 +1127,8 @@ testClearOnProtocolUpdate = describe "clearOnProtocolUpdate" $
             Seq.empty
             (sd'' ^. branches)
         assertEqual
-            "committed transactions should be received"
-            (HM.fromList [(getHash tr0, (normalTransaction tr0, TT.Received 1 (dummySuccessTransactionResult 1)))])
+            "committed transactions should be received with commit point 0"
+            (HM.fromList [(getHash tr0, (normalTransaction tr0, TT.Received 0 (dummySuccessTransactionResult 1)))])
             (sd'' ^. transactionTable . TT.ttHashMap)
   where
     tr0 = dummyTransaction 1


### PR DESCRIPTION
## Purpose

Fix a bug where account nonces and seqnumbers where not properly migrated over in p5->p6

Fixes: https://github.com/Concordium/concordium-node/issues/905

## Changes

_Describe the changes that were needed.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

