### PR TITLE
Remove pending blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Fix a bug in how the last timeout certificate is recovered at start-up.
 
+- Remove the concept of pending blocks.
+
 ## 6.0.4
 
 - Fix a bug in how timeout certificates across epoch boundaries are handled in catch-up.

--- a/concordium-consensus/src/Concordium/KonsensusV1/Consensus.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Consensus.hs
@@ -61,11 +61,6 @@ class MonadConsensusEvent m where
         [BlockPointer (MPV m)] ->
         m ()
 
-    -- |Called when a previously pending block becomes live. This should be used to trigger sending
-    -- a catch-up status message to all (non-pending) peers, since they may not be aware of the
-    -- block as it was not relayed when first received.
-    onPendingLive :: m ()
-
 -- |A baker context containing the baker identity. Used for accessing relevant baker keys and the baker id.
 newtype BakerContext = BakerContext
     { _bakerIdentity :: Maybe BakerIdentity

--- a/concordium-consensus/src/Concordium/KonsensusV1/Consensus/Blocks.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Consensus/Blocks.hs
@@ -990,8 +990,7 @@ executeBlock verifiedBlock = do
         gets (getLiveOrLastFinalizedBlock (blockParent (vbBlock verifiedBlock))) >>= \case
             Just parent -> do
                 res <- processBlock parent verifiedBlock
-                forM_ res $ \newBlock -> do
-                    checkedValidateBlock newBlock
+                forM_ res checkedValidateBlock
             Nothing -> return ()
 
 -- * Block production

--- a/concordium-consensus/src/Concordium/KonsensusV1/Consensus/Blocks.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Consensus/Blocks.hs
@@ -322,30 +322,8 @@ receiveBlockKnownParent parent pendingBlock = do
 -- |Process receiving a block when the parent is not live.
 -- Precondition: the block is for a round and epoch that have not already been finalized.
 --
--- A block with an unknown parent is added to the pending block table and marked pending, unless
--- one of the following conditions holds, in which case the block is rejected as invalid:
---
--- * The timestamp is no less than the receive time of the block + the early block threshold, or
---   we do not know the set of bakers for the block's epoch.
---   (Returns 'BlockResultEarly'.)
---
--- * The bakers for the block's epoch are known and either:
---
---     - the baker is not a valid baker for the epoch; or
---     - the baker is valid but the signature on the block is not valid.
---
--- We do not process any of the transactions in pending blocks. The transactions will be processed
--- as part of 'processPendingChild', if and when the parent block becomes live. Some reasons for
--- this choice include:
---
--- * When we encounter (honest) pending blocks, we are or should be catching up with the network.
---   Processing pending blocks' transactions prematurely will likely divert resources from that.
---
--- * Under normal circumstances, we would expect to receive any transactions in the block separately
---   from the block itself, so they likely will be processed in any event.
---
--- * Having a single point at which transactions are processed (i.e. in 'processBlock') simplifies
---   the block processing flow and avoids duplicating effort.
+-- If the timestamp is no less than the receive time of the block + the early block threshold, the
+-- function returns 'BlockResultEarly'. Otherwise, it returns 'BlockResultPending'.
 receiveBlockUnknownParent ::
     ( LowLevel.MonadTreeStateStore m,
       MonadState (SkovData (MPV m)) m,

--- a/concordium-consensus/src/Concordium/KonsensusV1/Consensus/CatchUp.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Consensus/CatchUp.hs
@@ -166,7 +166,7 @@ isCatchUpRequired CatchUpStatus{..} sd
         -- Check if we are missing any of the leaf blocks
         forM_ cusLeaves $ \leaf -> do
             leafStatus <- lift $ getRecentBlockStatus leaf sd
-            -- If the block is pending or unknown, we should attempt catch-up.
+            -- If the block is unknown, we should attempt catch-up.
             case leafStatus of
                 RecentBlock BlockUnknown -> exitRequired
                 _ -> return ()

--- a/concordium-consensus/src/Concordium/KonsensusV1/Consensus/CatchUp.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Consensus/CatchUp.hs
@@ -168,7 +168,7 @@ isCatchUpRequired CatchUpStatus{..} sd
             leafStatus <- lift $ getRecentBlockStatus leaf sd
             -- If the block is pending or unknown, we should attempt catch-up.
             case leafStatus of
-                RecentBlock BlockPendingOrUnknown -> exitRequired
+                RecentBlock BlockUnknown -> exitRequired
                 _ -> return ()
         when (cusCurrentRound == myCurrentRound) $ do
             let myCurrentRoundQuorum = sd ^. currentQuorumMessages . smBlockToWeightsAndSignatures

--- a/concordium-consensus/src/Concordium/KonsensusV1/Consensus/Finality.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Consensus/Finality.hs
@@ -254,8 +254,6 @@ processFinalizationHelper newFinalizedBlock newFinalizationEntry mCertifiedBlock
     purgeRoundExistingBlocks (blockRound newFinalizedBlock)
     -- Purge the 'roundExistingQCs' before the last finalized block.
     purgeRoundExistingQCs (blockRound newFinalizedBlock)
-    -- Purge any pending blocks that are no longer viable.
-    purgePending
     -- Advance the epoch if the new finalized block triggers the epoch transition.
     checkedAdvanceEpoch newFinalizationEntry newFinalizedBlock
     -- Log that the blocks are finalized.
@@ -396,26 +394,3 @@ pruneBranches parent newFin deltaHeight oldBranches = PruneResult{..}
         (newSurvivors, newRemoved) = List.partition ((`elem` parents) . parent) brs
     (removedFromBranches, prNewBranches) = pruneLimbs [] [newFin] Seq.Empty limbs
     prRemoved = removedFromTrunk ++ removedFromBranches
-
--- |Given a block that has never been live, mark the block as dead.
--- Any pending children will also be marked dead recursively.
-blockArriveDead :: (MonadState (SkovData pv) m, MonadLogger m) => BlockHash -> m ()
-blockArriveDead blockHsh = do
-    logEvent Konsensus LLDebug $ "Block " ++ show blockHsh ++ " arrived dead."
-    markBlockDead blockHsh
-    children <- takePendingChildren blockHsh
-    forM_ children (blockArriveDead . getHash)
-
--- |Purge pending blocks with timestamps preceding the last finalized block.
-purgePending :: (MonadState (SkovData pv) m, MonadLogger m) => m ()
-purgePending = do
-    lfTimestamp <- use $ lastFinalized . to blockTimestamp
-    let purgeLoop =
-            takeNextPendingUntil lfTimestamp >>= \case
-                Nothing -> return ()
-                Just pending -> do
-                    let pendingHash = getHash pending
-                    blockIsPending <- gets (isPending pendingHash)
-                    when blockIsPending $ blockArriveDead pendingHash
-                    purgeLoop
-    purgeLoop

--- a/concordium-consensus/src/Concordium/KonsensusV1/Consensus/Quorum.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Consensus/Quorum.hs
@@ -143,9 +143,6 @@ receiveQuorumMessage qm@QuorumMessage{..} skovData = receive
                         -- The block is unknown so catch up.
                         BlockUnknown ->
                             return CatchupRequired
-                        -- The block is already pending so wait for it to be executed.
-                        BlockPending _ ->
-                            return CatchupRequired
                         -- The block is executed but not finalized.
                         -- Perform the remaining checks before processing the 'QuorumMessage'.
                         BlockAlive targetBlock

--- a/concordium-consensus/src/Concordium/KonsensusV1/Consensus/Timeout.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Consensus/Timeout.hs
@@ -178,7 +178,7 @@ receiveTimeoutMessage tm@TimeoutMessage{tmBody = TimeoutMessageBody{..}} skovDat
                                     -- If the block is pending or unknown, then due to the checks above
                                     -- we know that we have to initiate catch up since the round of the quorum certificate
                                     -- is greater than our highest certified block.
-                                    RecentBlock BlockPendingOrUnknown -> return CatchupRequired
+                                    RecentBlock BlockUnknown -> return CatchupRequired
   where
     -- Get the bakers and finalizers for the epoch of the timeout message's QC.
     -- If they are not available, trigger catch-up.

--- a/concordium-consensus/src/Concordium/KonsensusV1/Consensus/Timeout.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Consensus/Timeout.hs
@@ -175,7 +175,7 @@ receiveTimeoutMessage tm@TimeoutMessage{tmBody = TimeoutMessageBody{..}} skovDat
                                     -- The timeout message is now verified and ready for being retransmitted.
                                     RecentBlock (BlockAliveOrFinalized qcBlock) ->
                                         received finInfo finalizationCommittee (Present qcBlock)
-                                    -- If the block is pending or unknown, then due to the checks above
+                                    -- If the block is unknown, then due to the checks above
                                     -- we know that we have to initiate catch up since the round of the quorum certificate
                                     -- is greater than our highest certified block.
                                     RecentBlock BlockUnknown -> return CatchupRequired

--- a/concordium-consensus/src/Concordium/KonsensusV1/SkovMonad.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/SkovMonad.hs
@@ -280,9 +280,6 @@ instance Monad m => MonadConsensusEvent (SkovV1T pv m) where
     onFinalize fe bp = do
         handler <- view onFinalizeHandler
         handler fe bp
-    onPendingLive = do
-        handler <- view onPendingLiveHandler
-        lift handler
 
 instance (MonadIO m, MonadLogger m) => TimerMonad (SkovV1T pv m) where
     type Timer (SkovV1T pv m) = ThreadTimer

--- a/concordium-consensus/src/Concordium/KonsensusV1/TestMonad.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TestMonad.hs
@@ -101,8 +101,6 @@ data TestEvent (pv :: ProtocolVersion)
       OnBlock !(Block pv)
     | -- |Implements 'onFinalize' of 'MonadConsensusEvent'.
       OnFinalize !FinalizationEntry
-    | -- |Implements 'onPendingLive' of 'MonadConsensusEvent'.
-      OnPendingLive
     deriving (Eq, Show)
 
 -- |List of events generated during a test run.
@@ -265,7 +263,6 @@ instance TimerMonad (TestMonad pv) where
 instance MonadConsensusEvent (TestMonad pv) where
     onBlock = tell . (: []) . OnBlock . bpBlock
     onFinalize fe _ = tell [OnFinalize fe]
-    onPendingLive = tell [OnPendingLive]
 
 instance MonadLogger (TestMonad pv) where
     logEvent src lvl msg = do

--- a/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Implementation.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Implementation.hs
@@ -36,9 +36,7 @@ import GHC.Stack
 import Lens.Micro.Platform
 
 import qualified Data.HashMap.Strict as HM
-import qualified Data.List as List
 import qualified Data.Map.Strict as Map
-import qualified Data.PQueue.Prio.Min as MPQ
 import qualified Data.Sequence as Seq
 
 import qualified Concordium.Genesis.Data.BaseV1 as Base
@@ -74,16 +72,6 @@ instance Exception TreeStateInvariantViolation where
         "Tree state invariant violation: "
             ++ show reason
 
--- |Status of a block that is held in memory i.e.
--- the block is either pending or alive.
--- Parameterized by the 'BlockPointer' and the 'SignedBlock'.
-data InMemoryBlockStatus pv
-    = -- |The block is awaiting its parent to become part of chain.
-      MemBlockPending !PendingBlock
-    | -- |The block is alive i.e. head of chain.
-      MemBlockAlive !(BlockPointer pv)
-    deriving (Show)
-
 -- |The block table yields blocks that are
 -- either alive or pending.
 -- Furthermore it holds a fixed size cache of hashes
@@ -109,7 +97,7 @@ data BlockTable pv = BlockTable
       -- * When a block is being marked as dead.
       --
       -- Note that non-finalized certified blocks exist both in the live map and on the disk.
-      _liveMap :: !(HM.HashMap BlockHash (InMemoryBlockStatus pv))
+      _liveMap :: !(HM.HashMap BlockHash (BlockPointer pv))
     }
     deriving (Show)
 
@@ -143,37 +131,6 @@ data PendingTransactions pv = PendingTransactions
 -- We make it classy such that we can provide an instance @HasPendingTransactions (SkovData pv) pv@
 -- making it easier to work with from a 'SkovData' context.
 makeClassy ''PendingTransactions
-
--- | Pending blocks are conceptually stored in a min priority queue,
--- where multiple blocks may have the same key, which is their parent,
--- and the priority is the block's round number.
--- When a block arrives (possibly dead), its pending children are removed
--- from the queue and handled.  This uses 'takePendingChildren'.
--- When a block is finalized, all pending blocks with a lower or equal round
--- number can be handled (they will become dead, since they can no longer
--- join the tree).  This uses 'takeNextPendingUntil'.
-data PendingBlocks = PendingBlocks
-    { -- |Pending blocks i.e. blocks that have not yet been included in the tree.
-      -- The entries of the pending blocks are keyed by the 'BlockHash' of their parent block.
-      _pendingBlocksTable :: !(HM.HashMap BlockHash [PendingBlock]),
-      -- |A priority queue on the (pending block hash, parent of pending block hash) tuple,
-      -- prioritised by the timestamp of the pending block. The queue in particular supports extracting
-      -- the pending block with minimal 'Timestamp'. Note that the queue can contain spurious pending
-      -- blocks, and a block is only actually in the pending blocks if it has an entry in the
-      -- '_pendingBlocksTable'.
-      _pendingBlocksQueue :: !(MPQ.MinPQueue Timestamp (BlockHash, BlockHash))
-    }
-    deriving (Eq, Show)
-
-makeClassy ''PendingBlocks
-
--- |A 'PendingBlocks' with no blocks.
-emptyPendingBlocks :: PendingBlocks
-emptyPendingBlocks =
-    PendingBlocks
-        { _pendingBlocksTable = HM.empty,
-          _pendingBlocksQueue = MPQ.empty
-        }
 
 -- |Data required to support 'TreeState'.
 --
@@ -225,8 +182,6 @@ data SkovData (pv :: ProtocolVersion) = SkovData
       _roundExistingQCs :: !(Map.Map Round QuorumCertificateCheckedWitness),
       -- |Genesis metadata
       _genesisMetadata :: !GenesisMetadata,
-      -- |Pending blocks
-      _skovPendingBlocks :: !PendingBlocks,
       -- |Pointer to the last finalized block.
       _lastFinalized :: !(BlockPointer pv),
       -- |A finalization entry that finalizes the last finalized block, unless that is the
@@ -257,10 +212,6 @@ makeLenses ''SkovData
 instance HasPendingTransactions (SkovData pv) pv where
     pendingTransactions = skovPendingTransactions
     {-# INLINE pendingTransactions #-}
-
-instance HasPendingBlocks (SkovData pv) where
-    pendingBlocks = skovPendingBlocks
-    {-# INLINE pendingBlocks #-}
 
 instance HasEpochBakers (SkovData pv) where
     epochBakers = skovEpochBakers
@@ -373,7 +324,6 @@ mkInitialSkovData rp genMeta genState _currentTimeout _skovEpochBakers transacti
         _roundExistingBlocks = Map.empty
         _roundExistingQCs = Map.empty
         _genesisMetadata = genMeta
-        _skovPendingBlocks = emptyPendingBlocks
         _lastFinalized = genesisBlockPointer
         _latestFinalizationEntry = Absent
         _statistics = Stats.initialConsensusStatistics
@@ -384,17 +334,11 @@ mkInitialSkovData rp genMeta genState _currentTimeout _skovEpochBakers transacti
 
 -- * Operations on the block table
 
--- |Look up whether the given block hash is a currently-pending block in the block table.
-isPending :: BlockHash -> SkovData pv -> Bool
-isPending bh sd = case sd ^? blockTable . liveMap . ix bh of
-    Just (MemBlockPending _) -> True
-    _ -> False
-
 -- |Get the 'BlockPointer' for a block hash that is live (not finalized).
 -- Returns 'Nothing' if the block is not in the live (non-finalized) blocks.
 getLiveBlock :: BlockHash -> SkovData pv -> Maybe (BlockPointer pv)
 getLiveBlock blockHash sd = case sd ^? blockTable . liveMap . ix blockHash of
-    Just (MemBlockAlive bp) -> Just bp
+    Just bp -> Just bp
     _ -> Nothing
 
 -- |Get the 'BlockPointer' for a block hash that is live or the last finalized block.
@@ -418,9 +362,7 @@ getMemoryBlockStatus blockHash sd
     -- Check if it's the focus block
     | getHash (sd ^. focusBlock) == blockHash = Just $! BlockAlive (sd ^. focusBlock)
     -- Check if it's a pending or live block
-    | Just status <- sd ^? blockTable . liveMap . ix blockHash = case status of
-        MemBlockPending sb -> Just $! BlockPending sb
-        MemBlockAlive bp -> Just $! BlockAlive bp
+    | Just bp <- sd ^? blockTable . liveMap . ix blockHash = Just $! BlockAlive bp
     -- Check if it's in the dead block cache
     | memberDeadCache blockHash (sd ^. blockTable . deadBlocks) = Just BlockDead
     -- Otherwise, we don't know
@@ -515,7 +457,7 @@ makeLiveBlock pb st height arriveTime energyCost = do
                   bpBlock = NormalBlock (pbBlock pb),
                   bpState = st
                 }
-    blockTable . liveMap . at' (getHash pb) ?=! MemBlockAlive bp
+    blockTable . liveMap . at' (getHash pb) ?=! bp
     return bp
 
 -- |Marks a block as dead.
@@ -542,11 +484,6 @@ markLiveBlockDead bp = do
     markBlockDead bh
     purgeBlockState $ bpState bp
     mapM_ (markTransactionDead bh) (blockTransactions bp)
-
--- |Mark a block as pending in the block table.
--- (Note, this does not update the pending block table.)
-markPending :: (MonadState (SkovData pv) m) => PendingBlock -> m ()
-markPending pb = blockTable . liveMap . at' (getHash pb) ?=! MemBlockPending pb
 
 -- |Update the transaction table to reflect that a list of blocks are finalized.
 -- This removes them the in-memory transaction table.
@@ -592,7 +529,7 @@ parentOfLive sd block
     | let lastFin = sd ^. lastFinalized,
       parentHash == getHash lastFin =
         lastFin
-    | Just (MemBlockAlive parent) <- sd ^. blockTable . liveMap . at' parentHash = parent
+    | Just parent <- sd ^. blockTable . liveMap . at' parentHash = parent
     | otherwise =
         error $
             "parentOfLive: parent block ("
@@ -671,65 +608,6 @@ branchesFromTop = revSeqToList . _branches
   where
     revSeqToList Seq.Empty = []
     revSeqToList (r Seq.:|> t) = t : revSeqToList r
-
--- * Operations on pending blocks
-
--- $pendingBlocks
--- Pending blocks are conceptually stored in a min priority queue,
--- where multiple blocks may have the same key, which is their parent,
--- and the priority is the block's timestamp.
--- When a block arrives (possibly dead), its pending children are removed
--- from the queue and handled.  This uses 'takePendingChildren'.
--- When a block is finalized, all pending blocks with a lower or equal timestamp
--- can be handled (they will become dead, since they can no longer join the tree).
--- This uses 'takeNextPendingUntil'.
-
--- |Add a block to the pending block table and queue.
--- [Note: this does not affect the '_branches' of the 'SkovData'.]
-addPendingBlock ::
-    (MonadState s m, HasPendingBlocks s) =>
-    -- |The 'PendingBlock' to add.
-    -- Note that we force it here to make sure it is
-    -- evaluted since there are no guarantees by just the looks of this function.
-    -- In practice it probably does not matter as the pending block is being pre-verified
-    -- before this function is called. But we do it for good measure here.
-    PendingBlock ->
-    m ()
-addPendingBlock !pb = do
-    pendingBlocksQueue %= MPQ.insert theTimestamp (blockHash, parentHash)
-    pendingBlocksTable . at' parentHash . non [] %= (pb :)
-  where
-    blockHash = getHash pb
-    theTimestamp = blockTimestamp pb
-    parentHash = blockParent pb
-
--- |Take the set of blocks that are pending a particular parent from the pending block table.
--- Note: this does not remove them from the pending blocks queue; blocks should be removed from
--- the queue as the finalized timestamp progresses.
-takePendingChildren :: (MonadState s m, HasPendingBlocks s) => BlockHash -> m [PendingBlock]
-takePendingChildren parent = pendingBlocksTable . at' parent . non [] <<.= []
-
--- |Return the next block that is pending its parent with timestamp
--- less than or equal to the given value, removing it from the pending
--- table.  Returns 'Nothing' if there is no such pending block.
-takeNextPendingUntil :: (MonadState s m, HasPendingBlocks s) => Timestamp -> m (Maybe PendingBlock)
-takeNextPendingUntil targetTimestamp = takeNextUntil =<< use pendingBlocksQueue
-  where
-    takeNextUntil pbq = case MPQ.minViewWithKey pbq of
-        Just ((r, (pending, parent)), pbq')
-            | r <= targetTimestamp -> do
-                (myPB, otherPBs) <-
-                    List.partition ((== pending) . getHash)
-                        <$> use (pendingBlocksTable . at' parent . non [])
-                case myPB of
-                    [] -> takeNextUntil pbq' -- Block is no longer actually pending
-                    (realPB : _) -> do
-                        pendingBlocksTable . at' parent . non [] .= otherPBs
-                        pendingBlocksQueue .= pbq'
-                        return (Just realPB)
-        _ -> do
-            pendingBlocksQueue .=! pbq
-            return Nothing
 
 -- * Operations on the transaction table
 
@@ -1107,9 +985,6 @@ bakersForCurrentEpoch sd
 -- their status changed to 'Received' and their 'CommitPoint' is reset.
 clearOnProtocolUpdate :: (MonadState (SkovData pv) m) => m ()
 clearOnProtocolUpdate = do
-    -- clear the pending block table
-    pendingBlocksTable .=! HM.empty
-    pendingBlocksQueue .=! MPQ.empty
     -- clear the block table
     blockTable .=! emptyBlockTable
     -- clear the branches

--- a/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Implementation.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Implementation.hs
@@ -337,9 +337,7 @@ mkInitialSkovData rp genMeta genState _currentTimeout _skovEpochBakers transacti
 -- |Get the 'BlockPointer' for a block hash that is live (not finalized).
 -- Returns 'Nothing' if the block is not in the live (non-finalized) blocks.
 getLiveBlock :: BlockHash -> SkovData pv -> Maybe (BlockPointer pv)
-getLiveBlock blockHash sd = case sd ^? blockTable . liveMap . ix blockHash of
-    Just bp -> Just bp
-    _ -> Nothing
+getLiveBlock blockHash sd = sd ^? blockTable . liveMap . ix blockHash
 
 -- |Get the 'BlockPointer' for a block hash that is live or the last finalized block.
 -- Returns 'Nothing' if the block is neither live nor the last finalized block.
@@ -361,7 +359,7 @@ getMemoryBlockStatus blockHash sd
     | getHash (sd ^. lastFinalized) == blockHash = Just $! BlockFinalized (sd ^. lastFinalized)
     -- Check if it's the focus block
     | getHash (sd ^. focusBlock) == blockHash = Just $! BlockAlive (sd ^. focusBlock)
-    -- Check if it's a pending or live block
+    -- Check if it's a live block
     | Just bp <- sd ^? blockTable . liveMap . ix blockHash = Just $! BlockAlive bp
     -- Check if it's in the dead block cache
     | memberDeadCache blockHash (sd ^. blockTable . deadBlocks) = Just BlockDead

--- a/concordium-consensus/src/Concordium/KonsensusV1/TreeState/StartUp.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TreeState/StartUp.hs
@@ -265,7 +265,6 @@ loadSkovData _runtimeParameters didRollback = do
             Just finEntry -> Map.singleton (qcRound qc) (toQuorumCertificateWitness qc)
               where
                 qc = feFinalizedQuorumCertificate finEntry
-    let _skovPendingBlocks = emptyPendingBlocks
     let _lastFinalized = lastFinBlock
     _latestFinalizationEntry <- maybe Absent Present <$> LowLevel.lookupLatestFinalizationEntry
     -- We will load our last timeout message if appropriate in 'loadCertifiedBlocks'.
@@ -421,7 +420,7 @@ loadCertifiedBlocks = do
     loadCertBlock (storedBlock, qc) = do
         blockPointer <- mkBlockPointer storedBlock
         cacheBlockState (bpState blockPointer)
-        blockTable . liveMap . at' (getHash blockPointer) ?=! MemBlockAlive blockPointer
+        blockTable . liveMap . at' (getHash blockPointer) ?=! blockPointer
         addToBranches blockPointer
         forM_ (blockTransactions blockPointer) $ \tr -> do
             -- Add transactions to the transaction table as 'TVer.TrustedSuccess', since they

--- a/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Types.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Types.hs
@@ -234,7 +234,6 @@ pattern BlockAliveOrFinalized :: BlockPointer pv -> BlockStatus pv
 pattern BlockAliveOrFinalized b <- (blockStatusBlock -> Just b)
 
 -- This tells GHC that these patterns are complete for 'BlockStatus'.
-{-# COMPLETE BlockUnknown, BlockAlive, BlockFinalized, BlockDead #-}
 {-# COMPLETE BlockUnknown, BlockAliveOrFinalized, BlockDead #-}
 
 -- |The status of a block as obtained without loading the block from disk.

--- a/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Types.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Types.hs
@@ -209,9 +209,7 @@ data TransactionStatus
 -- in a pattern match, then if 'BlockStatus pv' is to be modified the complete pragma MUST also be
 -- checked whether it is still sufficient.
 data BlockStatus pv
-    = -- |The block is awaiting its parent to become part of chain.
-      BlockPending !PendingBlock
-    | -- |The block is alive.
+    = -- |The block is alive.
       BlockAlive !(BlockPointer pv)
     | -- |The block is finalized.
       BlockFinalized !(BlockPointer pv)
@@ -231,24 +229,13 @@ blockStatusBlock (BlockAlive b) = Just b
 blockStatusBlock (BlockFinalized b) = Just b
 blockStatusBlock _ = Nothing
 
--- |Returns 'True' just when the 'BlockStatus' is either 'BlockPending' or 'BlockUnknown'.
-isPendingOrUnknown :: BlockStatus pv -> Bool
-isPendingOrUnknown BlockPending{} = True
-isPendingOrUnknown BlockUnknown = True
-isPendingOrUnknown _ = False
-
 -- |A (unidirectional) pattern for matching a block status that is either alive or finalized.
 pattern BlockAliveOrFinalized :: BlockPointer pv -> BlockStatus pv
 pattern BlockAliveOrFinalized b <- (blockStatusBlock -> Just b)
 
--- |A (unidirectional) pattern for matching a block status that is either pending or unknown.
-pattern BlockPendingOrUnknown :: BlockStatus pv
-pattern BlockPendingOrUnknown <- (isPendingOrUnknown -> True)
-
 -- This tells GHC that these patterns are complete for 'BlockStatus'.
-{-# COMPLETE BlockPending, BlockAliveOrFinalized, BlockDead, BlockUnknown #-}
-{-# COMPLETE BlockPendingOrUnknown, BlockAlive, BlockFinalized, BlockDead #-}
-{-# COMPLETE BlockPendingOrUnknown, BlockAliveOrFinalized, BlockDead #-}
+{-# COMPLETE BlockUnknown, BlockAlive, BlockFinalized, BlockDead #-}
+{-# COMPLETE BlockUnknown, BlockAliveOrFinalized, BlockDead #-}
 
 -- |The status of a block as obtained without loading the block from disk.
 data RecentBlockStatus pv


### PR DESCRIPTION
## Purpose

Closes https://github.com/Concordium/concordium-node/issues/1000.

## Changes

- The behaviour of the function `receiveBlockUnknownParent` has changed, so that it now returns `BlockResultPending` without marking or adding the block as pending. It still returns `BlockResultEarly` if if the timestamp is no less than the receive time of the block + the early block threshold.
- The type `PendingBlocks` (consisting of the pending block table and the pending block queue) is removed. As a consequence `SkovData` has no field `_skovPendingBlocks` anymore.
- The type `InMemoryBlockStatus` is removed, and the `_liveMap` in `BlockTable` is now a `HM.HashMap BlockHash (BlockPointer pv)` instead of the former `HM.HashMap BlockHash (InMemoryBlockStatus pv)`.
- The functions `addPendingBlock`, `markPending`, `blockArriveDead`, `purgePending`, `takePendingChildren`, `takeNextPendingUntil`, `processPendingChild` and `processPendingChildren` are removed.
- The `BlockPending` variant of `BlockStatus` is removed.


## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

