### PR TITLE
Fix spurious reporting of baker double signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased changes
 
+- Fix a bug where receiving a duplicate of an invalid block could be spuriously reported as double
+  signing.
+
 ## 6.0.1
 
 - Remove configuration option `no-rpc-server` and environment variable

--- a/concordium-consensus/src/Concordium/KonsensusV1/Types.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Types.hs
@@ -1352,11 +1352,12 @@ unsafeGetBlockKnownHash ts sbHash = do
 -- |Nominally, a proof that a baker signed a block in a particular round and epoch.
 -- For now, though, we do not include any information in the witness since we do not provide it to
 -- any external parties.
-data BlockSignatureWitness = BlockSignatureWitness
+newtype BlockSignatureWitness = BlockSignatureWitness {bswBlockHash :: BlockHash}
+    deriving (Eq, Show)
 
 -- |Derive a 'BlockSignatureWitness' from a signed block.
 toBlockSignatureWitness :: SignedBlock -> BlockSignatureWitness
-toBlockSignatureWitness _ = BlockSignatureWitness
+toBlockSignatureWitness = BlockSignatureWitness . getHash
 
 -- |A proof that contains the 'Epoch' for a 'QuorumCertificate'
 -- has been checked for a particular 'Round'.

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Consensus/Blocks.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Consensus/Blocks.hs
@@ -724,6 +724,14 @@ testReceiveDuplicate = runTestMonad noBaker testTime genesisData $ do
     res <- uponReceivingBlock $ signedPB testBB1
     liftIO $ res `shouldBe` BlockResultDuplicate
 
+-- |Receive an invalid block twice.
+testReceiveInvalidDuplicate :: Assertion
+testReceiveInvalidDuplicate = runTestMonad noBaker testTime genesisData $ do
+    let badBlock = signedPB (testBB1{bbStateHash = StateHashV0 minBound})
+    succeedReceiveBlockFailExecute badBlock
+    res <- uponReceivingBlock $ badBlock
+    liftIO $ res `shouldBe` BlockResultDuplicate
+
 testReceiveStale :: Assertion
 testReceiveStale = runTestMonad noBaker testTime genesisData $ do
     mapM_ (succeedReceiveBlock . signedPB) [testBB2', testBB3', testBB4']
@@ -1253,6 +1261,7 @@ tests = describe "KonsensusV1.Consensus.Blocks" $ do
         it "receive 4 blocks reordered, multiple epochs" testReceive4Reordered
         it "skip round 1, receive rounds 2,3,4" testReceiveWithTimeout
         it "receive duplicate block" testReceiveDuplicate
+        it "receive invalid duplicate block" testReceiveInvalidDuplicate
         it "receive stale round" testReceiveStale
         it "epoch transition" testReceiveEpoch
         it "block dies on old branch" testReceiveBlockDies


### PR DESCRIPTION
## Purpose

Fixes #949

Fix an issue where duplicate invalid blocks are spuriously reported as a case of double signing.

## Changes

- When double signing is detected, check that the block is actually distinct from the previous signed block.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
