### PR TITLE
Limit grpc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased changes
 
+- Extend Prometheus exporter with metric `grpc_connected_clients`, see
+  [docs/prometheus-exporter.md](https://github.com/Concordium/concordium-node/blob/main/docs/prometheus-exporter.md) for more details.
+- Add configuration options for imposing resource limits to the V2 gRPC server.
+  The following environment variables are added
+  - `CONCORDIUM_NODE_GRPC2_KEEPALIVE_INTERVAL`
+  - `CONCORDIUM_NODE_GRPC2_KEEPALIVE_TIMEOUT`
+  - `CONCORDIUM_NODE_GRPC2_TCP_KEEPALIVE`
+  - `CONCORDIUM_NODE_GRPC2_INVOKE_MAX_ENERGY`
+  - `CONCORDIUM_NODE_GRPC2_MAX_CONCURRENT_REQUESTS`
+  - `CONCORDIUM_NODE_GRPC2_MAX_CONCURRENT_REQUESTS_PER_CONNECTION`
+  - `CONCORDIUM_NODE_GRPC2_MAX_CONCURRENT_STREAMS`
+  - `CONCORDIUM_NODE_GRPC2_MAX_CONNECTIONS`
+  - `CONCORDIUM_NODE_GRPC2_REQUEST_TIMEOUT`
+
+  See
+  [docs/grpc2.md](https://github.com/Concordium/concordium-node/blob/main/docs/grpc2.md)
+  for an explanation of the options.
+
 ## 6.1.3
 
 - Fix a bug where stored peers are removed incorrectly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+## 6.1.4
+
 - Expose the health check service via grpc-web when grpc-web is enabled.
  Support for out-of-band catch-up for protocol versions beyond P6.
 - Extend Prometheus exporter with metric `grpc_connected_clients`, see

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -648,7 +648,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_node"
-version = "6.1.3"
+version = "6.1.4"
 dependencies = [
  "anyhow",
  "app_dirs2",

--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -13,10 +13,10 @@ license-file = "../LICENSE"
 
 [features]
 default = []
-test_utils = [ ]
+test_utils = []
 network_dump = []
-static = [ ]
-profiling = [ "static" ]
+static = []
+profiling = ["static"]
 
 [profile.release]
 codegen-units = 1

--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium_node"
-version = "6.1.3" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
+version = "6.1.4" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
 description = "Concordium Node"
 authors = ["Concordium <developers@concordium.com>"]
 exclude = [".gitignore", ".gitlab-ci.yml", "test/**/*","**/**/.gitignore","**/**/.gitlab-ci.yml"]

--- a/concordium-node/src/configuration.rs
+++ b/concordium-node/src/configuration.rs
@@ -450,9 +450,16 @@ pub struct GRPC2Config {
     #[structopt(
         long = "grpc2-max-concurrent-streams",
         help = "Maximum number of concurrently open streams.",
-        env = "CONCORDIUM_NODE_GRPC2_MAX_CONCURRENT_STREAMS",
+        env = "CONCORDIUM_NODE_GRPC2_MAX_CONCURRENT_STREAMS"
     )]
     pub max_concurrent_streams: Option<u32>,
+    #[structopt(
+        long = "grpc2-max-concurrent-requests",
+        help = "Maximum number of concurrent requests allowed for the grpc2 server.",
+        env = "CONCORDIUM_NODE_GRPC2_MAX_CONCURRENT_REQUESTS",
+        default_value = "100"
+    )]
+    pub max_concurrent_requests: usize,
     #[structopt(
         long = "grpc2-request-timeout",
         help = "Maximum amout of time to allow for processing a request (in seconds).",
@@ -462,13 +469,16 @@ pub struct GRPC2Config {
     pub request_timeout: u64,
     #[structopt(
         long = "grpc2-keep-alive-interval",
-        help = "Enable HTTP2 keepalive, and set the interval (in seconds) at which Ping frames are sent.",
-        env = "CONCORDIUM_NODE_GRPC2_KEEPALIVE_INTERVAL",
+        help = "Enable HTTP2 keepalive, and set the interval (in seconds) at which Ping frames \
+                are sent.",
+        env = "CONCORDIUM_NODE_GRPC2_KEEPALIVE_INTERVAL"
     )]
     pub keepalive_interval: Option<u64>,
     #[structopt(
         long = "grpc2-keep-alive-timeout",
