### PR TITLE
Database and catch-up fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   unresponsive node in protocol version 6.
 - Fix a bug where receiving a duplicate of an invalid block could be spuriously reported as double
   signing.
+- Fix a bug where database roll-back could fail on Windows.
+- Fix a bug where catch-up for ConcordiumBFT can loop or result in incorrect soft-banning of peers.
 
 ## 6.0.1
 

--- a/concordium-consensus/src/Concordium/KonsensusV1/Consensus/CatchUp.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Consensus/CatchUp.hs
@@ -435,8 +435,8 @@ processCatchUpTerminalData ::
     CatchUpTerminalData ->
     m TerminalDataResult
 processCatchUpTerminalData CatchUpTerminalData{..} = flip runContT return $ do
-    progress0 <- processFE False cutdLatestFinalizationEntry
-    progress1 <- foldM processQC progress0 cutdHighestQuorumCertificate
+    progress0 <- foldM processQC False cutdHighestQuorumCertificate
+    progress1 <- processFE progress0 cutdLatestFinalizationEntry
     progress2 <- processTC progress1 cutdTimeoutCertificate
     progress3 <- foldM processQM progress2 cutdCurrentRoundQuorumMessages
     progress4 <- foldM processTM progress3 cutdCurrentRoundTimeoutMessages

--- a/concordium-consensus/src/Concordium/KonsensusV1/Consensus/CatchUp.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Consensus/CatchUp.hs
@@ -387,22 +387,24 @@ data TerminalDataResult
 -- |Process the contents of a 'CatchUpTerminalData' record. This updates the state and so should
 -- be used with the global state lock.
 --
--- 1. Process the quorum certificates. There should be up to two of these. At most one can
---    result in updating the highest certified block and advancing the round. (The other one may
---    update the last finalized block.) When we advance the round, we do not immediately call
---    'makeBlock', which is called later.
+-- 1. Process the quorum certificate for the highest certified block, if present. This may
+--    result in updating the highest certified block advancing the round. When we advance the
+--    round, we do not immediately call 'makeBlock', which is called later.
 --
--- 2. Process the timeout certificate, if present. If the timeout certificate is relevant, it may
+-- 2. Process the finalization entry, if present. This may result in updating the last finalized
+--    block, and could advance to a new epoch.
+--
+-- 3. Process the timeout certificate, if present. If the timeout certificate is relevant, it may
 --    advance the round. As above, when we advance the round, we do not immediately call
 --    'makeBlock'.
 --
--- 3. Process the quorum messages. This may cause a QC to be generated and advance the round.
+-- 4. Process the quorum messages. This may cause a QC to be generated and advance the round.
 --    In that case, 'makeBlock' is immediately called as part of the processing.
 --
--- 4. Process the timeout messages. This may cause a TC to be generated and advance the round.
+-- 5. Process the timeout messages. This may cause a TC to be generated and advance the round.
 --    In that case, 'makeBlock' is immediately called as part of the processing.
 --
--- 5. Call 'makeBlock'. This will do nothing if the baker has already baked a block for the round,
+-- 6. Call 'makeBlock'. This will do nothing if the baker has already baked a block for the round,
 --    so it is fine to call even if it was already called.
 --
 -- Note that processing the QCs and TC can both cause the round to advance. We defer calling
@@ -435,6 +437,10 @@ processCatchUpTerminalData ::
     CatchUpTerminalData ->
     m TerminalDataResult
 processCatchUpTerminalData CatchUpTerminalData{..} = flip runContT return $ do
+    -- Processing the quorum certificate before the finalization entry is better in the common
+    -- case where the QC is for the successor block in the finalization entry. This is because
+    -- it will result in a single transaction on the treestate database, rather than separate
+    -- transactions for finalizing and recording the certified block.
     progress0 <- foldM processQC False cutdHighestQuorumCertificate
     progress1 <- processFE progress0 cutdLatestFinalizationEntry
     progress2 <- processTC progress1 cutdTimeoutCertificate
@@ -491,6 +497,9 @@ processCatchUpTerminalData CatchUpTerminalData{..} = flip runContT return $ do
                         "quorum certificate is inconsistent with the block it certifies."
                     )
                 -- We only care if the QC will advance our current round.
