### PR TITLE
Fix catch-up handling of timeout certificates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Fix a bug in how timeout certificates across epoch boundaries are handled in catch-up.
+
 ## 6.0.3
 
 - Update specification hash for protocol 5 to protocol 6 update.

--- a/concordium-consensus/src/Concordium/KonsensusV1/Consensus/CatchUp.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Consensus/CatchUp.hs
@@ -539,7 +539,7 @@ processCatchUpTerminalData CatchUpTerminalData{..} = flip runContT return $ do
                     else return currentProgress
             Nothing -> return currentProgress
 
-    -- This function determines the certified block and bakers to use verify the timeout
+    -- This function determines the certified block and bakers to use to verify the timeout
     -- certificate. Typically, this is the highest certified block. However, it can be that the
     -- highest certified block is in a later epoch from that in which the timeout certificate was
     -- generated. In that case, the timeout certificate might not be valid when considered with
@@ -560,7 +560,8 @@ processCatchUpTerminalData CatchUpTerminalData{..} = flip runContT return $ do
                 gets (getLiveOrLastFinalizedBlock (qcBlock qc)) >>= \case
                     Nothing -> do
                         -- The timeout is for a round that is ahead of our current round,
-                        -- so the
+                        -- so the QC should presumably for a live block (or the last finalized
+                        -- block) since otherwise we have not been caught up with the peer.
                         escape
                             currentProgress
                             "quorum certificate is not coherent with timeout certificate \

--- a/concordium-consensus/src/Concordium/KonsensusV1/Consensus/CatchUp/Types.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Consensus/CatchUp/Types.hs
@@ -116,6 +116,11 @@ instance Serialize CatchUpTerminalDataFlags where
 
 -- |The 'CatchUpTerminalData' is sent as part of a catch-up response that concludes catch-up with
 -- the peer (i.e. the peer has sent all relevant information).
