### PR TITLE
Remove obsolete binaries from the static binaries build script.

### DIFF
--- a/scripts/static-libraries/build-static-libraries.sh
+++ b/scripts/static-libraries/build-static-libraries.sh
@@ -29,8 +29,6 @@ LOCAL_INSTALL_ROOT=$(stack --stack-yaml /build/concordium-consensus/stack.static
 cp "$LOCAL_INSTALL_ROOT"/bin/{generate-update-keys,genesis,database-exporter} /binaries/bin/
 cp /build/concordium-base/rust-src/target/release/*.so /binaries/lib/
 cp /build/concordium-base/smart-contracts/wasm-chain-integration/target/release/*.so /binaries/lib/
-cargo build --release --manifest-path /build/concordium-base/rust-bins/Cargo.toml
-cp /build/concordium-base/rust-bins/target/release/{client,genesis_tool,generate_testdata} /binaries/bin/
 
 #############################################################################################################################
 ## Copy dependencies


### PR DESCRIPTION
## Purpose

Remove copying of obsolete tools that no longer exist when building static image.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
