### PR TITLE
Query account keys and check signatures.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - Disallow globals in initialization sections for V1 contracts in P6.
   - Support sign extension instructions in Wasm in P6.
   - Do not count custom sections towards module size when executing contracts.
+  - Support new `invoke` operations for retrieving account keys and checking signatures.
 
 ## 6.0.0
 

--- a/concordium-consensus/src/Concordium/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler.hs
@@ -1491,7 +1491,7 @@ handleContractUpdateV1 originAddr istance checkAndGetSender transferAmount recei
                                                                         Nothing
                                                                 )
                                                     Right (dataPayload, sigs) -> do
-                                                        -- Numbef of signatures to check.
+                                                        -- Number of signatures to check.
                                                         let numSigs = foldl' (\l m -> l + length m) 0 sigs
                                                         -- Lookup account keys
                                                         keys <- getAccountVerificationKeys account

--- a/concordium-consensus/src/Concordium/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler.hs
@@ -60,6 +60,7 @@ import Data.Time
 
 import qualified Concordium.ID.Account as AH
 import qualified Concordium.ID.Types as ID
+import qualified Concordium.Utils.Serialization as S
 
 import qualified Concordium.Cost as Cost
 import Concordium.Crypto.EncryptedTransfers
@@ -86,7 +87,9 @@ import Data.Ord
 import qualified Data.Set as Set
 
 import qualified Concordium.Crypto.BlsSignature as Bls
+import qualified Concordium.Crypto.Ed25519Signature as Ed25519
 import qualified Concordium.Crypto.Proofs as Proofs
+import qualified Concordium.Crypto.SignatureScheme as SigScheme
 import qualified Concordium.TransactionVerification as TVer
 
 import Lens.Micro.Platform
@@ -1397,7 +1400,129 @@ handleContractUpdateV1 originAddr istance checkAndGetSender transferAmount recei
                                                         WasmV1.Success
                                                         (Just returnValue)
                                                 )
+                                    WasmV1.QueryAccountKeys{..} -> do
+                                        -- Charge base cost for attempting to look up an account.
+                                        tickEnergy Cost.contractInstanceQueryAccountKeysBaseCost
+                                        -- Lookup account.
+                                        maybeAccount <- getStateAccount imqakAddress
+                                        case maybeAccount of
+                                            Nothing ->
+                                                -- The Wasm execution does not reset contract events for queries, hence we do not have to
+                                                -- add them here via an interrupt. They will be retained until the next interrupt.
+                                                go events
+                                                    =<< runInterpreter
+                                                        ( return
+                                                            . WasmV1.resumeReceiveFun
+                                                                rrdInterruptedConfig
+                                                                rrdCurrentState
+                                                                False
+                                                                entryBalance
+                                                                (WasmV1.Error $ WasmV1.EnvFailure $ WasmV1.MissingAccount imqakAddress)
+                                                                Nothing
+                                                        )
+                                            Just (_accountIndex, account) -> do
+                                                -- Lookup account keys
+                                                keys <- getAccountVerificationKeys account
+                                                -- Charge for the amount of data produced in the return value.
+                                                tickEnergy (Cost.contractInstanceQueryAccountKeysReturnCost (ID.getAccountInformationNumKeys keys))
+                                                -- Construct the return value.
+                                                let returnValue = WasmV1.byteStringToReturnValue $ S.encode keys
+                                                -- The Wasm execution does not reset contract events for queries, hence we do not have to
+                                                -- add them here via an interrupt. They will be retained until the next interrupt.
+                                                go events
+                                                    =<< runInterpreter
+                                                        ( return
+                                                            . WasmV1.resumeReceiveFun
+                                                                rrdInterruptedConfig
+                                                                rrdCurrentState
+                                                                False
+                                                                entryBalance
+                                                                WasmV1.Success
+                                                                (Just returnValue)
+                                                        )
+                                    WasmV1.CheckAccountSignature{..} -> do
+                                        let getSignatures = do
+                                                outerLen <- S.getWord8
+                                                S.getSafeSizedMapOf outerLen S.get $ do
+                                                    innerLen <- S.getWord8
+                                                    S.getSafeSizedMapOf innerLen S.get $ do
+                                                        schemeId <- S.get
+                                                        case schemeId of
+                                                            SigScheme.Ed25519 -> SigScheme.Signature <$> S.getShortByteString Ed25519.signatureSize
+                                            getData = do
+                                                dataLen <- S.getWord32be
+                                                dataPayload <- S.getByteString (fromIntegral dataLen)
+                                                sigs <- getSignatures
+                                                return (dataPayload, sigs)
+                                            r = S.runGet getData imcasPayload
+                                        tickEnergy Cost.contractInstanceQueryAccountKeysBaseCost
+                                        -- Lookup account.
+                                        maybeAccount <- getStateAccount imcasAddress
+                                        -- TODO: Maybe we need to charge more in failed cases as well.
+                                        case maybeAccount of
+                                            Nothing ->
+                                                -- The Wasm execution does not reset contract events for queries, hence we do not have to
+                                                -- add them here via an interrupt. They will be retained until the next interrupt.
+                                                go events
+                                                    =<< runInterpreter
+                                                        ( return
+                                                            . WasmV1.resumeReceiveFun
+                                                                rrdInterruptedConfig
+                                                                rrdCurrentState
+                                                                False
+                                                                entryBalance
+                                                                (WasmV1.Error $ WasmV1.EnvFailure $ WasmV1.MissingAccount imcasAddress)
+                                                                Nothing
+                                                        )
+                                            Just (_accountIndex, account) -> do
+                                                case r of
+                                                    Left _ ->
+                                                        -- The Wasm execution does not reset contract events for queries, hence we do not have to
+                                                        -- add them here via an interrupt. They will be retained until the next interrupt.
+                                                        go events
+                                                            =<< runInterpreter
+                                                                ( return
+                                                                    . WasmV1.resumeReceiveFun
+                                                                        rrdInterruptedConfig
+                                                                        rrdCurrentState
+                                                                        False
+                                                                        entryBalance
+                                                                        WasmV1.SignatureDataMalformed
+                                                                        Nothing
+                                                                )
+                                                    Right (dataPayload, sigs) -> do
+                                                        -- Numbef of signatures to check.
+                                                        let numSigs = foldl' (\l m -> l + length m) 0 sigs
+                                                        -- Lookup account keys
+                                                        keys <- getAccountVerificationKeys account
+                                                        tickEnergy (Cost.contractInstanceCheckAccountSignatureCost (fromIntegral (BS.length dataPayload)) numSigs)
+                                                        if verifyAccountSignature dataPayload sigs keys
+                                                            then -- The Wasm execution does not reset contract events for queries, hence we do not have to
+                                                            -- add them here via an interrupt. They will be retained until the next interrupt.
 
