### PR TITLE
 Add `GetBakerEarliestWinTime` query

### DIFF
--- a/concordium-consensus/lib.def
+++ b/concordium-consensus/lib.def
@@ -83,3 +83,4 @@ EXPORTS
  getBlockFinalizationSummaryV2
  getBlockItemsV2
  getLastFinalizedBlockSlotTimeV2
+ getBakerEarliestWinTimeV2

--- a/concordium-consensus/src/Concordium/External/GRPC2.hs
+++ b/concordium-consensus/src/Concordium/External/GRPC2.hs
@@ -152,7 +152,7 @@ data QueryResult
       QRSuccess
     | -- | The requested data could not be found.
       QRNotFound
-    | -- | The service is currently unavailable.
+    | -- | The service is not available at the current protocol version.
       QRUnavailable
 
 -- |Convert a QueryResult to a result code.

--- a/concordium-consensus/src/Concordium/KonsensusV1/Consensus.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Consensus.hs
@@ -21,16 +21,18 @@ import Concordium.Types.Parameters hiding (getChainParameters)
 import Concordium.Utils
 
 import qualified Concordium.Crypto.BlockSignature as Sig
+import Concordium.Genesis.Data.BaseV1
 import Concordium.GlobalState.BakerInfo
 import qualified Concordium.GlobalState.BlockState as BS
 import qualified Concordium.GlobalState.Persistent.BlockState as PBS
 import qualified Concordium.GlobalState.TreeState as GSTypes
+import Concordium.KonsensusV1.LeaderElection
 import Concordium.KonsensusV1.TreeState.Implementation
 import qualified Concordium.KonsensusV1.TreeState.LowLevel as LowLevel
 import Concordium.KonsensusV1.TreeState.Types
 import Concordium.KonsensusV1.Types
 import Concordium.Logger
-import Concordium.Types.SeedState (triggerBlockTime)
+import Concordium.Types.SeedState (currentLeadershipElectionNonce, epochTransitionTriggered, triggerBlockTime)
 import Concordium.Types.UpdateQueues
 import Concordium.Types.Updates
 
@@ -325,3 +327,52 @@ getProtocolUpdateState = do
                     { puQueuedTime = ts,
                       puProtocolUpdate = pu
                     }
+
+-- |Project the earliest timestamp at which the given baker might be required to bake.
+-- If the baker is not a baker in the current reward period, this will give a time at the start
+-- of the next reward period.
+bakerEarliestWinTimestamp ::
+    ( GSTypes.BlockState m ~ PBS.HashedPersistentBlockState (MPV m),
+      BS.BlockStateQuery m,
+      IsConsensusV1 (MPV m)
+    ) =>
+    BakerId ->
+    SkovData (MPV m) ->
+    m Timestamp
+bakerEarliestWinTimestamp baker sd = do
+    let lfBlock = sd ^. lastFinalized
+    -- The bakers with respect to the epoch of the last finalized block.
+    let fullBakers = sd ^. currentEpochBakers . bfBakers
+    let epochDuration = genesisEpochDuration . gmParameters $ sd ^. genesisMetadata
+    lfSeedState <- BS.getSeedState (bpState lfBlock)
+    let lfTriggerTime = lfSeedState ^. triggerBlockTime
+    chainParams <- BS.getChainParameters (bpState lfBlock)
+    let minBlockTime = chainParams ^. cpConsensusParameters . cpMinBlockTime
+    if null (fullBaker fullBakers baker)
+        then do
+            -- The baker is not a baker in the current payday, so take the start of the next payday
+            -- as the soonest that the account could be a baker (and thus bake).
+            let epochsTillPayday = (sd ^. nextPayday) - blockEpoch lfBlock - 1
+            return $!
+                addDuration
+                    lfTriggerTime
+                    (minBlockTime + fromIntegral epochsTillPayday * epochDuration)
+        else do
+            let findLeader nxtRound nxtTimestamp
+                    | baker
+                        == getLeaderFullBakers
+                            fullBakers
+                            (lfSeedState ^. currentLeadershipElectionNonce)
+                            nxtRound
+                            ^. Accounts.bakerIdentity =
+                        nxtTimestamp
+                    | nxtTimestamp >= lfTriggerTime = addDuration lfTriggerTime minBlockTime
+                    | otherwise = findLeader (nxtRound + 1) (addDuration nxtTimestamp minBlockTime)
+            let curRound = sd ^. roundStatus . rsCurrentRound
+            return $!
+                findLeader
+                    curRound
+                    ( addDuration
+                        (blockTimestamp lfBlock)
+                        (fromIntegral (curRound - blockRound lfBlock) * minBlockTime)
+                    )

