### PR TITLE
Resize when reading from database via the exporter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased changes
+- Fix a bug where the LMDB map was not resized when exporting the database. 
+  This could cause the exporing to fail when used on a running node.
 
 ## 6.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased changes
 - Fix a bug where the LMDB map was not resized when exporting the database. 
-  This could cause the exporing to fail when used on a running node.
+  This could cause the database exporter to fail when used on a running node.
+- Fix a bug where the database exporter creates files in the wrong path when invoked with a
+  relative `--exportpath`.
 
 ## 6.0.1
 

--- a/concordium-consensus/src/Concordium/ImportExport.hs
+++ b/concordium-consensus/src/Concordium/ImportExport.hs
@@ -46,7 +46,6 @@ import Control.Monad.IO.Class
 import Control.Monad.Reader
 import Control.Monad.State (evalStateT)
 import Control.Monad.Trans.Except
-import Control.Monad.Trans.Reader
 import qualified Data.Attoparsec.Text as AP
 import Data.Bits
 import qualified Data.ByteString as BS


### PR DESCRIPTION
## Purpose

Fix https://github.com/Concordium/concordium-node/issues/953
Fix #961 

## Changes

- Resize the LMDB map when reading from the database from the database exporter. (I.e. when not holding a write lock). 
- Do not duplicatively prepend the export path to the filename of a replaced chunk.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