+                                                                go events
+                                                                    =<< runInterpreter
+                                                                        ( return
+                                                                            . WasmV1.resumeReceiveFun
+                                                                                rrdInterruptedConfig
+                                                                                rrdCurrentState
+                                                                                False
+                                                                                entryBalance
+                                                                                WasmV1.Success
+                                                                                Nothing
+                                                                        )
+                                                            else
+                                                                go events
+                                                                    =<< runInterpreter
+                                                                        ( return
+                                                                            . WasmV1.resumeReceiveFun
+                                                                                rrdInterruptedConfig
+                                                                                rrdCurrentState
+                                                                                False
+                                                                                entryBalance
+                                                                                WasmV1.SignatureCheckFailed
+                                                                                Nothing
+                                                                        )
             -- start contract execution.
             -- transfer the amount from the sender to the contract at the start. This is so that the contract may immediately use it
             -- for, e.g., forwarding.
@@ -1412,7 +1537,8 @@ handleContractUpdateV1 originAddr istance checkAndGetSender transferAmount recei
               rcMaxParameterLen = Wasm.maxParameterLen $ protocolVersion @(MPV m),
               -- Check whether the number of logs and the size of return values are limited in the current protocol version.
               rcLimitLogsAndRvs = Wasm.limitLogsAndReturnValues $ protocolVersion @(MPV m),
-              rcFixRollbacks = demoteProtocolVersion (protocolVersion @(MPV m)) >= P6
+              rcFixRollbacks = demoteProtocolVersion (protocolVersion @(MPV m)) >= P6,
+              rcSupportAccountSignatureChecks = supportsAccountSignatureChecks $ protocolVersion @(MPV m)
             }
     transferAccountSync ::
         AccountAddress -> -- The target account address.

--- a/concordium-consensus/src/Concordium/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler.hs
@@ -1450,7 +1450,7 @@ handleContractUpdateV1 originAddr istance checkAndGetSender transferAmount recei
                                                         case schemeId of
                                                             SigScheme.Ed25519 -> SigScheme.Signature <$> S.getShortByteString Ed25519.signatureSize
                                             getData = do
-                                                dataLen <- S.getWord32be
+                                                dataLen <- S.getWord32le
                                                 dataPayload <- S.getByteString (fromIntegral dataLen)
                                                 sigs <- getSignatures
                                                 return (dataPayload, sigs)

