### PR TITLE
Add load-shedding to the GRPC V2 service.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased changes
 
+## 6.1.7
+
+ - Add load-shedding to the V2 GRPC API. In particular, if at the time of the
+  request the node is already handling more than
+  `CONCORDIUM_NODE_GRPC2_MAX_CONCURRENT_REQUESTS` requests then the incoming
+  request will be immediately rejected.
+
 ## 6.1.6
 
 - Fix a regression in the start up time. When upgrading from an earlier version, the first start-up

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_node"
-version = "6.1.6"
+version = "6.1.7"
 dependencies = [
  "anyhow",
  "app_dirs2",

--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium_node"
-version = "6.1.6" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
+version = "6.1.7" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
 description = "Concordium Node"
 authors = ["Concordium <developers@concordium.com>"]
 exclude = [".gitignore", ".gitlab-ci.yml", "test/**/*","**/**/.gitignore","**/**/.gitlab-ci.yml"]
@@ -78,7 +78,7 @@ tempfile = { version = "3.1" }
 tonic = { version = "0.9", features = ["tls"] }
 tonic-reflection = "0.9"
 tower-http = { version = "0.4", features = ["trace", "metrics"] }
-tower = "0.4"
+tower = {version = "0.4", features = ["load-shed"]}
 tonic-web = "0.9"
 prost = "0.11"
 tokio = { version = "1.20", features = ["macros", "rt-multi-thread", "signal", "io-util", "time"] }


### PR DESCRIPTION
## Purpose

Make the node more robust when under heavy load.

## Changes

- Add load-shedding layer that will immediately kill requests if we are currently handling the maximum amount.

- Move the metrics layer to the top so that we also see failed/shed requests in the metrics.

Metrics output

```

grpc_request_response_time_seconds_bucket{method="/concordium.v2.Queries/GetAccountInfo",status="ok",le="0.05"} 55273
grpc_request_response_time_seconds_bucket{method="/concordium.v2.Queries/GetAccountInfo",status="ok",le="0.1"} 55273
grpc_request_response_time_seconds_bucket{method="/concordium.v2.Queries/GetAccountInfo",status="ok",le="0.2"} 55273
grpc_request_response_time_seconds_bucket{method="/concordium.v2.Queries/GetAccountInfo",status="ok",le="0.5"} 55273
grpc_request_response_time_seconds_bucket{method="/concordium.v2.Queries/GetAccountInfo",status="ok",le="1"} 55273
grpc_request_response_time_seconds_bucket{method="/concordium.v2.Queries/GetAccountInfo",status="ok",le="+Inf"} 55273
grpc_request_response_time_seconds_sum{method="/concordium.v2.Queries/GetAccountInfo",status="ok"} 109.38622836500065
grpc_request_response_time_seconds_count{method="/concordium.v2.Queries/GetAccountInfo",status="ok"} 55273
grpc_request_response_time_seconds_bucket{method="/concordium.v2.Queries/GetAccountInfo",status="resource exhausted",le="0.05"} 1421
grpc_request_response_time_seconds_bucket{method="/concordium.v2.Queries/GetAccountInfo",status="resource exhausted",le="0.1"} 1421
grpc_request_response_time_seconds_bucket{method="/concordium.v2.Queries/GetAccountInfo",status="resource exhausted",le="0.2"} 1421
grpc_request_response_time_seconds_bucket{method="/concordium.v2.Queries/GetAccountInfo",status="resource exhausted",le="0.5"} 1421
grpc_request_response_time_seconds_bucket{method="/concordium.v2.Queries/GetAccountInfo",status="resource exhausted",le="1"} 1421
grpc_request_response_time_seconds_bucket{method="/concordium.v2.Queries/GetAccountInfo",status="resource exhausted",le="+Inf"} 1421
grpc_request_response_time_seconds_sum{method="/concordium.v2.Queries/GetAccountInfo",status="resource exhausted"} 0.0025329620000000023
grpc_request_response_time_seconds_count{method="/concordium.v2.Queries/GetAccountInfo",status="resource exhausted"} 1421
grpc_request_response_time_seconds_bucket{method="/concordium.v2.Queries/GetConsensusInfo",status="ok",le="0.05"} 56694
grpc_request_response_time_seconds_bucket{method="/concordium.v2.Queries/GetConsensusInfo",status="ok",le="0.1"} 56694
grpc_request_response_time_seconds_bucket{method="/concordium.v2.Queries/GetConsensusInfo",status="ok",le="0.2"} 56694
grpc_request_response_time_seconds_bucket{method="/concordium.v2.Queries/GetConsensusInfo",status="ok",le="0.5"} 56694
grpc_request_response_time_seconds_bucket{method="/concordium.v2.Queries/GetConsensusInfo",status="ok",le="1"} 56694
grpc_request_response_time_seconds_bucket{method="/concordium.v2.Queries/GetConsensusInfo",status="ok",le="+Inf"} 56694
grpc_request_response_time_seconds_sum{method="/concordium.v2.Queries/GetConsensusInfo",status="ok"} 15.892686203000073
grpc_request_response_time_seconds_count{method="/concordium.v2.Queries/GetConsensusInfo",status="ok"} 56694
grpc_request_response_time_seconds_bucket{method="/concordium.v2.Queries/GetConsensusInfo",status="resource exhausted",le="0.05"} 557
grpc_request_response_time_seconds_bucket{method="/concordium.v2.Queries/GetConsensusInfo",status="resource exhausted",le="0.1"} 557
grpc_request_response_time_seconds_bucket{method="/concordium.v2.Queries/GetConsensusInfo",status="resource exhausted",le="0.2"} 557
grpc_request_response_time_seconds_bucket{method="/concordium.v2.Queries/GetConsensusInfo",status="resource exhausted",le="0.5"} 557
grpc_request_response_time_seconds_bucket{method="/concordium.v2.Queries/GetConsensusInfo",status="resource exhausted",le="1"} 557
grpc_request_response_time_seconds_bucket{method="/concordium.v2.Queries/GetConsensusInfo",status="resource exhausted",le="+Inf"} 557
grpc_request_response_time_seconds_sum{method="/concordium.v2.Queries/GetConsensusInfo",status="resource exhausted"} 0.001219596
grpc_request_response_time_seconds_count{method="/concordium.v2.Queries/GetConsensusInfo",status="resource exhausted"} 557
```

and grpc response
```
Error getting account info: RPC error: Call failed: status: ResourceExhausted, message: "Too many concurrent requests.", details: [], metadata: MetadataMap { headers: {"content-type": "application/grpc", "date": "Thu, 12 Oct 2023 21:14:32 GMT"} } (0ms)
Error getting account info: RPC error: Call failed: status: ResourceExhausted, message: "Too many concurrent requests.", details: [], metadata: MetadataMap { headers: {"content-type": "application/grpc", "date": "Thu, 12 Oct 2023 21:14:32 GMT"} } (0ms)
```

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
