### PR TITLE
New consensus database recovery

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
@@ -92,6 +92,7 @@ import Concordium.Crypto.EncryptedTransfers
 import Concordium.GlobalState.ContractStateFFIHelpers (LoadCallback)
 import qualified Concordium.GlobalState.ContractStateV1 as StateV1
 import Concordium.GlobalState.Persistent.LMDB (FixedSizeSerialization)
+import Concordium.GlobalState.TransactionTable (TransactionTable)
 import Concordium.ID.Parameters (GlobalContext)
 import Concordium.ID.Types (AccountCredential)
 import qualified Concordium.ID.Types as ID
@@ -1388,6 +1389,13 @@ class (BlockStateOperations m, FixedSizeSerialization (BlockStateRef m)) => Bloc
     -- actively used, in particular, after a protocol update.
     collapseCaches :: m ()
 
+    -- |Cache the block state.
+    cacheBlockState :: BlockState m -> m ()
+
+    -- |Cache the block state and get the initial (empty) transaction table with the next account nonces
+    -- and update sequence numbers populated.
+    cacheBlockStateAndGetTransactionTable :: BlockState m -> m TransactionTable
+
 instance (Monad (t m), MonadTrans t, ModuleQuery m) => ModuleQuery (MGSTrans t m) where
     getModuleArtifact = lift . getModuleArtifact
     {-# INLINE getModuleArtifact #-}
@@ -1649,6 +1657,8 @@ instance (Monad (t m), MonadTrans t, BlockStateStorage m) => BlockStateStorage (
     serializeBlockState = lift . serializeBlockState
     blockStateLoadCallback = lift blockStateLoadCallback
     collapseCaches = lift collapseCaches
+    cacheBlockState = lift . cacheBlockState
+    cacheBlockStateAndGetTransactionTable = lift . cacheBlockStateAndGetTransactionTable
     {-# INLINE thawBlockState #-}
     {-# INLINE freezeBlockState #-}
     {-# INLINE dropUpdatableBlockState #-}
@@ -1659,6 +1669,8 @@ instance (Monad (t m), MonadTrans t, BlockStateStorage m) => BlockStateStorage (
     {-# INLINE serializeBlockState #-}
     {-# INLINE blockStateLoadCallback #-}
     {-# INLINE collapseCaches #-}
+    {-# INLINE cacheBlockState #-}
+    {-# INLINE cacheBlockStateAndGetTransactionTable #-}
 
 deriving via (MGSTrans MaybeT m) instance BlockStateQuery m => BlockStateQuery (MaybeT m)
 deriving via (MGSTrans MaybeT m) instance AccountOperations m => AccountOperations (MaybeT m)

--- a/concordium-consensus/src/Concordium/GlobalState/Classes.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Classes.hs
@@ -38,7 +38,7 @@ instance HasGlobalStateContext g (Identity g) where
 -- are defined where @t@ is a monad transformer and @m@ implements the typeclass.)
 -- The primary use for this is to provide instances for other types using the
 -- deriving via mechanism.
-newtype MGSTrans t (m :: Type -> Type) a = MGSTrans (t m a)
+newtype MGSTrans t (m :: Type -> Type) a = MGSTrans {runMGSTrans :: t m a}
     deriving (Functor, Applicative, Monad, MonadTrans, MonadIO)
 
 instance MonadProtocolVersion m => MonadProtocolVersion (MGSTrans t m) where

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -31,6 +31,7 @@ module Concordium.GlobalState.Persistent.BlockState (
     BlockRewardDetails (..),
     PersistentBlockStateMonad (..),
     withNewAccountCache,
+    cacheState,
     cacheStateAndGetTransactionTable,
     migratePersistentBlockState,
     SupportsPersistentState,
@@ -3512,6 +3513,10 @@ instance (IsProtocolVersion pv, PersistentState av pv r m) => BlockStateStorage 
         Cache.collapseCache (Proxy :: Proxy (AccountCache av))
         Cache.collapseCache (Proxy :: Proxy Modules.ModuleCache)
 
+    cacheBlockState = cacheState
+
+    cacheBlockStateAndGetTransactionTable = cacheStateAndGetTransactionTable
+
 -- |Migrate the block state from the representation used by protocol version
 -- @oldpv@ to the one used by protocol version @pv@. The migration is done gradually,
 -- and that is the reason for the monad @m@ and the transformer @t@. The inner monad @m@ is
@@ -3608,6 +3613,47 @@ migrateBlockPointers migration BlockStatePointers{..} = do
               bspTransactionOutcomes = newTransactionOutcomes,
               bspRewardDetails = newRewardDetails
             }
+
+-- |Cache the block state.
+cacheState ::
+    forall pv m.
+    (SupportsPersistentState pv m) =>
+    HashedPersistentBlockState pv ->
+    m ()
+cacheState hpbs = do
+    BlockStatePointers{..} <- loadPBS (hpbsPointers hpbs)
+    accts <- liftCache (return @_ @(PersistentAccount (AccountVersionFor pv))) bspAccounts
+    -- first cache the modules
+    mods <- cache bspModules
+    -- then cache the instances, but don't cache the modules again. Instead
+    -- share the references in memory we have already constructed by caching
+    -- modules above. Loading the modules here is cheap since we cached them.
+    insts <- runReaderT (cache bspInstances) =<< refLoad mods
+    ips <- cache bspIdentityProviders
+    ars <- cache bspAnonymityRevokers
+    birkParams <- cache bspBirkParameters
+    cryptoParams <- cache bspCryptographicParameters
+    upds <- cache bspUpdates
+    rels <- cache bspReleaseSchedule
+    red <- cache bspRewardDetails
+    _ <-
+        storePBS
+            (hpbsPointers hpbs)
+            BlockStatePointers
+                { bspAccounts = accts,
+                  bspInstances = insts,
+                  bspModules = mods,
+                  bspBank = bspBank,
+                  bspIdentityProviders = ips,
+                  bspAnonymityRevokers = ars,
+                  bspBirkParameters = birkParams,
+                  bspCryptographicParameters = cryptoParams,
+                  bspUpdates = upds,
+                  bspReleaseSchedule = rels,
+                  bspTransactionOutcomes = bspTransactionOutcomes,
+                  bspRewardDetails = red
+                }
+    return ()
 
 -- |Cache the block state and get the initial (empty) transaction table with the next account nonces
 -- and update sequence numbers populated.

--- a/concordium-consensus/src/Concordium/KonsensusV1/Consensus/Blocks.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Consensus/Blocks.hs
@@ -536,13 +536,15 @@ processBlock parent VerifiedBlock{vbBlock = pendingBlock, ..}
                                 -- This implies that the block is in the epoch after the last
                                 -- finalized block.
                                 newBlock <- addBlock pendingBlock blockState parent energyUsed
-                                checkFinality (blockQuorumCertificate pendingBlock)
-                                curRound <- use $ roundStatus . rsCurrentRound
                                 let certifiedParent =
                                         CertifiedBlock
                                             { cbQuorumCertificate = blockQuorumCertificate pendingBlock,
                                               cbQuorumBlock = parent
                                             }
+                                -- Write out the parent if it is newly certified, and check if
+                                -- it finalizes other blocks also.
+                                processCertifiedBlock certifiedParent
+                                curRound <- use $ roundStatus . rsCurrentRound
                                 if curRound < blockRound pendingBlock
                                     then case blockTimeoutCertificate pendingBlock of
                                         Present tc ->
@@ -685,11 +687,11 @@ processBlock parent VerifiedBlock{vbBlock = pendingBlock, ..}
                         (toRational $ genesisSignatureThreshold gmParameters)
                         _bfFinalizers
                         finEntry -> do
-                        -- We record that we have checked a valid QC for the successor round.
-                        -- We do not record the finalized round, because we expect it to be
-                        -- finalized, and we only keep entries for non-finalized rounds.
-                        recordCheckedQuorumCertificate $ feSuccessorQuorumCertificate finEntry
+                        -- We record that we have checked a valid QC for both rounds, since we
+                        -- retain these for each certified block from the last finalized block
+                        -- onwards.
                         recordCheckedQuorumCertificate $ feFinalizedQuorumCertificate finEntry
+                        recordCheckedQuorumCertificate $ feSuccessorQuorumCertificate finEntry
                         -- Check that the finalized block has timestamp past the trigger time for
                         -- the epoch. We use the seed state for the parent block to get the trigger
                         -- time, because that is in the same epoch.
@@ -708,7 +710,7 @@ processBlock parent VerifiedBlock{vbBlock = pendingBlock, ..}
                                     -- process the finalization now. The block we are finalizing is
                                     -- a live (non-finalized) block, and therefore it is at most
                                     -- one epoch after the last finalized block.
-                                    processFinalization finBlock finEntry
+                                    processFinalizationEntry finBlock finEntry
                                     shrinkTimeout finBlock
                                     -- Note: we do not update the highest certified block here
                                     -- because the parent block will be at least as high as that

--- a/concordium-consensus/src/Concordium/KonsensusV1/Consensus/Finality.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Consensus/Finality.hs
@@ -37,7 +37,9 @@ import Concordium.KonsensusV1.Types
 -- If so, the block and its ancestors are finalized, the tree is pruned to the decendants of the
 -- new last finalized block, and, if applicable, the epoch is advanced.
 -- If the block is already written, then it is assumed that it has already been processed in this
--- manner, and so no further action is taken.
+-- manner, and so no further action is taken. (Normally, `processCertifiedBlock` should not be
+-- called on a block that is already finalized, but it can happen if a roll-back occurred at
+-- start up.)
 --
 -- This function incorporates the functionality of @checkFinality@ from the bluepaper.
 processCertifiedBlock ::

--- a/concordium-consensus/src/Concordium/KonsensusV1/Consensus/Finality.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Consensus/Finality.hs
@@ -32,13 +32,61 @@ import qualified Concordium.KonsensusV1.TreeState.LowLevel as LowLevel
 import Concordium.KonsensusV1.TreeState.Types
 import Concordium.KonsensusV1.Types
 
--- |Check if a valid quorum certificate finalizes a block. If so, the block and its ancestors
--- are finalized, the tree is pruned to the decendants of the new last finalized block, and,
--- if applicable, the epoch is advanced.
+-- |Ensure that the given certified block is written to the low-level database.
+-- Check if the certified block causes its parent to become finalized.
+-- If so, the block and its ancestors are finalized, the tree is pruned to the decendants of the
+-- new last finalized block, and, if applicable, the epoch is advanced.
 --
--- PRECONDITION: the quorum certificate is valid. (If the target of the QC is not live, this
--- function will not make any change to the state, and will not error.)
-checkFinality ::
+-- This function incorporates the functionality of @checkFinality@ from the bluepaper.
+--
+-- PRECONDITION: the certified block is valid and live (and not finalized).
+processCertifiedBlock ::
+    ( MonadState (SkovData (MPV m)) m,
+      TimeMonad m,
+      MonadIO m,
+      LowLevel.MonadTreeStateStore m,
+      BlockStateStorage m,
+      GSTypes.BlockState m ~ PBS.HashedPersistentBlockState (MPV m),
+      MonadThrow m,
+      MonadConsensusEvent m,
+      MonadLogger m,
+      IsConsensusV1 (MPV m),
+      HasCallStack
+    ) =>
+    -- |The newly-certified block.
+    CertifiedBlock (MPV m) ->
+    m ()
+processCertifiedBlock cb@CertifiedBlock{..}
+    | NormalBlock block <- bpBlock cbQuorumBlock,
+      let parentQC = blockQuorumCertificate block,
+      qcRound cbQuorumCertificate == qcRound parentQC + 1,
+      qcEpoch cbQuorumCertificate == qcEpoch parentQC = do
+        let finalizedBlockHash = qcBlock parentQC
+        sd <- get
+        unless (finalizedBlockHash == getHash (sd ^. lastFinalized)) $ do
+            let !newFinalizedPtr = parentOfLive sd cbQuorumBlock
+            let newFinalizationEntry =
+                    FinalizationEntry
+                        { feFinalizedQuorumCertificate = parentQC,
+                          feSuccessorQuorumCertificate = cbQuorumCertificate,
+                          feSuccessorProof = getHash (sbBlock block)
+                        }
+            processFinalizationHelper newFinalizedPtr newFinalizationEntry (Just cb)
+            shrinkTimeout cbQuorumBlock
+    | otherwise = do
+        alreadyStored <- LowLevel.memberBlock (getHash cbQuorumBlock)
+        unless alreadyStored $ do
+            storedBlock <- makeStoredBlock cbQuorumBlock
+            LowLevel.writeCertifiedBlock storedBlock cbQuorumCertificate
+
+-- |Process a finalization entry that finalizes a block that is not currently considered finalized.
+--
+-- PRECONDITION:
+--  * The block is live and not already finalized.
+--  * The finalization entry is valid.
+--  * The block is at most one epoch later than the last finalized block. (This is implied by
+--    the block being live.)
+processFinalizationEntry ::
     ( MonadState (SkovData (MPV m)) m,
       TimeMonad m,
       MonadIO m,
@@ -50,63 +98,40 @@ checkFinality ::
       MonadLogger m,
       IsConsensusV1 (MPV m)
     ) =>
-    QuorumCertificate ->
-    m ()
-checkFinality qc = do
-    sd <- get
-    case getMemoryBlockStatus (qcBlock qc) sd of
-        Just (BlockAlive block) -> checkFinalityWithBlock qc block
-        _ -> return ()
-
--- |Check if a valid quorum certificate finalizes a block (the parent of the block in the QC).
--- If so, the block and its ancestors are finalized, the tree is pruned to the decendants of the
--- new last finalized block, and, if applicable, the epoch is advanced.
---
--- PRECONDITION: the quorum certificate is valid and for the supplied block, which is live
--- (and not finalized).
-checkFinalityWithBlock ::
-    ( MonadState (SkovData (MPV m)) m,
-      TimeMonad m,
-      MonadIO m,
-      LowLevel.MonadTreeStateStore m,
-      BlockStateStorage m,
-      GSTypes.BlockState m ~ PBS.HashedPersistentBlockState (MPV m),
-      MonadThrow m,
-      MonadConsensusEvent m,
-      MonadLogger m,
-      IsConsensusV1 (MPV m),
-      HasCallStack
-    ) =>
-    -- |An already verified quorum certificate that points
-    -- to the provided @BlockPointer (MPV m)@
-    QuorumCertificate ->
-    -- |A pointer to the block referenced by the quorum certificate
+    -- |Pointer to the block that is finalized.
     BlockPointer (MPV m) ->
+    -- |Finalization entry for the block.
+    FinalizationEntry ->
     m ()
-checkFinalityWithBlock qc blockPtr
-    | NormalBlock block <- bpBlock blockPtr,
-      let parentQC = blockQuorumCertificate block,
-      qcRound qc == qcRound parentQC + 1,
-      qcEpoch qc == qcEpoch parentQC = do
-        let finalizedBlockHash = qcBlock parentQC
-        sd <- get
-        unless (finalizedBlockHash == getHash (sd ^. lastFinalized)) $ do
-            let !newFinalizedPtr = parentOfLive sd blockPtr
-            let newFinalizationEntry =
-                    FinalizationEntry
-                        { feFinalizedQuorumCertificate = parentQC,
-                          feSuccessorQuorumCertificate = qc,
-                          feSuccessorProof = getHash (sbBlock block)
-                        }
-            processFinalization newFinalizedPtr newFinalizationEntry
-            shrinkTimeout blockPtr
-    | otherwise = return ()
+processFinalizationEntry newFinalizedPtr newFinalizationEntry =
+    processFinalizationHelper newFinalizedPtr newFinalizationEntry Nothing
+
+-- |Write a block's state out to the block state database and construct a 'LowLevel.StoredBlock'
+-- that can be written to the tree state database.
+makeStoredBlock ::
+    ( GSTypes.BlockState m ~ PBS.HashedPersistentBlockState (MPV m),
+      BlockStateStorage m
+    ) =>
+    BlockPointer (MPV m) ->
+    m (LowLevel.StoredBlock (MPV m))
+makeStoredBlock blockPtr = do
+    statePointer <- saveBlockState (bpState blockPtr)
+    return
+        LowLevel.StoredBlock
+            { stbInfo = blockMetadata blockPtr,
+              stbBlock = bpBlock blockPtr,
+              stbStatePointer = statePointer
+            }
 
 -- |Process the finalization of a block. The block must be live (not finalized) and the finalization
 -- entry must be a valid finalization entry for the block.
 --
 -- The new finalized block MUST be at most one epoch later than the prior last finalized block.
-processFinalization ::
+--
+-- This optionally takes the certified block following the newly-finalized block as a parameter.
+-- If this is provided, the certified block and its QC are written to the tree state database
+-- together with updating the finalized block and transaction indexes.
+processFinalizationHelper ::
     ( MonadState (SkovData (MPV m)) m,
       TimeMonad m,
       MonadIO m,
@@ -119,10 +144,15 @@ processFinalization ::
       IsConsensusV1 (MPV m),
       HasCallStack
     ) =>
+    -- |The newly finalized block.
     BlockPointer (MPV m) ->
+    -- |Finalization entry for the block.
     FinalizationEntry ->
+    -- |Optional newly-certified block to write to the low-level store.
+    Maybe (CertifiedBlock (MPV m)) ->
     m ()
-processFinalization newFinalizedBlock newFinalizationEntry = do
+{-# INLINE processFinalizationHelper #-}
+processFinalizationHelper newFinalizedBlock newFinalizationEntry mCertifiedBlock = do
     -- Update the finalization statistics
     now <- currentTime
     statistics %=! updateStatsOnFinalize now
@@ -147,16 +177,16 @@ processFinalization newFinalizedBlock newFinalizationEntry = do
     mapM_ (finalizeTransactions . blockTransactions) prFinalized
     -- Store the blocks and finalization entry in the low-level tree state database, including
     -- indexing the finalized transactions.
-    let makeStoredBlock blockPtr = do
-            statePointer <- saveBlockState (bpState blockPtr)
-            return
-                LowLevel.StoredBlock
-                    { stbInfo = blockMetadata blockPtr,
-                      stbBlock = bpBlock blockPtr,
-                      stbStatePointer = statePointer
-                    }
-    storedBlocks <- mapM makeStoredBlock prFinalized
-    LowLevel.writeBlocks storedBlocks newFinalizationEntry
+    -- Store the finalized blocks in the low-level tree state database.
+    finalizedBlocks <- mapM makeStoredBlock prFinalized
+    case mCertifiedBlock of
+        Nothing -> LowLevel.writeFinalizedBlocks finalizedBlocks newFinalizationEntry
+        Just certifiedBlock -> do
+            storedCertifiedBlock <- makeStoredBlock (cbQuorumBlock certifiedBlock)
+            LowLevel.writeCertifiedBlockWithFinalization
+                finalizedBlocks
+                storedCertifiedBlock
+                newFinalizationEntry
     -- Mark the removed blocks as dead, including purging their block states and updating the
     -- transaction table accordingly.
     forM_ prRemoved markLiveBlockDead
@@ -164,17 +194,13 @@ processFinalization newFinalizedBlock newFinalizationEntry = do
     branches .=! prNewBranches
     -- Update the last finalized block.
     lastFinalized .=! newFinalizedBlock
-    let finalizingQC = feSuccessorQuorumCertificate newFinalizationEntry
-    gets (getLiveBlock (qcBlock finalizingQC)) >>= \case
-        Nothing -> do
-            finalizingCertifiedBlock .= Absent
-        Just finalizingBlock -> do
-            finalizingCertifiedBlock .= Present (CertifiedBlock finalizingQC finalizingBlock)
+    -- Update the latest finalization entry.
+    latestFinalizationEntry .=! Present newFinalizationEntry
     -- Update the epoch bakers to reflect the new last finalized block.
     checkedAdvanceEpochBakers oldLastFinalized newFinalizedBlock
     -- Purge the 'roundExistingBlocks' up to the last finalized block.
     purgeRoundExistingBlocks (blockRound newFinalizedBlock)
-    -- Purge the 'roundExistingQCs' up to the last finalized block.
+    -- Purge the 'roundExistingQCs' before the last finalized block.
     purgeRoundExistingQCs (blockRound newFinalizedBlock)
     -- Purge any pending blocks that are no longer viable.
     purgePending

--- a/concordium-consensus/src/Concordium/KonsensusV1/Consensus/Quorum.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Consensus/Quorum.hs
@@ -294,11 +294,13 @@ processQuorumMessage vqm@(VerifiedQuorumMessage quorumMessage _ quorumBlock) mak
             logEvent Konsensus LLTrace $
                 "QC signed by finalizer indexes: "
                     ++ show (theFinalizerIndex <$> finalizerList (qcSignatories newQC))
-            checkFinality newQC
-            advanceRoundWithQuorum
-                CertifiedBlock
-                    { cbQuorumCertificate = newQC,
-                      cbQuorumBlock = quorumBlock
-                    }
+            let newCertifiedBlock =
+                    CertifiedBlock
+                        { cbQuorumCertificate = newQC,
+                          cbQuorumBlock = quorumBlock
+                        }
+            -- Process the certified block, including checking for finalization.
+            processCertifiedBlock newCertifiedBlock
+            advanceRoundWithQuorum newCertifiedBlock
             recordCheckedQuorumCertificate newQC
             makeBlock

--- a/concordium-consensus/src/Concordium/KonsensusV1/SkovMonad.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/SkovMonad.hs
@@ -483,7 +483,10 @@ initialiseExistingSkovV1 bakerCtx handlerCtx unliftSkov GlobalStateConfig{..} = 
                                 ++ " blocks. Truncating block state database."
                         liftIO $ truncateBlobStore (bscBlobStore . PBS.pbscBlobStore $ pbsc) bestState
                     let initContext = InitContext pbsc lldb
-                    initialSkovData <- runInitMonad (loadSkovData gscRuntimeParameters) initContext
+                    initialSkovData <-
+                        runInitMonad
+                            (loadSkovData gscRuntimeParameters (rollCount > 0))
+                            initContext
                     let !es =
                             ExistingSkov
                                 { esContext =

--- a/concordium-consensus/src/Concordium/KonsensusV1/SkovMonad.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/SkovMonad.hs
@@ -548,21 +548,26 @@ initialiseNewSkovV1 genData bakerCtx handlerCtx unliftSkov gsConfig@GlobalStateC
 -- (i.e. a protocol update has taken effect to a new consensus).
 --
 -- This ensures that the last finalized block state is cached and that the transaction table
--- correctly reflects the state of accounts.
+-- correctly reflects the state of accounts. It also loads the certified blocks from disk.
 activateSkovV1State ::
-    (IsProtocolVersion pv) =>
-    SkovV1Context pv m ->
-    SkovV1State pv ->
-    LogIO (SkovV1State pv)
-activateSkovV1State ctx uninitState =
-    runBlockState $ do
-        logEvent GlobalState LLTrace "Caching last finalized block and initializing transaction table"
-        let bps = bpState $ _lastFinalized $ _v1sSkovData uninitState
-        !tt <- cacheStateAndGetTransactionTable bps
-        logEvent GlobalState LLTrace "Done caching last finalized block"
-        return $! uninitState & v1sSkovData . transactionTable .~ tt
-  where
-    runBlockState a = runReaderT (runPersistentBlockStateMonad a) (_vcPersistentBlockStateContext ctx)
+    ( MonadLogger m,
+      MonadState (SkovData (MPV m)) m,
+      MonadThrow m,
+      BlockState m ~ HashedPersistentBlockState (MPV m),
+      LowLevel.MonadTreeStateStore m,
+      BlockStateStorage m,
+      TimeMonad m,
+      MonadIO m
+    ) =>
+    m ()
+activateSkovV1State = do
+    logEvent GlobalState LLTrace "Caching last finalized block and initializing transaction table"
+    bps <- use $ lastFinalized . to bpState
+    !tt <- cacheBlockStateAndGetTransactionTable bps
+    transactionTable .= tt
+    logEvent GlobalState LLTrace "Loading certified blocks"
+    loadCertifiedBlocks
+    logEvent GlobalState LLTrace "Done activating global state"
 
 -- |Gracefully close the disk storage used by the skov.
 shutdownSkovV1 :: SkovV1Context pv m -> LogIO ()

--- a/concordium-consensus/src/Concordium/KonsensusV1/SkovMonad.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/SkovMonad.hs
@@ -470,6 +470,7 @@ initialiseExistingSkovV1 bakerCtx handlerCtx unliftSkov GlobalStateConfig{..} = 
             pbscBlobStore <- liftIO $ loadBlobStore gscBlockStateFile
             let pbsc = PersistentBlockStateContext{..}
             let initWithLLDB lldb = do
+                    checkDatabaseVersion lldb
                     let checkBlockState bs = runBlobStoreT (isValidBlobRef bs) pbsc
                     (rollCount, bestState) <-
                         runReaderT

--- a/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Implementation.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Implementation.hs
@@ -229,8 +229,9 @@ data SkovData (pv :: ProtocolVersion) = SkovData
       _skovPendingBlocks :: !PendingBlocks,
       -- |Pointer to the last finalized block.
       _lastFinalized :: !(BlockPointer pv),
-      -- |Certified block that justifies the last finalized block being finalized.
-      _finalizingCertifiedBlock :: !(Option (CertifiedBlock pv)),
+      -- |A finalization entry that finalizes the last finalized block, unless that is the
+      -- genesis block.
+      _latestFinalizationEntry :: !(Option FinalizationEntry),
       -- |Baker and finalizer information with respect to the epoch of the last finalized block.
       -- Note: this is distinct from the current epoch.
       _skovEpochBakers :: !EpochBakers,
@@ -337,7 +338,7 @@ mkInitialSkovData rp genMeta genState _currentTimeout _skovEpochBakers =
         _genesisMetadata = genMeta
         _skovPendingBlocks = emptyPendingBlocks
         _lastFinalized = genesisBlockPointer
-        _finalizingCertifiedBlock = Absent
+        _latestFinalizationEntry = Absent
         _statistics = Stats.initialConsensusStatistics
         _currentTimeoutMessages = Absent
         _currentQuorumMessages = emptyQuorumMessages
@@ -388,7 +389,7 @@ getMemoryBlockStatus blockHash sd
     | otherwise = Nothing
 
 -- |Create a block pointer from a stored block.
-mkBlockPointer :: (MonadIO m) => LowLevel.StoredBlock (MPV m) -> m (BlockPointer (MPV m))
+mkBlockPointer :: (MonadIO m) => LowLevel.StoredBlock pv -> m (BlockPointer pv)
 mkBlockPointer sb@LowLevel.StoredBlock{..} = do
     bpState <- liftIO mkHashedPersistentBlockState
     return BlockPointer{bpInfo = stbInfo, bpBlock = stbBlock, ..}

--- a/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Implementation.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Implementation.hs
@@ -102,14 +102,13 @@ data BlockTable pv = BlockTable
       -- if we simply expunged dead blocks.
       _deadBlocks :: !DeadCache,
       -- |Map of live blocks.
-      -- Blocks are removed from this map by two means;
+      -- Blocks are removed from this map by two means:
       --
-      -- * When a block becomes finalized it is
-      -- being persisted (and so are the live blocks which are predecessors to the block
-      -- being finalized.)
-      -- and removed from this cache.
+      -- * When a block becomes finalized it is removed from the table, as it is persisted on disk.
       --
       -- * When a block is being marked as dead.
+      --
+      -- Note that non-finalized certified blocks exist both in the live map and on the disk.
       _liveMap :: !(HM.HashMap BlockHash (InMemoryBlockStatus pv))
     }
     deriving (Show)

--- a/concordium-consensus/src/Concordium/KonsensusV1/TreeState/LowLevel.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TreeState/LowLevel.hs
@@ -71,11 +71,19 @@ instance HasBlockMetadata (StoredBlock pv) where
 -- Durability is also expected from a persistent implementation.
 -- The write operations in particular may involve updating multiple tables and should guarantee
 -- transactional behaviour.
+--
+-- The following invariants apply:
+--     * Every block in the store is either finalized or certified.
+--     * The genesis block is always finalized and has height 0.
+--     * No other genesis blocks are stored in the database.
+--     * The latest finalization entry is always present if there is more than one finalized block.
+--     * If present, the latest finalization entry finalizes the last finalized block.
+--     * The transactions indexed in the store are exactly the transactions of finalized blocks.
 class (Monad m) => MonadTreeStateStore m where
-    -- |Get a finalized block by block hash.
+    -- |Get a block by block hash.
     lookupBlock :: BlockHash -> m (Maybe (StoredBlock (MPV m)))
 
-    -- |Determine if a block is present in the finalized block table.
+    -- |Determine if a block is present in the block table.
     memberBlock :: BlockHash -> m Bool
 
     -- |Get the first (i.e. genesis) block.
@@ -84,9 +92,9 @@ class (Monad m) => MonadTreeStateStore m where
     lookupFirstBlock = lookupBlockByHeight 0
 
     -- |Get the last finalized block.
-    lookupLastBlock :: m (Maybe (StoredBlock (MPV m)))
+    lookupLastFinalizedBlock :: m (Maybe (StoredBlock (MPV m)))
 
-    -- |Look up a block by height.
+    -- |Look up a finalized block by height.
     lookupBlockByHeight :: BlockHeight -> m (Maybe (StoredBlock (MPV m)))
 
     -- |Look up a transaction by its hash.
@@ -95,12 +103,68 @@ class (Monad m) => MonadTreeStateStore m where
     -- |Determine if a transaction is present in the finalized transaction table.
     memberTransaction :: TransactionHash -> m Bool
 
-    -- |Store the list of blocks and their transactions, updating the last finalization entry to
-    -- the supplied value.  (This should write the blocks as a single database transaction.)
-    writeBlocks :: [StoredBlock (MPV m)] -> FinalizationEntry -> m ()
+    -- |Record a finalization entry that finalizes a list of blocks, and mark the blocks and their
+    -- transactions as finalized.
+    -- This has the following effects:
+    --
+    -- 1. The QCs for all rounds up to and including the round of the new last finalized block
+    --    are removed.
+    -- 2. Each block where the QC was removed is also removed from the block table, unless it is in
+    --    the list of newly-finalized blocks.
+    -- 3. The finalization entry is updated to be the new finalization entry.
+    -- 4. Each newly-finalized block is added to the finalized blocks by height index.
+    -- 5. The transactions in the newly-finalized blocks are added to the finalized transactions.
+    --
+    -- The following preconditions are required to ensure the database invariants are maintained:
+    --
+    --   * The list of blocks is non-empty, consists of consecutive certified (non-finalized) blocks
+    --     that form a chain.
+    --   * The finalization entry is for the last of these blocks.
+    writeFinalizedBlocks :: [StoredBlock (MPV m)] -> FinalizationEntry -> m ()
+
+    -- |Write a certified block that does not finalize other blocks.
+    -- This has the following effects:
+    --
+    -- 1. The new certified block is written to the block table.
+    -- 2. The QC for the newly-certified block is written to the QC table.
+    --
+    -- The following preconditions are required to ensure the database invariants are maintained:
+    --
+    --   * The quorum certificate is for the supplied block.
+    --   * The parent block is the (previous) highest certified block.
+    writeCertifiedBlock ::
+        -- |The newly-certified block.
+        StoredBlock (MPV m) ->
+        -- |The quorum certificate for the block.
+        QuorumCertificate ->
+        m ()
+
+    -- |Write a certified block that does finalize other blocks. This is equivalent to calling
+    -- 'writeFinalizedBlocks' followed by 'writeCertifiedBlock', but uses a single transaction.
+    --
+    -- The following preconditions are required to ensure the database invariants are maintained:
+    --
+    --   * The list of blocks is non-empty, consists of consecutive certified (non-finalized) blocks
+    --     that form a chain.
+    --   * The last of these blocks is the parent of the newly-certified block.
+    --   * The finalization entry is for the parent block and the successor QC is for the
+    --     newly-certified block.
+    writeCertifiedBlockWithFinalization ::
+        -- |List of blocks that are newly finalized, in increasing order of height.
+        [StoredBlock (MPV m)] ->
+        -- |The newly-certified block.
+        StoredBlock (MPV m) ->
+        -- |A finalization entry that finalizes the last of the finalized blocks, with the successor
+        -- quorum certificate being for the newly-certified block.
+        FinalizationEntry ->
+        m ()
 
     -- |Look up the finalization entry for the last finalized block.
     lookupLatestFinalizationEntry :: m (Maybe FinalizationEntry)
+
+    -- |Look up all of the certified (non-finalized) blocks, with their quorum certificates.
+    -- The list is in order of increasing round number.
+    lookupCertifiedBlocks :: m [(StoredBlock (MPV m), QuorumCertificate)]
 
     -- |Look up the status of the current round.
     lookupCurrentRoundStatus :: m PersistentRoundStatus
@@ -119,10 +183,3 @@ class (Monad m) => MonadTreeStateStore m where
     -- On a potential rollback of the database then the consensus will initiate catchup and
     -- a new round status will be created when the consensus is fully caught up.
     writeCurrentRoundStatus :: PersistentRoundStatus -> m ()
-
-    -- |From the last block backwards, remove blocks and their associated transactions
-    -- from the database until the predicate returns 'True'. If any blocks are rolled back,
-    -- this also removes the latest finalization entry.
-    -- This returns @Right Int@ where the 'Int' indicates how many blocks were rolled back.
-    -- If an error occurred attempting to roll back, @Left reason@ is returned.
-    rollBackBlocksUntil :: (StoredBlock (MPV m) -> m Bool) -> m (Either String Int)

--- a/concordium-consensus/src/Concordium/KonsensusV1/TreeState/LowLevel.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TreeState/LowLevel.hs
@@ -111,13 +111,14 @@ class (Monad m) => MonadTreeStateStore m where
     --    are removed.
     -- 2. Each block where the QC was removed is also removed from the block table, unless it is in
     --    the list of newly-finalized blocks.
-    -- 3. The finalization entry is updated to be the new finalization entry.
-    -- 4. Each newly-finalized block is added to the finalized blocks by height index.
-    -- 5. The transactions in the newly-finalized blocks are added to the finalized transactions.
+    -- 3. Each newly-finalized block that didn't have a QC is written to the block table.
+    -- 4. The finalization entry is updated to be the new finalization entry.
+    -- 5. Each newly-finalized block is added to the finalized blocks by height index.
+    -- 6. The transactions in the newly-finalized blocks are added to the finalized transactions.
     --
     -- The following preconditions are required to ensure the database invariants are maintained:
     --
-    --   * The list of blocks is non-empty, consists of consecutive certified (non-finalized) blocks
+    --   * The list of blocks is non-empty, consists of consecutive non-finalized blocks
     --     that form a chain.
     --   * The finalization entry is for the last of these blocks.
     writeFinalizedBlocks :: [StoredBlock (MPV m)] -> FinalizationEntry -> m ()
@@ -144,7 +145,7 @@ class (Monad m) => MonadTreeStateStore m where
     --
     -- The following preconditions are required to ensure the database invariants are maintained:
     --
-    --   * The list of blocks is non-empty, consists of consecutive certified (non-finalized) blocks
+    --   * The list of blocks is non-empty, consists of consecutive non-finalized blocks
     --     that form a chain.
     --   * The last of these blocks is the parent of the newly-certified block.
     --   * The finalization entry is for the parent block and the successor QC is for the

--- a/concordium-consensus/src/Concordium/KonsensusV1/TreeState/LowLevel/LMDB.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TreeState/LowLevel/LMDB.hs
@@ -861,7 +861,7 @@ rollBackBlocksUntil checkState = do
                                         -- set the latest finalization entry to finalize the
                                         -- parent block so that the database invariant is
                                         -- restored.
-                                        storeRecord
+                                        storeReplaceRecord
                                             txn
                                             (dbh ^. latestFinalizationEntryStore)
                                             CSKLatestFinalizationEntry

--- a/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Types.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Types.hs
@@ -269,7 +269,10 @@ data PersistentRoundStatus = PersistentRoundStatus
       _prsLastSignedTimeoutMessage :: !(Option TimeoutMessage),
       -- |The round number of the last round for which we baked a block, or 0 if we have never
       -- baked a block.
-      _prsLastBakedRound :: !Round
+      _prsLastBakedRound :: !Round,
+      -- |The latest timeout certificate we have seen. This can be absent if we have a quorum
+      -- certificate for a more recent round.
+      _prsLatestTimeout :: !(Option TimeoutCertificate)
     }
     deriving (Eq, Show)
 
@@ -280,10 +283,12 @@ instance Serialize PersistentRoundStatus where
         put _prsLastSignedQuorumMessage
         put _prsLastSignedTimeoutMessage
         put _prsLastBakedRound
+        put _prsLatestTimeout
     get = do
         _prsLastSignedQuorumMessage <- get
         _prsLastSignedTimeoutMessage <- get
         _prsLastBakedRound <- get
+        _prsLatestTimeout <- get
         return PersistentRoundStatus{..}
 
 -- |The 'PersistentRoundStatus' at genesis.
@@ -292,7 +297,8 @@ initialPersistentRoundStatus =
     PersistentRoundStatus
         { _prsLastSignedQuorumMessage = Absent,
           _prsLastSignedTimeoutMessage = Absent,
-          _prsLastBakedRound = 0
+          _prsLastBakedRound = 0,
+          _prsLatestTimeout = Absent
         }
 
 -- |The last signed round (according to a given 'RoundStatus') for which we have produced a

--- a/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Types.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Types.hs
@@ -389,7 +389,7 @@ data RoundStatus (pv :: ProtocolVersion) = RoundStatus
       -- but is not required.
       --
       -- The purpose of this field is to support the creation of a block that is the first in a new
-      -- epoch. It should
+      -- epoch.
       _rsLastEpochFinalizationEntry :: !(Option FinalizationEntry),
       -- |The current duration to wait before a round times out.
       _rsCurrentTimeout :: !Duration

--- a/concordium-consensus/src/Concordium/MultiVersion.hs
+++ b/concordium-consensus/src/Concordium/MultiVersion.hs
@@ -420,9 +420,8 @@ activateConfiguration :: Skov.SkovConfiguration finconf UpdateHandler => EVersio
 activateConfiguration (EVersionedConfigurationV0 vc) = do
     activeState <- mvrLogIO . Skov.activateSkovState (vc0Context vc) =<< liftIO (readIORef (vc0State vc))
     liftIO (writeIORef (vc0State vc) activeState)
-activateConfiguration (EVersionedConfigurationV1 vc) = do
-    activeState <- mvrLogIO . SkovV1.activateSkovV1State (vc1Context vc) =<< liftIO (readIORef (vc1State vc))
-    liftIO (writeIORef (vc1State vc) activeState)
+activateConfiguration (EVersionedConfigurationV1 vc) =
+    liftSkovV1Update vc SkovV1.activateSkovV1State
 
 -- |This class makes it possible to use a multi-version configuration at a specific version.
 -- Essentially, this class provides instances of 'SkovMonad', 'FinalizationMonad' and

--- a/concordium-consensus/src/Concordium/TransactionVerification.hs
+++ b/concordium-consensus/src/Concordium/TransactionVerification.hs
@@ -50,6 +50,7 @@ data VerificationResult
 -- 'CredentialDeploymentSuccess' as ip's or ar's cannot be removed then nothing needs to be checked before executing
 -- 'ChainUpdateSuccess' it should be checked that the authorization keys match the current ones before executing
 -- 'NormalTransactionSuccess' it should be checked that the account information can still verify before executing
+-- 'TrustedSuccess' the signatures should be checked before executing
 data OkResult
     = -- |The 'CredentialDeployment' passed verification.
       CredentialDeploymentSuccess
@@ -69,6 +70,9 @@ data OkResult
         { keysHash :: !Sha256.Hash,
           nonce :: !Types.Nonce
         }
+    | -- |At start-up, the transaction was taken from a block that has already been verified, so
+      -- we trust that it was verified correctly, but do not have the keys used to verify it.
+      TrustedSuccess
     deriving (Eq, Show, Ord)
 
 -- |Verification results which are rejectable if the transaction was received individually.

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Timeout.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Timeout.hs
@@ -459,7 +459,7 @@ testReceiveTimeoutMessage = describe "Receive timeout message" $ do
     -- present in the @receivedTimeoutMessages@.
     liveBlockHash = BlockHash $ Hash.hash "live block"
     -- Another live block. This is just present in the live block table,
-    -- but noone has already sent a timeout message for it.
+    -- but no one has already sent a timeout message for it.
     -- It is used for triggering the double signing case together with the
     -- @liveBlockHash@.
     anotherLiveBlock = BlockHash $ Hash.hash "another live block"
@@ -473,12 +473,12 @@ testReceiveTimeoutMessage = describe "Receive timeout message" $ do
     fi fIdx = FinalizerInfo (FinalizerIndex fIdx) 1 (sigPublicKey' (fromIntegral fIdx)) vrfPublicKey (blsPublicKey fIdx) (BakerId $ AccountIndex $ fromIntegral fIdx)
     -- COnstruct the finalization committee
     finalizers = FinalizationCommittee (Vec.fromList [fi 0, fi 1, fi 2]) 3
-    -- Construct a set of 0 bakers and 3 finalisers with indecies 0,1,2.
+    -- Construct a set of 0 bakers and 3 finalisers with indices 0,1,2.
     bakersAndFinalizers = BakersAndFinalizers (FullBakers Vec.empty 0) finalizers
     -- A tree state where the following applies:
     -- - Current round is 2
     -- - Current epoch is 0
-    -- - There is a finalization committee consisting of the finalizers with indecies [0,1,2]
+    -- - There is a finalization committee consisting of the finalizers with indices [0,1,2]
     -- - There is a last finalized block for round 1, epoch 0.
     sd =
         dummyInitialSkovData
@@ -498,7 +498,7 @@ testReceiveTimeoutMessage = describe "Receive timeout message" $ do
     -- A low level database which consists of a finalized block for height 0 otherwise empty.
     lldb =
         let myLLDB = lldbWithGenesis @'P6
-        in  myLLDB{lldbBlockHashes = HM.singleton someOldFinalizedBlockHash $ BlockHeight 0}
+        in  myLLDB{lldbBlocks = HM.singleton someOldFinalizedBlockHash $ toStoredBlock (dummyBlock 20)}
     -- receive the timeout message in the provided tree state context and
     -- check that the result is as expected.
     receiveAndCheck skovData tm expect = do

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Types.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Types.hs
@@ -187,6 +187,7 @@ genPersistentRoundStatus = do
     _prsLastSignedQuorumMessage <- oneof [Present <$> genQuorumMessage, return Absent]
     _prsLastSignedTimeoutMessage <- oneof [Present <$> genTimeoutMessage, return Absent]
     _prsLastBakedRound <- genRound
+    _prsLatestTimeout <- oneof [Present <$> genTimeoutCertificate, return Absent]
     return PersistentRoundStatus{..}
 
 -- |Generate an arbitrary vrf key pair.


### PR DESCRIPTION
## Purpose

This changes the low-level tree state database so that certified blocks are stored. The reason for this is to allow the chain to fully recover its state necessary to be live after a restart.

## Changes

- Low-level tree state:
    - Both finalized and certified blocks are stored, indexed by block hash.
    - Finalized blocks are indexed by height.
    - Quorum certificates for certified blocks are stored, indexed by the round number.
    - `writeBlocks` is removed and replaced by `writeFinalizedBlocks`, `writeCertifiedBlock` and `writeCertifiedBlockWithFinalization`
    - `writeFinalizedBlocks` marks a series of certified blocks as finalized, removing the QCs and updating the latest finalization entry.
    - `writeCertifiedBlock` adds a new certified block.
    - `writeCertifiedBlockWithFinalization` adds a certified block and marks blocks as finalized in a single transaction. It is equivalent to doing both `writeCertifiedBlock` and `writeFinalizedBlocks`.
    - `lookupLastBlock` is renamed to `lookupLastFinalizedBlock`.
    - `lookupCertifiedBlocks` is added for getting the non-finalized certified blocks, that is required when loading the database.
    - The most recent timeout certificate is added to the persistent round status.
    - `rollBackBlocksUntil` is removed from the `MonadTreeStateStore` and only provided for the LMDB implementation. Its behaviour is changed to roll back certified blocks as well as finalized block where necessary, but to ensure that the latest finalization record is always valid.
- `finalizingCertifiedBlock` is removed from `SkovData`, and replaced with `latestFinalizationEntry`.
- `loadSkovData`: the QC for the last finalized block is added to the `roundExistingQCs`; the `latestFinalizationEntry` is loaded from the low-level database.
- `loadCertifiedBlocks` is added, which is called as part of `activateSkovV1State` when loading the state. It deals with loading certified blocks into the state (including adding their transactions to the transaction table) and also sets up the previous round timeout based on the stored timeout certificate (where appropriate). It should establish that the current round is the next one from the last we have a certified block are timeout certificate for. (Previously, as certified blocks and timeout certificates were not stored, this could not be guaranteed.)
- Finality:
    - `checkFinality`/`checkFinalityWithBlock` is replaced by `processCertifiedBlock`, which will store the certified block, as well as doing the finality checking and processing that was part of `checkFinality`.
    - `processFinalizationEntry` provides another route to finalization given a finalization entry instead of a certified block. (This is for when we might not have the successor block itself, such as during catch-up or in the case of an epoch transition. `processFinalization` was previously used for this purpose.)
    - `processFinalizationHelper` replaces `processFinalization` as an internal helper for implementing `processCertifiedBlock` and `processFinalizationEntry`.
- Catch up:
    - `CatchUpTerminalData` replaces `cutdQuorumCertificates` with `cutdLatestFinalizationEntry` and `cutdHighestQuorumCertificate`.
    - `cutdLatestFinalizationEntry` is used to send the latest finalization entry whenever the peer is behind on the last finalized block. It is processed as part of `processCatchUpTerminalData`.
    - `cutdHighestQuorumCertificate` is used to send the highest QC when the peer is behind on the highest certified block.
- Block state:
    - `cacheBlockState` and `cacheBlockStateAndGetTransactionTable` are added to the `BlockStateStorage` type class. This change is to make them usable inside the `SkovV1T` monad transformer.
    - `cacheBlockStateAndGetTransactionTable` is implemented by the existing `cacheStateAndGetTransactionTable`
    - `cacheBlockState` has a similar implementation to `cacheBlockStateAndGetTransactionTable`, but without building the transaction table.
- `activateSkovV1State` is revised so that it runs in the `SkovV1T` monad transformer, which slightly simplifies how it is implemented and used. It calls `loadCertfiedBlocks`.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
