### PR TITLE
Fix trigger time for first epoch after protocol update.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased changes
 
+- Fix a bug which caused the first epoch of the new protocol to be shorter than expected.
 - Fix a bug that caused an incorrect reporting of total stake in the first
   payday just after genesis when the node started from genesis at protocols 4 or 5.
 - Revise the behaviour of rollbacks in P6.


### PR DESCRIPTION
## Purpose

The trigger time of the first epoch in the new protocol was not set correctly as it was
simply set to the terminal block time (i.e. a timestamp in the past when the protocol update is in effect).

Hence the first epoch ends _near_ immediately when the protocol update has taken effect,
a side effect of this is, that the first payday of the new protocol is near 1 epoch short with respect to time.

This fixes https://github.com/Concordium/concordium-node/issues/906
## Changes

Instead of setting the trigger block to the time of the terminal block, then it is now correctly set to the 
time of the terminal block + the epoch duration.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

