### PR TITLE
Address comments on database changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Fix a bug in how the last timeout certificate is recovered at start-up.
+
 ## 6.0.4
 
 - Fix a bug in how timeout certificates across epoch boundaries are handled in catch-up.

--- a/concordium-consensus/src/Concordium/KonsensusV1/Consensus/Blocks.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Consensus/Blocks.hs
@@ -1034,6 +1034,7 @@ validateBlock blockHash BakerIdentity{..} finInfo = do
                     VerifiedQuorumMessage
                         { vqmMessage = quorumMessage,
                           vqmFinalizerWeight = finalizerWeight finInfo,
+                          vqmFinalizerBakerId = finalizerBakerId finInfo,
                           vqmBlock = block
                         }
                     makeBlock

--- a/concordium-consensus/src/Concordium/KonsensusV1/Consensus/CatchUp.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Consensus/CatchUp.hs
@@ -339,14 +339,13 @@ handleCatchUpRequest CatchUpStatus{..} skovData = do
     ourCurrentRound = skovData ^. roundStatus . rsCurrentRound
     getQuorumMessages
         | cusCurrentRound == ourCurrentRound = do
-            let qms = skovData ^.. currentQuorumMessages . smFinalizerToQuorumMessage . traversed
-            return $! filter newToPeer qms
+            return $! filter newToPeer quorumMessages
         | cusCurrentRound < ourCurrentRound = do
-            let qms = skovData ^.. currentQuorumMessages . smFinalizerToQuorumMessage . traversed
-            return qms
+            return quorumMessages
         | otherwise = do
             return []
       where
+        quorumMessages = skovData ^.. currentQuorumMessages . smBakerIdToQuorumMessage . traversed
         newToPeer qm = case Map.lookup (qmBlock qm) cusCurrentRoundQuorum of
             Nothing -> True
             Just s -> not (memberFinalizerSet (qmFinalizerIndex qm) s)

--- a/concordium-consensus/src/Concordium/KonsensusV1/Consensus/Quorum.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Consensus/Quorum.hs
@@ -74,6 +74,8 @@ data VerifiedQuorumMessage (pv :: ProtocolVersion) = VerifiedQuorumMessage
       vqmMessage :: !QuorumMessage,
       -- |The weight of the finalizer.
       vqmFinalizerWeight :: !VoterPower,
+      -- |The baker id of the finalizer.
+      vqmFinalizerBakerId :: !BakerId,
       -- |The block that is the target of the quorum message.
       vqmBlock :: !(BlockPointer pv)
     }
@@ -99,7 +101,7 @@ receiveQuorumMessage ::
 receiveQuorumMessage qm@QuorumMessage{..} skovData = receive
   where
     receive
-        -- Consenus has been shutdown.
+        -- Consensus has been shutdown.
         | skovData ^. isConsensusShutdown = return ConsensusShutdown
         -- The consensus runner is not caught up.
         | qmEpoch > skovData ^. roundStatus . rsCurrentEpoch =
@@ -160,12 +162,21 @@ receiveQuorumMessage qm@QuorumMessage{..} skovData = receive
                                 return $ Rejected InconsistentEpochs
                             -- Return the verified quorum message.
                             | otherwise -> do
-                                let vqm = VerifiedQuorumMessage qm finalizerWeight targetBlock
+                                let vqm =
+                                        VerifiedQuorumMessage
+                                            { vqmMessage = qm,
+                                              vqmFinalizerWeight = finalizerWeight,
+                                              vqmFinalizerBakerId = finalizerBakerId,
+                                              vqmBlock = targetBlock
+                                            }
                                 return $! case getExistingMessage of
                                     Just _ -> ReceivedNoRelay vqm
                                     Nothing -> Received vqm
-    -- Try get an existing 'QuorumMessage' if present otherwise return 'Nothing'.
-    getExistingMessage = skovData ^? currentQuorumMessages . smFinalizerToQuorumMessage . ix qmFinalizerIndex
+              where
+                -- Try get an existing 'QuorumMessage' if present otherwise return 'Nothing'.
+                getExistingMessage =
+                    skovData
+                        ^? currentQuorumMessages . smBakerIdToQuorumMessage . ix finalizerBakerId
     -- Extract the quorum signature message
     getQuorumSignatureMessage =
         let genesisHash = skovData ^. genesisMetadata . to gmCurrentGenesisHash
