### PR TITLE
Do not abort catch-up on `Stale`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ## 6.0.3
 
 - Update specification hash for protocol 5 to protocol 6 update.
+- Fix a bug where out-of-band catch-up fails in P6 when processing blocks that have already been
+  processed.
 
 ## 6.0.2
 

--- a/concordium-consensus/src/Concordium/MultiVersion.hs
+++ b/concordium-consensus/src/Concordium/MultiVersion.hs
@@ -2058,6 +2058,7 @@ importBlocks importFile = do
     doImport (ImportFinalizationRecord _ gi bs) = local disableBroadcastCallbacks $ fixResult <$> receiveFinalizationRecord gi bs
     fixResult Skov.ResultSuccess = Right ()
     fixResult Skov.ResultDuplicate = Right ()
+    fixResult Skov.ResultStale = Right ()
     fixResult Skov.ResultConsensusShutDown = Right ()
     fixResult e = Left (ImportOtherError e)
     -- Disable broadcast callbacks as the network layer is not started at the point of the out-of-band-catchup.


### PR DESCRIPTION
## Purpose

Addresses #974 

During out-of-band catch-up, consensus version 1 reports `ResultStale` for blocks that have already been processed, whereas consensus version 0 would report `ResultDuplicate`. However, `ResultStale` causes the catch-up to terminate. This changes the behaviour so that `ResultStale` does not cause catch-up to terminate.

## Changes

- Do not treat `ResultStale` as an aborting condition for out-of-band catch-up.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