-        help = "Timeout (in seconds) for responses to HTTP2 Ping frames. If the client does not respond in time then the connection will be closed. This has no effect unless `grpc2-keep-alive-interval` is set.",
+        help = "Timeout (in seconds) for responses to HTTP2 Ping frames. If the client does not \
+                respond in time then the connection will be closed. This has no effect unless \
+                `grpc2-keep-alive-interval` is set.",
         env = "CONCORDIUM_NODE_GRPC2_KEEPALIVE_TIMEOUT",
         default_value = "20"
     )]

--- a/concordium-node/src/configuration.rs
+++ b/concordium-node/src/configuration.rs
@@ -361,7 +361,7 @@ pub struct GRPC2Config {
         help = "Address the GRPC server should listen on, e.g., 127.0.0.1",
         env = "CONCORDIUM_NODE_GRPC2_LISTEN_ADDRESS"
     )]
-    pub listen_addr:                Option<std::net::IpAddr>,
+    pub listen_addr: Option<std::net::IpAddr>,
     #[structopt(
         name = "grpc2-listen-port",
         long = "grpc2-listen-port",
@@ -369,7 +369,7 @@ pub struct GRPC2Config {
         help = "Address the GRPC server should listen on, e.g. 11000",
         env = "CONCORDIUM_NODE_GRPC2_LISTEN_PORT"
     )]
-    pub listen_port:                Option<u16>,
+    pub listen_port: Option<u16>,
     #[structopt(
         name = "grpc2-x509-cert",
         long = "grpc2-x509-cert",
@@ -378,7 +378,7 @@ pub struct GRPC2Config {
         requires = "grpc2-listen-addr",
         requires = "grpc2-cert-private-key"
     )]
-    pub x509_cert:                  Option<PathBuf>,
+    pub x509_cert: Option<PathBuf>,
     #[structopt(
         name = "grpc2-cert-private-key",
         long = "grpc2-cert-private-key",
@@ -387,14 +387,14 @@ pub struct GRPC2Config {
         requires = "grpc2-listen-addr",
         requires = "grpc2-x509-cert"
     )]
-    pub cert_private_key:           Option<PathBuf>,
+    pub cert_private_key: Option<PathBuf>,
     #[structopt(
         long = "grpc2-enable-grpc-web",
         help = "Enable support for GRPC-Web protocol.",
         env = "CONCORDIUM_NODE_GRPC2_ENABLE_GRPC_WEB",
         requires = "grpc2-listen-addr"
     )]
-    pub enable_grpc_web:            bool,
+    pub enable_grpc_web: bool,
     #[structopt(
         long = "grpc2-endpoint-config",
         help = "Configuration file for endpoints, listing which endpoints should be enabled or \
@@ -403,7 +403,7 @@ pub struct GRPC2Config {
         env = "CONCORDIUM_NODE_GRPC2_ENDPOINT_CONFIG",
         requires = "grpc2-listen-addr"
     )]
-    pub endpoint_config:            Option<PathBuf>,
+    pub endpoint_config: Option<PathBuf>,
     #[structopt(
         long = "grpc2-invoke-max-energy",
         help = "Maximum amount of energy allowed for the InvokeInstance and InvokeContract (V1 \
@@ -411,7 +411,7 @@ pub struct GRPC2Config {
         env = "CONCORDIUM_NODE_GRPC2_INVOKE_MAX_ENERGY",
         default_value = "1000000"
     )]
-    pub invoke_max_energy:          u64,
+    pub invoke_max_energy: u64,
     #[structopt(
         long = "grpc2-health-max-finalized-delay",
         help = "Maximum amount of seconds that the time of the last finalized block can be behind \
@@ -426,7 +426,53 @@ pub struct GRPC2Config {
                 the number of peers does not affect the health check.",
         env = "CONCORDIUM_NODE_GRPC2_HEALTH_MIN_PEERS"
     )]
