### PR TITLE
Don't drop messages just after handshake completes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Fix a network layer bug where initial messages after the handshake could be
+  dropped in some circumstances.
 - Fix a bug which caused the first epoch of the new protocol to be shorter than expected.
 - Fix a bug that caused an incorrect reporting of total stake in the first
   payday just after genesis when the node started from genesis at protocols 4 or 5.

--- a/concordium-node/src/connection/low_level.rs
+++ b/concordium-node/src/connection/low_level.rs
@@ -307,7 +307,7 @@ impl ConnectionLowLevel {
         recv_xx_msg!(self, len, "C");
         let payload = self.socket_buffer.slice(len)[DHLEN + MAC_LENGTH..]
             [..len - DHLEN - MAC_LENGTH * 2]
-            .try_into()?;
+            .to_vec();
         self.socket.set_nodelay(false)?;
         Ok(payload)
     }
@@ -441,7 +441,9 @@ impl ConnectionLowLevel {
                     }
                 }
 
-                self.socket_buffer.reset();
+                // If we reach this point we have read the entire noise message.
+                // So consume it from the socket buffer.
+                self.socket_buffer.shift(to_read);
                 Ok(ReadResult::Complete(payload))
             } else {
                 Ok(ReadResult::Complete(self.decrypt()?))


### PR DESCRIPTION
## Purpose

If we are not the initiator of the handshake then
- we receive message A
- we respond with a B message -> when they process this, they send a C message, and they promote us to a peer

If at this point they'd have any broadcast messages, they would send them to us.

The way we read from the underlying socket means we can in principle read multiple messages at the same time if they happen to be received already by the network stack (in low_level::read_from_socket).

In particular this means that the C message can be in the network stack's buffer together with a number of followup messages.

The way reading from the socket works is that we read into an internal buffer. And that buffer is consumed as we read from it, until we have to refresh it from the network socket again.

Previously we cleared the buffer after reading message C, which made us drop some messages.

As a result the nonces kept track of by the noise session are incorrect. In particular we can observe the following in the `encrypt_with_ad` function in noise
```
ENCRYPT KEY = "5d5322c66db62e375d8ffae7ca32fc0104f6554de384c72e82c1089b5fd4c2f7", NONCE = 2, AD = [], IN_OUT = 8a32f36233773e3ebdcb69db3e9ca4d33051fdaf047cc859ca675a7e77830e0533e1c6724bcea50443e7278ed4b82585180007c8f8eb2ead44244f542c5b498ef6fa3a53c4c3ad849f9953bb13323a030f08df5a780d8282c3e2a4f2f818c80432c4358597046ee1702041779099d6401aded9eab79f21378b07a9b4fde2eb3acf293a730f3e9ed19192736799cd86d8cf29f9b4e407a0aaa1f2ba88977faadcb0afe214b949ba4ac8b9a849a52478e273ea2958b597d147a401171ddda7b26dde242f0cb2b91439e9b208342e93004585d5fad0d9323317620029c56965279a5cc525356dfd96090c64732eab59ae76e1161ce461b2989a7f06ba5f6c6c166188efaec12ee5653a6936ff3e7d8a60a480127213f7fc842f70b89bce6c7508c171fe183931fe2d12449acc0a79b3bfeab91d464ee7a17626a0cec5560c145d8951c916ed6d7b3d64a137ec5da759c2a2d616f05fae31cf27c9f81acf99204e80db96af9a5cb957dd74b4df83534ddbd39debe9d02a296f26533843a10198670aa3be1cccf3546cdd0ac74f0bd2c70cbcc693ba8b28426499b42953774d418cb0fe7e437173a2f8d6c0c59a04de8722dbeb1a0fb7f6d44e812aeb3d3f8879d47724c1e545da9e5846201406010df101ba025953eb257629d0ab92efa678979189, MAC = 0460512e509b5e3bbdea8a302f35f408
```

but on the receiving end when decrypting,

```
KEY = "5d5322c66db62e375d8ffae7ca32fc0104f6554de384c72e82c1089b5fd4c2f7", NONCE = 0, AD = [], IN_OUT = 8a32f36233773e3ebdcb69db3e9ca4d33051fdaf047cc859ca675a7e77830e0533e1c6724bcea50443e7278ed4b82585180007c8f8eb2ead44244f542c5b498ef6fa3a53c4c3ad849f9953bb13323a030f08df5a780d8282c3e2a4f2f818c80432c4358597046ee1702041779099d6401aded9eab79f21378b07a9b4fde2eb3acf293a730f3e9ed19192736799cd86d8cf29f9b4e407a0aaa1f2ba88977faadcb0afe214b949ba4ac8b9a849a52478e273ea2958b597d147a401171ddda7b26dde242f0cb2b91439e9b208342e93004585d5fad0d9323317620029c56965279a5cc525356dfd96090c64732eab59ae76e1161ce461b2989a7f06ba5f6c6c166188efaec12ee5653a6936ff3e7d8a60a480127213f7fc842f70b89bce6c7508c171fe183931fe2d12449acc0a79b3bfeab91d464ee7a17626a0cec5560c145d8951c916ed6d7b3d64a137ec5da759c2a2d616f05fae31cf27c9f81acf99204e80db96af9a5cb957dd74b4df83534ddbd39debe9d02a296f26533843a10198670aa3be1cccf3546cdd0ac74f0bd2c70cbcc693ba8b28426499b42953774d418cb0fe7e437173a2f8d6c0c59a04de8722dbeb1a0fb7f6d44e812aeb3d3f8879d47724c1e545da9e5846201406010df101ba025953eb257629d0ab92efa678979189, MAC = 0460512e509b5e3bbdea8a302f35f408
```

Observe that the message, MAC, and public key are all the same, but the NONCE is different (the nonce is tracked per noise session).

Fixes https://github.com/Concordium/concordium-node/issues/910

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