--- a/concordium-consensus/src/Concordium/Scheduler/WasmIntegration/V1.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/WasmIntegration/V1.hs
@@ -410,6 +410,14 @@ data InvokeMethod
     | -- |Check the signature using account keys
       CheckAccountSignature
         { imcasAddress :: !AccountAddress,
+          -- |The payload is a serialization of the message and signatures.
+          -- The message is serialized as
+          -- - u32 in little endian for length
+          -- - the message of the above length
+          -- signatures which are serialized as a nested map as transaction signatures
+          -- using u8 for lengths. The only difference from a transaction signature is
+          -- that the inner Signature is serialized as "SchemeId" followed by the signature
+          -- bytes which are assumed to be 64 bytes.
           imcasPayload :: !BS.ByteString
         }
     | -- |Query the account keys

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/AccountSignatureChecks.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/AccountSignatureChecks.hs
@@ -9,26 +9,26 @@
 module SchedulerTests.SmartContracts.V1.AccountSignatureChecks (tests) where
 
 import Control.Monad (when)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Short as BSS
+import qualified Data.Serialize as S
+import Data.Word
 import Test.HUnit (Assertion, assertEqual, assertFailure)
 import Test.Hspec
-import qualified Data.Serialize as S
-import qualified Data.ByteString.Short as BSS
-import qualified Data.ByteString as BS
-import Data.Word
 
-import qualified Concordium.Types as Types
-import qualified Concordium.Types.Execution as Types
 import Concordium.GlobalState.BlockState
 import Concordium.GlobalState.Persistent.BlockState
 import qualified Concordium.GlobalState.Wasm as GSWasm
 import qualified Concordium.Scheduler.InvokeContract as InvokeContract
+import qualified Concordium.Types as Types
+import qualified Concordium.Types.Execution as Types
 import qualified Concordium.Types.InvokeContract as InvokeContract
 import Concordium.Wasm
 
+import Concordium.Crypto.SignatureScheme (KeyPair (verifyKey), SchemeId (Ed25519), Signature (..), sign)
+import Control.Monad.IO.Class
 import qualified SchedulerTests.Helpers as Helpers
 import qualified SchedulerTests.SmartContracts.V1.InvokeHelpers as InvokeHelpers
-import Concordium.Crypto.SignatureScheme (SchemeId(Ed25519), KeyPair (verifyKey), sign, Signature(..))
-import Control.Monad.IO.Class
 
 seed :: Int
 seed = 17
