### PR TITLE
Update P6 specification hash, bump node version to 6.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased changes
 
+## 6.0.3
+
+- Update specification hash for protocol 5 to protocol 6 update.
+
 ## 6.0.2
 
 - Fix a bug where the LMDB map was not resized when exporting the database. 

--- a/concordium-consensus/src/Concordium/ProtocolUpdate/P5/ProtocolP6.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/P5/ProtocolP6.hs
@@ -68,9 +68,8 @@ import Concordium.Kontrol
 
 -- |The hash that identifies a update from P5 to P6 protocol.
 -- This is the hash of the published specification document.
--- FIXME: Update the hash https://github.com/Concordium/concordium-update-proposals/issues/47
 updateHash :: SHA256.Hash
-updateHash = read "0000000000000000000000000000000000000000000000000000000000000000"
+updateHash = read "ede9cf0b2185e9e8657f5c3fd8b6f30cef2f1ef4d9692aa4f6ef6a9fb4a762cd"
 
 -- |Construct the genesis data for a P5.ProtocolP6 update.
 -- It is assumed that the last finalized block is the terminal block of the old chain:

--- a/concordium-consensus/src/Concordium/ProtocolUpdate/P5/ProtocolP6.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/P5/ProtocolP6.hs
@@ -3,10 +3,10 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies #-}
 
--- FIXME: This is currently a dummy update, and the details, including the update hash, need to be resolved before release.
--- https://github.com/Concordium/concordium-update-proposals/issues/47
-
 -- |This module implements the P5.ProtocolP6 protocol update.
+-- The update is specified at:
+-- https://github.com/Concordium/concordium-update-proposals/blob/main/updates/P6.txt
+--
 -- This protocol update is valid at protocol version P6, and updates
 -- to protocol version P6.
 -- The block state is changed during the update.

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -648,7 +648,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_node"
-version = "6.0.2"
+version = "6.0.3"
 dependencies = [
  "anyhow",
  "app_dirs2",

--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium_node"
-version = "6.0.2" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
+version = "6.0.3" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
 description = "Concordium Node"
 authors = ["Concordium <developers@concordium.com>"]
 exclude = [".gitignore", ".gitlab-ci.yml", "test/**/*","**/**/.gitignore","**/**/.gitlab-ci.yml"]

--- a/service/windows/installer/Node.wxs
+++ b/service/windows/installer/Node.wxs
@@ -2,9 +2,9 @@
 <!-- When updating the product version, the Product Id should be refreshed, otherwise it will not be
     possible to upgrade an existing installation.
 -->
-<?define VersionNumber="6.0.2" ?>
+<?define VersionNumber="6.0.3" ?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:Util="http://schemas.microsoft.com/wix/UtilExtension">
-    <Product Name="Concordium Node" Manufacturer="Concordium Software" Id="d1c82638-bf71-4e4d-8828-9531c626721f" UpgradeCode="297295b4-c716-4d33-8170-0f6136663bfd" Language="1033" Codepage="1252" Version="$(var.VersionNumber)">
+    <Product Name="Concordium Node" Manufacturer="Concordium Software" Id="4530d9e4-073b-4b2a-b5f7-c4118bbbd9d0" UpgradeCode="297295b4-c716-4d33-8170-0f6136663bfd" Language="1033" Codepage="1252" Version="$(var.VersionNumber)">
         <Package Id="*" Keywords="Concordium Installer" Description="Concordium Node $(var.VersionNumber) Installer" Manufacturer="Concordium Software" InstallerVersion="500" Languages="1033" Compressed="yes" InstallScope="perMachine" />
         <MajorUpgrade Schedule="afterInstallValidate" DowngradeErrorMessage="The currently-installed version of [ProductName] is newer than the version you are trying to install. The installation cannot continue. If you wish to install this version, please remove the newer version first." />
         <Media Id="1" Cabinet="Node.cab" EmbedCab="yes" />


### PR DESCRIPTION
## Purpose

Update protocol 6 specification hash away from the dummy one.

Bump node version to 6.0.3

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.