+                -- Note: we do not check whether we have already checked a valid QC for the round
+                -- as this could potentially come from a finalization entry where we are missing
+                -- the block.
                 currentRound <- use $ roundStatus . rsCurrentRound
                 if currentRound == qcRound qc
                     then do

--- a/concordium-consensus/src/Concordium/KonsensusV1/TreeState/LowLevel/LMDB.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TreeState/LowLevel/LMDB.hs
@@ -854,14 +854,14 @@ rollBackBlocksUntil checkState = do
             let loop ::
                     -- Current count of blocks rolled back
                     Int ->
-                    -- Accumulated list of rolled-back finalized blocks
+                    -- Accumulated list of rolled-back finalized blocks in ascending height order
                     [BlockHash] ->
                     -- Block to roll back
                     StoredBlock pv ->
                     -- Quorum certificate on the block
                     QuorumCertificate ->
                     -- Total number of blocks rolled back,
-                    -- List of hashes of rolled-back blocks,
+                    -- List of hashes of rolled-back blocks in ascending height order,
                     -- New last finalized block
                     IO (Int, [BlockHash], StoredBlock pv)
                 loop !c hashes fin finQC = case stbBlock fin of

--- a/concordium-consensus/src/Concordium/KonsensusV1/TreeState/LowLevel/LMDB.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TreeState/LowLevel/LMDB.hs
@@ -906,7 +906,7 @@ rollBackBlocksUntil checkState = do
                                                   feSuccessorQuorumCertificate = finQC,
                                                   feSuccessorProof = getHash (sbBlock block)
                                                 }
-                                        return (c, hashes, parent)
+                                        return (c + 1, finHash : hashes, parent)
             loadRecord txn (dbh ^. latestFinalizationEntryStore) CSKLatestFinalizationEntry
                 >>= \case
                     Nothing ->

