### PR TITLE
Enabled out-of-band catch-up by default on Mac and Ubuntu

### DIFF
--- a/jenkinsfiles/ubuntu.Jenkinsfile
+++ b/jenkinsfiles/ubuntu.Jenkinsfile
@@ -89,6 +89,7 @@ pipeline {
                         --build-arg static_binaries_image_tag=${STATIC_BINARIES_IMAGE_TAG}\
                         --build-arg build_env_name=${ENVIRONMENT_CAP}\
                         --build-arg build_env_name_lower=${ENVIRONMENT}\
+                        --build-arg build_catchup_url=https://catchup.${DOMAIN}/blocks.idx\
                         --build-arg build_genesis_hash=$(cat ${GENESIS_HASH_PATH} | tr -cd "[:alnum:]")\
                         --build-arg build_collector_backend_url=https://dashboard.${DOMAIN}/nodes/post\
                         --build-arg build_grpc2_listen_port=${GRPC2_PORT}\

--- a/scripts/distribution/macOS-package/template/payload/tmp/Concordium Node/LaunchDaemons/software.concordium.mainnet.node.plist
+++ b/scripts/distribution/macOS-package/template/payload/tmp/Concordium Node/LaunchDaemons/software.concordium.mainnet.node.plist
@@ -20,6 +20,10 @@
         <key>CONCORDIUM_NODE_CONNECTION_BOOTSTRAP_NODES</key>
         <string>bootstrap.mainnet.concordium.software:8888</string>
 
+        <!-- The url of the catchup file. This speeds up the catchup process. -->
+        <key>CONCORDIUM_NODE_CONSENSUS_DOWNLOAD_BLOCKS_FROM</key>
+        <string>https://catchup.mainnet.concordium.software/blocks.idx</string>
+
         <!-- Desired number of nodes to be connected to. -->
         <key>CONCORDIUM_NODE_CONNECTION_DESIRED_NODES</key>
         <string>5</string>

--- a/scripts/distribution/macOS-package/template/payload/tmp/Concordium Node/LaunchDaemons/software.concordium.testnet.node.plist
+++ b/scripts/distribution/macOS-package/template/payload/tmp/Concordium Node/LaunchDaemons/software.concordium.testnet.node.plist
@@ -20,6 +20,10 @@
         <key>CONCORDIUM_NODE_CONNECTION_BOOTSTRAP_NODES</key>
         <string>bootstrap.testnet.concordium.com:8888</string>
 
+        <!-- The url of the catchup file. This speeds up the catchup process. -->
+        <key>CONCORDIUM_NODE_CONSENSUS_DOWNLOAD_BLOCKS_FROM</key>
+        <string>https://catchup.testnet.concordium.com/blocks.idx</string>
+
         <!-- Desired number of nodes to be connected to. -->
         <key>CONCORDIUM_NODE_CONNECTION_DESIRED_NODES</key>
         <string>5</string>

--- a/scripts/distribution/ubuntu-packages/build-mainnet-deb.sh
+++ b/scripts/distribution/ubuntu-packages/build-mainnet-deb.sh
@@ -23,6 +23,7 @@ docker build\
        --build-arg static_binaries_image_tag=$STATIC_BINARIES_IMAGE_TAG\
        --build-arg build_env_name=Mainnet\
        --build-arg build_env_name_lower=mainnet\
+       --build-arg build_catchup_url=https://catchup.mainnet.concordium.software/blocks.idx\
        --build-arg build_genesis_hash=9dd9ca4d19e9393877d2c44b70f89acbfc0883c2243e5eeaecc0d1cd0503f478\
        --build-arg build_collector_backend_url=https://dashboard.mainnet.concordium.software/nodes/post\
        --build-arg build_grpc2_listen_port=20000\

--- a/scripts/distribution/ubuntu-packages/build-mainnet-deb.sh
+++ b/scripts/distribution/ubuntu-packages/build-mainnet-deb.sh
@@ -11,6 +11,8 @@ set -euxo pipefail
 # Set STATIC_BINARIES_IMAGE_TAG to latest if not already set
 export STATIC_BINARIES_IMAGE_TAG="${STATIC_BINARIES_IMAGE_TAG:-latest}"
 
+# If the static-node-binaries image exists we use the binaries therein.
+# Otherwise we build it first.
 if ! docker inspect --type=image static-node-binaries:$STATIC_BINARIES_IMAGE_TAG > /dev/null 2> /dev/null ; then
     # build static binaries
     export STATIC_LIBRARIES_IMAGE_TAG="${STATIC_LIBRARIES_IMAGE_TAG:-latest}"

--- a/scripts/distribution/ubuntu-packages/build-testnet-deb.sh
+++ b/scripts/distribution/ubuntu-packages/build-testnet-deb.sh
@@ -25,6 +25,7 @@ docker build\
        --build-arg static_binaries_image_tag=$STATIC_BINARIES_IMAGE_TAG\
        --build-arg build_env_name=Testnet\
        --build-arg build_env_name_lower=testnet\
+       --build-arg build_catchup_url=https://catchup.testnet.concordium.com/blocks.idx\
        --build-arg build_genesis_hash=4221332d34e1694168c2a0c0b3fd0f273809612cb13d000d5c2e00e85f50f796\
        --build-arg build_collector_backend_url=https://dashboard.testnet.concordium.com/nodes/post\
        --build-arg build_grpc2_listen_port=20001\

--- a/scripts/distribution/ubuntu-packages/deb.Dockerfile
+++ b/scripts/distribution/ubuntu-packages/deb.Dockerfile
@@ -23,6 +23,7 @@ DEBIAN_FRONTEND=noninteractive apt-get -y install debhelper dh-exec libgmp10
 
 ARG build_env_name=Testnet
 ARG build_env_name_lower=testnet
+ARG build_catchup_url=https://catchup.testnet.concordium.com/blocks.idx
 ARG build_genesis_hash=b6078154d6717e909ce0da4a45a25151b592824f31624b755900a74429e3073d
 ARG build_collector_backend_url=https://dashboard.testnet.concordium.com/nodes/post
 ARG build_grpc2_listen_port=20001

--- a/scripts/distribution/ubuntu-packages/template/debian/concordium-node.service
+++ b/scripts/distribution/ubuntu-packages/template/debian/concordium-node.service
@@ -49,6 +49,8 @@ Environment=CONCORDIUM_NODE_CONNECTION_MAX_ALLOWED_NODES=10
 Environment=CONCORDIUM_NODE_GRPC2_LISTEN_ADDRESS=0.0.0.0
 # And its port of the GRPC V2 server.
 Environment=CONCORDIUM_NODE_GRPC2_LISTEN_PORT=${build_grpc2_listen_port}
+# The url of the catchup file. This speeds up the catchup process.
+Environment=CONCORDIUM_NODE_CONSENSUS_DOWNLOAD_BLOCKS_FROM=${build_catchup_url}
 
 # maximum number of __connections__ the node can have. This can temporarily be more than
 # the number of peers when incoming connections are processed. 

--- a/scripts/distribution/ubuntu-packages/template/instantiate.sh
+++ b/scripts/distribution/ubuntu-packages/template/instantiate.sh
@@ -7,6 +7,7 @@
 # Expects the following environment variables to be set.
 # - build_env_name (e.g., Testnet)
 # - build_env_name_lower (e.g., testnet)
+# - build_catchup_url (e.g. https://catchup.testnet.concordium.com/blocks.idx)
 # - build_genesis_hash
 # - build_collector_backend_url (e.g. https://dashboard.testnet.concordium.com/nodes/post)
 # - build_grpc2_listen_port (e.g., 20001)
@@ -18,11 +19,11 @@
 
 export build_version=$(./binaries/concordium-node --version | cut -d ' ' -f 2)
 
-if [[ -z "$build_env_name"  || -z "$build_env_name_lower" || -z "$build_version"
-        || -z "$build_genesis_hash" || -z "$build_collector_backend_url"
+if [[ -z "$build_env_name"  || -z "$build_env_name_lower" ||-z "$build_catchup_url"
+        || -z "$build_version" || -z "$build_genesis_hash" || -z "$build_collector_backend_url"
         || -z "$build_grpc2_listen_port" || -z "$build_listen_port" || -z "$build_bootstrap" ]];
 then
-    echo 'All of $build_env_name $build_env_name_lower $build_version $build_genesis_hash $build_collector_backend_url $build_grpc2_listen_port $build_listen_port $build_bootstrap must be set.'
+    echo 'All of $build_env_name $build_env_name_lower $build_catchup_url $build_version $build_genesis_hash $build_collector_backend_url $build_grpc2_listen_port $build_listen_port $build_bootstrap must be set.'
     exit 1
 fi
 
@@ -39,6 +40,7 @@ do
     mv "$file" "$file.tmp"
     envsubst '$build_env_name
               $build_env_name_lower
+              $build_catchup_url
               $build_version
               $build_genesis_hash
               $build_collector_backend_url

--- a/scripts/distribution/ubuntu-packages/template/instantiate.sh
+++ b/scripts/distribution/ubuntu-packages/template/instantiate.sh
@@ -19,7 +19,7 @@
 
 export build_version=$(./binaries/concordium-node --version | cut -d ' ' -f 2)
 
-if [[ -z "$build_env_name"  || -z "$build_env_name_lower" ||-z "$build_catchup_url"
+if [[ -z "$build_env_name"  || -z "$build_env_name_lower" || -z "$build_catchup_url"
         || -z "$build_version" || -z "$build_genesis_hash" || -z "$build_collector_backend_url"
         || -z "$build_grpc2_listen_port" || -z "$build_listen_port" || -z "$build_bootstrap" ]];
 then


### PR DESCRIPTION
## Purpose

Addresses #967 

## Changes

Set default URL values for out-of-band catch-up for Ubuntu and Mac for both mainnet and testnet, thus enabling them by default. Docker already had default values set and the Windows one is handled in this PR #963

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