--- a/concordium-consensus/src/Concordium/KonsensusV1/LeaderElection.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/LeaderElection.hs
@@ -96,7 +96,7 @@ updateSeedStateForBlock ::
     -- |Updated seed state
     SeedState 'SeedStateVersion1
 updateSeedStateForBlock ts bn isEffective ss
-    -- Epoch tranisition is already in progress.
+    -- Epoch transition is already in progress.
     | ss ^. epochTransitionTriggered = ss
     -- The block timestamp is beyond the trigger time of the epoch
     -- and there is also a protocol update effective.

--- a/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Types.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Types.hs
@@ -359,13 +359,13 @@ data RoundTimeout (pv :: ProtocolVersion) = RoundTimeout
 --
 -- INVARIANTS:
 --
---  * @_rsCurrentEpoch > qcEpoch (cbQuorumCertificate _rsHighestCertifiedBlock)@.
+--  * @_rsCurrentRound > qcRound (cbQuorumCertificate _rsHighestCertifiedBlock)@.
 --
 --  * If @_rsPreviousRoundTimeout = Absent@ then
---    @_rsCurrentEpoch = 1 + qcEpoch (cbQuorumCertificate _rsHighestCertifiedBlock)@.
+--    @_rsCurrentRound = 1 + qcRound (cbQuorumCertificate _rsHighestCertifiedBlock)@.
 --
 --  * If @_rsPreviousRoundTimeout = Present timeout@ then
