### PR TITLE
Support for epoch winning bakers and first block queries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   quorum certificate, timeout certificate and epoch finalization entry contained in the block (where present).
 - Add endpoint `GetBakerEarliestWinTime` to GRPCV2 API. Provided a baker ID, it returns the
   earliest time at which the node projects that the baker could be required to bake a block.
+- Add endpoint `GetFirstBlockEpoch` to GRPCV2 API. It returns the block hash of the first block in
+  a given epoch.
+- Add endpoint `GitWinningBakersEpoch` to GRPCV2 API. It returns a list of the bakers that won
+  rounds in a specified (finalized) epoch. This only supports consensus version 1.
 - Fix a bug in how the last timeout certificate is recovered at start-up.
 
 ## 6.0.4

--- a/concordium-consensus/lib.def
+++ b/concordium-consensus/lib.def
@@ -53,6 +53,8 @@ EXPORTS
  getModuleSourceV2
  getInstanceListV2
  getAncestorsV2
+ getFirstBlockEpochV2
+ getWinningBakersEpochV2
  getInstanceInfoV2
  getInstanceStateV2
  getNextAccountSequenceNumberV2

--- a/concordium-consensus/src/Concordium/External/GRPC2.hs
+++ b/concordium-consensus/src/Concordium/External/GRPC2.hs
@@ -110,6 +110,18 @@ decodeBlockHashInput n dt =
                     Right (rBlockHeight, rGenesisIndex, rRestrict) -> return $ Queries.Relative{..}
             _ -> error "Precondition violation in FFI call: Unknown block hash input type"
 
+-- |Decode an 'Queries.EpochRequest' given the tag byte and data.
+-- The tags supported by 'decodeBlockHashInput' are also supported here (0-4), corresponding to
+-- a 'Queries.EpochOfBlock'. The tag 5 is used for 'Queries.SpecifiedEpoch'.
+decodeEpochRequest :: Word8 -> Ptr Word8 -> IO Queries.EpochRequest
+decodeEpochRequest 5 dt = do
+    -- 8 bytes for epoch, 4 bytes for genesis index
+    inputData <- BS.unsafePackCStringLen (castPtr dt, 12)
+    case S.decode inputData of
+        Left err -> error $ "Precondition violation in FFI call: " ++ err
+        Right (erEpoch, erGenesisIndex) -> return $! Queries.SpecifiedEpoch{..}
+decodeEpochRequest n dt = Queries.EpochOfBlock <$> decodeBlockHashInput n dt
+
 -- | Decode an account address from a foreign ptr. Assumes 32 bytes are available.
 decodeAccountAddress :: Ptr Word8 -> IO AccountAddress
 decodeAccountAddress accPtr = coerce <$> FBS.create @AccountAddressSize (\p -> copyBytes p accPtr 32)
@@ -146,12 +158,14 @@ decodeReceiveName ptr len = Wasm.ReceiveName <$> decodeText ptr len
 data QueryResult
     = -- | An invalid argument was provided by the client.
       QRInvalidArgument
-    | -- | An internal error occured.
+    | -- | An internal error occurred.
       QRInternalError
     | -- | The query succeeded.
       QRSuccess
     | -- | The requested data could not be found.
       QRNotFound
+    | -- | The requested data is for a future epoch or genesis index.
+      QRFutureEpoch
 
 -- |Convert a QueryResult to a result code.
 queryResultCode :: QueryResult -> Int64
@@ -159,6 +173,7 @@ queryResultCode QRInvalidArgument = -2
 queryResultCode QRInternalError = -1
 queryResultCode QRSuccess = 0
 queryResultCode QRNotFound = 1
+queryResultCode QRFutureEpoch = 2
 
 getAccountInfoV2 ::
     StablePtr Ext.ConsensusRunner ->
@@ -411,6 +426,52 @@ getAncestorsV2 cptr channel blockType blockHashPtr depth outHash cbk = do
     bhi <- decodeBlockHashInput blockType blockHashPtr
     response <- runMVR (Q.getAncestors bhi (BlockHeight depth)) mvr
     returnStreamWithBlock (sender channel) outHash response
