### PR TITLE
Retroactively fix chain update handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased changes
 
+- Apply fix for processing of chain parameter updates when they occur at the same time
+  retroactively to all protocol versions. This may break compatibility with any local/private
+  chains on which the bug occurs.
+
 ## 6.0.3
 
 - Update specification hash for protocol 5 to protocol 6 update.

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -2776,7 +2776,7 @@ doProcessUpdateQueues ::
 doProcessUpdateQueues pbs ts = do
     bsp <- loadPBS pbs
     let (u, ars, ips) = (bspUpdates bsp, bspAnonymityRevokers bsp, bspIdentityProviders bsp)
-    (changes, (u', ars', ips')) <- processUpdateQueues (protocolVersion @pv) ts (u, ars, ips)
+    (changes, (u', ars', ips')) <- processUpdateQueues ts (u, ars, ips)
     (changes,) <$> storePBS pbs bsp{bspUpdates = u', bspAnonymityRevokers = ars', bspIdentityProviders = ips'}
 
 doProcessReleaseSchedule :: forall m pv. (SupportsPersistentState pv m) => PersistentBlockState pv -> Timestamp -> m (PersistentBlockState pv)

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/UpdateQueues.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/UpdateQueues.hs
@@ -18,54 +18,40 @@ import Concordium.GlobalState.Persistent.BlobStore
 import qualified Concordium.GlobalState.Persistent.BlockState.Updates as PU
 import Concordium.Types
 
--- This is a regression test for https://github.com/Concordium/concordium-node/issues/972
--- In protocol version 1-5 the chain parameter update effects were sometimes lost
--- if they were effective at the same time. This is fixed in protocol 6.
-testCase :: forall pv. IsProtocolVersion pv => SProtocolVersion pv -> String -> IO ()
-testCase spv pvString = do
+-- This tests that chain parameter updates that are scheduled at the same time are not lost
+-- when calling 'PU.processUpdateQueues'.
+testCase :: forall cpv. IsChainParametersVersion cpv => SChainParametersVersion cpv -> String -> IO ()
+testCase scpv pvString = do
     -- Schedule three updates
     let rootKeyUpdate = UVRootKeys dummyHigherLevelKeys
-    let poolParameterUpdate = UVPoolParameters (dummyChainParameters @(ChainParametersVersionFor pv) ^. cpPoolParameters)
-    let euroEnergyExchange = UVEuroPerEnergy (_erEuroPerEnergy (dummyChainParameters @(ChainParametersVersionFor pv) ^. cpExchangeRates))
+    let poolParameterUpdate = UVPoolParameters (dummyChainParameters @cpv ^. cpPoolParameters)
+    let euroEnergyExchange = UVEuroPerEnergy (_erEuroPerEnergy (dummyChainParameters @cpv ^. cpExchangeRates))
     -- The first two are scheduled at effectiveTime = 123
     -- The last one is schedule for a millisecond earlier.
     let effectiveTime = 123 :: TransactionTime
     effects <- liftIO . runBlobStoreTemp "." $ do
-        u1 <- refMake =<< PU.initialUpdates (withIsAuthorizationsVersionForPV spv dummyKeyCollection) dummyChainParameters
+        (u1 :: BufferedRef (PU.Updates' cpv)) <-
+            refMake
+                =<< PU.initialUpdates (withIsAuthorizationsVersionFor scpv dummyKeyCollection) dummyChainParameters
         enqueuedState <-
             PU.enqueueUpdate effectiveTime poolParameterUpdate
                 =<< PU.enqueueUpdate (effectiveTime - 1) euroEnergyExchange
                 =<< PU.enqueueUpdate effectiveTime rootKeyUpdate u1
         ars <- refMake dummyArs
         ips <- refMake dummyIdentityProviders
-        fst <$> PU.processUpdateQueues (protocolVersion @pv) (transactionTimeToTimestamp effectiveTime) (enqueuedState, ars, ips)
-    -- In protocol version <= 5 the pool parameter update is not returned, since it occurs
-    -- at the same time as the root keys update.
-    if demoteProtocolVersion spv <= P5
-        then
-            assertEqual
-                (pvString ++ ": Only the root key update is returned at effectiveTime")
-                [ (effectiveTime - 1, euroEnergyExchange),
-                  (effectiveTime, rootKeyUpdate)
-                ]
-                effects
-        else -- In P6 and up all updates are returned.
-
-            assertEqual
-                (pvString ++ ": All updates should be returned")
-                [ (effectiveTime - 1, euroEnergyExchange),
-                  (effectiveTime, rootKeyUpdate),
-                  (effectiveTime, poolParameterUpdate)
-                ]
-                effects
+        fst <$> PU.processUpdateQueues (transactionTimeToTimestamp effectiveTime) (enqueuedState, ars, ips)
+    assertEqual
+        (pvString ++ ": All updates should be returned")
+        [ (effectiveTime - 1, euroEnergyExchange),
+          (effectiveTime, rootKeyUpdate),
+          (effectiveTime, poolParameterUpdate)
+        ]
+        effects
 
 tests :: Spec
 tests = do
     describe "Scheduler.UpdateQueues" $ do
         specify "Correct effects are returned" $ do
-            testCase SP1 "P1"
-            testCase SP2 "P2"
-            testCase SP3 "P3"
-            testCase SP4 "P4"
-            testCase SP5 "P5"
-            testCase SP6 "P6"
+            testCase SChainParametersV0 "CPV0"
+            testCase SChainParametersV1 "CPV1"
+            testCase SChainParametersV2 "CPV2"


### PR DESCRIPTION
## Purpose

Closes #979.

## Changes

- Disable buggy chain update handling for protocol versions <= P5.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
