### PR TITLE
Cleanup timeout certificate checking.

### DIFF
--- a/concordium-consensus/src/Concordium/KonsensusV1/Types.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Types.hs
@@ -609,27 +609,6 @@ instance HashableTo Hash.Hash (Option TimeoutCertificate) where
         putWord8 1
         put tc
 
--- |Check the signature in a timeout certificate.
-checkTimeoutCertificateSignature ::
-    -- |Genesis block hash
-    BlockHash ->
-    -- |Get the public keys for a set of finalizers for a given 'Epoch'.
-    (FinalizerSet -> Epoch -> [BakerAggregationVerifyKey]) ->
-    TimeoutCertificate ->
-    Bool
-checkTimeoutCertificateSignature tsmGenesis toKeys TimeoutCertificate{..} =
-    Bls.verifyAggregateHybrid msgsKeys (theTimeoutSignature tcAggregateSignature)
-  where
-    msgsKeysForEpoch tsmQCEpoch finalizerRounds =
-        [ ( timeoutSignatureMessageBytes TimeoutSignatureMessage{tsmRound = tcRound, ..},
-            toKeys fs tsmQCEpoch
-          )
-          | (tsmQCRound, fs) <- finalizerRoundsList finalizerRounds
-        ]
-    msgsKeys =
-        msgsKeysForEpoch tcMinEpoch tcFinalizerQCRoundsFirstEpoch
-            ++ msgsKeysForEpoch (tcMinEpoch + 1) tcFinalizerQCRoundsSecondEpoch
-
 -- |Check that the signature on a timeout certificate is correct and that it contains a sufficient
 -- weight of signatures with respect to the finalization committee of a given epoch (the epoch of
 -- the quorum certificate that the timeout certificate should be valid with respect to).
@@ -691,14 +670,15 @@ checkTimeoutCertificate tsmGenesis sigThreshold finCom1 finCom2 finComQC Timeout
     check :: [(BS.ByteString, [Bls.PublicKey])] -> Set.Set BakerId -> Bool
     check msgKeys finBakerIds =
         Bls.verifyAggregateHybrid msgKeys (theTimeoutSignature tcAggregateSignature)
-            && toRational (computeWeight finComQC (Set.toAscList finBakerIds)) >= targetWeight
+            && toRational (computeWeight (Set.toAscList finBakerIds)) >= targetWeight
     -- The target weight of finalizers for the signature to be considered valid.
     targetWeight = sigThreshold * toRational (committeeTotalWeight finComQC)
-    -- Compute the weight of the provided list of baker ids using the 'FinalizationCommittee'.
+    -- Compute the weight of the provided list of baker ids using the 'FinalizationCommittee' from the QC
+    -- of the TC.
     -- Note that this function assumes that the list of baker ids and the finalization committee
     -- is sorted in ascending order of baker id.
-    computeWeight :: FinalizationCommittee -> [BakerId] -> VoterPower
-    computeWeight committee bids = snd $ foldl' maybeAdd (bids, 0) $ committeeFinalizers committee
+    computeWeight :: [BakerId] -> VoterPower
+    computeWeight bids = snd $ foldl' maybeAdd (bids, 0) $ committeeFinalizers finComQC
       where
         -- Adds the weight to the sum if the finalizer indices matches otherwise
         -- continue to the next finalizer info.

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Timeout.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Timeout.hs
@@ -45,6 +45,8 @@ import ConcordiumTests.KonsensusV1.Common
 import ConcordiumTests.KonsensusV1.TreeStateTest hiding (tests)
 import ConcordiumTests.KonsensusV1.Types hiding (tests)
 
+import qualified ConcordiumTests.KonsensusV1.Consensus.Blocks as TestBlocks
+
 -- |Test that 'updateCurrentTimeout' correctly calculates a new timeout given the current timeout and the
 -- `timeoutIncrease` parameter.
 testUpdateCurrentTimeout :: Duration -> Ratio Word64 -> Duration -> Assertion
@@ -623,6 +625,32 @@ testExecuteTimeoutMessages = describe "execute timeout messages" $ do
             Dummy.dummyKeyCollection
             Dummy.dummyChainParameters
 
+-- |Tests the 'checkTimeoutCertificate' function.
+testCheckTimeoutCertificate :: Spec
+testCheckTimeoutCertificate = describe "check timeout certificate" $ do
+    it "accepts timeout certificate" checkOkTC
+    it "rejects with wrong genesis" wrongGenesis
+    it "rejects when there is not enough weight" insufficientWeight
+  where
+    checkOkTC = runTest $ do
+        finComm <- use $ skovEpochBakers . currentEpochBakers . bfFinalizers
+        qc <- use $ roundStatus . rsHighestCertifiedBlock . to cbQuorumCertificate
+        checkOk $ checkTimeoutCertificate okGenesisHash sigThreshold finComm finComm finComm $ TestBlocks.validTimeoutFor qc (Round 1)
+    wrongGenesis = runTest $ do
+        finComm <- use $ skovEpochBakers . currentEpochBakers . bfFinalizers
+        qc <- use $ roundStatus . rsHighestCertifiedBlock . to cbQuorumCertificate
+        checkNotOk $ checkTimeoutCertificate invalidGenesisHash sigThreshold finComm finComm finComm $ TestBlocks.validTimeoutFor qc (Round 1)
+    insufficientWeight = runTest $ do
+        finComm <- use $ skovEpochBakers . currentEpochBakers . bfFinalizers
+        qc <- use $ roundStatus . rsHighestCertifiedBlock . to cbQuorumCertificate
+        let finComm' = finComm{committeeFinalizers = Vec.tail $ committeeFinalizers finComm}
+        checkNotOk $ checkTimeoutCertificate okGenesisHash sigThreshold finComm finComm finComm' $ TestBlocks.validTimeoutFor qc (Round 1)
+    checkOk = liftIO . assertBool "Check failed"
+    checkNotOk b = liftIO . assertBool "Check failed" $ not b
+    runTest = runTestMonad (BakerContext Nothing) (timestampToUTCTime 1_000) TestBlocks.genesisData
+    okGenesisHash = TestBlocks.genesisHash
+    invalidGenesisHash = genesisHash
+
 tests :: Spec
 tests = describe "KonsensusV1.Timeout" $ do
     testReceiveTimeoutMessage
@@ -637,3 +665,4 @@ tests = describe "KonsensusV1.Timeout" $ do
     it "Test processTimeout" testProcessTimeout
     it "Test uponTimeoutEvent" testUponTimeoutEvent
     testUpdateTimeoutMessages
+    testCheckTimeoutCertificate


### PR DESCRIPTION
Remove `checkTimeoutCertificateSignature` and add a few tests for `checkTimeoutCertificate`

This concludes https://github.com/Concordium/concordium-node/issues/752

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.