@@ -188,15 +199,15 @@ addQuorumMessage ::
     -- |The resulting messages.
     QuorumMessages
 addQuorumMessage
-    (VerifiedQuorumMessage quorumMessage@QuorumMessage{..} weight _)
+    (VerifiedQuorumMessage quorumMessage@QuorumMessage{..} weight bId _)
     (QuorumMessages currentMessages currentWeights) =
         QuorumMessages
-            { _smFinalizerToQuorumMessage = newSignatureMessages,
+            { _smBakerIdToQuorumMessage = newSignatureMessages,
               _smBlockToWeightsAndSignatures = updatedWeightAndSignature
             }
       where
         finalizerIndex = qmFinalizerIndex
-        newSignatureMessages = Map.insert finalizerIndex quorumMessage currentMessages
+        newSignatureMessages = Map.insert bId quorumMessage currentMessages
         justOrIncrement =
             maybe
                 (Just (weight, qmSignature, finalizerSet [finalizerIndex]))
@@ -277,7 +288,7 @@ processQuorumMessage ::
     -- |Continuation to make a block
     m () ->
     m ()
-processQuorumMessage vqm@(VerifiedQuorumMessage quorumMessage _ quorumBlock) makeBlock = do
+processQuorumMessage vqm@VerifiedQuorumMessage{..} makeBlock = do
     currentRound <- use (roundStatus . rsCurrentRound)
     -- Check that the round of the 'QuorumMessage' corresponds to
     -- the current round of the tree state.
@@ -285,10 +296,10 @@ processQuorumMessage vqm@(VerifiedQuorumMessage quorumMessage _ quorumBlock) mak
     -- then the rounds (quorum message round and current round) should be equal when this function is
     -- called immediately after 'receiveQuorumMessage'
     -- and so the 'not equal' case below shouldn't happen in normal operation.
-    when (currentRound == qmRound quorumMessage) $ do
+    when (currentRound == qmRound vqmMessage) $ do
         currentQuorumMessages %=! addQuorumMessage vqm
         skovData <- get
-        let maybeQuorumCertificate = makeQuorumCertificate quorumBlock skovData
+        let maybeQuorumCertificate = makeQuorumCertificate vqmBlock skovData
         forM_ maybeQuorumCertificate $ \newQC -> do
             logEvent Konsensus LLDebug $
                 "Quorum certificate generated for block "
@@ -301,7 +312,7 @@ processQuorumMessage vqm@(VerifiedQuorumMessage quorumMessage _ quorumBlock) mak
             let newCertifiedBlock =
                     CertifiedBlock
                         { cbQuorumCertificate = newQC,
-                          cbQuorumBlock = quorumBlock
+                          cbQuorumBlock = vqmBlock
                         }
             -- Process the certified block, including checking for finalization.
             processCertifiedBlock newCertifiedBlock

--- a/concordium-consensus/src/Concordium/KonsensusV1/TreeState/LowLevel.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TreeState/LowLevel.hs
@@ -132,7 +132,6 @@ class (Monad m) => MonadTreeStateStore m where
     -- The following preconditions are required to ensure the database invariants are maintained:
     --
     --   * The quorum certificate is for the supplied block.
-    --   * The parent block is the (previous) highest certified block.
     writeCertifiedBlock ::
         -- |The newly-certified block.
         StoredBlock (MPV m) ->

--- a/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Types.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Types.hs
@@ -453,8 +453,8 @@ makeClassy ''EpochBakers
 
 -- |Quorum messages collected for a round.
 data QuorumMessages = QuorumMessages
-    { -- |Map of finalizer indices to signature messages.
-      _smFinalizerToQuorumMessage :: !(Map.Map FinalizerIndex QuorumMessage),
+    { -- |Map of baker ids to signature messages.
+      _smBakerIdToQuorumMessage :: !(Map.Map BakerId QuorumMessage),
       -- |Accumulated weights and the aggregated signature for the blocks signed off by quorum signature message.
       -- The 'VoterPower' here is in relation to the 'Epoch' of the block being finalized.
       _smBlockToWeightsAndSignatures :: !(Map.Map BlockHash (VoterPower, QuorumSignature, FinalizerSet))

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/CatchUp.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/CatchUp.hs
@@ -180,7 +180,7 @@ basicCatchupResponse = runTest $ do
                   cutdCurrentRoundTimeoutMessages = [tmR4]
                 }
         expectedBlocksServed = pbBlock . TestBlocks.signedPB <$> [TestBlocks.testBB1, TestBlocks.testBB2, TestBlocks.testBB3]
-        finToQMsgMap = Map.insert (FinalizerIndex 1) qmR4 Map.empty
+        finToQMsgMap = Map.insert 1 qmR4 Map.empty
         finToTMMap = Map.insert (FinalizerIndex 0) tmR4 Map.empty
     -- Setting the current quorum, timeout message.
     currentQuorumMessages .= QuorumMessages finToQMsgMap Map.empty
@@ -218,7 +218,7 @@ catchupWithEpochTransitionResponse = runTest $ do
                   cutdCurrentRoundTimeoutMessages = [tmR4]
                 }
         expectedBlocksServed = pbBlock . TestBlocks.signedPB <$> [TestBlocks.testBB2E, TestBlocks.testBB3E]
-        finToQMsgMap = Map.insert (FinalizerIndex 1) qmR4 Map.empty
+        finToQMsgMap = Map.insert 1 qmR4 Map.empty
         finToTMMap = Map.insert (FinalizerIndex 0) tmR4 Map.empty
     -- Setting the current quorum, timeout message and latest finalization entry.
     currentQuorumMessages .= QuorumMessages finToQMsgMap Map.empty
@@ -258,7 +258,7 @@ catchupWithTimeoutsResponse = runTest $ do
                   cutdCurrentRoundTimeoutMessages = [tmR5]
                 }
         expectedBlocksServed = pbBlock . TestBlocks.signedPB <$> [TestBlocks.testBB1E, TestBlocks.testBB2E, TestBlocks.testBB3E, TestBlocks.testBB5E']
-        finToQMsgMap = Map.insert (FinalizerIndex 1) qmR5 Map.empty
+        finToQMsgMap = Map.insert 1 qmR5 Map.empty
         finToTMMap = Map.insert (FinalizerIndex 0) tmR5 Map.empty
     -- Setting the current quorum, timeout message and finalization entry.
     currentQuorumMessages .= QuorumMessages finToQMsgMap Map.empty
@@ -528,7 +528,7 @@ testCatchup = do
             qmR4Sig = signQuorumSignatureMessage qsmR4 (bakerAggregationKey . fst $ TestBlocks.bakers !! 1)
             qmR4 = buildQuorumMessage qsmR4 qmR4Sig (FinalizerIndex 1)
             tmR4 = head $ timeoutMessagesFor b4QC (Round 4) 0
-            finToQMsgMap = Map.insert (FinalizerIndex 1) qmR4 Map.empty
+            finToQMsgMap = Map.insert 1 qmR4 Map.empty
             finToTMMap = Map.insert (FinalizerIndex 0) tmR4 Map.empty
         -- Setting the current quorum and timeout message.
         currentQuorumMessages .= QuorumMessages finToQMsgMap Map.empty


### PR DESCRIPTION
## Purpose

Closes #984.

## Changes

- `QuorumMessages` structure is revised to index by baker ID instead of finalizer ID, because the latter is not stable across epochs. Consequently, the baker ID is added to the `VerifiedQuorumMessage` structure.
- In `loadCertifiedBlocks`:
    - When loading the latest timeout certificate, we find an appropriate certified block to pair it. Typically, this is the highest certified block, but it can be that that is invalid and we need to use a block from the previous epoch.
    - Load the last sent quorum message into the quorum messages for the current round if it is appropriate.
- Documentation updates.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