+
+getFirstBlockEpochV2 ::
+    StablePtr Ext.ConsensusRunner ->
+    -- |Query type.
+    Word8 ->
+    -- |Query payload data.
+    Ptr Word8 ->
+    -- |Out pointer for the result block hash.
+    Ptr Word8 ->
+    IO Int64
+getFirstBlockEpochV2 cptr queryType queryDataPtr outHash = do
+    Ext.ConsensusRunner mvr <- deRefStablePtr cptr
+    epochReq <- decodeEpochRequest queryType queryDataPtr
+    response <- runMVR (Q.getFirstBlockEpoch epochReq) mvr
+    case response of
+        Left Q.EQEBlockNotFound -> return $ queryResultCode QRNotFound
+        Left Q.EQEFutureEpoch -> return $ queryResultCode QRFutureEpoch
+        Left Q.EQEInvalidEpoch -> return $ queryResultCode QRInvalidArgument
+        Left Q.EQEInvalidGenesisIndex -> return $ queryResultCode QRInvalidArgument
+        Right res -> do
+            copyHashTo outHash (Q.BQRBlock res ())
+            return $ queryResultCode QRSuccess
+
+getWinningBakersEpochV2 ::
+    StablePtr Ext.ConsensusRunner ->
+    Ptr SenderChannel ->
+    -- |Query type.
+    Word8 ->
+    -- |Query payload data.
+    Ptr Word8 ->
+    -- |Stream callback.
+    FunPtr (Ptr SenderChannel -> Ptr Word8 -> Int64 -> IO Int32) ->
+    IO Int64
+getWinningBakersEpochV2 cptr channel queryType queryDataPtr cbk = do
+    Ext.ConsensusRunner mvr <- deRefStablePtr cptr
+    let sender = callChannelSendCallback cbk channel
+    epochReq <- decodeEpochRequest queryType queryDataPtr
+    response <- runMVR (Q.getWinningBakersEpoch epochReq) mvr
+    case response of
+        Left Q.EQEBlockNotFound -> return $ queryResultCode QRNotFound
+        Left Q.EQEFutureEpoch -> return $ queryResultCode QRFutureEpoch
+        Left Q.EQEInvalidEpoch -> return $ queryResultCode QRInvalidArgument
+        Left Q.EQEInvalidGenesisIndex -> return $ queryResultCode QRInvalidArgument
+        Right res -> do
+            _ <- enqueueMessages sender res
+            return $ queryResultCode QRSuccess
 
 getBlockItemStatusV2 ::
     StablePtr Ext.ConsensusRunner ->
@@ -1153,6 +1214,29 @@ foreign export ccall
         Word64 ->
         -- |Out pointer for writing the block hash that was used.
         Ptr Word8 ->
+        FunPtr (Ptr SenderChannel -> Ptr Word8 -> Int64 -> IO Int32) ->
+        IO Int64
+
+foreign export ccall
+    getFirstBlockEpochV2 ::
+        StablePtr Ext.ConsensusRunner ->
+        -- |Query type.
+        Word8 ->
+        -- |Query payload data.
+        Ptr Word8 ->
+        -- |Out pointer for the result block hash.
+        Ptr Word8 ->
+        IO Int64
+
+foreign export ccall
+    getWinningBakersEpochV2 ::
+        StablePtr Ext.ConsensusRunner ->
+        Ptr SenderChannel ->
+        -- |Query type.
+        Word8 ->
+        -- |Query payload data.
+        Ptr Word8 ->
+        -- |Stream callback.
         FunPtr (Ptr SenderChannel -> Ptr Word8 -> Int64 -> IO Int32) ->
         IO Int64
 

--- a/concordium-consensus/src/Concordium/KonsensusV1/Consensus.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Consensus.hs
@@ -356,9 +356,10 @@ getWinningBakersForEpoch targetEpoch sd = do
         bakers <- BS.getCurrentEpochBakers (bpState lastOfEpoch)
         seedState <- BS.getSeedState (bpState lastOfEpoch)
         let leNonce = seedState ^. currentLeadershipElectionNonce
+        let roundWinner = getLeaderFullBakers bakers leNonce
         let roundWB rnd present =
                 WinningBaker
