### PR TITLE
Enable out-of-band catch-up on Windows by default

### DIFF
--- a/service/windows/installer/resources/nodes.toml
+++ b/service/windows/installer/resources/nodes.toml
@@ -48,6 +48,8 @@ collector.enabled = false
 # non-baker nodes. It significantly reduces CPU use when the node's database is
 # large and seems to have little downside.
 node.env.CONCORDIUM_NODE_RUNTIME_HASKELL_RTS_FLAGS = '-I0'
+# Enable out-of-band catch-up to download blocks.
+node.env.CONCORDIUM_NODE_CONSENSUS_DOWNLOAD_BLOCKS_FROM = "https://catchup.mainnet.concordium.software/blocks.idx"
 
 [node.testnet]
 # Controls whether the node is enabled
@@ -91,3 +93,5 @@ collector.enabled = false
 # non-baker nodes. It significantly reduces CPU use when the node's database is
 # large and seems to have little downside.
 node.env.CONCORDIUM_NODE_RUNTIME_HASKELL_RTS_FLAGS = '-I0'
+# Enable out-of-band catch-up to download blocks.
+node.env.CONCORDIUM_NODE_CONSENSUS_DOWNLOAD_BLOCKS_FROM = "https://catchup.testnet.concordium.com/blocks.idx"


### PR DESCRIPTION
## Purpose

Update the node configuration set up by the Windows installer to enable out-of-band catch-up by default.

## Changes

- Set the `CONCORDIUM_NODE_CONSENSUS_DOWNLOAD_BLOCKS_FROM` environment variable for the node for mainnet and testnet configurations.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