@@ -112,34 +112,34 @@ runGetKeysTests spv pvString = when (Types.demoteProtocolVersion spv >= Types.P4
         let param = Parameter (BSS.toShort (S.encode (Helpers.accountAddressFromSeed seed)))
         result <- getKeys addr1 param bs
         case result of
-          InvokeContract.Failure{..} -> do
-            if Types.supportsAccountSignatureChecks (Types.protocolVersion @pv) then 
-              liftIO $ assertFailure $ pvString ++ ": Call failed with reason: " ++ show rcrReason
-            else
-              liftIO $ assertEqual (pvString ++ ": Execution should cause runtime error: ") Types.RuntimeFailure rcrReason
-          InvokeContract.Success{rcrReturnValue = Nothing} -> do
-            liftIO $ assertFailure "Call succeded with no return value."
-          InvokeContract.Success{rcrReturnValue = Just rv} -> do
-            let expected = S.runPut $ do
-                  S.putWord8 1 -- length of the outer map
-                  S.putWord8 0 -- credential index
-                  S.putWord8 1 -- length of the inner map
-                  S.putWord8 0 -- key index
-                  S.put Ed25519 -- scheme id
-                  S.put (verifyKey (Helpers.keyPairFromSeed seed)) -- the public key
-                  S.putWord8 1 -- threshold for the credential
-                  S.putWord8 1 -- threshold for the account
-            liftIO (assertEqual (pvString ++ ": Retrieved key is correct: ") expected rv)
-            
+            InvokeContract.Failure{..} -> do
+                if Types.supportsAccountSignatureChecks (Types.protocolVersion @pv)
+                    then liftIO $ assertFailure $ pvString ++ ": Call failed with reason: " ++ show rcrReason
+                    else liftIO $ assertEqual (pvString ++ ": Execution should cause runtime error: ") Types.RuntimeFailure rcrReason
+            InvokeContract.Success{rcrReturnValue = Nothing} -> do
+                liftIO $ assertFailure "Call succeded with no return value."
+            InvokeContract.Success{rcrReturnValue = Just rv} -> do
+                let expected = S.runPut $ do
+                        S.putWord8 1 -- length of the outer map
+                        S.putWord8 0 -- credential index
+                        S.putWord8 1 -- length of the inner map
+                        S.putWord8 0 -- key index
+                        S.put Ed25519 -- scheme id
+                        S.put (verifyKey (Helpers.keyPairFromSeed seed)) -- the public key
+                        S.putWord8 1 -- threshold for the credential
+                        S.putWord8 1 -- threshold for the account
+                liftIO (assertEqual (pvString ++ ": Retrieved key is correct: ") expected rv)
+
 runCheckSignatureTests ::
-  forall pv. Types.IsProtocolVersion pv =>
-  Types.SProtocolVersion pv ->
-  String ->
-  -- |Parameter for the call.
-  BS.ByteString ->
-  -- |Expected response code.
-  Word64 ->
-  Assertion
+    forall pv.
+    Types.IsProtocolVersion pv =>
+    Types.SProtocolVersion pv ->
+    String ->
+    -- |Parameter for the call.
+    BS.ByteString ->
+    -- |Expected response code.
+    Word64 ->
+    Assertion
 runCheckSignatureTests spv pvString paramBS expectedCode = when (Types.demoteProtocolVersion spv >= Types.P4) $ do
     Helpers.runTestBlockState @pv $ do
         initState <- thawBlockState =<< initialBlockState
@@ -149,88 +149,87 @@ runCheckSignatureTests spv pvString paramBS expectedCode = when (Types.demotePro
         let param = Parameter (BSS.toShort paramBS)
         result <- checkSignature addr1 param bs
         case result of
-          InvokeContract.Failure{..} -> do
-            if Types.supportsAccountSignatureChecks (Types.protocolVersion @pv) then 
-              liftIO $ assertFailure $ pvString ++ ": Call failed with reason: " ++ show rcrReason
-            else
-              liftIO $ assertEqual (pvString ++ ": Execution should cause runtime error: ") Types.RuntimeFailure rcrReason
-          InvokeContract.Success{rcrReturnValue = Nothing} -> do
-            liftIO $ assertFailure "Call succeded with no return value."
-          InvokeContract.Success{rcrReturnValue = Just rv} -> do
-            let expected = S.runPut $ S.putWord64le expectedCode
-            liftIO (assertEqual (pvString ++ ": Correct response code: ") (BS.unpack expected) (BS.unpack rv))
+            InvokeContract.Failure{..} -> do
+                if Types.supportsAccountSignatureChecks (Types.protocolVersion @pv)
+                    then liftIO $ assertFailure $ pvString ++ ": Call failed with reason: " ++ show rcrReason
+                    else liftIO $ assertEqual (pvString ++ ": Execution should cause runtime error: ") Types.RuntimeFailure rcrReason
+            InvokeContract.Success{rcrReturnValue = Nothing} -> do
+                liftIO $ assertFailure "Call succeded with no return value."
+            InvokeContract.Success{rcrReturnValue = Just rv} -> do
+                let expected = S.runPut $ S.putWord64le expectedCode
+                liftIO (assertEqual (pvString ++ ": Correct response code: ") (BS.unpack expected) (BS.unpack rv))
 
 -- |Test for success
 runCheckSignatureTest1 :: forall pv. Types.IsProtocolVersion pv => Types.SProtocolVersion pv -> String -> Assertion
 runCheckSignatureTest1 spv pvString = do
-        let message = BS.replicate 123 17
-        let kp = Helpers.keyPairFromSeed seed
-        let Signature sig = sign kp message
-        let paramBS = S.runPut $ do
-              S.put $ Helpers.accountAddressFromSeed seed
-              S.putWord32le (fromIntegral (BS.length message))
-              S.putByteString message
-              S.putWord8 1 -- number of outer signatures
-              S.putWord8 0 -- credential index
-              S.putWord8 1 -- number of inner signatures
-              S.putWord8 0 -- key index
-              S.put Ed25519 -- signature scheme ID
-              S.putShortByteString sig
-        runCheckSignatureTests spv pvString paramBS 0
+    let message = BS.replicate 123 17
+    let kp = Helpers.keyPairFromSeed seed
+    let Signature sig = sign kp message
+    let paramBS = S.runPut $ do
+            S.put $ Helpers.accountAddressFromSeed seed
+            S.putWord32le (fromIntegral (BS.length message))
+            S.putByteString message
+            S.putWord8 1 -- number of outer signatures
+            S.putWord8 0 -- credential index
+            S.putWord8 1 -- number of inner signatures
+            S.putWord8 0 -- key index
+            S.put Ed25519 -- signature scheme ID
+            S.putShortByteString sig
+    runCheckSignatureTests spv pvString paramBS 0
 
 -- |Test missing account.
 runCheckSignatureTest2 :: forall pv. Types.IsProtocolVersion pv => Types.SProtocolVersion pv -> String -> Assertion
 runCheckSignatureTest2 spv pvString = do
-        let message = BS.replicate 123 17
-        let kp = Helpers.keyPairFromSeed seed
-        let Signature sig = sign kp message
-        let paramBS = S.runPut $ do
-              S.put $ Helpers.accountAddressFromSeed (seed + 1) -- use incorrect seed, account does not exist.
-              S.putWord32le (fromIntegral (BS.length message))
-              S.putByteString message
-              S.putWord8 1 -- number of outer signatures
-              S.putWord8 0 -- credential index
-              S.putWord8 1 -- number of inner signatures
-              S.putWord8 0 -- key index
-              S.put Ed25519 -- signature scheme ID
-              S.putShortByteString sig
-        runCheckSignatureTests spv pvString paramBS 0x02_0000_0000
+    let message = BS.replicate 123 17
+    let kp = Helpers.keyPairFromSeed seed
+    let Signature sig = sign kp message
+    let paramBS = S.runPut $ do
+            S.put $ Helpers.accountAddressFromSeed (seed + 1) -- use incorrect seed, account does not exist.
+            S.putWord32le (fromIntegral (BS.length message))
+            S.putByteString message
+            S.putWord8 1 -- number of outer signatures
+            S.putWord8 0 -- credential index
+            S.putWord8 1 -- number of inner signatures
+            S.putWord8 0 -- key index
+            S.put Ed25519 -- signature scheme ID
+            S.putShortByteString sig
+    runCheckSignatureTests spv pvString paramBS 0x02_0000_0000
 
 -- |Test incorrect signature.
 runCheckSignatureTest3 :: forall pv. Types.IsProtocolVersion pv => Types.SProtocolVersion pv -> String -> Assertion
 runCheckSignatureTest3 spv pvString = do
-        let message = BS.replicate 123 17
-        let kp = Helpers.keyPairFromSeed (seed + 1) -- use incorrect seed for keys, leading to incorrect signature
-        let Signature sig = sign kp message
-        let paramBS = S.runPut $ do
-              S.put $ Helpers.accountAddressFromSeed seed -- use incorrect seed, account does not exist.
-              S.putWord32le (fromIntegral (BS.length message))
-              S.putByteString message
-              S.putWord8 1 -- number of outer signatures
-              S.putWord8 0 -- credential index
-              S.putWord8 1 -- number of inner signatures
-              S.putWord8 0 -- key index
-              S.put Ed25519 -- signature scheme ID
-              S.putShortByteString sig
-        runCheckSignatureTests spv pvString paramBS 0x0b_0000_0000
+    let message = BS.replicate 123 17
+    let kp = Helpers.keyPairFromSeed (seed + 1) -- use incorrect seed for keys, leading to incorrect signature
+    let Signature sig = sign kp message
+    let paramBS = S.runPut $ do
+            S.put $ Helpers.accountAddressFromSeed seed -- use incorrect seed, account does not exist.
+            S.putWord32le (fromIntegral (BS.length message))
+            S.putByteString message
+            S.putWord8 1 -- number of outer signatures
+            S.putWord8 0 -- credential index
+            S.putWord8 1 -- number of inner signatures
+            S.putWord8 0 -- key index
+            S.put Ed25519 -- signature scheme ID
+            S.putShortByteString sig
+    runCheckSignatureTests spv pvString paramBS 0x0b_0000_0000
 
 -- |Test malformed data.
 runCheckSignatureTest4 :: forall pv. Types.IsProtocolVersion pv => Types.SProtocolVersion pv -> String -> Assertion
 runCheckSignatureTest4 spv pvString = do
-        let message = BS.replicate 123 17
-        let kp = Helpers.keyPairFromSeed (seed + 1) -- use incorrect seed for keys, leading to incorrect signature
-        let Signature sig = sign kp message
-        let paramBS = S.runPut $ do
-              S.put $ Helpers.accountAddressFromSeed seed -- use incorrect seed, account does not exist.
-              S.putWord32le maxBound -- incorrect length data
-              S.putByteString message
-              S.putWord8 1 -- number of outer signatures
-              S.putWord8 0 -- credential index
-              S.putWord8 1 -- number of inner signatures
-              S.putWord8 0 -- key index
-              S.put Ed25519 -- signature scheme ID
-              S.putShortByteString sig
-        runCheckSignatureTests spv pvString paramBS 0x0a_0000_0000
+    let message = BS.replicate 123 17
+    let kp = Helpers.keyPairFromSeed (seed + 1) -- use incorrect seed for keys, leading to incorrect signature
+    let Signature sig = sign kp message
+    let paramBS = S.runPut $ do
+            S.put $ Helpers.accountAddressFromSeed seed -- use incorrect seed, account does not exist.
+            S.putWord32le maxBound -- incorrect length data
+            S.putByteString message
+            S.putWord8 1 -- number of outer signatures
+            S.putWord8 0 -- credential index
+            S.putWord8 1 -- number of inner signatures
+            S.putWord8 0 -- key index
+            S.put Ed25519 -- signature scheme ID
+            S.putShortByteString sig
+    runCheckSignatureTests spv pvString paramBS 0x0a_0000_0000
 
 tests :: Spec
 tests = describe "V1: Get account keys and check signatures" $ do

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/AccountSignatureChecks.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/AccountSignatureChecks.hs
@@ -1,0 +1,251 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | This module tests that tests account signature checks
+-- and retrieving account keys.
+module SchedulerTests.SmartContracts.V1.AccountSignatureChecks (tests) where
+
+import Control.Monad (when)
+import Test.HUnit (Assertion, assertEqual, assertFailure)
+import Test.Hspec
+import qualified Data.Serialize as S
+import qualified Data.ByteString.Short as BSS
+import qualified Data.ByteString as BS
+import Data.Word
+
+import qualified Concordium.Types as Types
+import qualified Concordium.Types.Execution as Types
+import Concordium.GlobalState.BlockState
+import Concordium.GlobalState.Persistent.BlockState
+import qualified Concordium.GlobalState.Wasm as GSWasm
+import qualified Concordium.Scheduler.InvokeContract as InvokeContract
+import qualified Concordium.Types.InvokeContract as InvokeContract
+import Concordium.Wasm
+
+import qualified SchedulerTests.Helpers as Helpers
+import qualified SchedulerTests.SmartContracts.V1.InvokeHelpers as InvokeHelpers
+import Concordium.Crypto.SignatureScheme (SchemeId(Ed25519), KeyPair (verifyKey), sign, Signature(..))
+import Control.Monad.IO.Class
+
+seed :: Int
+seed = 17
+
+-- empty state, no accounts, no modules, no instances
+initialBlockState :: Types.IsProtocolVersion pv => Helpers.PersistentBSM pv (HashedPersistentBlockState pv)
+initialBlockState =
+    Helpers.createTestBlockStateWithAccountsM
+        [Helpers.makeTestAccountFromSeed 1_000 seed]
+
+sourceFile :: FilePath
+sourceFile = "../concordium-base/smart-contracts/testdata/contracts/v1/account-signature-checks.wasm"
+
+deployModule1 ::
+    forall pv.
+    Types.IsProtocolVersion pv =>
+    PersistentBlockState pv ->
+    Helpers.PersistentBSM
+        pv
+        ( (InvokeHelpers.PersistentModuleInterfaceV GSWasm.V1, WasmModuleV GSWasm.V1),
+          PersistentBlockState pv
+        )
+deployModule1 = InvokeHelpers.deployModuleV1 (Types.protocolVersion @pv) sourceFile
+
+-- Initialize contract a.
+initContract ::
+    Types.IsProtocolVersion pv =>
+    PersistentBlockState pv ->
+    (InvokeHelpers.PersistentModuleInterfaceV GSWasm.V1, WasmModuleV GSWasm.V1) ->
+    Helpers.PersistentBSM pv (Types.ContractAddress, PersistentBlockState pv)
+initContract =
+    InvokeHelpers.initContractV1
+        (Helpers.accountAddressFromSeed seed)
+        (InitName "init_contract")
+        emptyParameter
+        0
+
+-- |Invoke the entrypoint @@ on contract @a@.
+getKeys ::
+    Types.IsProtocolVersion pv =>
+    Types.ContractAddress ->
+    Parameter ->
+    HashedPersistentBlockState pv ->
+    Helpers.PersistentBSM pv InvokeContract.InvokeContractResult
+getKeys ccContract ccParameter bs = do
+    let ctx =
+            InvokeContract.ContractContext
+                { ccInvoker = Nothing,
+                  ccAmount = 0,
+                  ccMethod = ReceiveName "contract.get_keys",
+                  ccEnergy = 1_000_000_000,
+                  ..
+                }
+    InvokeContract.invokeContract ctx (Types.ChainMetadata 123) bs
+
+-- |Invoke the entrypoint @@ on contract @a@.
+checkSignature ::
+    Types.IsProtocolVersion pv =>
+    Types.ContractAddress ->
+    Parameter ->
+    HashedPersistentBlockState pv ->
+    Helpers.PersistentBSM pv InvokeContract.InvokeContractResult
+checkSignature ccContract ccParameter bs = do
+    let ctx =
+            InvokeContract.ContractContext
+                { ccInvoker = Nothing,
+                  ccAmount = 0,
+                  ccMethod = ReceiveName "contract.check_signature",
+                  ccEnergy = 1_000_000_000,
+                  ..
+                }
+    InvokeContract.invokeContract ctx (Types.ChainMetadata 123) bs
+
+runGetKeysTests :: forall pv. Types.IsProtocolVersion pv => Types.SProtocolVersion pv -> String -> Assertion
+runGetKeysTests spv pvString = when (Types.demoteProtocolVersion spv >= Types.P4) $ do
+    Helpers.runTestBlockState @pv $ do
+        initState <- thawBlockState =<< initialBlockState
+        (mod1, bsWithMod) <- deployModule1 initState
+        (addr1, mutState) <- initContract bsWithMod mod1
+        bs <- freezeBlockState mutState
+        let param = Parameter (BSS.toShort (S.encode (Helpers.accountAddressFromSeed seed)))
+        result <- getKeys addr1 param bs
+        case result of
+          InvokeContract.Failure{..} -> do
+            if Types.supportsAccountSignatureChecks (Types.protocolVersion @pv) then 
+              liftIO $ assertFailure $ pvString ++ ": Call failed with reason: " ++ show rcrReason
+            else
+              liftIO $ assertEqual (pvString ++ ": Execution should cause runtime error: ") Types.RuntimeFailure rcrReason
+          InvokeContract.Success{rcrReturnValue = Nothing} -> do
+            liftIO $ assertFailure "Call succeded with no return value."
+          InvokeContract.Success{rcrReturnValue = Just rv} -> do
+            let expected = S.runPut $ do
+                  S.putWord8 1 -- length of the outer map
+                  S.putWord8 0 -- credential index
+                  S.putWord8 1 -- length of the inner map
+                  S.putWord8 0 -- key index
+                  S.put Ed25519 -- scheme id
+                  S.put (verifyKey (Helpers.keyPairFromSeed seed)) -- the public key
+                  S.putWord8 1 -- threshold for the credential
+                  S.putWord8 1 -- threshold for the account
+            liftIO (assertEqual (pvString ++ ": Retrieved key is correct: ") expected rv)
+            
+runCheckSignatureTests ::
+  forall pv. Types.IsProtocolVersion pv =>
+  Types.SProtocolVersion pv ->
+  String ->
+  -- |Parameter for the call.
+  BS.ByteString ->
+  -- |Expected response code.
+  Word64 ->
+  Assertion
+runCheckSignatureTests spv pvString paramBS expectedCode = when (Types.demoteProtocolVersion spv >= Types.P4) $ do
+    Helpers.runTestBlockState @pv $ do
+        initState <- thawBlockState =<< initialBlockState
+        (mod1, bsWithMod) <- deployModule1 initState
+        (addr1, mutState) <- initContract bsWithMod mod1
+        bs <- freezeBlockState mutState
+        let param = Parameter (BSS.toShort paramBS)
+        result <- checkSignature addr1 param bs
+        case result of
+          InvokeContract.Failure{..} -> do
+            if Types.supportsAccountSignatureChecks (Types.protocolVersion @pv) then 
+              liftIO $ assertFailure $ pvString ++ ": Call failed with reason: " ++ show rcrReason
+            else
+              liftIO $ assertEqual (pvString ++ ": Execution should cause runtime error: ") Types.RuntimeFailure rcrReason
+          InvokeContract.Success{rcrReturnValue = Nothing} -> do
+            liftIO $ assertFailure "Call succeded with no return value."
+          InvokeContract.Success{rcrReturnValue = Just rv} -> do
+            let expected = S.runPut $ S.putWord64le expectedCode
+            liftIO (assertEqual (pvString ++ ": Correct response code: ") (BS.unpack expected) (BS.unpack rv))
+
+-- |Test for success
+runCheckSignatureTest1 :: forall pv. Types.IsProtocolVersion pv => Types.SProtocolVersion pv -> String -> Assertion
+runCheckSignatureTest1 spv pvString = do
+        let message = BS.replicate 123 17
+        let kp = Helpers.keyPairFromSeed seed
+        let Signature sig = sign kp message
+        let paramBS = S.runPut $ do
+              S.put $ Helpers.accountAddressFromSeed seed
+              S.putWord32le (fromIntegral (BS.length message))
+              S.putByteString message
+              S.putWord8 1 -- number of outer signatures
+              S.putWord8 0 -- credential index
+              S.putWord8 1 -- number of inner signatures
+              S.putWord8 0 -- key index
+              S.put Ed25519 -- signature scheme ID
+              S.putShortByteString sig
+        runCheckSignatureTests spv pvString paramBS 0
+
+-- |Test missing account.
+runCheckSignatureTest2 :: forall pv. Types.IsProtocolVersion pv => Types.SProtocolVersion pv -> String -> Assertion
+runCheckSignatureTest2 spv pvString = do
+        let message = BS.replicate 123 17
+        let kp = Helpers.keyPairFromSeed seed
+        let Signature sig = sign kp message
+        let paramBS = S.runPut $ do
+              S.put $ Helpers.accountAddressFromSeed (seed + 1) -- use incorrect seed, account does not exist.
+              S.putWord32le (fromIntegral (BS.length message))
+              S.putByteString message
+              S.putWord8 1 -- number of outer signatures
+              S.putWord8 0 -- credential index
+              S.putWord8 1 -- number of inner signatures
+              S.putWord8 0 -- key index
+              S.put Ed25519 -- signature scheme ID
+              S.putShortByteString sig
+        runCheckSignatureTests spv pvString paramBS 0x02_0000_0000
+
+-- |Test incorrect signature.
+runCheckSignatureTest3 :: forall pv. Types.IsProtocolVersion pv => Types.SProtocolVersion pv -> String -> Assertion
+runCheckSignatureTest3 spv pvString = do
+        let message = BS.replicate 123 17
+        let kp = Helpers.keyPairFromSeed (seed + 1) -- use incorrect seed for keys, leading to incorrect signature
+        let Signature sig = sign kp message
+        let paramBS = S.runPut $ do
+              S.put $ Helpers.accountAddressFromSeed seed -- use incorrect seed, account does not exist.
+              S.putWord32le (fromIntegral (BS.length message))
+              S.putByteString message
+              S.putWord8 1 -- number of outer signatures
+              S.putWord8 0 -- credential index
+              S.putWord8 1 -- number of inner signatures
+              S.putWord8 0 -- key index
+              S.put Ed25519 -- signature scheme ID
+              S.putShortByteString sig
+        runCheckSignatureTests spv pvString paramBS 0x0b_0000_0000
+
+-- |Test malformed data.
+runCheckSignatureTest4 :: forall pv. Types.IsProtocolVersion pv => Types.SProtocolVersion pv -> String -> Assertion
+runCheckSignatureTest4 spv pvString = do
+        let message = BS.replicate 123 17
+        let kp = Helpers.keyPairFromSeed (seed + 1) -- use incorrect seed for keys, leading to incorrect signature
+        let Signature sig = sign kp message
+        let paramBS = S.runPut $ do
+              S.put $ Helpers.accountAddressFromSeed seed -- use incorrect seed, account does not exist.
+              S.putWord32le maxBound -- incorrect length data
+              S.putByteString message
+              S.putWord8 1 -- number of outer signatures
+              S.putWord8 0 -- credential index
+              S.putWord8 1 -- number of inner signatures
+              S.putWord8 0 -- key index
+              S.put Ed25519 -- signature scheme ID
+              S.putShortByteString sig
+        runCheckSignatureTests spv pvString paramBS 0x0a_0000_0000
+
+tests :: Spec
+tests = describe "V1: Get account keys and check signatures" $ do
+    specify "Get account keys" $
+        sequence_ $
+            Helpers.forEveryProtocolVersion runGetKeysTests
+    specify "Check account signature keys 1" $
+        sequence_ $
+            Helpers.forEveryProtocolVersion runCheckSignatureTest1
+    specify "Check account signature keys 2" $
+        sequence_ $
+            Helpers.forEveryProtocolVersion runCheckSignatureTest2
+    specify "Check account signature keys 3" $
+        sequence_ $
+            Helpers.forEveryProtocolVersion runCheckSignatureTest3
+    specify "Check account signature keys 4" $
+        sequence_ $
+            Helpers.forEveryProtocolVersion runCheckSignatureTest4

--- a/concordium-consensus/tests/scheduler/Spec.hs
+++ b/concordium-consensus/tests/scheduler/Spec.hs
@@ -30,6 +30,7 @@ import qualified SchedulerTests.SmartContracts.V0.RelaxedRestrictions (tests)
 import qualified SchedulerTests.SmartContracts.V0.SmartContractTests (tests)
 
 import qualified SchedulerTests.SmartContracts.Invoke (tests)
+import qualified SchedulerTests.SmartContracts.V1.AccountSignatureChecks (tests)
 import qualified SchedulerTests.SmartContracts.V1.AllNewHostFunctions (tests)
 import qualified SchedulerTests.SmartContracts.V1.Checkpointing (tests)
 import qualified SchedulerTests.SmartContracts.V1.Counter (tests)
@@ -101,3 +102,4 @@ main = hspec $ do
     SchedulerTests.Delegation.tests
     SchedulerTests.SmartContracts.V1.P6WasmFeatures.tests
     SchedulerTests.SmartContracts.V1.CustomSectionSize.tests
+    SchedulerTests.SmartContracts.V1.AccountSignatureChecks.tests


### PR DESCRIPTION
## Purpose

Closes https://github.com/Concordium/concordium-base/issues/388

Depends on
- [x] https://github.com/Concordium/concordium-base/pull/404/

## Changes

Add two new operations that can be invoked via `invoke`, retrieving account keys and checking account signatures.

- [x] Analyze performance

Benchmarking running a node locally suggests the cost assignments are good. The worst case seems to be around 0.7s for block execution with 3_000_000 NRG.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.