-                    { wbWinner = getLeaderFullBakers bakers leNonce rnd ^. Accounts.bakerIdentity,
+                    { wbWinner = roundWinner rnd ^. Accounts.bakerIdentity,
                       wbRound = rnd,
                       wbPresent = present
                     }

--- a/concordium-consensus/src/Concordium/KonsensusV1/Consensus.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Consensus.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -18,6 +19,7 @@ import Concordium.Types
 import qualified Concordium.Types.Accounts as Accounts
 import Concordium.Types.BakerIdentity
 import Concordium.Types.Parameters hiding (getChainParameters)
+import Concordium.Types.Queries
 import Concordium.Utils
 
 import qualified Concordium.Crypto.BlockSignature as Sig
@@ -25,12 +27,13 @@ import Concordium.GlobalState.BakerInfo
 import qualified Concordium.GlobalState.BlockState as BS
 import qualified Concordium.GlobalState.Persistent.BlockState as PBS
 import qualified Concordium.GlobalState.TreeState as GSTypes
+import Concordium.KonsensusV1.LeaderElection
 import Concordium.KonsensusV1.TreeState.Implementation
 import qualified Concordium.KonsensusV1.TreeState.LowLevel as LowLevel
 import Concordium.KonsensusV1.TreeState.Types
 import Concordium.KonsensusV1.Types
 import Concordium.Logger
-import Concordium.Types.SeedState (triggerBlockTime)
+import Concordium.Types.SeedState (currentLeadershipElectionNonce, triggerBlockTime)
 import Concordium.Types.UpdateQueues
 import Concordium.Types.Updates
 
@@ -325,3 +328,62 @@ getProtocolUpdateState = do
                     { puQueuedTime = ts,
                       puProtocolUpdate = pu
                     }
+
+-- |Get the list of rounds that fall within a finalized epoch, together with which baker was
+-- eligible to bake in that round and whether a block in that round was included in the finalized
+-- chain.
+-- This returns 'Nothing' if the epoch is not completely finalized (i.e. there is no finalized
+-- block in a higher round).
+getWinningBakersForEpoch ::
+    forall m.
+    ( GSTypes.BlockState m ~ PBS.HashedPersistentBlockState (MPV m),
+      BS.BlockStateQuery m,
+      LowLevel.MonadTreeStateStore m,
+      MonadIO m
+    ) =>
+    Epoch ->
+    SkovData (MPV m) ->
+    m (Maybe [WinningBaker])
+getWinningBakersForEpoch targetEpoch sd = do
+    -- We start with the first finalized block of the next epoch.
+    -- If there is no such block, then we don't consider the target epoch finalized, so return no
+    -- result.
+    mFirstBlockNextEpoch <- getFirstFinalizedBlockOfEpoch (Left $ targetEpoch + 1) sd
+    forM mFirstBlockNextEpoch $ \startBlock -> do
+        -- The start block will be a finalized block and not the genesis block (its epoch is > 1).
+        -- Its parent will be in the target epoch. (There are no empty epochs.)
+        lastOfEpoch <- parentOfFinalized startBlock
+        bakers <- BS.getCurrentEpochBakers (bpState lastOfEpoch)
+        seedState <- BS.getSeedState (bpState lastOfEpoch)
+        let leNonce = seedState ^. currentLeadershipElectionNonce
+        let roundWB rnd present =
+                WinningBaker
+                    { wbWinner = getLeaderFullBakers bakers leNonce rnd ^. Accounts.bakerIdentity,
+                      wbRound = rnd,
+                      wbPresent = present
+                    }
+        -- We construct the list of rounds starting from the round before @startBlock@ and moving
+        -- backwards to the round after the first ancestor of @startBlock@ that is in an earlier
+        -- epoch than @targetEpoch@.
+        let go ::
+                BlockPointer (MPV m) -> -- Block in at most round @rnd@
+                Round -> -- Next round to include in list
+                [WinningBaker] -> -- Currently accumulated list
+                m [WinningBaker]
+            go prevBaked rnd l
+                | rnd == 0 = do
+                    -- The genesis block (i.e. in round 0) has no baker, so stop.
+                    return l
+                | blockRound prevBaked /= rnd = do
+                    -- prevBaked is the block in the highest round <= rnd, so the round must have
+                    -- timed out.
+                    go prevBaked (rnd - 1) (roundWB rnd False : l)
+                | blockEpoch prevBaked == targetEpoch = do
+                    -- blockRound prevBaked == rnd, so a block in the round is present.
+                    newPrevBaked <- parentOfFinalized prevBaked
+                    go newPrevBaked (rnd - 1) (roundWB rnd True : l)
+                | otherwise = do
+                    -- Here prevBaked must be in a previous epoch, and blockRound prevBaked == rnd,
+                    -- so we stop.
+                    return l
+        go lastOfEpoch (blockRound startBlock - 1) []

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -1207,6 +1207,136 @@ getDelegatorsRewardPeriod bhi maybeBakerId = do
               pdrpiStake = dcDelegatorCapital
             }
 
