### PR TITLE
Move types from KonsensusV1/Types.hs to base.

### DIFF
--- a/concordium-consensus/src/Concordium/KonsensusV1/Types.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Types.hs
@@ -7,19 +7,25 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
-module Concordium.KonsensusV1.Types where
+-- |Types that are relevant exclusively for ConsensusV1 and
+-- are node internal.
+-- Types that are exclusive to ConsensusV1 but exposed in the API
+-- are defined in the base module 'Concordium.Types.KonsensusV1',
+-- which are re-exported here.
+module Concordium.KonsensusV1.Types (
+    module Concordium.KonsensusV1.Types,
+    module Concordium.Types.KonsensusV1,
+) where
 
 import Control.Monad
 import Data.Bits
 import qualified Data.ByteString as BS
 import Data.List (foldl')
-import qualified Data.Map.Strict as Map
 import Data.Maybe
 import Data.Serialize
 import qualified Data.Set as Set
 import qualified Data.Vector as Vector
 import Data.Word
-import Numeric.Natural
 
 import qualified Concordium.Crypto.BlockSignature as BlockSig
 import qualified Concordium.Crypto.BlsSignature as Bls
@@ -30,10 +36,10 @@ import Concordium.Genesis.Data.BaseV1
 import qualified Concordium.GlobalState.Basic.BlockState.LFMBTree as LFMBT
 import Concordium.Types
 import Concordium.Types.HashableTo
+import Concordium.Types.KonsensusV1
 import Concordium.Types.Parameters (IsConsensusV1)
 import Concordium.Types.Transactions
 import Concordium.Utils.BinarySearch
-import Concordium.Utils.Serialization
 
 -- |A strict version of 'Maybe'.
 data Option a
@@ -115,11 +121,6 @@ quorumSignatureMessageBytes QuorumSignatureMessage{..} = runPut $ do
     put qsmRound
     put qsmEpoch
 
--- |Signature by a finalizer on a 'QuorumSignatureMessage', or an aggregation of signatures on a
--- common message.
-newtype QuorumSignature = QuorumSignature {theQuorumSignature :: Bls.Signature}
-    deriving (Eq, Ord, Show, Serialize, Semigroup, Monoid)
-
 -- |Sign a 'QuorumSignatureMessage' with a baker's private key.
 signQuorumSignatureMessage :: QuorumSignatureMessage -> BakerAggregationPrivateKey -> QuorumSignature
 signQuorumSignatureMessage msg privKey =
@@ -138,10 +139,6 @@ checkQuorumSignature ::
 checkQuorumSignature msg pubKeys =
     Bls.verifyAggregate (quorumSignatureMessageBytes msg) pubKeys
         . theQuorumSignature
-
--- |Index of a finalizer in the finalization committee vector.
-newtype FinalizerIndex = FinalizerIndex {theFinalizerIndex :: Word32}
-    deriving (Eq, Ord, Show, Enum, Bounded, Serialize)
 
 -- |The message that is multicast by a finalizer when validating and signing blocks.
 data QuorumMessage = QuorumMessage
@@ -226,113 +223,6 @@ finalizerByBakerId = binarySearch finalizerBakerId . committeeFinalizers
 finalizerByIndex :: FinalizationCommittee -> FinalizerIndex -> Maybe FinalizerInfo
 finalizerByIndex finCom finInd =
     committeeFinalizers finCom Vector.!? fromIntegral (theFinalizerIndex finInd)
-
--- |A set of 'FinalizerIndex'es.
--- This is represented as a bit vector, where the bit @i@ is set iff the finalizer index @i@ is
--- in the set.
-newtype FinalizerSet = FinalizerSet {theFinalizerSet :: Natural}
-    deriving (Eq)
-
--- |The serialization of a 'FinalizerSet' consists of a length (Word32, big-endian), followed by
--- that many bytes, the first of which (if any) must be non-zero. These bytes encode the bit-vector
--- in big-endian. This enforces that the serialization of a finalizer set is unique.
-instance Serialize FinalizerSet where
-    put fs = do
-        let (byteCount, putBytes) = unroll 0 (return ()) (theFinalizerSet fs)
-        putWord32be byteCount
-        putBytes
-      where
-        unroll :: Word32 -> Put -> Natural -> (Word32, Put)
-        -- Compute the number of bytes and construct a 'Put' that serializes in big-endian.
-        -- We do this by adding the low order byte to the accumulated 'Put' (at the start)
-        -- and recursing with the bitvector shifted right 8 bits.
-        unroll bc cont 0 = (bc, cont)
-        unroll bc cont n = unroll (bc + 1) (putWord8 (fromIntegral n) >> cont) (shiftR n 8)
-    get = label "FinalizerSet" $ do
-        byteCount <- getWord32be
-        FinalizerSet <$> roll1 byteCount
-      where
-        roll1 0 = return 0
-        roll1 bc = do
-            b <- getWord8
-            when (b == 0) $ fail "unexpected 0 byte"
-            roll (bc - 1) (fromIntegral b)
-        roll 0 n = return n
-        roll bc n = do
-            b <- getWord8
-            roll (bc - 1) (shiftL n 8 .|. fromIntegral b)
-
--- |Convert a 'FinalizerSet' to a list of 'FinalizerIndex', in ascending order.
-finalizerList :: FinalizerSet -> [FinalizerIndex]
-finalizerList = unroll 0 . theFinalizerSet
-  where
-    unroll _ 0 = []
-    unroll i x
-        | testBit x 0 = FinalizerIndex i : r
-        | otherwise = r
-      where
-        r = unroll (i + 1) (shiftR x 1)
-
--- |The empty set of finalizers
-emptyFinalizerSet :: FinalizerSet
-emptyFinalizerSet = FinalizerSet 0
-
--- |Add a finalizer to a 'FinalizerSet'.
-addFinalizer :: FinalizerSet -> FinalizerIndex -> FinalizerSet
-addFinalizer (FinalizerSet setOfFinalizers) (FinalizerIndex i) = FinalizerSet $ setBit setOfFinalizers (fromIntegral i)
-
--- |Test whether a given finalizer index is present in a finalizer set.
-memberFinalizerSet :: FinalizerIndex -> FinalizerSet -> Bool
-memberFinalizerSet (FinalizerIndex fi) (FinalizerSet setOfFinalizers) =
-    testBit setOfFinalizers (fromIntegral fi)
-
--- |Convert a list of [FinalizerIndex] to a 'FinalizerSet'.
-finalizerSet :: [FinalizerIndex] -> FinalizerSet
-finalizerSet = foldl' addFinalizer (FinalizerSet 0)
-
--- |Test if the first finalizer set is a subset of the second.
-subsetFinalizerSet :: FinalizerSet -> FinalizerSet -> Bool
-subsetFinalizerSet (FinalizerSet s1) (FinalizerSet s2) = s1 .&. s2 == s1
-
-instance Show FinalizerSet where
-    show = show . finalizerList
-
--- | A quorum certificate, to be formed when enough finalizers have signed the same 'QuorumSignatureMessage'.
-data QuorumCertificate = QuorumCertificate
-    { -- |Hash of the block this certificate refers to.
-      qcBlock :: !BlockHash,
-      -- |Round of the block this certificate refers to.
-      qcRound :: !Round,
-      -- |Epoch of the block this certificate refers to.
-      qcEpoch :: !Epoch,
-      -- |Aggregate signature on the 'QuorumSignatureMessage' with the block hash 'qcBlock'.
-      qcAggregateSignature :: !QuorumSignature,
-      -- |The set of finalizers whose signature is in 'qcAggregateSignature'.
-      qcSignatories :: !FinalizerSet
-    }
-    deriving (Eq, Show)
-
--- |For generating a genesis quorum certificate with empty signature and empty finalizer set.
-genesisQuorumCertificate :: BlockHash -> QuorumCertificate
-genesisQuorumCertificate genesisHash = QuorumCertificate genesisHash 0 0 mempty $ FinalizerSet 0
-
-instance Serialize QuorumCertificate where
-    put QuorumCertificate{..} = do
-        put qcBlock
-        put qcRound
-        put qcEpoch
-        put qcAggregateSignature
-        put qcSignatories
-    get = do
-        qcBlock <- get
-        qcRound <- get
-        qcEpoch <- get
-        qcAggregateSignature <- get
-        qcSignatories <- get
-        return QuorumCertificate{..}
-
-instance HashableTo Hash.Hash QuorumCertificate where
-    getHash = Hash.hash . encode
 
 -- |Check that the quorum certificate has:
 --
@@ -509,10 +399,6 @@ timeoutSignatureMessageBytes TimeoutSignatureMessage{..} = runPut $ do
     put tsmQCRound
     put tsmQCEpoch
 
--- |Signature by a finalizer on a 'TimeoutSignatureMessage', or an aggregation of such signatures.
-newtype TimeoutSignature = TimeoutSignature {theTimeoutSignature :: Bls.Signature}
-    deriving (Eq, Ord, Show, Serialize, Semigroup, Monoid)
-
 -- |Sign a 'TimeoutSignatureMessage' with a Baker's private key.
 signTimeoutSignatureMessage :: TimeoutSignatureMessage -> BakerAggregationPrivateKey -> TimeoutSignature
 signTimeoutSignatureMessage msg privKey =
@@ -524,84 +410,6 @@ checkTimeoutSignatureSingle ::
 checkTimeoutSignatureSingle msg pubKey =
     Bls.verify (timeoutSignatureMessageBytes msg) pubKey
         . theTimeoutSignature
-
--- |Data structure recording which finalizers have quorum certificates for which rounds.
---
--- Invariant: @Map.size theFinalizerRounds <= fromIntegral (maxBound :: Word32)@.
-newtype FinalizerRounds = FinalizerRounds {theFinalizerRounds :: Map.Map Round FinalizerSet}
-    deriving (Eq, Show)
-
-instance Serialize FinalizerRounds where
-    put (FinalizerRounds fr) = do
-        putWord32be $ fromIntegral $ Map.size fr
-        putSafeSizedMapOf put put fr
-    get = do
-        count <- getWord32be
-        FinalizerRounds <$> getSafeSizedMapOf count get get
-
--- |Unpack a 'FinalizerRounds' as a list of rounds and finalizer sets, in ascending order of
--- round.
-finalizerRoundsList :: FinalizerRounds -> [(Round, FinalizerSet)]
-finalizerRoundsList = Map.toAscList . theFinalizerRounds
-
--- |A timeout certificate aggregates signatures on timeout messages for the same round.
--- Finalizers may have different QC rounds.
---
--- Invariant: If 'tcFinalizerQCRoundsSecondEpoch' is not empty, then so is
--- 'tcFinalizerQCRoundsFirstEpoch'.
-data TimeoutCertificate = TimeoutCertificate
-    { -- |The round that has timed-out.
-      tcRound :: !Round,
-      -- |The minimum epoch for which we include signatures.
-      tcMinEpoch :: !Epoch,
-      -- |The rounds for which finalizers have their best QCs in the epoch 'tcMinEpoch'.
-      tcFinalizerQCRoundsFirstEpoch :: !FinalizerRounds,
-      -- |The rounds for which finalizers have their best QCs in the epoch @tcMinEpoch + 1@.
-      tcFinalizerQCRoundsSecondEpoch :: !FinalizerRounds,
-      -- |Aggregate of the finalizers' 'TimeoutSignature's on the round and QC round.
-      tcAggregateSignature :: !TimeoutSignature
-    }
-    deriving (Eq, Show)
-
--- |Returns 'True' if and only if the finalizers are exclusively in 'tcFinalizerQCRoundsFirstEpoch'
--- in a 'TimeoutCertificate'.
-tcIsSingleEpoch :: TimeoutCertificate -> Bool
-tcIsSingleEpoch = null . theFinalizerRounds . tcFinalizerQCRoundsSecondEpoch
-
--- |The maximum epoch for which a 'TimeoutCertificate' includes signatures.
--- (This will be 'tcMinEpoch' in the case that the certificate contains no signatures.)
-tcMaxEpoch :: TimeoutCertificate -> Epoch
-tcMaxEpoch tc
-    | tcIsSingleEpoch tc = tcMinEpoch tc
-    | otherwise = tcMinEpoch tc + 1
-
--- |The maximum round for which a 'TimeoutCertificate' includes signatures.
--- (This will be 0 if the certificate contains no signatures.)
-tcMaxRound :: TimeoutCertificate -> Round
-tcMaxRound tc =
-    max
-        (maxRound (tcFinalizerQCRoundsFirstEpoch tc))
-        (maxRound (tcFinalizerQCRoundsSecondEpoch tc))
-  where
-    maxRound (FinalizerRounds r) = maybe 0 fst (Map.lookupMax r)
-
-instance Serialize TimeoutCertificate where
-    put TimeoutCertificate{..} = do
-        put tcRound
-        put tcMinEpoch
-        put tcAggregateSignature
-        put tcFinalizerQCRoundsFirstEpoch
-        put tcFinalizerQCRoundsSecondEpoch
-    get = label "TimeoutCertificate" $ do
-        tcRound <- get
-        tcMinEpoch <- get
-        tcAggregateSignature <- get
-        tcFinalizerQCRoundsFirstEpoch <- get
-        tcFinalizerQCRoundsSecondEpoch <- get
-        when (null (theFinalizerRounds tcFinalizerQCRoundsFirstEpoch)) $
-            unless (null (theFinalizerRounds tcFinalizerQCRoundsSecondEpoch)) $
-                fail "tcMinEpoch is not the minimum epoch"
-        return TimeoutCertificate{..}
 
 instance HashableTo Hash.Hash (Option TimeoutCertificate) where
     getHash Absent = Hash.hash $ encode (0 :: Word8)

--- a/concordium-consensus/src/Concordium/KonsensusV1/Types.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Types.hs
@@ -138,6 +138,10 @@ checkQuorumSignatureSingle msg pubKey =
     Bls.verify (quorumSignatureMessageBytes msg) pubKey
         . theQuorumSignature
 
+-- |Index of a finalizer in the finalization committee vector.
+newtype FinalizerIndex = FinalizerIndex {theFinalizerIndex :: Word32}
+    deriving (Eq, Ord, Show, Enum, Bounded, Serialize)
+
 -- |Check the signature on a 'QuorumSignatureMessage' that is signed by multiple parties.
 checkQuorumSignature ::
     QuorumSignatureMessage -> [BakerAggregationVerifyKey] -> QuorumSignature -> Bool
@@ -228,6 +232,79 @@ finalizerByBakerId = binarySearch finalizerBakerId . committeeFinalizers
 finalizerByIndex :: FinalizationCommittee -> FinalizerIndex -> Maybe FinalizerInfo
 finalizerByIndex finCom finInd =
     committeeFinalizers finCom Vector.!? fromIntegral (theFinalizerIndex finInd)
+
+-- |A set of 'FinalizerIndex'es.
+-- This is represented as a bit vector, where the bit @i@ is set iff the finalizer index @i@ is
+-- in the set.
+newtype FinalizerSet = FinalizerSet {theFinalizerSet :: Natural}
+    deriving (Eq)
+
+-- |The serialization of a 'FinalizerSet' consists of a length (Word32, big-endian), followed by
+-- that many bytes, the first of which (if any) must be non-zero. These bytes encode the bit-vector
+-- in big-endian. This enforces that the serialization of a finalizer set is unique.
+instance Serialize FinalizerSet where
+    put fs = do
+        let (byteCount, putBytes) = unroll 0 (return ()) (theFinalizerSet fs)
+        putWord32be byteCount
+        putBytes
+      where
+        unroll :: Word32 -> Put -> Natural -> (Word32, Put)
+        -- Compute the number of bytes and construct a 'Put' that serializes in big-endian.
+        -- We do this by adding the low order byte to the accumulated 'Put' (at the start)
+        -- and recursing with the bitvector shifted right 8 bits.
+        unroll bc cont 0 = (bc, cont)
+        unroll bc cont n = unroll (bc + 1) (putWord8 (fromIntegral n) >> cont) (shiftR n 8)
+    get = label "FinalizerSet" $ do
+        byteCount <- getWord32be
+        FinalizerSet <$> roll1 byteCount
+      where
+        roll1 0 = return 0
+        roll1 bc = do
+            b <- getWord8
+            when (b == 0) $ fail "unexpected 0 byte"
+            roll (bc - 1) (fromIntegral b)
+        roll 0 n = return n
+        roll bc n = do
+            b <- getWord8
+            roll (bc - 1) (shiftL n 8 .|. fromIntegral b)
+
+-- |Convert a 'FinalizerSet' to a list of 'FinalizerIndex', in ascending order.
+finalizerList :: FinalizerSet -> [FinalizerIndex]
+finalizerList = unroll 0 . theFinalizerSet
+  where
+    unroll _ 0 = []
+    unroll i x
+        | testBit x 0 = FinalizerIndex i : r
+        | otherwise = r
+      where
+        r = unroll (i + 1) (shiftR x 1)
+
+-- |The empty set of finalizers
+emptyFinalizerSet :: FinalizerSet
+emptyFinalizerSet = FinalizerSet 0
+
+instance EmptyFinalizerSet FinalizerSet where
+    finalizerSetEmpty = emptyFinalizerSet
+
+-- |Add a finalizer to a 'FinalizerSet'.
+addFinalizer :: FinalizerSet -> FinalizerIndex -> FinalizerSet
+addFinalizer (FinalizerSet setOfFinalizers) (FinalizerIndex i) = FinalizerSet $ setBit setOfFinalizers (fromIntegral i)
+
+-- |Test whether a given finalizer index is present in a finalizer set.
+memberFinalizerSet :: FinalizerIndex -> FinalizerSet -> Bool
+memberFinalizerSet (FinalizerIndex fi) (FinalizerSet setOfFinalizers) =
+    testBit setOfFinalizers (fromIntegral fi)
+
+-- |Convert a list of [FinalizerIndex] to a 'FinalizerSet'.
+finalizerSet :: [FinalizerIndex] -> FinalizerSet
+finalizerSet = foldl' addFinalizer (FinalizerSet 0)
+
+-- |Test if the first finalizer set is a subset of the second.
+subsetFinalizerSet :: FinalizerSet -> FinalizerSet -> Bool
+subsetFinalizerSet (FinalizerSet s1) (FinalizerSet s2) = s1 .&. s2 == s1
+
+instance Show FinalizerSet where
+    show = show . finalizerList
 
 -- |Check that the quorum certificate has:
 --
@@ -1159,80 +1236,3 @@ newtype QuorumCertificateCheckedWitness = QuorumCertificateCheckedWitness Epoch
 -- |Get the associated 'QuorumCertificateWitness' for a 'QuorumCertificate'.
 toQuorumCertificateWitness :: QuorumCertificate -> QuorumCertificateCheckedWitness
 toQuorumCertificateWitness qc = QuorumCertificateCheckedWitness (qcEpoch qc)
-
--- |Index of a finalizer in the finalization committee vector.
-newtype FinalizerIndex = FinalizerIndex {theFinalizerIndex :: Word32}
-    deriving (Eq, Ord, Show, Enum, Bounded, Serialize)
-
--- |A set of 'FinalizerIndex'es.
--- This is represented as a bit vector, where the bit @i@ is set iff the finalizer index @i@ is
--- in the set.
-newtype FinalizerSet = FinalizerSet {theFinalizerSet :: Natural}
-    deriving (Eq)
-
--- |Convert a 'FinalizerSet' to a list of 'FinalizerIndex', in ascending order.
-finalizerList :: FinalizerSet -> [FinalizerIndex]
-finalizerList = unroll 0 . theFinalizerSet
-  where
-    unroll _ 0 = []
-    unroll i x
-        | testBit x 0 = FinalizerIndex i : r
-        | otherwise = r
-      where
-        r = unroll (i + 1) (shiftR x 1)
-
--- |The empty set of finalizers
-emptyFinalizerSet :: FinalizerSet
-emptyFinalizerSet = FinalizerSet 0
-
-instance EmptyFinalizerSet FinalizerSet where
-    finalizerSetEmpty = emptyFinalizerSet
-
--- |Add a finalizer to a 'FinalizerSet'.
-addFinalizer :: FinalizerSet -> FinalizerIndex -> FinalizerSet
-addFinalizer (FinalizerSet setOfFinalizers) (FinalizerIndex i) = FinalizerSet $ setBit setOfFinalizers (fromIntegral i)
-
--- |Test whether a given finalizer index is present in a finalizer set.
-memberFinalizerSet :: FinalizerIndex -> FinalizerSet -> Bool
-memberFinalizerSet (FinalizerIndex fi) (FinalizerSet setOfFinalizers) =
-    testBit setOfFinalizers (fromIntegral fi)
-
--- |Convert a list of [FinalizerIndex] to a 'FinalizerSet'.
-finalizerSet :: [FinalizerIndex] -> FinalizerSet
-finalizerSet = foldl' addFinalizer (FinalizerSet 0)
-
--- |Test if the first finalizer set is a subset of the second.
-subsetFinalizerSet :: FinalizerSet -> FinalizerSet -> Bool
-subsetFinalizerSet (FinalizerSet s1) (FinalizerSet s2) = s1 .&. s2 == s1
-
-instance Show FinalizerSet where
-    show = show . finalizerList
-
--- |The serialization of a 'FinalizerSet' consists of a length (Word32, big-endian), followed by
--- that many bytes, the first of which (if any) must be non-zero. These bytes encode the bit-vector
--- in big-endian. This enforces that the serialization of a finalizer set is unique.
-instance Serialize FinalizerSet where
-    put fs = do
-        let (byteCount, putBytes) = unroll 0 (return ()) (theFinalizerSet fs)
-        putWord32be byteCount
-        putBytes
-      where
-        unroll :: Word32 -> Put -> Natural -> (Word32, Put)
-        -- Compute the number of bytes and construct a 'Put' that serializes in big-endian.
-        -- We do this by adding the low order byte to the accumulated 'Put' (at the start)
-        -- and recursing with the bitvector shifted right 8 bits.
-        unroll bc cont 0 = (bc, cont)
-        unroll bc cont n = unroll (bc + 1) (putWord8 (fromIntegral n) >> cont) (shiftR n 8)
-    get = label "FinalizerSet" $ do
-        byteCount <- getWord32be
-        FinalizerSet <$> roll1 byteCount
-      where
-        roll1 0 = return 0
-        roll1 bc = do
-            b <- getWord8
-            when (b == 0) $ fail "unexpected 0 byte"
-            roll (bc - 1) (fromIntegral b)
-        roll 0 n = return n
-        roll bc n = do
-            b <- getWord8
-            roll (bc - 1) (shiftL n 8 .|. fromIntegral b)


### PR DESCRIPTION
## Purpose

Move types that are exposed by the API to base.

## Changes
- Moved type definitions from KonsensusV1/Types.hs to Types/KonsensusV1.hs (new module in base).
- Re-exported Types/KonsensusV1.hs via KonsensusV1/Types.hs

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