+--
+-- Note: in some circumstances, 'cutdHighestQuorumCertificate' should not be the actual highest
+-- quorum certificate available to the node. Specifically, when the timeout certificate is present,
+-- it must be valid with respect to the epoch of 'cutdHighestQuorumCertificate'. This means that
+-- it may be necessary to use an earlier quorum certificate in this case.
 data CatchUpTerminalData = CatchUpTerminalData
     { -- |Finalization entry for the latest finalized block.
       cutdLatestFinalizationEntry :: !(Option FinalizationEntry),

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/CatchUp.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/CatchUp.hs
@@ -136,7 +136,7 @@ mkTimeout :: Round -> BakedBlock -> TestMonad 'P6 ()
 mkTimeout rnd bb =
     mapM_
         ( \bid ->
-            let x = testTimeoutMessage bid rnd $ blockQuorumCertificate $ pbBlock $ TestBlocks.signedPB bb
+            let x = testTimeoutMessage bid rnd $ validQCFor bb
             in  succeedReceiveExecuteTimeoutMessage x
         )
         [0 .. 3]
@@ -272,7 +272,7 @@ catchupWithOneTimeoutAtEndResponse = runTest $ do
         (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
         [TestBlocks.testBB1, TestBlocks.testBB2, TestBlocks.testBB3]
     -- Generate a TC for round 3.
-    mkTimeout (Round 3) TestBlocks.testBB3
+    mkTimeout (Round 3) TestBlocks.testBB2
     -- b2 has a qc for b1, b3 has a qc for b2 and
     -- b1 and b2 is in consecutive rounds so b1 is finalized.
     let request =
@@ -309,8 +309,8 @@ catchupWithTwoTimeoutsAtEndResponse = runTest $ do
         (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
         [TestBlocks.testBB1, TestBlocks.testBB2, TestBlocks.testBB3]
     -- Generate a TC for round 3 and round 4.
-    mkTimeout (Round 3) TestBlocks.testBB3
-    mkTimeout (Round 4) TestBlocks.testBB3
+    mkTimeout (Round 3) TestBlocks.testBB2
+    mkTimeout (Round 4) TestBlocks.testBB2
     -- b2 has a qc for b1, b3 has a qc for b2 and
     -- b1 and b2 is in consecutive rounds so b1 is finalized.
     let request =
@@ -347,7 +347,7 @@ catchupWithTwoBranchesResponse = runTest $ do
         [TestBlocks.testBB1, TestBlocks.testBB2, TestBlocks.testBB3]
     -- block 1 is finalized as b2 has a qc for b1 and b3 has a qc for b2.
     -- Timeout round 3.
-    mkTimeout (Round 3) TestBlocks.testBB2
+    mkTimeout (Round 3) TestBlocks.testBB1
     -- we grab the timeout certificate for round 3 in the round status
     -- so we can create a b4 with this tc.
     -- todo: maybe just spell out this tc.
@@ -404,6 +404,42 @@ catchupWithTwoBranchesResponse = runTest $ do
                         }
     assertCatchupResponse expectedTerminalData expectedBlocksServed =<< handleCatchUpRequest request =<< get
 
+-- |Test case where we have a timeout and a QC for a round where the block starts the new epoch.
+-- The timeout refers to the old epoch. In this case, catch-up should send the highest certified
+-- at the time the timeout was generated, rather than the actual highest certified block.
+catchupWithEpochTransitionTimeout :: Assertion
+catchupWithEpochTransitionTimeout = runTest $ do
+    mapM_
+        (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
+        [TestBlocks.testBB1E, TestBlocks.testBB2E, TestBlocks.testBB3E]
+    -- Timeout round 3
+    mkTimeout (Round 3) TestBlocks.testBB2E
+    TestBlocks.succeedReceiveBlock . TestBlocks.signedPB $ TestBlocks.testBB4E
+    hcb <- use (roundStatus . rsHighestCertifiedBlock)
+    liftIO $ assertEqual "Highest certified block round" 3 (cbRound hcb)
+    let request =
+            CatchUpStatus
+                { cusLastFinalizedBlock = TestBlocks.genesisHash,
+                  cusLastFinalizedRound = Round 0,
+                  cusLeaves = [],
+                  cusBranches = [],
+                  cusCurrentRound = Round 1,
+                  cusCurrentRoundQuorum = Map.empty,
+                  cusCurrentRoundTimeouts = Absent
+                }
+    let expectedBlocksServed =
+            validSignBlock
+                <$> [TestBlocks.testBB1E, TestBlocks.testBB2E, TestBlocks.testBB3E, TestBlocks.testBB4E]
+    let expectedTerminalData =
+            CatchUpTerminalData
+                { cutdHighestQuorumCertificate = Present $ validQCFor testBB2E,
+                  cutdLatestFinalizationEntry = Present testEpochFinEntry,
+                  cutdTimeoutCertificate = Present $ validTimeoutForFinalizers [0 .. 3] (validQCFor testBB2E) 3,
+                  cutdCurrentRoundQuorumMessages = [],
+                  cutdCurrentRoundTimeoutMessages = []
+                }
+    assertCatchupResponse expectedTerminalData expectedBlocksServed =<< handleCatchUpRequest request =<< get
+
 -- |Checking that the 'CatchUpStatus' is correctly generated from a state where:
 -- there are 3 blocks for round 1,2 and 3, where the first block is finalized.
 -- The block in round 3 never gets a 'QuorumCertificate' and hence round 3 times out.
@@ -415,7 +451,7 @@ testMakeCatchupStatus = runTest $ do
         [TestBlocks.testBB1, TestBlocks.testBB2, TestBlocks.testBB3]
     -- block 1 is finalized as b2 has a qc for b1 and b3 has a qc for b2.
     -- Now we time out round 3 with a reference to b1.
-    mkTimeout (Round 3) TestBlocks.testBB2
+    mkTimeout (Round 3) TestBlocks.testBB1
 
     -- we grab the timeout certificate for round 3 in the round status
     -- so we can create a b4 with this tc.
@@ -574,7 +610,7 @@ testCatchupTCAtEnd = do
         mapM_
             (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
             [TestBlocks.testBB1, TestBlocks.testBB2, TestBlocks.testBB3]
-        mkTimeout (Round 3) TestBlocks.testBB3
+        mkTimeout (Round 3) TestBlocks.testBB2
         sd <- get
         let statusMessage = makeCatchUpStatusMessage sd
         return (statusMessage, sd)
@@ -704,3 +740,4 @@ tests = describe "KonsensusV1.CatchUp" $ do
     it "Test isCatchUpRequired: Catch-up responder is behind last finalized" testCatchupRequiredBehindLastFinalized
     it "Test isCatchUpRequired: Catch-up responder is behind" testCatchupRequiredBehind
     it "Test isCatchUpRequired: Catch-up same round" testCatchupRequiredSameRound
+    it "Test handleCatchUpRequest: Epoch transition with timeout" catchupWithEpochTransitionTimeout


### PR DESCRIPTION
## Purpose

Addresses #981.

## Changes

- When constructing catch-up terminal data that contains a timeout certificate, ensure that the "highest quorum certificate" sent is for the same epoch in which the timeout certificate was constructed.
- When processing catch-up terminal data that contains a timeout certificate, process the "highest quorum certificate" if necessary when the epoch is different from the epoch of out highest certified block. This allows us to accept the timeout certificate as appropriate.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
