### PR TITLE
Log when a round is advanced.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Fix a bug in how the last timeout certificate is recovered at start-up.
 - Fix the behaviour of the block last finalized pointer in the `GetBlockInfo` so that it
   consistently returns the last finalized block at the time the block was baked.
+- Add debug-level logging when a round is advanced, either due to a quorum certificate or a
+  timeout certificate.
 
 ## 6.0.4
 

--- a/concordium-consensus/src/Concordium/KonsensusV1/Consensus/Timeout.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Consensus/Timeout.hs
@@ -113,7 +113,7 @@ receiveTimeoutMessage ::
     -- |Result of receiving the 'TimeoutMessage'.
     m (ReceiveTimeoutMessageResult (MPV m))
 receiveTimeoutMessage tm@TimeoutMessage{tmBody = TimeoutMessageBody{..}} skovData
-    -- Consenus has been shutdown.
+    -- Consensus has been shutdown.
     | skovData ^. isConsensusShutdown = return ConsensusShutdown
     --  The round of the 'TimeoutMessage' is obsolete.
     | tmRound < currentRound =


### PR DESCRIPTION
## Purpose

Closes #975 

This produces log messages each time the round is advanced, either by a QC or a TC. For example:

```
2023-08-18T14:52:41.622048500+02:00 DEBUG: Konsensus: Advancing round: round 34 timed out.
2023-08-18T14:52:41.828110800+02:00 DEBUG: Konsensus: Advancing round: round 35 certified block 2d8eede2e8fc749d6da21f3e9e875fdc4b6339668dfb48f47d7a497d24976be5
```

## Changes

- Add debug-level logging to `advanceRoundWithTimeout`.
- Add debug-level logging to `advanceRoundWithQuorum`.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
