### PR TITLE
Fix the block last finalized pointer returned by `GetBlockInfo`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Add endpoint `GetBakerEarliestWinTime` to GRPCV2 API. Provided a baker ID, it returns the
   earliest time at which the node projects that the baker could be required to bake a block.
 - Fix a bug in how the last timeout certificate is recovered at start-up.
+- Fix the behaviour of the block last finalized pointer in the `GetBlockInfo` so that it
+  consistently returns the last finalized block at the time the block was baked.
 
 ## 6.0.4
 

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -699,10 +699,7 @@ getBlockInfo =
                                 (getHash <$> lastFinalizedBlock)
                                 (use (SkovV1.lastFinalized . to getHash))
                     else getHash <$> bpParent bp
-            biBlockLastFinalized <-
-                if biFinalized
-                    then return $ getHash bp
-                    else getHash <$> bpLastFinalized bp
+            biBlockLastFinalized <- getHash <$> bpLastFinalized bp
             let biBlockHeight = localToAbsoluteBlockHeight (evcGenesisHeight evc) (SkovV1.blockHeight bp)
             let biEraBlockHeight = SkovV1.blockHeight bp
             let biBlockReceiveTime = SkovV1.blockReceiveTime bp


### PR DESCRIPTION
## Purpose

Fixes #1002.

## Changes

- Change the implementation of `lastFinalizedOf` to correctly get an ancestor of a block that is considered finalized when examining the chain just to the given block. In particular, this requires two blocks to be in the same epoch, as well as in consecutive rounds.
- Change the implementation of `getBlockInfo` to always use the result provided by `lastFinalizedOf`, instead of using the block itself when it is finalized.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
