### PR TITLE
Share Account Map Database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Fix an bug that caused the node to crash on Windows when processing a protocol update.
+
 ## 6.2.2
 
 - The transaction table is only used for tracking next available account nonce

--- a/concordium-consensus/src/Concordium/External.hs
+++ b/concordium-consensus/src/Concordium/External.hs
@@ -39,7 +39,6 @@ import Concordium.GlobalState.Persistent.TreeState (InitException (..))
 import Concordium.MultiVersion (
     Callbacks (..),
     CatchUpConfiguration (..),
-    DiskStateConfig (..),
     MVR (..),
     MultiVersionConfiguration (..),
     MultiVersionRunner (..),
@@ -459,7 +458,7 @@ startConsensus
             appDataPath <- peekCStringLen (appDataC, fromIntegral appDataLenC)
             -- Do globalstate migration if necessary
             migrateGlobalState appDataPath logM
-            let mvcStateConfig = DiskStateConfig appDataPath
+            mvcStateConfig <- MV.makeDiskStateConfig appDataPath
             let mvcFinalizationConfig =
                     BufferedFinalization
                         ( FinalizationInstance
@@ -607,7 +606,7 @@ startConsensusPassive
             appDataPath <- peekCStringLen (appDataC, fromIntegral appDataLenC)
             -- Do globalstate migration if necessary
             migrateGlobalState appDataPath logM
-            let mvcStateConfig = DiskStateConfig appDataPath
+            mvcStateConfig <- MV.makeDiskStateConfig appDataPath
             let mvcFinalizationConfig = NoFinalization
             -- Callbacks
             regenesisRef <- makeRegenesisRef regenesisFree regenesisPtr

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -3762,8 +3762,7 @@ cacheState hpbs = do
     rels <- cache bspReleaseSchedule
     red <- cache bspRewardDetails
     _ <-
-        storePBS
-            (hpbsPointers hpbs)
+        storePBS (hpbsPointers hpbs) $!
             BlockStatePointers
                 { bspAccounts = accts,
                   bspInstances = insts,

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
@@ -328,15 +328,11 @@ checkExistingDatabase ::
     FilePath ->
     -- | Block state file
     FilePath ->
-    -- | Account map path
-    FilePath ->
     m Bool
-checkExistingDatabase treeStateDir blockStateFile accountMapDir = do
+checkExistingDatabase treeStateDir blockStateFile = do
     let treeStateFile = treeStateDir </> "data.mdb"
-    let accountMapFile = accountMapDir </> "data.mdb"
     bsPathEx <- liftIO $ doesPathExist blockStateFile
     tsPathEx <- liftIO $ doesPathExist treeStateFile
-    amPathEx <- liftIO $ doesPathExist accountMapFile
 
     -- Check whether a path is a normal file that is readable and writable
     let checkRWFile :: FilePath -> InitException -> m ()
@@ -362,11 +358,9 @@ checkExistingDatabase treeStateDir blockStateFile accountMapDir = do
             -- check whether it is a normal file and whether we have the right permissions
             checkRWFile blockStateFile BlockStatePermissionError
             checkRWFile treeStateFile TreeStatePermissionError
-            when amPathEx $ checkRWFile accountMapFile AccountMapPermissionError
             logEvent TreeState LLTrace "Existing database found."
             logEvent TreeState LLTrace $ "TreeState filepath: " ++ show treeStateFile
             logEvent TreeState LLTrace $ "BlockState filepath: " ++ show blockStateFile
-            logEvent TreeState LLTrace $ if amPathEx then "AccountMap filepath: " ++ show accountMapFile else "AccountMap not found"
             return True
         | bsPathEx -> do
             logEvent GlobalState LLWarning "Block state file exists, but tree state database does not. Deleting the block state file."

--- a/concordium-consensus/src/Concordium/KonsensusV1/SkovMonad.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/SkovMonad.hs
@@ -344,8 +344,8 @@ data GlobalStateConfig = GlobalStateConfig
       gscTreeStateDirectory :: !FilePath,
       -- | Path to the block state file.
       gscBlockStateFile :: !FilePath,
-      -- | Path to the account map directory
-      gscAccountMapDirectory :: !FilePath
+      -- | Account map.
+      gscAccountMap :: !LMDBAccountMap.DatabaseHandlers
     }
 
 -- | Context used by the 'InitMonad'.
@@ -498,7 +498,7 @@ initialiseExistingSkovV1 ::
     LogIO (Maybe (ExistingSkov pv m))
 initialiseExistingSkovV1 bakerCtx handlerCtx unliftSkov gsc@GlobalStateConfig{..} = do
     logEvent Skov LLDebug "Attempting to use existing global state."
-    existingDB <- checkExistingDatabase gscTreeStateDirectory gscBlockStateFile gscAccountMapDirectory
+    existingDB <- checkExistingDatabase gscTreeStateDirectory gscBlockStateFile
     if existingDB
         then do
             pbsc <- newPersistentBlockStateContext False gsc
@@ -762,5 +762,5 @@ newPersistentBlockStateContext initialize GlobalStateConfig{..} = liftIO $ do
     pbscBlobStore <- if initialize then createBlobStore gscBlockStateFile else loadBlobStore gscBlockStateFile
     pbscAccountCache <- newAccountCache $ rpAccountsCacheSize gscRuntimeParameters
     pbscModuleCache <- Modules.newModuleCache $ rpModulesCacheSize gscRuntimeParameters
-    pbscAccountMap <- LMDBAccountMap.openDatabase gscAccountMapDirectory
+    let pbscAccountMap = gscAccountMap
     return PersistentBlockStateContext{..}

--- a/concordium-consensus/src/Concordium/MultiVersion.hs
+++ b/concordium-consensus/src/Concordium/MultiVersion.hs
@@ -1435,7 +1435,10 @@ shutdownMultiVersionRunner MultiVersionRunner{..} = mask_ $ do
     -- Acquire the write lock. This prevents further updates, as they will block.
     takeMVar mvWriteLock
     versions <- readIORef mvVersions
+    -- Shut down the consensus databases.
     runLoggerT (forM_ versions evcShutdown) mvLog
+    -- Shut down the global account map.
+    LMDBAccountMap.closeDatabase (globalAccountMap (mvcStateConfig mvConfiguration))
 
 -- | Lift a version-0 consensus skov action to the 'MVR' monad, running it on a
 --  particular 'VersionedConfigurationV0'. Note that this does not

--- a/concordium-consensus/src/Concordium/MultiVersion.hs
+++ b/concordium-consensus/src/Concordium/MultiVersion.hs
@@ -174,6 +174,7 @@ data DiskStateConfig = DiskStateConfig
       globalAccountMap :: !LMDBAccountMap.DatabaseHandlers
     }
 
+-- | Create a 'DiskStateConfig', opening the shared account map database in the process.
 makeDiskStateConfig :: FilePath -> IO DiskStateConfig
 makeDiskStateConfig stateBasePath = do
     globalAccountMap <- LMDBAccountMap.openDatabase (stateBasePath </> "accountmap")

--- a/concordium-consensus/test-runners/app/Main.hs
+++ b/concordium-consensus/test-runners/app/Main.hs
@@ -297,10 +297,11 @@ callbacks myPeerId peersRef monitorChan = Callbacks{..}
     notifyUnsupportedProtocolUpdate = Nothing
 
 -- | Construct a 'MultiVersionConfiguration' to use for each baker node.
-config :: FilePath -> BakerIdentity -> MultiVersionConfiguration (BufferedFinalization ThreadTimer)
-config dataPath bid = MultiVersionConfiguration{..}
+config :: FilePath -> BakerIdentity -> IO (MultiVersionConfiguration (BufferedFinalization ThreadTimer))
+config dataPath bid = do
+    mvcStateConfig <- makeDiskStateConfig dataPath
+    return MultiVersionConfiguration{..}
   where
-    mvcStateConfig = DiskStateConfig dataPath
     mvcFinalizationConfig =
         BufferedFinalization
             ( FinalizationInstance
@@ -369,7 +370,7 @@ main = do
                     let s = show now ++ "-" ++ show (bakerId bid)
                         d = "data" </> ("db" ++ s)
                     createDirectoryIfMissing True d
-                    let bconfig = config d bid
+                    bconfig <- config d bid
                     logFile <- openFile ("consensus-" ++ s ++ ".log") WriteMode
                     let blogger src lvl msg = {- when (lvl == LLInfo) $ -} do
                             timestamp <- getCurrentTime

--- a/concordium-consensus/test-runners/catchup/Main.hs
+++ b/concordium-consensus/test-runners/catchup/Main.hs
@@ -313,10 +313,11 @@ callbacks myPeerId peersRef monitorChan = Callbacks{..}
     notifyUnsupportedProtocolUpdate = Nothing
 
 -- | Construct a 'MultiVersionConfiguration' to use for each baker node.
-config :: FilePath -> BakerIdentity -> MultiVersionConfiguration (BufferedFinalization ThreadTimer)
-config dataPath bid = MultiVersionConfiguration{..}
+config :: FilePath -> BakerIdentity -> IO (MultiVersionConfiguration (BufferedFinalization ThreadTimer))
+config dataPath bid = do
+    mvcStateConfig <- makeDiskStateConfig dataPath
+    return MultiVersionConfiguration{..}
   where
-    mvcStateConfig = DiskStateConfig dataPath
     mvcFinalizationConfig =
         BufferedFinalization
             ( FinalizationInstance
@@ -395,7 +396,7 @@ main = do
                     let s = show now ++ "-" ++ show (bakerId bid)
                         d = "data" </> ("db" ++ s)
                     createDirectoryIfMissing True d
-                    let bconfig = config d bid
+                    bconfig <- config d bid
                     logFile <- openFile ("consensus-" ++ s ++ ".log") WriteMode
                     let blogger src lvl msg = {- when (lvl == LLInfo) $ -} do
                             timestamp <- getCurrentTime

--- a/concordium-consensus/test-runners/deterministic/Main.hs
+++ b/concordium-consensus/test-runners/deterministic/Main.hs
@@ -34,6 +34,7 @@ import System.Random
 
 import Concordium.Afgjort.Finalize.Types
 import Concordium.GlobalState
+import qualified Concordium.GlobalState.AccountMap.LMDB as LMDBAccountMap
 import Concordium.GlobalState.BakerInfo
 import Concordium.GlobalState.Block
 import qualified Concordium.GlobalState.BlockPointer as BS
@@ -69,7 +70,9 @@ type PV = 'P5
 -- | Construct the global state configuration.
 --  Can be customised if changing the configuration.
 makeGlobalStateConfig :: RuntimeParameters -> FilePath -> FilePath -> FilePath -> IO GlobalStateConfig
-makeGlobalStateConfig rt treeStateDir blockStateFile accMapDirectory = return $ GlobalStateConfig rt treeStateDir blockStateFile accMapDirectory
+makeGlobalStateConfig rt treeStateDir blockStateFile accMapDirectory = do
+    accMap <- LMDBAccountMap.openDatabase accMapDirectory
+    return $ GlobalStateConfig rt treeStateDir blockStateFile accMap
 
 {-
 type TreeConfig = PairGSConfig MemoryTreeMemoryBlockConfig DiskTreeDiskBlockConfig

--- a/concordium-consensus/test-runners/execute-chain/Main.hs
+++ b/concordium-consensus/test-runners/execute-chain/Main.hs
@@ -36,12 +36,13 @@ main = do
             hFlush logFile
     let dataDir = "data" </> ("db" ++ show now)
     createDirectoryIfMissing True dataDir
+    diskStateConfig <- makeDiskStateConfig dataDir
     let config ::
             MultiVersionConfiguration
                 (NoFinalization ThreadTimer)
         config =
             MultiVersionConfiguration
-                { mvcStateConfig = DiskStateConfig dataDir,
+                { mvcStateConfig = diskStateConfig,
                   mvcFinalizationConfig = NoFinalization,
                   mvcRuntimeParameters = defaultRuntimeParameters{rpTransactionsPurgingDelay = 0, rpAccountsCacheSize = 10000}
                 }

--- a/concordium-consensus/tests/consensus/ConcordiumTests/FinalizationRecover.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/FinalizationRecover.hs
@@ -16,6 +16,7 @@ import Concordium.Startup
 import Concordium.Types.ProtocolVersion
 
 import Concordium.GlobalState
+import qualified Concordium.GlobalState.AccountMap.LMDB as LMDBAccountMap
 import Concordium.GlobalState.BakerInfo
 import Concordium.GlobalState.Block
 import qualified Concordium.GlobalState.DummyData as Dummy
@@ -36,8 +37,10 @@ type PV = 'P1
 dummyArs :: AnonymityRevokers
 dummyArs = emptyAnonymityRevokers
 
-makeGlobalStateConfig :: FilePath -> RuntimeParameters -> GlobalStateConfig
-makeGlobalStateConfig tempDir rt = GlobalStateConfig rt tempDir (tempDir </> "data" <.> "blob") (tempDir </> "accountmap")
+makeGlobalStateConfig :: FilePath -> RuntimeParameters -> IO GlobalStateConfig
+makeGlobalStateConfig tempDir rt = do
+    accountMap <- LMDBAccountMap.openDatabase (tempDir </> "accountmap")
+    return $ GlobalStateConfig rt tempDir (tempDir </> "data" <.> "blob") accountMap
 
 genesis :: Word -> (GenesisData PV, [(BakerIdentity, FullBakerInfo)], Amount)
 genesis nBakers =
@@ -80,7 +83,8 @@ setup nBakers = withTempDirectory "." "tmp-consensus-data" $ \tempDir -> do
                 fullBakers
                 genTotal
     let finInstances = map (makeFinalizationInstance . fst) bakers
-    (gsc, gss) <- runSilentLogger (initialiseGlobalState genData $ makeGlobalStateConfig tempDir defaultRuntimeParameters)
+    gsConfig <- makeGlobalStateConfig tempDir defaultRuntimeParameters
+    (gsc, gss) <- runSilentLogger (initialiseGlobalState genData gsConfig)
     active <- forM finInstances (\inst -> (initialState inst,) <$> runSilentLogger (getFinalizationState (Just inst) gsc gss))
     passive <- (initialPassiveState,) <$> runSilentLogger (getFinalizationState Nothing gsc gss)
     return $ passive : active

--- a/concordium-consensus/tests/consensus/ConcordiumTests/PassiveFinalization.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/PassiveFinalization.hs
@@ -28,6 +28,7 @@ import Concordium.Crypto.SHA256
 
 import Concordium.Genesis.Data.P1
 import Concordium.GlobalState
+import qualified Concordium.GlobalState.AccountMap.LMDB as LMDBAccountMap
 import Concordium.GlobalState.BakerInfo
 import Concordium.GlobalState.Block
 import qualified Concordium.GlobalState.BlockPointer as BS
@@ -367,10 +368,11 @@ createInitStates additionalFinMembers = do
                             }
                     }
         createState (bid, _, _, _) = liftIO $ withTempDirectory "." "tmp-consensus-data" $ \tempDir -> do
+            accountMap <- LMDBAccountMap.openDatabase (tempDir </> "accountmap")
             let fininst = FinalizationInstance (bakerSignKey bid) (bakerElectionKey bid) (bakerAggregationKey bid)
                 config =
                     SkovConfig
-                        (GlobalStateConfig defaultRuntimeParameters tempDir (tempDir </> "data" <.> "blob") (tempDir </> "accountmap"))
+                        (GlobalStateConfig defaultRuntimeParameters tempDir (tempDir </> "data" <.> "blob") accountMap)
                         (ActiveFinalization fininst)
                         NoHandler
             (initCtx, initState) <- runSilentLogger (initialiseSkov gen config)

--- a/concordium-consensus/tests/consensus/ConcordiumTests/Update.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/Update.hs
@@ -50,6 +50,7 @@ import Concordium.Types.Accounts
 import Concordium.Crypto.SHA256 as Hash
 import Data.FixedByteString as FBS
 
+import qualified Concordium.GlobalState.AccountMap.LMDB as LMDBAccountMap
 import qualified Concordium.GlobalState.DummyData as Dummy
 
 -- | Protocol version
@@ -132,10 +133,11 @@ createInitStates dir = do
         createState uni =
             liftIO
                 . ( \(bid, _, _, _) -> do
+                        accountMap <- LMDBAccountMap.openDatabase (dir </> uni <.> "accountmap")
                         let fininst = FinalizationInstance (bakerSignKey bid) (bakerElectionKey bid) (bakerAggregationKey bid)
                             config =
                                 SkovConfig
-                                    (GlobalStateConfig defaultRuntimeParameters (dir </> uni) (dir </> uni <.> "dat") (dir </> uni <.> "accountmap"))
+                                    (GlobalStateConfig defaultRuntimeParameters (dir </> uni) (dir </> uni <.> "dat") accountMap)
                                     (ActiveFinalization fininst)
                                     NoHandler
                         (initCtx, initState) <- runSilentLogger (initialiseSkov gen config)

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/PersistentTreeState.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/PersistentTreeState.hs
@@ -20,6 +20,7 @@ import Concordium.Crypto.DummyData
 import qualified Concordium.Crypto.SHA256 as SHA256
 import Concordium.Crypto.VRF as VRF
 import Concordium.GlobalState
+import qualified Concordium.GlobalState.AccountMap.LMDB as LMDBAccountMap
 import Concordium.GlobalState.BlockMonads
 import Concordium.GlobalState.BlockPointer hiding (BlockPointer)
 import Concordium.GlobalState.Classes
@@ -73,10 +74,11 @@ instance HasGlobalState (SkovPersistentData PV) (SkovPersistentData PV) where
 createGlobalState :: FilePath -> IO (PBS.PersistentBlockStateContext PV, SkovPersistentData PV)
 createGlobalState dbDir = do
     now <- utcTimeToTimestamp <$> getCurrentTime
+    accountMap <- LMDBAccountMap.openDatabase (dbDir </> "accountmap")
     let
         n = 3
         genesis = makeTestingGenesisDataP5 now n 1 1 dummyFinalizationCommitteeMaxSize dummyCryptographicParameters emptyIdentityProviders emptyAnonymityRevokers maxBound dummyKeyCollection dummyChainParameters
-        config = GlobalStateConfig defaultRuntimeParameters dbDir (dbDir </> "blockstate" <.> "dat") (dbDir </> "accountmap")
+        config = GlobalStateConfig defaultRuntimeParameters dbDir (dbDir </> "blockstate" <.> "dat") accountMap
     (x, y) <- runSilentLogger $ initialiseGlobalState genesis config
     return (x, y)
 

--- a/concordium-consensus/tests/scheduler/SchedulerTests/Payday.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/Payday.hs
@@ -36,6 +36,7 @@ import Concordium.Types.DummyData
 import Concordium.Types.SeedState
 
 import Concordium.Birk.Bake
+import qualified Concordium.GlobalState.AccountMap.LMDB as LMDBAccountMap
 import Concordium.GlobalState.BakerInfo
 import Concordium.GlobalState.Basic.BlockState.PoolRewards (BakerPoolRewardDetails (transactionFeesAccrued))
 import Concordium.GlobalState.BlockPointer (BlockPointer (_bpState))
@@ -336,9 +337,10 @@ withPersistentState pbsc is f =
 
 createGlobalState :: (IsProtocolVersion pv, IsConsensusV0 pv) => FilePath -> IO (PersistentBlockStateContext pv, MyPersistentTreeState pv)
 createGlobalState dbDir = do
+    accMap <- LMDBAccountMap.openDatabase (dbDir </> "accountmap")
     let
         n = 5
-        config = GlobalStateConfig defaultRuntimeParameters dbDir (dbDir </> "blockstate" <.> "dat") (dbDir </> "accountmap")
+        config = GlobalStateConfig defaultRuntimeParameters dbDir (dbDir </> "blockstate" <.> "dat") accMap
     (x, y) <- runSilentLogger $ initialiseGlobalState (genesis n ^. _1) config
     return (x, y)
 


### PR DESCRIPTION
## Purpose

Closes #1088

This revises the handling of the account map database so that it is only opened once, and then shared across all protocol versions. This should fix #1088, which appears to be caused by re-opening the account map database, in particular after it has already been resized.

## Changes

The account map `DatabaseHandlers` object is created earlier, and passed in when each consensus instance is started.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.