### PR TITLE
Add `CommisionRates` to `GetPoolInfo`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased changes
+- `GetPoolInfo` now also returns the commission rates for the current reward period.
 - Add `GetBakersRewardPeriod` to GRPCV2 API. Provided a block, then it returns information about bakers
   for the reward period of the block.
 

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -2672,7 +2672,8 @@ doGetPoolStatus pbs (Just psBakerId@(BakerId aid)) = case delegationChainParamet
                                                         fromIntegral effectiveStake
                                                             / fromIntegral (_bakerTotalStake epochBakers),
                                                       bpsBakerEquityCapital = bcBakerEquityCapital bc,
-                                                      bpsDelegatedCapital = bcTotalDelegatorCapital bc
+                                                      bpsDelegatedCapital = bcTotalDelegatorCapital bc,
+                                                      bpsCommissionRates = psPoolInfo ^. BaseAccounts.poolCommissionRates
                                                     }
                         return $ Just BakerPoolStatus{..}
 


### PR DESCRIPTION
## Purpose

Also return the commission rates that apply for a baker pool in the current reward period for `GetPoolStatus`

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

