### PR TITLE
Report pending finalization committee parameter updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## Unreleased changes
 
+- Fix a bug where `GetBlockPendingUpdates` fails to report pending updates to the finalization
+  committee parameters.
+
 ## 6.2.3
 
-- Fix an bug that caused the node to crash on Windows when processing a protocol update.
+- Fix a bug that caused the node to crash on Windows when processing a protocol update.
 
 ## 6.2.2
 

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -822,6 +822,7 @@ getBlockPendingUpdates = liftSkovQueryStateBHI query
                 `merge` queueMapperOptional PUETimeoutParameters _pTimeoutParametersQueue
                 `merge` queueMapperOptional PUEMinBlockTime _pMinBlockTimeQueue
                 `merge` queueMapperOptional PUEBlockEnergyLimit _pBlockEnergyLimitQueue
+                `merge` queueMapperOptional PUEFinalizationCommitteeParameters _pFinalizationCommitteeParametersQueue
           where
             cpv :: SChainParametersVersion cpv
             cpv = chainParametersVersion


### PR DESCRIPTION
## Purpose

Fixes #1098

## Changes

- Include the finalization committee parameters in the pending chain updates reported by `GetBlockPendingUpdates`.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