---    @_rsCurrentEpoch = 1 + qcEpoch (rtQuorumCertificate timeout)@.
+--    @_rsCurrentRound = 1 + qcRound (rtQuorumCertificate timeout)@.
 data RoundStatus (pv :: ProtocolVersion) = RoundStatus
     { -- |The current 'Round'. If the previous round did not time out, this should be
       -- @1 + cbRound _rsHighestCertifiedBlock@. Otherwise, it should be
@@ -382,7 +382,9 @@ data RoundStatus (pv :: ProtocolVersion) = RoundStatus
       -- This is set to 'True' when the round is advanced, and set to 'False' when we have attempted
       -- to bake for the round.
       _rsRoundEligibleToBake :: !Bool,
-      -- |The current epoch.
+      -- |The current epoch. This should either be the same as the epoch of the last finalized
+      -- block (if its timestamp is before the trigger block time) or the next epoch from the last
+      -- finalized block (if its timestamp is at least the trigger block time).
       _rsCurrentEpoch :: !Epoch,
       -- |If present, an epoch finalization entry for @_currentEpoch - 1@. An entry MUST be
       -- present if @_currentEpoch > blockEpoch _lastFinalized@. Otherwise, an entry MAY be present,
@@ -433,7 +435,9 @@ data BakersAndFinalizers = BakersAndFinalizers
 makeLenses ''BakersAndFinalizers
 
 -- |The bakers and finalizers associated with the previous, current and next epochs (with respect
--- to a particular epoch).
+-- to a particular epoch). Note that the current epoch referred to here is typically the epoch
+-- of the last finalized block, which is distinct from the current epoch as recorded in the
+-- 'RoundStatus' structure.
 data EpochBakers = EpochBakers
     { -- |The bakers and finalizers for the previous epoch.
       -- (If the current epoch is 0, then this is the same as the bakers and finalizers for the

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -1423,3 +1423,11 @@ getNumberOfNonFinalizedTransactions =
     liftSkovQueryLatest
         queryNumberOfNonFinalizedTransactions
         (use (SkovV1.transactionTable . to TT.getNumberOfNonFinalizedTransactions))
+
+-- |Get the earliest time at which a baker is projected to win the lottery.
+-- Returns 'Nothing' for consensus version 0.
+getBakerEarliestWinTime :: BakerId -> MVR finconf (Maybe Timestamp)
+getBakerEarliestWinTime bid =
+    liftSkovQueryLatest
+        (return Nothing)
+        (fmap Just . ConsensusV1.bakerEarliestWinTimestamp bid =<< get)

--- a/concordium-node/build.rs
+++ b/concordium-node/build.rs
@@ -492,6 +492,15 @@ fn build_grpc2(proto_root_input: &str) -> std::io::Result<()> {
         )
         .method(
             tonic_build::manual::Method::builder()
+                .name("get_baker_earliest_win_time")
+                .route_name("GetBakerEarliestWinTime")
+                .input_type("crate::grpc2::types::BakerId")
+                .output_type("Vec<u8>")
+                .codec_path("crate::grpc2::RawCodec")
+                .build(),
+        )
+        .method(
+            tonic_build::manual::Method::builder()
                 .name("get_block_chain_parameters")
                 .route_name("GetBlockChainParameters")
                 .input_type("crate::grpc2::types::BlockHashInput")

--- a/concordium-node/src/consensus_ffi/helpers.rs
+++ b/concordium-node/src/consensus_ffi/helpers.rs
@@ -394,6 +394,7 @@ pub enum ConsensusQueryResponse {
     InternalError,
     Ok,
     NotFound,
+    Unavailable,
 }
 
 impl ConsensusQueryResponse {
@@ -405,6 +406,7 @@ impl ConsensusQueryResponse {
             Self::InternalError => Err(tonic::Status::internal(format!("Internal error: {}. Please report this bug at https://github.com/Concordium/concordium-node/issues.", msg))),
             Self::Ok => Ok(()),
             Self::NotFound => Err(tonic::Status::not_found(format!("{} not found.", msg))),
+            Self::Unavailable => Err(tonic::Status::unavailable("Service unavailable."))
         }
     }
 }
@@ -430,6 +432,7 @@ impl TryFrom<i64> for ConsensusQueryResponse {
             -1 => Ok(Self::InternalError),
             0 => Ok(Self::Ok),
             1 => Ok(Self::NotFound),
+            2 => Ok(Self::Unavailable),
             unknown_code => Err(ConsensusQueryUnknownCode {
                 unknown_code,
             }),

--- a/concordium-node/src/consensus_ffi/helpers.rs
+++ b/concordium-node/src/consensus_ffi/helpers.rs
@@ -406,7 +406,7 @@ impl ConsensusQueryResponse {
             Self::InternalError => Err(tonic::Status::internal(format!("Internal error: {}. Please report this bug at https://github.com/Concordium/concordium-node/issues.", msg))),
             Self::Ok => Ok(()),
             Self::NotFound => Err(tonic::Status::not_found(format!("{} not found.", msg))),
-            Self::Unavailable => Err(tonic::Status::unavailable("Service unavailable."))
+            Self::Unavailable => Err(tonic::Status::unavailable("The service is not available at the current protocol version."))
         }
     }
 }

--- a/concordium-node/src/grpc2.rs
+++ b/concordium-node/src/grpc2.rs
@@ -662,6 +662,8 @@ struct ServiceConfig {
     get_account_transaction_sign_hash: bool,
     #[serde(default)]
     get_block_items: bool,
+    #[serde(default)]
+    get_baker_earliest_win_time: bool,
 }
 
 impl ServiceConfig {
@@ -717,6 +719,7 @@ impl ServiceConfig {
             send_block_item: true,
             get_account_transaction_sign_hash: true,
             get_block_items: true,
+            get_baker_earliest_win_time: true,
         }
     }
 
@@ -1786,6 +1789,18 @@ pub mod server {
                 self.consensus.get_block_finalization_summary_v2(request.get_ref())?;
             let mut response = tonic::Response::new(response);
             add_hash(&mut response, hash)?;
+            Ok(response)
+        }
+
+        async fn get_baker_earliest_win_time(
+            &self,
+            request: tonic::Request<crate::grpc2::types::BakerId>,
+        ) -> Result<tonic::Response<Vec<u8>>, tonic::Status> {
+            if !self.service_config.get_baker_earliest_win_time {
+                return Err(tonic::Status::unimplemented("`GetBakerEarliestWinTime` is not enabled."));
+            }
+            let response = self.consensus.get_baker_earliest_win_time_v2(request.get_ref())?;
+            let response = tonic::Response::new(response);
             Ok(response)
         }
 

--- a/docs/grpc2.md
+++ b/docs/grpc2.md
@@ -89,6 +89,7 @@ If these are enabled then the following options become available
   get_next_update_sequence_numbers = true
   get_block_chain_parameters = true
   get_block_finalization_summary = true
+  get_baker_earliest_win_time = true
   shutdown = false
   peer_connect = true
   peer_disconnect = true


### PR DESCRIPTION
## Purpose

Add `GetBakerEarliestWinTime` query.

## Changes

- Implement a query for the earliest win time of a baker.
- Expose the query in the GRPC2 interface.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