-    pub health_min_peers:           Option<usize>,
+    pub health_min_peers: Option<usize>,
+    #[structopt(
+        long = "grpc2-max-connections",
+        help = "Maximum number of connections that the GRPC server will allow at any given time.",
+        env = "CONCORDIUM_NODE_GRPC2_MAX_CONNECTIONS",
+        default_value = "500"
+    )]
+    pub max_connections: usize,
+    #[structopt(
+        long = "grpc2-tcp-keep-alive-interval",
+        help = "The interval (in seconds) at which TCP keepalive probes are sent.",
+        env = "CONCORDIUM_NODE_GRPC2_TCP_KEEPALIVE"
+    )]
+    pub tcp_keepalive: Option<u64>,
+    #[structopt(
+        long = "grpc2-max-concurrent-requests-per-connection",
+        help = "Maximum number of concurrent requests per connection.",
+        env = "CONCORDIUM_NODE_GRPC2_MAX_CONCURRENT_REQUESTS_PER_CONNECTION",
+        default_value = "10"
+    )]
+    pub max_concurrent_requests_per_connection: usize,
+    #[structopt(
+        long = "grpc2-max-concurrent-streams",
+        help = "Maximum number of concurrently open streams.",
+        env = "CONCORDIUM_NODE_GRPC2_MAX_CONCURRENT_STREAMS",
+    )]
+    pub max_concurrent_streams: Option<u32>,
+    #[structopt(
+        long = "grpc2-request-timeout",
+        help = "Maximum amout of time to allow for processing a request (in seconds).",
+        env = "CONCORDIUM_NODE_GRPC2_REQUEST_TIMEOUT",
+        default_value = "30"
+    )]
+    pub request_timeout: u64,
+    #[structopt(
+        long = "grpc2-keep-alive-interval",
+        help = "Enable HTTP2 keepalive, and set the interval (in seconds) at which Ping frames are sent.",
+        env = "CONCORDIUM_NODE_GRPC2_KEEPALIVE_INTERVAL",
+    )]
+    pub keepalive_interval: Option<u64>,
+    #[structopt(
+        long = "grpc2-keep-alive-timeout",
+        help = "Timeout (in seconds) for responses to HTTP2 Ping frames. If the client does not respond in time then the connection will be closed. This has no effect unless `grpc2-keep-alive-interval` is set.",
+        env = "CONCORDIUM_NODE_GRPC2_KEEPALIVE_TIMEOUT",
+        default_value = "20"
+    )]
+    pub keepalive_timeout: u64,
 }
 
 impl GRPC2Config {

--- a/concordium-node/src/stats_export_service.rs
+++ b/concordium-node/src/stats_export_service.rs
@@ -276,7 +276,7 @@ pub struct StatsExportService {
     /// bucket in which they are contained.
     pub peer_bucket_size: IntGaugeVec,
     /// The number of connections maintained by the GRPC V2 server.
-    pub grpc_connected_clients: GenericGauge<AtomicU64>
+    pub grpc_connected_clients: GenericGauge<AtomicU64>,
 }
 
 impl StatsExportService {
@@ -483,12 +483,11 @@ impl StatsExportService {
         )?;
         registry.register(Box::new(peer_bucket_size.clone()))?;
 
-        let grpc2_connected_clients = GenericGauge::with_opts(Opts::new(
-            "grpc2_connected_clients",
+        let grpc_connected_clients = GenericGauge::with_opts(Opts::new(
+            "grpc_connected_clients",
             "Current number of clients connected to the GRPC V2 interface.",
         ))?;
-        registry.register(Box::new(grpc2_connected_clients.clone()))?;
-
+        registry.register(Box::new(grpc_connected_clients.clone()))?;
 
         Ok(StatsExportService {
             registry,
@@ -524,7 +523,7 @@ impl StatsExportService {
             avg_bps_in,
             avg_bps_out,
             peer_bucket_size,
-            grpc_connected_clients: grpc2_connected_clients,
+            grpc_connected_clients,
         })
     }
 

--- a/concordium-node/src/stats_export_service.rs
+++ b/concordium-node/src/stats_export_service.rs
@@ -275,6 +275,8 @@ pub struct StatsExportService {
     /// The number of peers that recently connected to the node labelled by the
     /// bucket in which they are contained.
     pub peer_bucket_size: IntGaugeVec,
+    /// The number of connections maintained by the GRPC V2 server.
+    pub grpc_connected_clients: GenericGauge<AtomicU64>
 }
 
 impl StatsExportService {
@@ -481,6 +483,13 @@ impl StatsExportService {
         )?;
         registry.register(Box::new(peer_bucket_size.clone()))?;
 
+        let grpc2_connected_clients = GenericGauge::with_opts(Opts::new(
+            "grpc2_connected_clients",
+            "Current number of clients connected to the GRPC V2 interface.",
+        ))?;
+        registry.register(Box::new(grpc2_connected_clients.clone()))?;
+
+
         Ok(StatsExportService {
             registry,
             packets_received,
@@ -515,6 +524,7 @@ impl StatsExportService {
             avg_bps_in,
             avg_bps_out,
             peer_bucket_size,
+            grpc_connected_clients: grpc2_connected_clients,
         })
     }
 

--- a/concordium-node/src/stats_export_service.rs
+++ b/concordium-node/src/stats_export_service.rs
@@ -485,7 +485,7 @@ impl StatsExportService {
 
         let grpc_connected_clients = GenericGauge::with_opts(Opts::new(
             "grpc_connected_clients",
-            "Current number of clients connected to the GRPC V2 interface.",
+            "Current number of clients connected to the gRPC V2 interface",
         ))?;
         registry.register(Box::new(grpc_connected_clients.clone()))?;
 

--- a/docs/grpc2.md
+++ b/docs/grpc2.md
@@ -150,7 +150,7 @@ connected clients are alive and responding in desired time.
   least 50 open file descriptors for consensus.
 
 - `--grpc2-request-timeout` (`CONCORDIUM_NODE_GRPC2_REQUEST_TIMEOUT`)
-  Maximum amout of time to allow for processing a request (in seconds). Defaults
+  Maximum amount of time to allow for processing a request (in seconds). Defaults
   to 30s. Note that as for `grpc2-max-concurrent-requests`, for streaming
   responses, this does not mean that the stream must be consumed in 30s. It only
   means that the time until the initial response must be less than 30s.

--- a/docs/grpc2.md
+++ b/docs/grpc2.md
@@ -111,7 +111,7 @@ The following configuration options for the GRPC2 server can be used to ensure
 connected clients are alive and responding in desired time.
 
 - `--grpc2-keep-alive-interval` (`CONCORDIUM_NODE_GRPC2_KEEPALIVE_INTERVAL`)
-  Enable HTTP2 keepalive, and set the interval (in seconds) at which Ping frames are sent. [env:
+  Enable HTTP2 keepalive, and set the interval (in seconds) at which Ping frames are sent.
 
 - `--grpc2-keep-alive-timeout` (`CONCORDIUM_NODE_GRPC2_KEEPALIVE_TIMEOUT`)
   Timeout (in seconds) for responses to HTTP2 Ping frames. If the client does not respond in time then the
@@ -123,7 +123,11 @@ connected clients are alive and responding in desired time.
 ### Configuration options for limiting resource usage
 
 - `--grpc2-invoke-max-energy` (`CONCORDIUM_NODE_GRPC2_INVOKE_MAX_ENERGY`)
-  Maximum amount of energy allowed for the InvokeInstance and InvokeContract (V1 API) endpoints.
+  Maximum amount of energy allowed for a call to the InvokeInstance (and also
+  InvokeContract of the V1 API) endpoint. If the caller supplies the maximum
+  energy as part of the call then the energy used for the execution of
+  the call is the **minimum** of `CONCORDIUM_NODE_GRPC2_INVOKE_MAX_ENERGY` and
+  the caller supplied energy.
 
 - `--grpc2-max-concurrent-requests` (`CONCORDIUM_NODE_GRPC2_MAX_CONCURRENT_REQUESTS`)
   Global (i.e., not per connection) number of concurrent requests allowed.

--- a/docs/grpc2.md
+++ b/docs/grpc2.md
@@ -47,8 +47,8 @@ If these are enabled then the following options become available
   available.
 
   The format of the file is a simple key-value list, with values being booleans.
-  Keys are names of endpoints in snake_case. For example the following configuration file 
-  would enable all available endpoints except the ones flagged with `false` i.e. `get_account_info`, 
+  Keys are names of endpoints in snake_case. For example the following configuration file
+  would enable all available endpoints except the ones flagged with `false` i.e. `get_account_info`,
   `shutdown`, `dump_start` and `dump_end`.
 
   ```toml
@@ -104,3 +104,49 @@ If these are enabled then the following options become available
   get_account_transaction_sign_hash = true
   get_block_items = true
   ```
+
+### Configuration options for checking client liveness
+
+The following configuration options for the GRPC2 server can be used to ensure
+connected clients are alive and responding in desired time.
+
+- `--grpc2-keep-alive-interval` (`CONCORDIUM_NODE_GRPC2_KEEPALIVE_INTERVAL`)
+  Enable HTTP2 keepalive, and set the interval (in seconds) at which Ping frames are sent. [env:
+
+- `--grpc2-keep-alive-timeout` (`CONCORDIUM_NODE_GRPC2_KEEPALIVE_TIMEOUT`)
+  Timeout (in seconds) for responses to HTTP2 Ping frames. If the client does not respond in time then the
+  connection will be closed. This has no effect unless `grpc2-keep-alive-interval` is set.
+
+- `--grpc2-tcp-keep-alive-interval` (`CONCORDIUM_NODE_GRPC2_TCP_KEEPALIVE`)
+  The interval (in seconds) at which TCP keepalive probes are sent.
+
+### Configuration options for limiting resource usage
+
+- `--grpc2-invoke-max-energy` (`CONCORDIUM_NODE_GRPC2_INVOKE_MAX_ENERGY`)
+  Maximum amount of energy allowed for the InvokeInstance and InvokeContract (V1 API) endpoints.
+
+- `--grpc2-max-concurrent-requests` (`CONCORDIUM_NODE_GRPC2_MAX_CONCURRENT_REQUESTS`)
+  Global (i.e., not per connection) number of concurrent requests allowed.
+  Defaults to 100. Note that when a request has a streaming response, the
+  request counts as completed once the stream is constructed.
+
+- `--grpc2-max-concurrent-requests-per-connection` (`CONCORDIUM_NODE_GRPC2_MAX_CONCURRENT_REQUESTS_PER_CONNECTION`)
+  Maximum number of concurrent requests **per connection**. Defaults to 10.
+
+- `--grpc2-max-concurrent-streams` (`CONCORDIUM_NODE_GRPC2_MAX_CONCURRENT_STREAMS`)
+  Maximum number of concurrently open streams **per connection**. For requests with streaming
+  responses this limits the amount of unconsumed streams that the node will maintain.
+
+- `--grpc2-max-connections` (`CONCORDIUM_NODE_GRPC2_MAX_CONNECTIONS`)
+  Maximum number of **connections** that the GRPC server will allow at any given
+  time. Defaults to 500. This value should be set low enough so that the node
+  process will never run out of file descriptors for consensus and P2P
+  connection handling. This value should be set so that together with
+  `hard-connection-limit` and `grpc2-max-concurrent-requests` it still leaves at
+  least 50 open file descriptors for consensus.
+
+- `--grpc2-request-timeout` (`CONCORDIUM_NODE_GRPC2_REQUEST_TIMEOUT`)
+  Maximum amout of time to allow for processing a request (in seconds). Defaults
+  to 30s. Note that as for `grpc2-max-concurrent-requests`, for streaming
+  responses, this does not mean that the stream must be consumed in 30s. It only
+  means that the time until the initial response must be less than 30s.

--- a/docs/prometheus-exporter.md
+++ b/docs/prometheus-exporter.md
@@ -190,6 +190,10 @@ Possible values of `status` are:
 Current number of gRPC requests being handled by the node.
 Streaming gRPC methods are counted as in flight until the response stream is closed.
 
+### `grpc_connected_clients`
+
+Current number of clients connected to the gRPC V2 interface.
+
 ### `consensus_baking_committee`
 
 The baking committee status of the node for the current best block.

--- a/service/windows/installer/Node.wxs
+++ b/service/windows/installer/Node.wxs
@@ -2,9 +2,9 @@
 <!-- When updating the product version, the Product Id should be refreshed, otherwise it will not be
     possible to upgrade an existing installation.
 -->
-<?define VersionNumber="6.1.3" ?>
+<?define VersionNumber="6.1.4" ?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:Util="http://schemas.microsoft.com/wix/UtilExtension">
-    <Product Name="Concordium Node" Manufacturer="Concordium Software" Id="a8c62950-e398-4ae4-8fa3-872a746d0fa0" UpgradeCode="297295b4-c716-4d33-8170-0f6136663bfd" Language="1033" Codepage="1252" Version="$(var.VersionNumber)">
+    <Product Name="Concordium Node" Manufacturer="Concordium Software" Id="3e3b0234-b6d0-47e2-adb5-1cfd6f1cb5ca" UpgradeCode="297295b4-c716-4d33-8170-0f6136663bfd" Language="1033" Codepage="1252" Version="$(var.VersionNumber)">
         <Package Id="*" Keywords="Concordium Installer" Description="Concordium Node $(var.VersionNumber) Installer" Manufacturer="Concordium Software" InstallerVersion="500" Languages="1033" Compressed="yes" InstallScope="perMachine" />
         <MajorUpgrade Schedule="afterInstallValidate" DowngradeErrorMessage="The currently-installed version of [ProductName] is newer than the version you are trying to install. The installation cannot continue. If you wish to install this version, please remove the newer version first." />
         <Media Id="1" Cabinet="Node.cab" EmbedCab="yes" />


### PR DESCRIPTION
## Purpose

Introduce configurations options to limit resources used by the gRPC V2 server.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.