+-- ** Epoch indexed
+
+data EpochQueryError
+    = -- |The specified block was not found.
+      EQEBlockNotFound
+    | -- |The specified epoch or genesis index is in the future.
+      EQEFutureEpoch
+    | -- |The epoch is not valid for the specified genesis index.
+      EQEInvalidEpoch
+    | -- |The genesis index does not support the query.
+      EQEInvalidGenesisIndex
+
+-- |Get the first finalized block in a specified epoch.
+-- The epoch can be specified directly by the genesis index and epoch number, or indirectly by a
+-- 'BlockHashInput' that references a block.
+--
+-- The following failure cases apply:
+--   * If the input is a 'BlockHashInput' and the specified block cannot be resolved, this returns
+--     'EQEBlockNotFound'.
+--   * If the specified genesis index is greater than the current one, returns 'EQEFutureEpoch'.
+--   * If the specified epoch is after the epoch of the last finalized block
+--      - returns 'EQEFutureEpoch' if the genesis index is the current one
+--      - returns 'EQEInvalidEpoch' otherwise.
+--   * If the specified epoch contains no finalized blocks then returns 'EQEBlockNotFound'.
+--     This only applies to consensus version 0, as epochs cannot be empty in consensus version 1.
+getFirstBlockEpoch :: forall finconf. EpochRequest -> MVR finconf (Either EpochQueryError BlockHash)
+getFirstBlockEpoch SpecifiedEpoch{..} = MVR $ \mvr -> do
+    versions <- readIORef $ mvVersions mvr
+    case versions Vec.!? fromIntegral erGenesisIndex of
+        Nothing -> return $ Left EQEFutureEpoch
+        Just evc -> do
+            let isCurrentVersion = fromIntegral erGenesisIndex == Vec.length versions
+            liftSkovQuery
+                mvr
+                evc
+                ( do
+                    -- Consensus version 0
+                    getFirstFinalizedOfEpoch (Left erEpoch) <&> \case
+                        Left FutureEpoch
+                            | isCurrentVersion -> Left EQEFutureEpoch
+                            | otherwise -> Left EQEInvalidEpoch
+                        Left EmptyEpoch -> Left EQEBlockNotFound
+                        Right block -> Right $! getHash @BlockHash block
+                )
+                ( do
+                    -- Consensus version 1#
+                    (SkovV1.getFirstFinalizedBlockOfEpoch (Left erEpoch) =<< get) <&> \case
+                        Nothing
+                            | isCurrentVersion -> Left EQEFutureEpoch
+                            | otherwise -> Left EQEInvalidEpoch
+                        Just block -> Right $! getHash @BlockHash block
+                )
+getFirstBlockEpoch (EpochOfBlock blockInput) = do
+    versions <- MVR $ readIORef . mvVersions
+    let curVI = fromIntegral (Vec.length versions - 1)
+    unBHIResponse <$> liftSkovQueryBHIAndVersion (epochOfBlockV0 curVI) (epochOfBlockV1 curVI) blockInput
+  where
+    unBHIResponse BQRNoBlock = Left EQEBlockNotFound
+    unBHIResponse (BQRBlock _ res) = res
+    epochOfBlockV0 curVersionIndex evc b =
+        getFirstFinalizedOfEpoch (Right b) <&> \case
+            Left FutureEpoch
+                | evcIndex evc == curVersionIndex -> Left EQEFutureEpoch
+                | otherwise -> Left EQEInvalidEpoch
+            Left EmptyEpoch -> Left EQEBlockNotFound
+            Right epochBlock -> Right (getHash epochBlock)
+    epochOfBlockV1 curVersionIndex evc b _ =
+        (SkovV1.getFirstFinalizedBlockOfEpoch (Right b) =<< get) <&> \case
+            Nothing
+                | evcIndex evc == curVersionIndex -> Left EQEFutureEpoch
+                | otherwise -> Left EQEInvalidEpoch
+            Just epochBlock -> Right (getHash epochBlock)
+
+-- |Get the list of bakers that won the lottery in a particular historical epoch (i.e. the last
+-- finalized block is in a later epoch). This lists the winners for each round in the epoch,
+-- starting from the round after the last block in the previous epoch, running to the round before
+-- the first block in the next epoch. It also indicates if a block in each round was included in
+-- the finalized chain.
+-- The epoch can be specified directly by the genesis index and epoch number, or indirectly by a
+-- 'BlockHashInput' that references a block.
+--
+-- The following failure cases apply:
+--   * If the input is a 'BlockHashInput' and the specified block cannot be resolved, this returns
+--     'EQEBlockNotFound'.
+--   * If the specified genesis index is greater than the current one, returns 'EQEFutureEpoch'.
+--   * If the specified genesis index is on consensus version 0, returns 'EQEInvalidGenesisIndex'.
+--   * If the specified epoch not less than the epoch of the last finalized block,
+--      - returns 'EQEFutureEpoch' if the genesis index is the current one
+--      - returns 'EQEInvalidEpoch' otherwise.
+getWinningBakersEpoch ::
+    forall finconf.
+    EpochRequest ->
+    MVR finconf (Either EpochQueryError [WinningBaker])
+getWinningBakersEpoch SpecifiedEpoch{..} = MVR $ \mvr -> do
+    versions <- readIORef $ mvVersions mvr
+    case versions Vec.!? fromIntegral erGenesisIndex of
+        Nothing -> return $ Left EQEFutureEpoch
+        Just evc -> do
+            liftSkovQuery
+                mvr
+                evc
+                (return (Left EQEInvalidGenesisIndex))
+                ( do
+                    let isCurrentVersion = fromIntegral erGenesisIndex == Vec.length versions
+                    mwbs <- ConsensusV1.getWinningBakersForEpoch erEpoch =<< get
+                    return $! case mwbs of
+                        Nothing
+                            | isCurrentVersion -> Left EQEFutureEpoch
+                            | otherwise -> Left EQEInvalidEpoch
+                        Just wbs -> Right wbs
+                )
+getWinningBakersEpoch (EpochOfBlock blockInput) = do
+    versions <- MVR $ readIORef . mvVersions
+    let curVersionIndex = fromIntegral (Vec.length versions - 1)
+    res <-
+        liftSkovQueryBHIAndVersion
+            (\_ _ -> return (Left EQEInvalidGenesisIndex))
+            ( \evc b _ -> do
+                mwbs <- ConsensusV1.getWinningBakersForEpoch (SkovV1.blockEpoch b) =<< get
+                return $! case mwbs of
+                    Nothing
+                        | evcIndex evc == curVersionIndex -> Left EQEFutureEpoch
+                        | otherwise -> Left EQEInvalidEpoch
+                    Just wbs -> Right wbs
+            )
+            blockInput
+    return $! case res of
+        BQRNoBlock -> Left EQEBlockNotFound
+        BQRBlock _ r -> r
+
 -- ** Transaction indexed
 
 -- |Get the status of a transaction specified by its hash.

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -1255,7 +1255,7 @@ getFirstBlockEpoch SpecifiedEpoch{..} = MVR $ \mvr -> do
                         Right block -> Right $! getHash @BlockHash block
                 )
                 ( do
-                    -- Consensus version 1#
+                    -- Consensus version 1
                     (SkovV1.getFirstFinalizedBlockOfEpoch (Left erEpoch) =<< get) <&> \case
                         Nothing
                             | isCurrentVersion -> Left EQEFutureEpoch

--- a/concordium-consensus/src/Concordium/Skov/Monad.hs
+++ b/concordium-consensus/src/Concordium/Skov/Monad.hs
@@ -12,7 +12,7 @@
 
 module Concordium.Skov.Monad (
     module Concordium.Skov.CatchUp.Types,
-    EpochResult (..),
+    EpochFailureResult (..),
     module Concordium.Skov.Monad,
 ) where
 
@@ -202,7 +202,7 @@ class
     -- specified directly, or indirectly as the epoch of a supplied block.
     getFirstFinalizedOfEpoch ::
         Either Epoch (BlockPointerType m) ->
-        m (Either EpochResult (BlockPointerType m))
+        m (Either EpochFailureResult (BlockPointerType m))
 
     -- |Get a block's state.
     queryBlockState :: BlockPointerType m -> m (BlockState m)

--- a/concordium-consensus/src/Concordium/Skov/Monad.hs
+++ b/concordium-consensus/src/Concordium/Skov/Monad.hs
@@ -12,6 +12,7 @@
 
 module Concordium.Skov.Monad (
     module Concordium.Skov.CatchUp.Types,
+    EpochResult (..),
     module Concordium.Skov.Monad,
 ) where
 
@@ -197,6 +198,12 @@ class
     -- |Get a list of all the blocks at a given height in the tree.
     getBlocksAtHeight :: BlockHeight -> m [BlockPointerType m]
 
+    -- |Get the first finalized block (if any) in a given epoch. The epoch can either be
+    -- specified directly, or indirectly as the epoch of a supplied block.
+    getFirstFinalizedOfEpoch ::
+        Either Epoch (BlockPointerType m) ->
+        m (Either EpochResult (BlockPointerType m))
+
     -- |Get a block's state.
     queryBlockState :: BlockPointerType m -> m (BlockState m)
 
@@ -353,6 +360,7 @@ instance (Monad (t m), MonadTrans t, SkovQueryMonad m) => SkovQueryMonad (MGSTra
     getCurrentHeight = lift getCurrentHeight
     branchesFromTop = lift branchesFromTop
     getBlocksAtHeight = lift . getBlocksAtHeight
+    getFirstFinalizedOfEpoch = lift . getFirstFinalizedOfEpoch
     queryBlockState = lift . queryBlockState
     queryTransactionStatus = lift . queryTransactionStatus
     queryNonFinalizedTransactions = lift . queryNonFinalizedTransactions
@@ -495,6 +503,8 @@ instance
 
     {- - INLINE getBlocksAtHeight - -}
     getBlocksAtHeight = lift . doGetBlocksAtHeight
+
+    getFirstFinalizedOfEpoch = lift . doGetFirstFinalizedOfEpoch
 
     {- - INLINE queryBlockState - -}
     queryBlockState = lift . blockState

--- a/concordium-consensus/src/Concordium/Skov/Query.hs
+++ b/concordium-consensus/src/Concordium/Skov/Query.hs
@@ -77,8 +77,8 @@ doGetBlocksAtHeight h = do
             mb <- getFinalizedAtHeight h
             return (toList mb)
 
--- |Result of querying for the first finalized block in an epoch.
-data EpochResult
+-- |Result of querying for the first finalized block in an epoch, when the query fails.
+data EpochFailureResult
     = -- |There are currently no finalized blocks in the given epoch.
       FutureEpoch
     | -- |The epoch is in the past, but was empty.
@@ -87,7 +87,7 @@ data EpochResult
 doGetFirstFinalizedOfEpoch ::
     TreeStateMonad m =>
     Either Epoch (BlockPointerType m) ->
-    m (Either EpochResult (BlockPointerType m))
+    m (Either EpochFailureResult (BlockPointerType m))
 doGetFirstFinalizedOfEpoch epochOrBlock = do
     epochLength <- gdEpochLength <$> getGenesisData
     let blockEpoch b = fromIntegral (blockSlot b `div` epochLength)

--- a/concordium-consensus/src/Concordium/Skov/Query.hs
+++ b/concordium-consensus/src/Concordium/Skov/Query.hs
@@ -21,6 +21,7 @@ import qualified Concordium.TransactionVerification as TV
 import Concordium.Types
 import Concordium.Types.Transactions
 import Concordium.Types.UpdateQueues (ProtocolUpdateStatus (..))
+import Concordium.Utils.InterpolationSearch
 
 doResolveBlock :: TreeStateMonad m => BlockHash -> m (Maybe (BlockPointerType m))
 {- - INLINE doResolveBlock - -}
@@ -75,6 +76,46 @@ doGetBlocksAtHeight h = do
         LT -> do
             mb <- getFinalizedAtHeight h
             return (toList mb)
+
+-- |Result of querying for the first finalized block in an epoch.
+data EpochResult
+    = -- |There are currently no finalized blocks in the given epoch.
+      FutureEpoch
+    | -- |The epoch is in the past, but was empty.
+      EmptyEpoch
+
+doGetFirstFinalizedOfEpoch ::
+    TreeStateMonad m =>
+    Either Epoch (BlockPointerType m) ->
+    m (Either EpochResult (BlockPointerType m))
+doGetFirstFinalizedOfEpoch epochOrBlock = do
+    epochLength <- gdEpochLength <$> getGenesisData
+    let blockEpoch b = fromIntegral (blockSlot b `div` epochLength)
+    let targetEpoch = case epochOrBlock of
+            Left epoch -> epoch
+            Right block -> blockEpoch block
+    -- This should be safe to call for any height up to the height of the last finalized block.
+    let unsafeFinalizedAtHeight h =
+            getFinalizedAtHeight h <&> \case
+                Nothing -> error $ "Missing finalized block at height " ++ show h
+                Just b -> (blockEpoch b, b)
+    lastFin <- fst <$> getLastFinalized
+    if targetEpoch > blockEpoch lastFin
+        then return $ Left FutureEpoch
+        else do
+            gen <- unsafeFinalizedAtHeight 0
+            let low = (0, gen)
+            -- If we were given a block, use that as the upper bound, so long as it is finalized.
+            let high = case epochOrBlock of
+                    Right guess
+                        | bpHeight guess <= bpHeight lastFin ->
+                            (bpHeight guess, (blockEpoch guess, guess))
+                    _ ->
+                        (bpHeight lastFin, (blockEpoch lastFin, lastFin))
+            res <- interpolationSearchFirstM unsafeFinalizedAtHeight targetEpoch low high
+            return $! case res of
+                Nothing -> Left EmptyEpoch
+                Just (_, block) -> Right block
 
 doBlockLastFinalizedIndex :: TreeStateMonad m => BlockPointerType m -> m FinalizationIndex
 {- - INLINE doBlockLastFinalizedIndex - -}

--- a/concordium-consensus/src/Concordium/Skov/Query.hs
+++ b/concordium-consensus/src/Concordium/Skov/Query.hs
@@ -95,6 +95,9 @@ doGetFirstFinalizedOfEpoch epochOrBlock = do
             Left epoch -> epoch
             Right block -> blockEpoch block
     -- This should be safe to call for any height up to the height of the last finalized block.
+    -- Concurrent writers cannot remove finalized blocks from the persistent state, and when the
+    -- state was last updated, all blocks that were considered finalized must have been finalized
+    -- in the persistent state.
     let unsafeFinalizedAtHeight h =
             getFinalizedAtHeight h <&> \case
                 Nothing -> error $ "Missing finalized block at height " ++ show h

--- a/concordium-node/build.rs
+++ b/concordium-node/build.rs
@@ -626,6 +626,25 @@ fn build_grpc2(proto_root_input: &str) -> std::io::Result<()> {
                 .server_streaming()
                 .build(),
         )
+        .method(
+            tonic_build::manual::Method::builder()
+                .name("get_first_block_epoch")
+                .route_name("GetFirstBlockEpoch")
+                .input_type("crate::grpc2::types::EpochRequest")
+                .output_type("crate::grpc2::types::BlockHash")
+                .codec_path("tonic::codec::ProstCodec")
+                .build(),
+        )
+        .method(
+            tonic_build::manual::Method::builder()
+                .name("get_winning_bakers_epoch")
+                .route_name("GetWinningBakersEpoch")
+                .input_type("crate::grpc2::types::EpochRequest")
+                .output_type("Vec<u8>")
+                .codec_path("crate::grpc2::RawCodec")
+                .server_streaming()
+                .build(),
+        )
         .build();
     // Due to the slightly hacky nature of the RawCodec (i.e., it does not support
     // deserialization) we cannot build the client. But we also don't need it in the

--- a/concordium-node/src/consensus_ffi/ffi.rs
+++ b/concordium-node/src/consensus_ffi/ffi.rs
@@ -803,6 +803,64 @@ extern "C" {
         ) -> i32,
     ) -> i64;
 
+    /// Get the first block of a specified epoch
+    ///
+    /// * `consensus` - Pointer to the current consensus.
+    /// * `query_type` - Tag indicating the query type (specified epoch or
+    ///   block).
+    /// * `query_data` - Additional data to specify the epoch/block, depending
+    ///   on the tag.
+    /// * `out_hash` - Location to write the block hash on success.
+    ///
+    /// The return code is one of the following:
+    ///
+    /// * Success (0) - The block was found and written in `out_hash`.
+    /// * NotFound (1) - The block used to query for the epoch was not found, or
+    ///   the epoch is finalized but empty (only applies in consensus version
+    ///   0).
+    /// * FutureEpoch (2) - The query is for a future genesis index, or the
+    ///   current one but the epoch contains no finalized blocks yet.
+    /// * InvalidArgument (-2) - The specified epoch is for a past genesis index
+    ///   and will never contain finalized blocks.
+    pub fn getFirstBlockEpochV2(
+        consensus: *mut consensus_runner,
+        query_type: u8,
+        query_data: *const u8,
+        out_hash: *mut u8,
+    ) -> i64;
+
+    /// Stream a list of the winners of rounds in a specified epoch, including
+    /// whether the a block in the round was included in the finalized
+    /// chain.
+    ///
+    /// * `consensus` - Pointer to the current consensus.
+    /// * `stream` - Pointer to the response stream.
+    /// * `query_type` - Tag indicating the query type (specified epoch or
+    ///   block).
+    /// * `query_data` - Additional data to specify the epoch/block, depending
+    ///   on the tag.
+    /// * `callback` - Callback for writing to the response stream.
+    ///
+    /// The return code is one of the following:
+    /// * Success (0) - The epoch is finalized and the winners are streamed.
+    /// * NotFound (1) - The block used to query for the epoch was not found.
+    /// * FutureEpoch (2) - The query is for a future genesis index, or the
+    ///   current one but the epoch is not finalized yet.
+    /// * InvalidArgument (-2) - The query is for a past genesis index where the
+    ///   epoch was never finalized, or for a genesis index in consensus version
+    ///   0.
+    pub fn getWinningBakersEpochV2(
+        consensus: *mut consensus_runner,
+        stream: *mut futures::channel::mpsc::Sender<Result<Vec<u8>, tonic::Status>>,
+        query_type: u8,
+        query_data: *const u8,
+        callback: extern "C" fn(
+            *mut futures::channel::mpsc::Sender<Result<Vec<u8>, tonic::Status>>,
+            *const u8,
+            i64,
+        ) -> i32,
+    ) -> i64;
+
     /// Get the list of accounts in a given block and, if the block exists,
     /// enqueue them into the provided [Sender](futures::channel::mpsc::Sender).
     ///
@@ -2294,6 +2352,48 @@ impl ConsensusContainer {
         .try_into()?;
         response.ensure_ok("block")?;
         Ok(buf)
+    }
+
+    pub fn get_first_block_epoch_v2(
+        &self,
+        query: &crate::grpc2::types::EpochRequest,
+    ) -> Result<[u8; 32], tonic::Status> {
+        use crate::grpc2::Require;
+        let consensus = self.consensus.load(Ordering::SeqCst);
+        let mut buf = [0u8; 32];
+        let epoch_request = crate::grpc2::types::epoch_request_to_ffi(query).require()?;
+        let (query_tag, query_data) = epoch_request.to_ptr();
+        let response: ConsensusQueryResponse = unsafe {
+            getFirstBlockEpochV2(consensus, query_tag, query_data.as_ptr(), buf.as_mut_ptr())
+        }
+        .try_into()?;
+        response.ensure_ok("block")?;
+        Ok(buf)
+    }
+
+    /// Get the winning bakers for a particular epoch.
+    pub fn get_winning_bakers_epoch_v2(
+        &self,
+        query: &crate::grpc2::types::EpochRequest,
+        sender: futures::channel::mpsc::Sender<Result<Vec<u8>, tonic::Status>>,
+    ) -> Result<(), tonic::Status> {
+        use crate::grpc2::Require;
+        let sender = Box::new(sender);
+        let consensus = self.consensus.load(Ordering::SeqCst);
+        let epoch_request = crate::grpc2::types::epoch_request_to_ffi(query).require()?;
+        let (query_tag, query_data) = epoch_request.to_ptr();
+        let response: ConsensusQueryResponse = unsafe {
+            getWinningBakersEpochV2(
+                consensus,
+                Box::into_raw(sender),
+                query_tag,
+                query_data.as_ptr(),
+                enqueue_bytearray_callback,
+            )
+        }
+        .try_into()?;
+        response.ensure_ok("block")?;
+        Ok(())
     }
 
     /// Get information about a specific transaction.

--- a/concordium-node/src/consensus_ffi/helpers.rs
+++ b/concordium-node/src/consensus_ffi/helpers.rs
@@ -407,8 +407,8 @@ impl ConsensusQueryResponse {
             Self::InternalError => Err(tonic::Status::internal(format!("Internal error: {}. Please report this bug at https://github.com/Concordium/concordium-node/issues.", msg))),
             Self::Ok => Ok(()),
             Self::NotFound => Err(tonic::Status::not_found(format!("{} not found.", msg))),
-            Self::Unavailable => Err(tonic::Status::unavailable("The service is not available at the current protocol version."))
-            Self::FutureEpoch => Err(tonic::Status::unavailable("Future epoch."))
+            Self::Unavailable => Err(tonic::Status::unavailable("The service is not available at the current protocol version.")),
+            Self::FutureEpoch => Err(tonic::Status::unavailable("Future epoch.")),
         }
     }
 }