--- a/concordium-consensus/src/Concordium/KonsensusV1/TreeState/LowLevel/LMDB.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TreeState/LowLevel/LMDB.hs
@@ -851,7 +851,20 @@ rollBackBlocksUntil checkState = do
             throwM . DatabaseRecoveryFailure $
                 "Genesis block state could not be recovered."
         (count', hashes, newLastFin) <- asWriteTransaction $ \dbh txn -> do
-            let loop !c hashes fin finQC = case stbBlock fin of
+            let loop ::
+                    -- Current count of blocks rolled back
+                    Int ->
+                    -- Accumulated list of rolled-back finalized blocks
+                    [BlockHash] ->
+                    -- Block to roll back
+                    StoredBlock pv ->
+                    -- Quorum certificate on the block
+                    QuorumCertificate ->
+                    -- Total number of blocks rolled back,
+                    -- List of hashes of rolled-back blocks,
+                    -- New last finalized block
+                    IO (Int, [BlockHash], StoredBlock pv)
+                loop !c hashes fin finQC = case stbBlock fin of
                     GenesisBlock _ -> do
                         -- As a special case, the genesis block is self-finalizing.
                         -- We thus remove the latest finalization entry.
@@ -877,9 +890,9 @@ rollBackBlocksUntil checkState = do
                                 if isPresent (blockTimeoutCertificate block)
                                     || isPresent (blockEpochFinalizationEntry block)
                                     then do
-                                        -- If the block has a timeout certificate or a finalization
-                                        -- entry, then the QC on this block does not explicitly
-                                        -- finalize the parent block, so we roll back.
+                                        -- If the block has a timeout certificate or an epoch
+                                        -- finalization entry, then the QC on this block does not
+                                        -- explicitly finalize the parent block, so we roll back.
                                         -- (Note, the presence of a timeout certificate indicates the
                                         -- block is not in the next round from its parent, and the
                                         -- presence of an epoch finalization entry indicates that block
@@ -891,11 +904,11 @@ rollBackBlocksUntil checkState = do
                                             parent
                                             (blockQuorumCertificate block)
                                     else do
-                                        -- The block does not have a timeout certificate or finalization
-                                        -- entry, so the parent block is explicitly finalized. We thus
-                                        -- set the latest finalization entry to finalize the
-                                        -- parent block so that the database invariant is
-                                        -- restored.
+                                        -- The block does not have a timeout certificate or epoch
+                                        -- finalization entry, so the parent block is explicitly
+                                        -- finalized. We thus set the latest finalization entry to
+                                        -- finalize the parent block so that the database invariant
+                                        -- is restored.
                                         storeReplaceRecord
                                             txn
                                             (dbh ^. latestFinalizationEntryStore)

--- a/concordium-consensus/src/Concordium/MultiVersion.hs
+++ b/concordium-consensus/src/Concordium/MultiVersion.hs
@@ -1696,7 +1696,9 @@ handleCatchUpStatusV1 ::
     VersionedConfigurationV1 finconf pv ->
     KonsensusV1.CatchUpMessage ->
     MVR finconf Skov.UpdateResult
-handleCatchUpStatusV1 CatchUpConfiguration{..} vc = handleMsg
+handleCatchUpStatusV1 CatchUpConfiguration{..} vc msg = do
+    logEvent Runner LLTrace $ "Handling catch-up message: " ++ show msg
+    handleMsg msg
   where
     handleMsg KonsensusV1.CatchUpStatusMessage{..} = do
         st <- liftIO $ readIORef $ vc1State vc
@@ -1727,14 +1729,18 @@ handleCatchUpStatusV1 CatchUpConfiguration{..} vc = handleMsg
         -- any such blocks now need to be caught up.
         endState <- liftIO $ readIORef $ vc1State vc
         let status = KonsensusV1.makeCatchUpStatus (SkovV1._v1sSkovData endState)
+        let response =
+                KonsensusV1.CatchUpResponseMessage
+                    { cumStatus = status,
+                      cumTerminalData = terminal
+                    }
+        logEvent Runner LLTrace $
+            "Sending catch-up response: " ++ show response
         liftIO $
             catchUpCallback Skov.MessageCatchUpStatus $
                 encode $
-                    VersionedCatchUpStatusV1 $
-                        KonsensusV1.CatchUpResponseMessage
-                            { cumStatus = status,
-                              cumTerminalData = terminal
-                            }
+                    VersionedCatchUpStatusV1 response
+
         checkShouldCatchUp cumStatus endState False
     handleMsg KonsensusV1.CatchUpResponseMessage{cumTerminalData = Present terminal, ..} = do
         res <- runSkovV1Transaction vc $ do
@@ -1778,6 +1784,7 @@ getCatchUpRequest = do
         (EVersionedConfigurationV1 vc) -> do
             st <- liftIO $ readIORef $ vc1State vc
             let cus = KonsensusV1.makeCatchUpRequestMessage $ SkovV1._v1sSkovData st
+            logEvent Runner LLTrace $ "Sending catch-up request: " ++ show cus
             return (vc1Index vc, encodeLazy $ VersionedCatchUpStatusV1 cus)
 
 -- |Deserialize and receive a transaction.  The transaction is passed to

--- a/concordium-consensus/src/Concordium/MultiVersion.hs
+++ b/concordium-consensus/src/Concordium/MultiVersion.hs
@@ -1721,7 +1721,7 @@ handleCatchUpStatusV1 CatchUpConfiguration{..} vc msg = do
                         blockLoop (count + 1) next
         (count, terminal) <- blockLoop 0 x
         logEvent Runner LLTrace $
-            "Sent " ++ show count ++ " blocks in response to a finalization request."
+            "Sent " ++ show count ++ " blocks in response to a catch-up request."
         -- We compute the catch-up status with respect to the state now (after sending the blocks)
         -- because we could have new information since startState that might have been sent to the
         -- peer while it was receiving our catch-up blocks. In that event, the peer might discard


### PR DESCRIPTION
## Purpose

This addresses:

#947: Database truncation fails during roll-back on Windows
#958: Catch-up loops or soft-bans peers


## Changes

- When attempting to read beyond the end of the block state database, the file is remapped. This is changed so that the file is not remapped unless it is longer than the existing map. This addresses #947 because the file cannot be truncated on Windows while it is memory-mapped. The roll-back process can attempt to read beyond the end of the database multiple times, causing the file to be mapped repeatedly (prior to this change). When truncating the file, only the latest mapping is forced to close, and thus the other mappings can cause failure.
- Process the quorum certificate for the highest certified block before the finalization entry. Also, change the criterion for doing so to be that it will advance the round (rather than we have already checked such a QC). This resolves #958.
- Fix an issue with accounting for which blocks are rolled back. This mainly affects logging, but could cause some misbehaviour if only one block is rolled back.
- Additional trace-level logging of catch-up messages.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
