### PR TITLE
Add getFinalizedBlockHeight back to lib.def.

### DIFF
--- a/concordium-consensus/lib.def
+++ b/concordium-consensus/lib.def
@@ -63,7 +63,7 @@ EXPORTS
  getBakersRewardPeriodV2
  getBlockCertificatesV2
  getBakerEarliestWinTimeV2
-
+ getLastFinalizedBlockHeight
  dryRunStart
  dryRunEnd
  dryRunGetAccountInfo


### PR DESCRIPTION
## Purpose

Accidentally removed getLastFinalizedBlockHeight from lib.def in #1073 

This reintroduces it.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
