### PR TITLE
Fix startup time regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased changes
 
+- Fix a regression in the start up time. When upgrading from an earlier version, the first start-up
+  time may be longer than usual, as the genesis state hashes are computed. Subsequent restarts
+  will not suffer this penalty.
+
 ## 6.1.5
 
 - Enable out of band catchup by default in all distributions.

--- a/concordium-consensus/src/Concordium/ImportExport.hs
+++ b/concordium-consensus/src/Concordium/ImportExport.hs
@@ -473,7 +473,7 @@ exportConsensusV0Blocks firstBlock outDir chunkSize genIndex startHeight blockIn
                     let getBlockAt height =
                             resizeOnResized (readFinalizedBlockAtHeight height) >>= \case
                                 Nothing -> return Nothing
-                                Just b | NormalBlock normalBlock <- sbBlock b -> do
+                                Just (b, _) | NormalBlock normalBlock <- sbBlock b -> do
                                     let serializedBlock = runPut $ putVersionedBlock (protocolVersion @pv) normalBlock
                                     case blockFields normalBlock of
                                         Nothing -> throwM . userError $ "Error: Trying to export a genesis block."
@@ -673,7 +673,7 @@ exportSections dbDir outDir chunkSize genIndex startHeight blockIndex lastWritte
                                 Left err -> do
                                     logEvent External LLError $ "Database section " ++ show genIndex ++ " cannot be exported: " ++ err
                                     return (True, Empty)
-                                Right (_, sb) -> do
+                                Right (_, (sb, _)) -> do
                                     evalStateT
                                         (exportConsensusV0Blocks @pv sb outDir chunkSize genIndex startHeight blockIndex lastWrittenChunkM)
                                         (DBState dbh)


### PR DESCRIPTION
## Purpose

Addresses #1045

This fixes a regression in start-up time that is caused by always having to recompute the block state hashes of genesis blocks. Instead, the block state hashes are computed once and stored in the tree state database, so that future restarts will not need to compute them.

## Changes

These changes apply only to consensus version 0. Consenus version 1 (ConcordiumBFT) already stores the genesis state hash in the tree state database.

- Add a "genesisStateHash" entry in the metadata table of the tree state.
- When looking up blocks in the tree state database, also return the state hash, if it is available. (This is either present in the block, for baked blocks, or is looked up in the metadata table, for the genesis block.)
- Set the "genesisStateHash" when starting a new genesis, or when loading an existing state where it has not already been written.
- When loading blocks, use the state hash provided by the tree state database where available. The state hash only needs to be computed for genesis blocks when the "genesisStateHash" is not present.

## Checklist

- [X] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