--- a/concordium-node/src/consensus_ffi/helpers.rs
+++ b/concordium-node/src/consensus_ffi/helpers.rs
@@ -394,6 +394,7 @@ pub enum ConsensusQueryResponse {
     InternalError,
     Ok,
     NotFound,
+    FutureEpoch,
 }
 
 impl ConsensusQueryResponse {
@@ -405,6 +406,7 @@ impl ConsensusQueryResponse {
             Self::InternalError => Err(tonic::Status::internal(format!("Internal error: {}. Please report this bug at https://github.com/Concordium/concordium-node/issues.", msg))),
             Self::Ok => Ok(()),
             Self::NotFound => Err(tonic::Status::not_found(format!("{} not found.", msg))),
+            Self::FutureEpoch => Err(tonic::Status::unavailable("Future epoch."))
         }
     }
 }
@@ -430,6 +432,7 @@ impl TryFrom<i64> for ConsensusQueryResponse {
             -1 => Ok(Self::InternalError),
             0 => Ok(Self::Ok),
             1 => Ok(Self::NotFound),
+            2 => Ok(Self::FutureEpoch),
             unknown_code => Err(ConsensusQueryUnknownCode {
                 unknown_code,
             }),


### PR DESCRIPTION
## Purpose

Support GRPCv2 endpoints `GetWinningBakersEpoch` (for getting the list of bakers that won in a given epoch) and `GetFirstBlockEpoch` (for getting the first block in a given epoch).


## Changes

- Add a new query result code that represents when a query refers to a future epoch.
- Implement getting the first finalized block of an epoch for both consensus versions.
- Implement the `GetWinningBakersEpoch` endpoint (supports consensus v1 only).
- Implement the `GetFirstBlockEpoch` endpoint (supports both consensus versions).

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
