### PR TITLE
Change genesis repo to github

### DIFF
--- a/jenkinsfiles/distribution-image.Jenkinsfile
+++ b/jenkinsfiles/distribution-image.Jenkinsfile
@@ -29,12 +29,12 @@ pipeline {
             environment {
                 // Overrides the parameter 'genesis_path'
                 // Use default genesis path for each environment, if the genesis_path param has not been set.
-                // Uses library function defined here: https://gitlab.com/Concordium/infra/jenkins-library/-/blob/master/vars/defaultGenesis.groovy
+                // Uses library function defined here: https://github.com/Concordium/concordium-infra-jenkins-library/blob/master/vars/defaultGenesis.groovy
                 genesis_path = defaultGenesis(environment, genesis_path)
             }
             steps {
                 sh 'printenv'
-                sshagent (credentials: ['jenkins-gitlab-ssh']) {
+                sshagent (credentials: ['jenkins-github-ssh']) {
                     sh './scripts/distribution/docker/build-distribution-image.sh'
                 }
             }

--- a/jenkinsfiles/ubuntu.Jenkinsfile
+++ b/jenkinsfiles/ubuntu.Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
             )}""".trim()
         
         // Use default genesis path for each environment, if the GENESIS_PATH param has not been set.
-        // Uses library function defined here: https://gitlab.com/Concordium/infra/jenkins-library/-/blob/master/vars/defaultGenesis.groovy
+        // Uses library function defined here: https://github.com/Concordium/concordium-infra-jenkins-library/blob/master/vars/defaultGenesis.groovy
         GENESIS_FULL_PATH = defaultGenesis(ENVIRONMENT, GENESIS_PATH)
         DOMAIN = concordiumDomain(ENVIRONMENT)
         BUILD_FILE = "concordium-${ENVIRONMENT}-node_${CODE_VERSION}_amd64.deb"
@@ -76,7 +76,7 @@ pipeline {
         stage('Checkout genesis') {
             steps {
                 dir('genesis') {
-                    git credentialsId: 'jenkins-gitlab-ssh', url: 'git@gitlab.com:Concordium/genesis-data.git'
+                    git credentialsId: 'jenkins-github-ssh', url: 'git@github.com:Concordium/concordium-infra-genesis-data.git'
                 }
                     // Copy genesis.dat file into place in data dir, and rename.
                     sh '''

--- a/scripts/distribution/docker/builder.Dockerfile
+++ b/scripts/distribution/docker/builder.Dockerfile
@@ -24,9 +24,9 @@ FROM static-node-binaries:${static_binaries_image_tag} as binaries
 FROM alpine/git:latest as genesis-data
 ARG genesis_ref
 ARG genesis_path
-RUN mkdir -p -m 0600 ~/.ssh && ssh-keyscan gitlab.com >> ~/.ssh/known_hosts
-RUN --mount=type=ssh git clone --depth 1 --branch "${genesis_ref}" git@gitlab.com:Concordium/genesis-data.git
-RUN mv "genesis-data/${genesis_path}" /data
+RUN mkdir -p -m 0600 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
+RUN --mount=type=ssh git clone --depth 1 --branch "${genesis_ref}" git@github.com:Concordium/concordium-infra-genesis-data.git
+RUN mv "concordium-infra-genesis-data/${genesis_path}" /data
 
 FROM ubuntu:20.04
  

--- a/scripts/static-libraries/README.md
+++ b/scripts/static-libraries/README.md
@@ -1,7 +1,7 @@
 # Static libraries scripts
 
 Static libraries are built using an fPIC GHC created with
-[these](https://gitlab.com/Concordium/devops/-/tree/master/fpic) scripts by
+[these](https://github.com/Concordium/concordium-infra-devops/tree/master/fpic) scripts by
 [this](http://jenkins.internal.concordium.com/job/fpic-ghc_jenkinsfile/) job.
 
 The script is consumed by various Docker build jobs, usually as a designated "build static libraries" stage


### PR DESCRIPTION
## Purpose

Genesis repo was moved to Github.

## Changes

Change all references to Concordium Gitlab  repos to point the the relevant Github repo.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

