### PR TITLE
After updating Jenkins Docker now recognizes buildx is installed

### DIFF
--- a/jenkinsfiles/activate-distribution-image.Jenkinsfile
+++ b/jenkinsfiles/activate-distribution-image.Jenkinsfile
@@ -49,10 +49,9 @@ node {
         }
     }
     stage('update') {
-        // Use buildx to push destination tags. Docker doesen't recognise that buildx is installed, so invoking buildx directly.
-        sh "/usr/libexec/docker/cli-plugins/buildx imagetools create ${source_image_name} --tag ${destination_image_name}"
+        sh "docker buildx imagetools create ${source_image_name} --tag ${destination_image_name}"
         if (params.set_latest) {
-            sh "/usr/libexec/docker/cli-plugins/buildx imagetools create ${source_image_name} --tag ${docker_repo}:latest"
+            sh "docker buildx imagetools create ${source_image_name} --tag ${docker_repo}:latest"
         }
     }
     if (params.delete_source) {


### PR DESCRIPTION
## Purpose

The Docker version used by Jenkins now recognizes that the buildx tool is installed.

## Changes

No longer need to invoke the buildx tool directly, but using the docker cli instead.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

