### PR TITLE
Convert P6 tests to also run for P7 and onwards

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
@@ -408,6 +408,7 @@ blobBSFileLength BlobStoreAccess{..} = mask $ \restore -> do
 readBlobBS :: BlobStoreAccess -> BlobRef a -> IO BS.ByteString
 readBlobBS bs@BlobStoreAccess{..} br@(BlobRef offset) = do
     let ioffset = fromIntegral offset
+    when (ioffset < 0) $ throwIO $ userError "Attempted to read an invalid BlobRef"
     let dataOffset = ioffset + 8
     mmap0 <- readIORef blobStoreMMap
     mmap <-

--- a/concordium-consensus/tests/consensus/ConcordiumTests/EndToEnd/CredentialDeploymentTests.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/EndToEnd/CredentialDeploymentTests.hs
@@ -95,16 +95,14 @@ testBB1 =
           bbTransactions = Vec.fromList [credBi1],
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-                DBHashesV0 $
-                    BlockDerivableHashesV0
-                        { bdhv0TransactionOutcomesHash = read "b9444648bf759471276fdba1930af0c543847d22de89c27939791898d757516d",
-                          bdhv0BlockStateHash = read "b8bc96ec5f162db36784ea96ec29e3e8ad92abff341a6847e3bf524fdada28ff"
-                        }
+                DerivableBlockHashesV0
+                    { dbhv0TransactionOutcomesHash = read "b9444648bf759471276fdba1930af0c543847d22de89c27939791898d757516d",
+                      dbhv0BlockStateHash = read "b8bc96ec5f162db36784ea96ec29e3e8ad92abff341a6847e3bf524fdada28ff"
+                    }
             SBlockHashVersion1 ->
-                DBHashesV1 $
-                    BlockDerivableHashesV1
-                        { bdhv1BlockResultHash = read "4afb7f50e89b6ae3fb04fbb3854a70cf31bff01dfcbbd65d22f5d20032f4bce0"
-                        }
+                DerivableBlockHashesV1
+                    { dbhv1BlockResultHash = read "4afb7f50e89b6ae3fb04fbb3854a70cf31bff01dfcbbd65d22f5d20032f4bce0"
+                    }
         }
   where
     sProtocolVersion = protocolVersion @pv
@@ -126,16 +124,14 @@ testBB2 =
           bbTransactions = Vec.empty,
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-                DBHashesV0 $
-                    BlockDerivableHashesV0
-                        { bdhv0TransactionOutcomesHash = read "375fef64a251f353d608171d283d00fe00aa0bd77596ba7703c810f48056ef89",
-                          bdhv0BlockStateHash = read "798d5089818bcc7b8873e2585fb4fbf3d4dceffca32531259f466e7c435c8817"
-                        }
+                DerivableBlockHashesV0
+                    { dbhv0TransactionOutcomesHash = read "375fef64a251f353d608171d283d00fe00aa0bd77596ba7703c810f48056ef89",
+                      dbhv0BlockStateHash = read "798d5089818bcc7b8873e2585fb4fbf3d4dceffca32531259f466e7c435c8817"
+                    }
             SBlockHashVersion1 ->
-                DBHashesV1 $
-                    BlockDerivableHashesV1
-                        { bdhv1BlockResultHash = read "612cb7a13a9cb8d403f2b4992321f3919debd923c9fdaadd68153a417064b1d7"
-                        }
+                DerivableBlockHashesV1
+                    { dbhv1BlockResultHash = read "612cb7a13a9cb8d403f2b4992321f3919debd923c9fdaadd68153a417064b1d7"
+                    }
         }
   where
     sProtocolVersion = protocolVersion @pv
@@ -157,16 +153,14 @@ testBB3 =
           bbTransactions = Vec.empty,
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-                DBHashesV0 $
-                    BlockDerivableHashesV0
-                        { bdhv0TransactionOutcomesHash = read "375fef64a251f353d608171d283d00fe00aa0bd77596ba7703c810f48056ef89",
-                          bdhv0BlockStateHash = read "4da0deab5b564cd77c617a2ac7dc8a6064f87e99b09e58c87b5f9e687db2197a"
-                        }
+                DerivableBlockHashesV0
+                    { dbhv0TransactionOutcomesHash = read "375fef64a251f353d608171d283d00fe00aa0bd77596ba7703c810f48056ef89",
+                      dbhv0BlockStateHash = read "4da0deab5b564cd77c617a2ac7dc8a6064f87e99b09e58c87b5f9e687db2197a"
+                    }
             SBlockHashVersion1 ->
-                DBHashesV1 $
-                    BlockDerivableHashesV1
-                        { bdhv1BlockResultHash = read "83d2d20e5836df6dddbbfc65bbc13f67f8117cc871bbd4eeb635efe528571397"
-                        }
+                DerivableBlockHashesV1
+                    { dbhv1BlockResultHash = read "83d2d20e5836df6dddbbfc65bbc13f67f8117cc871bbd4eeb635efe528571397"
+                    }
         }
   where
     sProtocolVersion = protocolVersion @pv
@@ -212,16 +206,14 @@ testBB2' =
           bbTransactions = Vec.fromList [credBi2],
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-                DBHashesV0 $
-                    BlockDerivableHashesV0
-                        { bdhv0TransactionOutcomesHash = read "abc4628869bb526115226dd01ad54bf33f54609fa770d50a9242aaf009f42fa1",
-                          bdhv0BlockStateHash = read "e3cf3b280159bc20645738fb1343486d16104989a524fb5feb59ac1b0b7af9ad"
-                        }
+                DerivableBlockHashesV0
+                    { dbhv0TransactionOutcomesHash = read "abc4628869bb526115226dd01ad54bf33f54609fa770d50a9242aaf009f42fa1",
+                      dbhv0BlockStateHash = read "e3cf3b280159bc20645738fb1343486d16104989a524fb5feb59ac1b0b7af9ad"
+                    }
             SBlockHashVersion1 ->
-                DBHashesV1 $
-                    BlockDerivableHashesV1
-                        { bdhv1BlockResultHash = read "04225271b518f16c0cb63282d08bff365d6236ff6c1e63e0da5c40fc3af96136"
-                        }
+                DerivableBlockHashesV1
+                    { dbhv1BlockResultHash = read "04225271b518f16c0cb63282d08bff365d6236ff6c1e63e0da5c40fc3af96136"
+                    }
         }
   where
     sProtocolVersion = protocolVersion @pv
@@ -243,16 +235,14 @@ testBB3' =
           bbTransactions = Vec.fromList [credBi3],
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-                DBHashesV0 $
-                    BlockDerivableHashesV0
-                        { bdhv0TransactionOutcomesHash = read "3af8504795a03353248be256f66366263f7484c814c5a26760210bbdfd609003",
-                          bdhv0BlockStateHash = read "67eb8f778a4a43efa80c73a954110154ae417e21d43c33b857b962af36913e29"
-                        }
+                DerivableBlockHashesV0
+                    { dbhv0TransactionOutcomesHash = read "3af8504795a03353248be256f66366263f7484c814c5a26760210bbdfd609003",
+                      dbhv0BlockStateHash = read "67eb8f778a4a43efa80c73a954110154ae417e21d43c33b857b962af36913e29"
+                    }
             SBlockHashVersion1 ->
-                DBHashesV1 $
-                    BlockDerivableHashesV1
-                        { bdhv1BlockResultHash = read "ca469c03bae422c5059e40f5ea683bd7be0d4bae0b8295021a674af78ef04f37"
-                        }
+                DerivableBlockHashesV1
+                    { dbhv1BlockResultHash = read "ca469c03bae422c5059e40f5ea683bd7be0d4bae0b8295021a674af78ef04f37"
+                    }
         }
   where
     sProtocolVersion = protocolVersion @pv
@@ -272,16 +262,14 @@ testBB4 =
           bbTransactions = Vec.empty,
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-                DBHashesV0 $
-                    BlockDerivableHashesV0
-                        { bdhv0TransactionOutcomesHash = read "b0972dd7af05ed6feaa40099fffa9c5c5e0ba9741938166cdb57584780688743",
-                          bdhv0BlockStateHash = read "9e698b9c6425b382d8fda5584f530688c237ad013e8aaf848fea274e50244111"
-                        }
+                DerivableBlockHashesV0
+                    { dbhv0TransactionOutcomesHash = read "b0972dd7af05ed6feaa40099fffa9c5c5e0ba9741938166cdb57584780688743",
+                      dbhv0BlockStateHash = read "9e698b9c6425b382d8fda5584f530688c237ad013e8aaf848fea274e50244111"
+                    }
             SBlockHashVersion1 ->
-                DBHashesV1 $
-                    BlockDerivableHashesV1
-                        { bdhv1BlockResultHash = read "3f2846dfe9e52dd9537831df434e876ae029f43e7855fe5eba0212b7df4b2645"
-                        }
+                DerivableBlockHashesV1
+                    { dbhv1BlockResultHash = read "3f2846dfe9e52dd9537831df434e876ae029f43e7855fe5eba0212b7df4b2645"
+                    }
         }
   where
     sProtocolVersion = protocolVersion @pv
@@ -301,16 +289,14 @@ testBB5 =
           bbTransactions = Vec.empty,
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-                DBHashesV0 $
-                    BlockDerivableHashesV0
-                        { bdhv0TransactionOutcomesHash = read "b0972dd7af05ed6feaa40099fffa9c5c5e0ba9741938166cdb57584780688743",
-                          bdhv0BlockStateHash = read "d9dd62c227d1cbc0d42da0d90bfc11d61533d058cc54b0745d6a597039dbe0ec"
-                        }
+                DerivableBlockHashesV0
+                    { dbhv0TransactionOutcomesHash = read "b0972dd7af05ed6feaa40099fffa9c5c5e0ba9741938166cdb57584780688743",
+                      dbhv0BlockStateHash = read "d9dd62c227d1cbc0d42da0d90bfc11d61533d058cc54b0745d6a597039dbe0ec"
+                    }
             SBlockHashVersion1 ->
-                DBHashesV1 $
-                    BlockDerivableHashesV1
-                        { bdhv1BlockResultHash = read "7bafef3db7a89a0475c4132a71fda2fa67d6e9ace01d02aaf9fd8cdc05c4e4ad"
-                        }
+                DerivableBlockHashesV1
+                    { dbhv1BlockResultHash = read "7bafef3db7a89a0475c4132a71fda2fa67d6e9ace01d02aaf9fd8cdc05c4e4ad"
+                    }
         }
   where
     sProtocolVersion = protocolVersion @pv

--- a/concordium-consensus/tests/consensus/ConcordiumTests/EndToEnd/CredentialDeploymentTests.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/EndToEnd/CredentialDeploymentTests.hs
@@ -1,9 +1,9 @@
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE GADTs #-}
 
 -- | End to end tests for credential deployments.
 -- For future maintainers: Note that the blocks below have hardcoded transaction outcome and state hashes.
@@ -33,9 +33,10 @@ import Concordium.KonsensusV1.Types
 import Concordium.Types
 import Concordium.Types.HashableTo
 import Concordium.Types.Option
-import Concordium.Types.Transactions
 import Concordium.Types.Parameters
+import Concordium.Types.Transactions
 
+import qualified ConcordiumTests.KonsensusV1.Common as Common
 import ConcordiumTests.KonsensusV1.Consensus.Blocks hiding (testBB1, testBB2, testBB2', testBB3, testBB3', tests)
 
 -- | Helper for reading an 'AccountCreation' from a 'ByteString'.
@@ -94,17 +95,16 @@ testBB1 =
           bbTransactions = Vec.fromList [credBi1],
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-              DBHashesV0 $
-                BlockDerivableHashesV0
-                    { bdhv0TransactionOutcomesHash = read "b9444648bf759471276fdba1930af0c543847d22de89c27939791898d757516d",
-                      bdhv0BlockStateHash = read "b8bc96ec5f162db36784ea96ec29e3e8ad92abff341a6847e3bf524fdada28ff"
-                    }
+                DBHashesV0 $
+                    BlockDerivableHashesV0
+                        { bdhv0TransactionOutcomesHash = read "b9444648bf759471276fdba1930af0c543847d22de89c27939791898d757516d",
+                          bdhv0BlockStateHash = read "b8bc96ec5f162db36784ea96ec29e3e8ad92abff341a6847e3bf524fdada28ff"
+                        }
             SBlockHashVersion1 ->
                 DBHashesV1 $
                     BlockDerivableHashesV1
                         { bdhv1BlockResultHash = read "4afb7f50e89b6ae3fb04fbb3854a70cf31bff01dfcbbd65d22f5d20032f4bce0"
                         }
-
         }
   where
     sProtocolVersion = protocolVersion @pv
@@ -126,11 +126,11 @@ testBB2 =
           bbTransactions = Vec.empty,
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-              DBHashesV0 $
-                BlockDerivableHashesV0
-                    { bdhv0TransactionOutcomesHash = read "375fef64a251f353d608171d283d00fe00aa0bd77596ba7703c810f48056ef89",
-                      bdhv0BlockStateHash = read "798d5089818bcc7b8873e2585fb4fbf3d4dceffca32531259f466e7c435c8817"
-                    }
+                DBHashesV0 $
+                    BlockDerivableHashesV0
+                        { bdhv0TransactionOutcomesHash = read "375fef64a251f353d608171d283d00fe00aa0bd77596ba7703c810f48056ef89",
+                          bdhv0BlockStateHash = read "798d5089818bcc7b8873e2585fb4fbf3d4dceffca32531259f466e7c435c8817"
+                        }
             SBlockHashVersion1 ->
                 DBHashesV1 $
                     BlockDerivableHashesV1
@@ -156,11 +156,12 @@ testBB3 =
           bbNonce = computeBlockNonce (genesisLEN sProtocolVersion) 3 (bakerVRFKey sProtocolVersion bakerId),
           bbTransactions = Vec.empty,
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
-            SBlockHashVersion0 -> DBHashesV0 $
-                BlockDerivableHashesV0
-                    { bdhv0TransactionOutcomesHash = read "375fef64a251f353d608171d283d00fe00aa0bd77596ba7703c810f48056ef89",
-                      bdhv0BlockStateHash = read "4da0deab5b564cd77c617a2ac7dc8a6064f87e99b09e58c87b5f9e687db2197a"
-                    }
+            SBlockHashVersion0 ->
+                DBHashesV0 $
+                    BlockDerivableHashesV0
+                        { bdhv0TransactionOutcomesHash = read "375fef64a251f353d608171d283d00fe00aa0bd77596ba7703c810f48056ef89",
+                          bdhv0BlockStateHash = read "4da0deab5b564cd77c617a2ac7dc8a6064f87e99b09e58c87b5f9e687db2197a"
+                        }
             SBlockHashVersion1 ->
                 DBHashesV1 $
                     BlockDerivableHashesV1
@@ -172,24 +173,27 @@ testBB3 =
     bakerId = 4
 
 -- | A test that deploys a single credential, and it ends up in the last finalized block.
-testDeployCredential :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> String ->
-  Spec
-testDeployCredential sProtocolVersion pvString =
-  it (pvString ++ ": deploy and finalize one credential") $
-   runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
-    lfbState0 <- use (lastFinalized . to bpState)
-    noAccs0 <- length <$> getAccountList lfbState0
-    let b1 = signedPB testBB1
-    succeedReceiveBlock b1
-    let b2 = signedPB testBB2
-    succeedReceiveBlock b2
-    -- b3 finalizes b1 as it carries a qc for b2 (which carries a qc for b1).
-    let b3 = signedPB testBB3
-    succeedReceiveBlock b3
-    -- check that the account is now present in the last finalized block.
-    lfbState1 <- use (lastFinalized . to bpState)
-    noAccs1 <- length <$> getAccountList lfbState1
-    liftIO $ assertEqual "there should be one extra account in lfb" (noAccs0 + 1) noAccs1
+testDeployCredential ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    Spec
+testDeployCredential sProtocolVersion =
+    it "deploy and finalize one credential" $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            lfbState0 <- use (lastFinalized . to bpState)
+            noAccs0 <- length <$> getAccountList lfbState0
+            let b1 = signedPB testBB1
+            succeedReceiveBlock b1
+            let b2 = signedPB testBB2
+            succeedReceiveBlock b2
+            -- b3 finalizes b1 as it carries a qc for b2 (which carries a qc for b1).
+            let b3 = signedPB testBB3
+            succeedReceiveBlock b3
+            -- check that the account is now present in the last finalized block.
+            lfbState1 <- use (lastFinalized . to bpState)
+            noAccs1 <- length <$> getAccountList lfbState1
+            liftIO $ assertEqual "there should be one extra account in lfb" (noAccs0 + 1) noAccs1
 
 -- | Valid block for round 2.
 --  This block has one credential deployment.
@@ -207,16 +211,17 @@ testBB2' =
           bbNonce = computeBlockNonce (genesisLEN sProtocolVersion) 2 (bakerVRFKey sProtocolVersion bakerId),
           bbTransactions = Vec.fromList [credBi2],
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
-            SBlockHashVersion0 -> DBHashesV0 $
-                BlockDerivableHashesV0
-                    { bdhv0TransactionOutcomesHash = read "abc4628869bb526115226dd01ad54bf33f54609fa770d50a9242aaf009f42fa1",
-                      bdhv0BlockStateHash = read "e3cf3b280159bc20645738fb1343486d16104989a524fb5feb59ac1b0b7af9ad"
-                    }
+            SBlockHashVersion0 ->
+                DBHashesV0 $
+                    BlockDerivableHashesV0
+                        { bdhv0TransactionOutcomesHash = read "abc4628869bb526115226dd01ad54bf33f54609fa770d50a9242aaf009f42fa1",
+                          bdhv0BlockStateHash = read "e3cf3b280159bc20645738fb1343486d16104989a524fb5feb59ac1b0b7af9ad"
+                        }
             SBlockHashVersion1 ->
-              DBHashesV1 $ BlockDerivableHashesV1
+                DBHashesV1 $
+                    BlockDerivableHashesV1
                         { bdhv1BlockResultHash = read "04225271b518f16c0cb63282d08bff365d6236ff6c1e63e0da5c40fc3af96136"
                         }
-
         }
   where
     sProtocolVersion = protocolVersion @pv
@@ -237,13 +242,15 @@ testBB3' =
           bbNonce = computeBlockNonce (genesisLEN sProtocolVersion) 3 (bakerVRFKey sProtocolVersion bakerId),
           bbTransactions = Vec.fromList [credBi3],
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
-            SBlockHashVersion0 -> DBHashesV0 $
-                BlockDerivableHashesV0
-                    { bdhv0TransactionOutcomesHash = read "3af8504795a03353248be256f66366263f7484c814c5a26760210bbdfd609003",
-                      bdhv0BlockStateHash = read "67eb8f778a4a43efa80c73a954110154ae417e21d43c33b857b962af36913e29"
-                    }
+            SBlockHashVersion0 ->
+                DBHashesV0 $
+                    BlockDerivableHashesV0
+                        { bdhv0TransactionOutcomesHash = read "3af8504795a03353248be256f66366263f7484c814c5a26760210bbdfd609003",
+                          bdhv0BlockStateHash = read "67eb8f778a4a43efa80c73a954110154ae417e21d43c33b857b962af36913e29"
+                        }
             SBlockHashVersion1 ->
-              DBHashesV1 $ BlockDerivableHashesV1
+                DBHashesV1 $
+                    BlockDerivableHashesV1
                         { bdhv1BlockResultHash = read "ca469c03bae422c5059e40f5ea683bd7be0d4bae0b8295021a674af78ef04f37"
                         }
         }
@@ -264,13 +271,15 @@ testBB4 =
           bbNonce = computeBlockNonce (genesisLEN sProtocolVersion) 4 (bakerVRFKey sProtocolVersion bakerId),
           bbTransactions = Vec.empty,
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
-            SBlockHashVersion0 -> DBHashesV0 $
-                BlockDerivableHashesV0
-                    { bdhv0TransactionOutcomesHash = read "b0972dd7af05ed6feaa40099fffa9c5c5e0ba9741938166cdb57584780688743",
-                      bdhv0BlockStateHash = read "9e698b9c6425b382d8fda5584f530688c237ad013e8aaf848fea274e50244111"
-                    }
+            SBlockHashVersion0 ->
+                DBHashesV0 $
+                    BlockDerivableHashesV0
+                        { bdhv0TransactionOutcomesHash = read "b0972dd7af05ed6feaa40099fffa9c5c5e0ba9741938166cdb57584780688743",
+                          bdhv0BlockStateHash = read "9e698b9c6425b382d8fda5584f530688c237ad013e8aaf848fea274e50244111"
+                        }
             SBlockHashVersion1 ->
-              DBHashesV1 $ BlockDerivableHashesV1
+                DBHashesV1 $
+                    BlockDerivableHashesV1
                         { bdhv1BlockResultHash = read "3f2846dfe9e52dd9537831df434e876ae029f43e7855fe5eba0212b7df4b2645"
                         }
         }
@@ -291,13 +300,15 @@ testBB5 =
           bbNonce = computeBlockNonce (genesisLEN sProtocolVersion) 5 (bakerVRFKey sProtocolVersion bakerId),
           bbTransactions = Vec.empty,
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
-            SBlockHashVersion0 -> DBHashesV0 $
-                BlockDerivableHashesV0
-                    { bdhv0TransactionOutcomesHash = read "b0972dd7af05ed6feaa40099fffa9c5c5e0ba9741938166cdb57584780688743",
-                      bdhv0BlockStateHash = read "d9dd62c227d1cbc0d42da0d90bfc11d61533d058cc54b0745d6a597039dbe0ec"
-                    }
+            SBlockHashVersion0 ->
+                DBHashesV0 $
+                    BlockDerivableHashesV0
+                        { bdhv0TransactionOutcomesHash = read "b0972dd7af05ed6feaa40099fffa9c5c5e0ba9741938166cdb57584780688743",
+                          bdhv0BlockStateHash = read "d9dd62c227d1cbc0d42da0d90bfc11d61533d058cc54b0745d6a597039dbe0ec"
+                        }
             SBlockHashVersion1 ->
-              DBHashesV1 $ BlockDerivableHashesV1
+                DBHashesV1 $
+                    BlockDerivableHashesV1
                         { bdhv1BlockResultHash = read "7bafef3db7a89a0475c4132a71fda2fa67d6e9ace01d02aaf9fd8cdc05c4e4ad"
                         }
         }
@@ -313,110 +324,115 @@ getAccAddress accCreation = case credential accCreation of
 
 -- | Test that two credential deployments (each on their own branch and with same block height) does not:
 --  * Alter the state of the parent block (a new child difference map and associated reference is created).
-testDeployCredentialBranching :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> String ->
-  Spec
-testDeployCredentialBranching sProtocolVersion pvString = it (pvString ++ ": deploy two credentials in two branches") $
-  runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
-    genesisState <- use (lastFinalized . to bpState)
-    noGenesisAccs <- length <$> getAccountList genesisState
-    let b1 = signedPB testBB1
-    succeedReceiveBlock b1
-    -- Branch
-    let b2 = signedPB testBB2'
-    succeedReceiveBlock b2
-    -- Another branch.
-    let b3 = signedPB testBB3'
-    succeedReceiveBlock b3
+testDeployCredentialBranching ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    Spec
+testDeployCredentialBranching sProtocolVersion =
+    it "deploy two credentials in two branches" $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            genesisState <- use (lastFinalized . to bpState)
+            noGenesisAccs <- length <$> getAccountList genesisState
+            let b1 = signedPB testBB1
+            succeedReceiveBlock b1
+            -- Branch
+            let b2 = signedPB testBB2'
+            succeedReceiveBlock b2
+            -- Another branch.
+            let b3 = signedPB testBB3'
+            succeedReceiveBlock b3
 
-    sd <- get
+            sd <- get
 
-    -- Check that only the first credential deployed is present in block b1.
-    case sd ^. blockTable . liveMap . at' (getHash b1) of
-        Nothing -> liftIO $ assertFailure "failed getting bp1"
-        Just bp1 -> do
-            noAccountsBp1 <- length <$> getAccountList (bpState bp1)
-            liftIO $ assertEqual "check that there is one extra account" (noGenesisAccs + 1) noAccountsBp1
-            getAccount (bpState bp1) (getAccAddress cred1) >>= \case
+            -- Check that only the first credential deployed is present in block b1.
+            case sd ^. blockTable . liveMap . at' (getHash b1) of
+                Nothing -> liftIO $ assertFailure "failed getting bp1"
+                Just bp1 -> do
+                    noAccountsBp1 <- length <$> getAccountList (bpState bp1)
+                    liftIO $ assertEqual "check that there is one extra account" (noGenesisAccs + 1) noAccountsBp1
+                    getAccount (bpState bp1) (getAccAddress cred1) >>= \case
+                        Nothing -> liftIO $ assertFailure "Should yield cred1"
+                        Just (accIndex, _) -> liftIO $ assertEqual "incorrect account index" noGenesisAccs (fromIntegral accIndex)
+
+                    getAccount (bpState bp1) (getAccAddress cred2) >>= \case
+                        Nothing -> return ()
+                        Just _ -> liftIO $ assertFailure "cred2 should not be present"
+
+                    getAccount (bpState bp1) (getAccAddress cred3) >>= \case
+                        Nothing -> return ()
+                        Just _ -> liftIO $ assertFailure "cred3 should not be present"
+
+            -- Check that cred1 and cred2 is present in b2 (but not cred3)
+            case sd ^. blockTable . liveMap . at' (getHash b2) of
+                Nothing -> liftIO $ assertFailure "failed getting bp1"
+                Just bp2 -> do
+                    noAccountsBp2 <- length <$> getAccountList (bpState bp2)
+                    liftIO $ assertEqual "check that there is one extra account" (noGenesisAccs + 2) noAccountsBp2
+                    getAccount (bpState bp2) (getAccAddress cred1) >>= \case
+                        Nothing -> liftIO $ assertFailure "Should yield cred1"
+                        Just (accIndex, _) -> liftIO $ assertEqual "incorrect account index" noGenesisAccs (fromIntegral accIndex)
+
+                    getAccount (bpState bp2) (getAccAddress cred2) >>= \case
+                        Nothing -> liftIO $ assertFailure "Should yield cred2"
+                        Just (accIndex, _) -> liftIO $ assertEqual "incorrect account index" (noGenesisAccs + 1) (fromIntegral accIndex)
+
+                    getAccount (bpState bp2) (getAccAddress cred3) >>= \case
+                        Nothing -> return ()
+                        Just _ -> liftIO $ assertFailure $ "cred3 should not be present: " <> show (getAccAddress cred3)
+
+            -- Check that cred1 and cred3 is present in b3 (but not cred2)
+            case sd ^. blockTable . liveMap . at' (getHash b3) of
+                Nothing -> liftIO $ assertFailure "failed getting bp1"
+                Just bp3 -> do
+                    noAccountsBp3 <- length <$> getAccountList (bpState bp3)
+                    liftIO $ assertEqual "check that there is one extra account" (noGenesisAccs + 2) noAccountsBp3
+                    getAccount (bpState bp3) (getAccAddress cred1) >>= \case
+                        Nothing -> liftIO $ assertFailure "Should yield cred1"
+                        Just (accIndex, _) -> liftIO $ assertEqual "incorrect account index" noGenesisAccs (fromIntegral accIndex)
+
+                    getAccount (bpState bp3) (getAccAddress cred3) >>= \case
+                        Nothing -> liftIO $ assertFailure "Should yield cred3"
+                        Just (accIndex, _) -> liftIO $ assertEqual "incorrect account index" (noGenesisAccs + 1) (fromIntegral accIndex)
+
+                    getAccount (bpState bp3) (getAccAddress cred2) >>= \case
+                        Nothing -> return ()
+                        Just _ -> liftIO $ assertFailure $ "cred2 should not be present: " <> show (getAccAddress cred3)
+
+            -- finalize bp3 and make sure that the state of the lfb matches b3.
+            let b4 = signedPB testBB4
+            succeedReceiveBlock b4
+            let b5 = signedPB testBB5
+            succeedReceiveBlock b5
+
+            lfbState <- use (lastFinalized . to bpState)
+            noAccountsLfb <- length <$> getAccountList lfbState
+            liftIO $ assertEqual "check that there aer two extra accounts (cred 1 and 3)" (noGenesisAccs + 2) noAccountsLfb
+
+            getAccount lfbState (getAccAddress cred1) >>= \case
                 Nothing -> liftIO $ assertFailure "Should yield cred1"
                 Just (accIndex, _) -> liftIO $ assertEqual "incorrect account index" noGenesisAccs (fromIntegral accIndex)
 
-            getAccount (bpState bp1) (getAccAddress cred2) >>= \case
-                Nothing -> return ()
-                Just _ -> liftIO $ assertFailure "cred2 should not be present"
-
-            getAccount (bpState bp1) (getAccAddress cred3) >>= \case
-                Nothing -> return ()
-                Just _ -> liftIO $ assertFailure "cred3 should not be present"
-
-    -- Check that cred1 and cred2 is present in b2 (but not cred3)
-    case sd ^. blockTable . liveMap . at' (getHash b2) of
-        Nothing -> liftIO $ assertFailure "failed getting bp1"
-        Just bp2 -> do
-            noAccountsBp2 <- length <$> getAccountList (bpState bp2)
-            liftIO $ assertEqual "check that there is one extra account" (noGenesisAccs + 2) noAccountsBp2
-            getAccount (bpState bp2) (getAccAddress cred1) >>= \case
-                Nothing -> liftIO $ assertFailure "Should yield cred1"
-                Just (accIndex, _) -> liftIO $ assertEqual "incorrect account index" noGenesisAccs (fromIntegral accIndex)
-
-            getAccount (bpState bp2) (getAccAddress cred2) >>= \case
-                Nothing -> liftIO $ assertFailure "Should yield cred2"
-                Just (accIndex, _) -> liftIO $ assertEqual "incorrect account index" (noGenesisAccs + 1) (fromIntegral accIndex)
-
-            getAccount (bpState bp2) (getAccAddress cred3) >>= \case
-                Nothing -> return ()
-                Just _ -> liftIO $ assertFailure $ "cred3 should not be present: " <> show (getAccAddress cred3)
-
-    -- Check that cred1 and cred3 is present in b3 (but not cred2)
-    case sd ^. blockTable . liveMap . at' (getHash b3) of
-        Nothing -> liftIO $ assertFailure "failed getting bp1"
-        Just bp3 -> do
-            noAccountsBp3 <- length <$> getAccountList (bpState bp3)
-            liftIO $ assertEqual "check that there is one extra account" (noGenesisAccs + 2) noAccountsBp3
-            getAccount (bpState bp3) (getAccAddress cred1) >>= \case
-                Nothing -> liftIO $ assertFailure "Should yield cred1"
-                Just (accIndex, _) -> liftIO $ assertEqual "incorrect account index" noGenesisAccs (fromIntegral accIndex)
-
-            getAccount (bpState bp3) (getAccAddress cred3) >>= \case
+            getAccount lfbState (getAccAddress cred3) >>= \case
                 Nothing -> liftIO $ assertFailure "Should yield cred3"
                 Just (accIndex, _) -> liftIO $ assertEqual "incorrect account index" (noGenesisAccs + 1) (fromIntegral accIndex)
 
-            getAccount (bpState bp3) (getAccAddress cred2) >>= \case
+            getAccount lfbState (getAccAddress cred2) >>= \case
                 Nothing -> return ()
-                Just _ -> liftIO $ assertFailure $ "cred2 should not be present: " <> show (getAccAddress cred3)
+                Just _ -> liftIO $ assertFailure $ "cred2 should not be present: " <> show (getAccAddress cred2)
 
-    -- finalize bp3 and make sure that the state of the lfb matches b3.
-    let b4 = signedPB testBB4
-    succeedReceiveBlock b4
-    let b5 = signedPB testBB5
-    succeedReceiveBlock b5
-
-    lfbState <- use (lastFinalized . to bpState)
-    noAccountsLfb <- length <$> getAccountList lfbState
-    liftIO $ assertEqual "check that there aer two extra accounts (cred 1 and 3)" (noGenesisAccs + 2) noAccountsLfb
-
-    getAccount lfbState (getAccAddress cred1) >>= \case
-        Nothing -> liftIO $ assertFailure "Should yield cred1"
-        Just (accIndex, _) -> liftIO $ assertEqual "incorrect account index" noGenesisAccs (fromIntegral accIndex)
-
-    getAccount lfbState (getAccAddress cred3) >>= \case
-        Nothing -> liftIO $ assertFailure "Should yield cred3"
-        Just (accIndex, _) -> liftIO $ assertEqual "incorrect account index" (noGenesisAccs + 1) (fromIntegral accIndex)
-
-    getAccount lfbState (getAccAddress cred2) >>= \case
-        Nothing -> return ()
-        Just _ -> liftIO $ assertFailure $ "cred2 should not be present: " <> show (getAccAddress cred2)
-
-    -- Check that querying the old bs is not affected by the updated lmdb backed account map.
-    noFinal <- length <$> getAccountList genesisState
-    liftIO $ assertEqual "There should be the same number of accounts present" noGenesisAccs noFinal
-    -- We thaw here so we can use @bsoGetAccountIndex@ for querying account index directly.
-    updatableBlockState <- thawBlockState genesisState
-    bsoGetAccountIndex updatableBlockState (getAccAddress cred1) >>= \case
-        Nothing -> return ()
-        Just _ -> liftIO $ assertFailure "cred 1 should not be present."
+            -- Check that querying the old bs is not affected by the updated lmdb backed account map.
+            noFinal <- length <$> getAccountList genesisState
+            liftIO $ assertEqual "There should be the same number of accounts present" noGenesisAccs noFinal
+            -- We thaw here so we can use @bsoGetAccountIndex@ for querying account index directly.
+            updatableBlockState <- thawBlockState genesisState
+            bsoGetAccountIndex updatableBlockState (getAccAddress cred1) >>= \case
+                Nothing -> return ()
+                Just _ -> liftIO $ assertFailure "cred 1 should not be present."
 
 tests :: Word -> Spec
 tests _ = describe "EndToEndTests.CredentialDeployments" $ do
-    forEveryProtocolVersionConsensusV1 $ \spv pvString -> do
-       testDeployCredential spv pvString
-       testDeployCredentialBranching spv pvString
+    Common.forEveryProtocolVersionConsensusV1 $ \spv pvString ->
+        describe pvString $ do
+            testDeployCredential spv
+            testDeployCredentialBranching spv

--- a/concordium-consensus/tests/consensus/ConcordiumTests/EndToEnd/TransactionTableIntegrationTest.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/EndToEnd/TransactionTableIntegrationTest.hs
@@ -1,6 +1,6 @@
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE GADTs #-}
 {-# LANGUAGE TypeApplications #-}
 
 -- | End to end test that check transaction table is as expected while the tree state processes blocks.
@@ -21,9 +21,10 @@ import Concordium.KonsensusV1.Types
 import Concordium.Types
 import Concordium.Types.Execution
 import Concordium.Types.Option
-import Concordium.Types.Transactions
 import Concordium.Types.Parameters
+import Concordium.Types.Transactions
 
+import qualified ConcordiumTests.KonsensusV1.Common as Common
 import ConcordiumTests.KonsensusV1.Consensus.Blocks hiding (testBB1, testBB2, testBB2', testBB3, testBB3', tests)
 
 -- | Make a raw transfer transaction with the provided nonce.
@@ -62,17 +63,17 @@ testBB1 =
           bbNonce = computeBlockNonce (genesisLEN sProtocolVersion) 1 (bakerVRFKey sProtocolVersion bakerId),
           bbTransactions = Vec.fromList [transfer1],
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
-            SBlockHashVersion0 -> DBHashesV0 $
-                BlockDerivableHashesV0
-                    { bdhv0TransactionOutcomesHash = read "13907ff30e010398b3438b73a55f6fd02177d653527aafb6b77360a646cb938c",
-                      bdhv0BlockStateHash = read "84d5b24177c60db5fb17f62a5cc93a500afc6565977f080cbd9260a68be66925"
-                    }
+            SBlockHashVersion0 ->
+                DBHashesV0 $
+                    BlockDerivableHashesV0
+                        { bdhv0TransactionOutcomesHash = read "13907ff30e010398b3438b73a55f6fd02177d653527aafb6b77360a646cb938c",
+                          bdhv0BlockStateHash = read "84d5b24177c60db5fb17f62a5cc93a500afc6565977f080cbd9260a68be66925"
+                        }
             SBlockHashVersion1 ->
                 DBHashesV1 $
                     BlockDerivableHashesV1
                         { bdhv1BlockResultHash = read "2265bb2759ce64984122dae6df3ee505e92bbca35d334802cbfbb8d4eaba7d4b"
                         }
-
         }
   where
     sProtocolVersion = protocolVersion @pv
@@ -93,16 +94,17 @@ testBB2 =
           bbNonce = computeBlockNonce (genesisLEN sProtocolVersion) 2 (bakerVRFKey sProtocolVersion bakerId),
           bbTransactions = Vec.empty,
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
-            SBlockHashVersion0 -> DBHashesV0 $
-                BlockDerivableHashesV0
-                    { bdhv0TransactionOutcomesHash = read "f840ea702e095175b8c2fceacc2377d5d2d0be867350bc0bdd8c6d56ee14797c",
-                      bdhv0BlockStateHash = read "0b286c7356d7c69717e42b39fc3cabf2fd82dbc4713f2e752084b1b9e2c5bdb8"
-                    }
+            SBlockHashVersion0 ->
+                DBHashesV0 $
+                    BlockDerivableHashesV0
+                        { bdhv0TransactionOutcomesHash = read "f840ea702e095175b8c2fceacc2377d5d2d0be867350bc0bdd8c6d56ee14797c",
+                          bdhv0BlockStateHash = read "0b286c7356d7c69717e42b39fc3cabf2fd82dbc4713f2e752084b1b9e2c5bdb8"
+                        }
             SBlockHashVersion1 ->
-              DBHashesV1 $ BlockDerivableHashesV1
+                DBHashesV1 $
+                    BlockDerivableHashesV1
                         { bdhv1BlockResultHash = read "a5e6a885a642a94deeccf8df29aa55062b4ae32423bc8dd9ed5ce3c076928cf9"
                         }
-
         }
   where
     sProtocolVersion = protocolVersion @pv
@@ -123,16 +125,17 @@ testBB3 =
           bbNonce = computeBlockNonce (genesisLEN sProtocolVersion) 3 (bakerVRFKey sProtocolVersion bakerId),
           bbTransactions = Vec.empty,
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
-            SBlockHashVersion0 -> DBHashesV0 $
-                BlockDerivableHashesV0
-                    { bdhv0TransactionOutcomesHash = read "9bbf1ab9edd3744bc88dfc0a6aa87a89dc51765d9a4b57bc8c7c49b1fb151099",
-                      bdhv0BlockStateHash = read "80d087748edeea46b7d0b8f25c8fb50bb015b498c11eeb03e8efe8b59e7d40f9"
-                    }
-            SBlockHashVersion1 -> DBHashesV1 $
+            SBlockHashVersion0 ->
+                DBHashesV0 $
+                    BlockDerivableHashesV0
+                        { bdhv0TransactionOutcomesHash = read "9bbf1ab9edd3744bc88dfc0a6aa87a89dc51765d9a4b57bc8c7c49b1fb151099",
+                          bdhv0BlockStateHash = read "80d087748edeea46b7d0b8f25c8fb50bb015b498c11eeb03e8efe8b59e7d40f9"
+                        }
+            SBlockHashVersion1 ->
+                DBHashesV1 $
                     BlockDerivableHashesV1
                         { bdhv1BlockResultHash = read "8202d3d2b8ddb55e355dd53f0d8206abf0c48e773f9b49de8e261fb3a050d858"
                         }
-
         }
   where
     sProtocolVersion = protocolVersion @pv
@@ -152,12 +155,14 @@ testBB4 =
           bbNonce = computeBlockNonce (genesisLEN sProtocolVersion) 4 (bakerVRFKey sProtocolVersion bakerId),
           bbTransactions = Vec.fromList [transfer2],
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
-            SBlockHashVersion0 -> DBHashesV0 $
-                BlockDerivableHashesV0
-                    { bdhv0TransactionOutcomesHash = read "d46c011009b5315c7cd32bb1345bd2e73a3cd6111a7e4d06c33e863f16c8c8bd",
-                      bdhv0BlockStateHash = read "a47ca3a8412ad577df94ae8ebc288f8972a499ce5315033bfc2f2c18ce00bfb8"
-                    }
-            SBlockHashVersion1 -> DBHashesV1 $
+            SBlockHashVersion0 ->
+                DBHashesV0 $
+                    BlockDerivableHashesV0
+                        { bdhv0TransactionOutcomesHash = read "d46c011009b5315c7cd32bb1345bd2e73a3cd6111a7e4d06c33e863f16c8c8bd",
+                          bdhv0BlockStateHash = read "a47ca3a8412ad577df94ae8ebc288f8972a499ce5315033bfc2f2c18ce00bfb8"
+                        }
+            SBlockHashVersion1 ->
+                DBHashesV1 $
                     BlockDerivableHashesV1
                         { bdhv1BlockResultHash = read "b3eb61d1b5a821e7ad9f2ba4b5b10071f106093d6bd2d9ebeb4fcb58e1fdb97d"
                         }
@@ -168,59 +173,62 @@ testBB4 =
 
 -- | Test that the @getNextAccountNonce@ returns correctly when adding a new transaction for an account A, after
 --  some prior transactions for account A has been finalized (and the transaction table is fully purged).
-testAccountNonce :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> String ->
-  Spec
-testAccountNonce sProtocolVersion pvString =
-  it (pvString ++ "account nonce test") $ runTestMonad @pv noBaker testTime (genesisData sProtocolVersion) $ do
-    nonce <- getNextAccountNonce sender =<< get
-    liftIO $
-        assertEqual
-            "Transaction is not received"
-            (1, True)
-            nonce
-    let b1 = signedPB testBB1
-    succeedReceiveBlock b1
-    let b2 = signedPB testBB2
-    succeedReceiveBlock b2
+testAccountNonce ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    Spec
+testAccountNonce sProtocolVersion =
+    it "account nonce test" $ runTestMonad @pv noBaker testTime (genesisData sProtocolVersion) $ do
+        nonce <- getNextAccountNonce sender =<< get
+        liftIO $
+            assertEqual
+                "Transaction is not received"
+                (1, True)
+                nonce
+        let b1 = signedPB testBB1
+        succeedReceiveBlock b1
+        let b2 = signedPB testBB2
+        succeedReceiveBlock b2
 
-    nonce' <- getNextAccountNonce sender =<< get
-    liftIO $
-        assertEqual
-            "Transaction is in non-finalized transactions"
-            (2, False)
-            nonce'
+        nonce' <- getNextAccountNonce sender =<< get
+        liftIO $
+            assertEqual
+                "Transaction is in non-finalized transactions"
+                (2, False)
+                nonce'
 
-    let b3 = signedPB testBB3
-    succeedReceiveBlock b3
-    -- transaction in b1 is now finalized and we force purge the table so
-    -- sender is expunged from transaction table.
-    purgeTransactionTable True (posixSecondsToUTCTime 1)
-    sd <- get
-    nonce'' <- getNextAccountNonce sender sd
-    liftIO $
-        assertEqual
-            "first transaction should be finalized"
-            (2, True)
-            nonce''
-    liftIO $
-        assertEqual
-            "transaction should not be in the anft map for the sender anymore"
-            Nothing
-            (sd ^? transactionTable . TT.ttNonFinalizedTransactions . ix sender)
+        let b3 = signedPB testBB3
+        succeedReceiveBlock b3
+        -- transaction in b1 is now finalized and we force purge the table so
+        -- sender is expunged from transaction table.
+        purgeTransactionTable True (posixSecondsToUTCTime 1)
+        sd <- get
+        nonce'' <- getNextAccountNonce sender sd
+        liftIO $
+            assertEqual
+                "first transaction should be finalized"
+                (2, True)
+                nonce''
+        liftIO $
+            assertEqual
+                "transaction should not be in the anft map for the sender anymore"
+                Nothing
+                (sd ^? transactionTable . TT.ttNonFinalizedTransactions . ix sender)
 
-    let b4 = signedPB testBB4
-    succeedReceiveBlock b4
-    nonce''' <- getNextAccountNonce sender =<< get
-    liftIO $
-        assertEqual
-            "sender should be present in tt again and anftNextNonce is correctly set"
-            (3, False)
-            nonce'''
+        let b4 = signedPB testBB4
+        succeedReceiveBlock b4
+        nonce''' <- getNextAccountNonce sender =<< get
+        liftIO $
+            assertEqual
+                "sender should be present in tt again and anftNextNonce is correctly set"
+                (3, False)
+                nonce'''
   where
     sender = accountAddressEmbed foundationAccountAddress
 
 tests :: Spec
 tests = describe "EndToEndTests.TransactionTableIntegrationTest" $ do
-    forEveryProtocolVersionConsensusV1 $ \spv pvString -> do
-      testAccountNonce spv pvString
-
+    Common.forEveryProtocolVersionConsensusV1 $ \spv pvString ->
+        describe pvString $
+            testAccountNonce spv

--- a/concordium-consensus/tests/consensus/ConcordiumTests/EndToEnd/TransactionTableIntegrationTest.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/EndToEnd/TransactionTableIntegrationTest.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- | End to end test that check transaction table is as expected while the tree state processes blocks.
 module ConcordiumTests.EndToEnd.TransactionTableIntegrationTest (tests) where
@@ -19,6 +22,7 @@ import Concordium.Types
 import Concordium.Types.Execution
 import Concordium.Types.Option
 import Concordium.Types.Transactions
+import Concordium.Types.Parameters
 
 import ConcordiumTests.KonsensusV1.Consensus.Blocks hiding (testBB1, testBB2, testBB2', testBB3, testBB3', tests)
 
@@ -45,103 +49,129 @@ transfer2 :: BlockItem
 transfer2 = normalTransaction $ addMetadata (\x -> NormalTransaction{biTransaction = x}) 1001 (biTransaction $ mkTransferTransaction 2)
 
 -- | Valid block for round 1 with 1 normal transfer
-testBB1 :: BakedBlock PV
+testBB1 :: forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => BakedBlock pv
 testBB1 =
     BakedBlock
         { bbRound = 1,
           bbEpoch = 0,
           bbTimestamp = 1_000,
           bbBaker = bakerId,
-          bbQuorumCertificate = genesisQuorumCertificate genesisHash,
+          bbQuorumCertificate = genesisQuorumCertificate (genesisHash sProtocolVersion),
           bbTimeoutCertificate = Absent,
           bbEpochFinalizationEntry = Absent,
-          bbNonce = computeBlockNonce genesisLEN 1 (bakerVRFKey bakerId),
+          bbNonce = computeBlockNonce (genesisLEN sProtocolVersion) 1 (bakerVRFKey sProtocolVersion bakerId),
           bbTransactions = Vec.fromList [transfer1],
-          bbDerivableHashes =
-            DBHashesV0 $
+          bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
+            SBlockHashVersion0 -> DBHashesV0 $
                 BlockDerivableHashesV0
                     { bdhv0TransactionOutcomesHash = read "13907ff30e010398b3438b73a55f6fd02177d653527aafb6b77360a646cb938c",
                       bdhv0BlockStateHash = read "84d5b24177c60db5fb17f62a5cc93a500afc6565977f080cbd9260a68be66925"
                     }
+            SBlockHashVersion1 ->
+                DBHashesV1 $
+                    BlockDerivableHashesV1
+                        { bdhv1BlockResultHash = read "2265bb2759ce64984122dae6df3ee505e92bbca35d334802cbfbb8d4eaba7d4b"
+                        }
+
         }
   where
+    sProtocolVersion = protocolVersion @pv
     bakerId = 2
 
 -- | Valid block for round 2.
 --  This block carries a QC for 'testBB1' thus certifying it.
-testBB2 :: BakedBlock PV
+testBB2 :: forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => BakedBlock pv
 testBB2 =
     BakedBlock
         { bbRound = 2,
           bbEpoch = 0,
           bbTimestamp = 3_000,
           bbBaker = bakerId,
-          bbQuorumCertificate = validQCFor testBB1,
+          bbQuorumCertificate = validQCFor @pv testBB1,
           bbTimeoutCertificate = Absent,
           bbEpochFinalizationEntry = Absent,
-          bbNonce = computeBlockNonce genesisLEN 2 (bakerVRFKey bakerId),
+          bbNonce = computeBlockNonce (genesisLEN sProtocolVersion) 2 (bakerVRFKey sProtocolVersion bakerId),
           bbTransactions = Vec.empty,
-          bbDerivableHashes =
-            DBHashesV0 $
+          bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
+            SBlockHashVersion0 -> DBHashesV0 $
                 BlockDerivableHashesV0
                     { bdhv0TransactionOutcomesHash = read "f840ea702e095175b8c2fceacc2377d5d2d0be867350bc0bdd8c6d56ee14797c",
                       bdhv0BlockStateHash = read "0b286c7356d7c69717e42b39fc3cabf2fd82dbc4713f2e752084b1b9e2c5bdb8"
                     }
+            SBlockHashVersion1 ->
+              DBHashesV1 $ BlockDerivableHashesV1
+                        { bdhv1BlockResultHash = read "a5e6a885a642a94deeccf8df29aa55062b4ae32423bc8dd9ed5ce3c076928cf9"
+                        }
+
         }
   where
+    sProtocolVersion = protocolVersion @pv
     bakerId = 4
 
 -- | Valid block for round 3, finalizes 'testBB1' as this block
 --  carries a QC for 'testBB2'.
-testBB3 :: BakedBlock PV
+testBB3 :: forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => BakedBlock pv
 testBB3 =
     BakedBlock
         { bbRound = 3,
           bbEpoch = 0,
           bbTimestamp = 5_000,
           bbBaker = bakerId,
-          bbQuorumCertificate = validQCFor testBB2,
+          bbQuorumCertificate = validQCFor @pv testBB2,
           bbTimeoutCertificate = Absent,
           bbEpochFinalizationEntry = Absent,
-          bbNonce = computeBlockNonce genesisLEN 3 (bakerVRFKey bakerId),
+          bbNonce = computeBlockNonce (genesisLEN sProtocolVersion) 3 (bakerVRFKey sProtocolVersion bakerId),
           bbTransactions = Vec.empty,
-          bbDerivableHashes =
-            DBHashesV0 $
+          bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
+            SBlockHashVersion0 -> DBHashesV0 $
                 BlockDerivableHashesV0
                     { bdhv0TransactionOutcomesHash = read "9bbf1ab9edd3744bc88dfc0a6aa87a89dc51765d9a4b57bc8c7c49b1fb151099",
                       bdhv0BlockStateHash = read "80d087748edeea46b7d0b8f25c8fb50bb015b498c11eeb03e8efe8b59e7d40f9"
                     }
+            SBlockHashVersion1 -> DBHashesV1 $
+                    BlockDerivableHashesV1
+                        { bdhv1BlockResultHash = read "8202d3d2b8ddb55e355dd53f0d8206abf0c48e773f9b49de8e261fb3a050d858"
+                        }
+
         }
   where
+    sProtocolVersion = protocolVersion @pv
     bakerId = 4
 
 -- | Valid block for round 4 with 1 normal transfer
-testBB4 :: BakedBlock PV
+testBB4 :: forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => BakedBlock pv
 testBB4 =
     BakedBlock
         { bbRound = 4,
           bbEpoch = 0,
           bbTimestamp = 7_000,
           bbBaker = bakerId,
-          bbQuorumCertificate = validQCFor testBB3,
+          bbQuorumCertificate = validQCFor @pv testBB3,
           bbTimeoutCertificate = Absent,
           bbEpochFinalizationEntry = Absent,
-          bbNonce = computeBlockNonce genesisLEN 4 (bakerVRFKey bakerId),
+          bbNonce = computeBlockNonce (genesisLEN sProtocolVersion) 4 (bakerVRFKey sProtocolVersion bakerId),
           bbTransactions = Vec.fromList [transfer2],
-          bbDerivableHashes =
-            DBHashesV0 $
+          bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
+            SBlockHashVersion0 -> DBHashesV0 $
                 BlockDerivableHashesV0
                     { bdhv0TransactionOutcomesHash = read "d46c011009b5315c7cd32bb1345bd2e73a3cd6111a7e4d06c33e863f16c8c8bd",
                       bdhv0BlockStateHash = read "a47ca3a8412ad577df94ae8ebc288f8972a499ce5315033bfc2f2c18ce00bfb8"
                     }
+            SBlockHashVersion1 -> DBHashesV1 $
+                    BlockDerivableHashesV1
+                        { bdhv1BlockResultHash = read "b3eb61d1b5a821e7ad9f2ba4b5b10071f106093d6bd2d9ebeb4fcb58e1fdb97d"
+                        }
         }
   where
+    sProtocolVersion = protocolVersion @pv
     bakerId = 3
 
 -- | Test that the @getNextAccountNonce@ returns correctly when adding a new transaction for an account A, after
 --  some prior transactions for account A has been finalized (and the transaction table is fully purged).
-testAccountNonce :: Assertion
-testAccountNonce = runTestMonad noBaker testTime genesisData $ do
+testAccountNonce :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> String ->
+  Spec
+testAccountNonce sProtocolVersion pvString =
+  it (pvString ++ "account nonce test") $ runTestMonad @pv noBaker testTime (genesisData sProtocolVersion) $ do
     nonce <- getNextAccountNonce sender =<< get
     liftIO $
         assertEqual
@@ -191,4 +221,6 @@ testAccountNonce = runTestMonad noBaker testTime genesisData $ do
 
 tests :: Spec
 tests = describe "EndToEndTests.TransactionTableIntegrationTest" $ do
-    it "account nonce test" testAccountNonce
+    forEveryProtocolVersionConsensusV1 $ \spv pvString -> do
+      testAccountNonce spv pvString
+

--- a/concordium-consensus/tests/consensus/ConcordiumTests/EndToEnd/TransactionTableIntegrationTest.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/EndToEnd/TransactionTableIntegrationTest.hs
@@ -64,16 +64,14 @@ testBB1 =
           bbTransactions = Vec.fromList [transfer1],
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-                DBHashesV0 $
-                    BlockDerivableHashesV0
-                        { bdhv0TransactionOutcomesHash = read "13907ff30e010398b3438b73a55f6fd02177d653527aafb6b77360a646cb938c",
-                          bdhv0BlockStateHash = read "84d5b24177c60db5fb17f62a5cc93a500afc6565977f080cbd9260a68be66925"
-                        }
+                DerivableBlockHashesV0
+                    { dbhv0TransactionOutcomesHash = read "13907ff30e010398b3438b73a55f6fd02177d653527aafb6b77360a646cb938c",
+                      dbhv0BlockStateHash = read "84d5b24177c60db5fb17f62a5cc93a500afc6565977f080cbd9260a68be66925"
+                    }
             SBlockHashVersion1 ->
-                DBHashesV1 $
-                    BlockDerivableHashesV1
-                        { bdhv1BlockResultHash = read "2265bb2759ce64984122dae6df3ee505e92bbca35d334802cbfbb8d4eaba7d4b"
-                        }
+                DerivableBlockHashesV1
+                    { dbhv1BlockResultHash = read "2265bb2759ce64984122dae6df3ee505e92bbca35d334802cbfbb8d4eaba7d4b"
+                    }
         }
   where
     sProtocolVersion = protocolVersion @pv
@@ -95,16 +93,14 @@ testBB2 =
           bbTransactions = Vec.empty,
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-                DBHashesV0 $
-                    BlockDerivableHashesV0
-                        { bdhv0TransactionOutcomesHash = read "f840ea702e095175b8c2fceacc2377d5d2d0be867350bc0bdd8c6d56ee14797c",
-                          bdhv0BlockStateHash = read "0b286c7356d7c69717e42b39fc3cabf2fd82dbc4713f2e752084b1b9e2c5bdb8"
-                        }
+                DerivableBlockHashesV0
+                    { dbhv0TransactionOutcomesHash = read "f840ea702e095175b8c2fceacc2377d5d2d0be867350bc0bdd8c6d56ee14797c",
+                      dbhv0BlockStateHash = read "0b286c7356d7c69717e42b39fc3cabf2fd82dbc4713f2e752084b1b9e2c5bdb8"
+                    }
             SBlockHashVersion1 ->
-                DBHashesV1 $
-                    BlockDerivableHashesV1
-                        { bdhv1BlockResultHash = read "a5e6a885a642a94deeccf8df29aa55062b4ae32423bc8dd9ed5ce3c076928cf9"
-                        }
+                DerivableBlockHashesV1
+                    { dbhv1BlockResultHash = read "a5e6a885a642a94deeccf8df29aa55062b4ae32423bc8dd9ed5ce3c076928cf9"
+                    }
         }
   where
     sProtocolVersion = protocolVersion @pv
@@ -126,16 +122,14 @@ testBB3 =
           bbTransactions = Vec.empty,
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-                DBHashesV0 $
-                    BlockDerivableHashesV0
-                        { bdhv0TransactionOutcomesHash = read "9bbf1ab9edd3744bc88dfc0a6aa87a89dc51765d9a4b57bc8c7c49b1fb151099",
-                          bdhv0BlockStateHash = read "80d087748edeea46b7d0b8f25c8fb50bb015b498c11eeb03e8efe8b59e7d40f9"
-                        }
+                DerivableBlockHashesV0
+                    { dbhv0TransactionOutcomesHash = read "9bbf1ab9edd3744bc88dfc0a6aa87a89dc51765d9a4b57bc8c7c49b1fb151099",
+                      dbhv0BlockStateHash = read "80d087748edeea46b7d0b8f25c8fb50bb015b498c11eeb03e8efe8b59e7d40f9"
+                    }
             SBlockHashVersion1 ->
-                DBHashesV1 $
-                    BlockDerivableHashesV1
-                        { bdhv1BlockResultHash = read "8202d3d2b8ddb55e355dd53f0d8206abf0c48e773f9b49de8e261fb3a050d858"
-                        }
+                DerivableBlockHashesV1
+                    { dbhv1BlockResultHash = read "8202d3d2b8ddb55e355dd53f0d8206abf0c48e773f9b49de8e261fb3a050d858"
+                    }
         }
   where
     sProtocolVersion = protocolVersion @pv
@@ -156,16 +150,14 @@ testBB4 =
           bbTransactions = Vec.fromList [transfer2],
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-                DBHashesV0 $
-                    BlockDerivableHashesV0
-                        { bdhv0TransactionOutcomesHash = read "d46c011009b5315c7cd32bb1345bd2e73a3cd6111a7e4d06c33e863f16c8c8bd",
-                          bdhv0BlockStateHash = read "a47ca3a8412ad577df94ae8ebc288f8972a499ce5315033bfc2f2c18ce00bfb8"
-                        }
+                DerivableBlockHashesV0
+                    { dbhv0TransactionOutcomesHash = read "d46c011009b5315c7cd32bb1345bd2e73a3cd6111a7e4d06c33e863f16c8c8bd",
+                      dbhv0BlockStateHash = read "a47ca3a8412ad577df94ae8ebc288f8972a499ce5315033bfc2f2c18ce00bfb8"
+                    }
             SBlockHashVersion1 ->
-                DBHashesV1 $
-                    BlockDerivableHashesV1
-                        { bdhv1BlockResultHash = read "b3eb61d1b5a821e7ad9f2ba4b5b10071f106093d6bd2d9ebeb4fcb58e1fdb97d"
-                        }
+                DerivableBlockHashesV1
+                    { dbhv1BlockResultHash = read "b3eb61d1b5a821e7ad9f2ba4b5b10071f106093d6bd2d9ebeb4fcb58e1fdb97d"
+                    }
         }
   where
     sProtocolVersion = protocolVersion @pv

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/CatchUp.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/CatchUp.hs
@@ -33,6 +33,7 @@ import Concordium.KonsensusV1.Types
 import Concordium.Types.Option
 import ConcordiumTests.KonsensusV1.Consensus.Blocks
 
+import qualified ConcordiumTests.KonsensusV1.Common as Common
 import qualified ConcordiumTests.KonsensusV1.Consensus.Blocks as TestBlocks
 
 -- | Checking that the @CatchupPartialResponse m@ is as expected.
@@ -178,9 +179,9 @@ runTest =
 
 -- | Testing a basic test scenario where the node N knows
 --  of the block in round 1 and 2 and catches up the third block and a tm + qm for round 3.
-basicCatchupResponse :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> String -> Spec
-basicCatchupResponse sProtocolVersion pvString =
-    it (pvString ++ ": Test handleCatchUpRequest: Basics") $ runTest @pv $ do
+basicCatchupResponse :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> Spec
+basicCatchupResponse sProtocolVersion =
+    it "Test handleCatchUpRequest: Basics" $ runTest @pv $ do
         mapM_
             (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
             [TestBlocks.testBB1, TestBlocks.testBB2, TestBlocks.testBB3]
@@ -219,9 +220,9 @@ basicCatchupResponse sProtocolVersion pvString =
         assertCatchupResponse expectedTerminalData expectedBlocksServed =<< handleCatchUpRequest request =<< get
 
 -- | A test where the response covers an epoch transition.
-catchupWithEpochTransitionResponse :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> String -> Spec
-catchupWithEpochTransitionResponse sProtocolVersion pvString =
-    it (pvString ++ ": Test handleCatchUpRequest: Epoch transition") $ runTest @pv $ do
+catchupWithEpochTransitionResponse :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> Spec
+catchupWithEpochTransitionResponse sProtocolVersion =
+    it "Test handleCatchUpRequest: Epoch transition" $ runTest @pv $ do
         mapM_
             (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
             [TestBlocks.testBB1E, TestBlocks.testBB2E, TestBlocks.testBB3E]
@@ -273,10 +274,9 @@ catchupWithTimeoutsResponse ::
     forall pv.
     (IsConsensusV1 pv, IsProtocolVersion pv) =>
     SProtocolVersion pv ->
-    String ->
     Spec
-catchupWithTimeoutsResponse sProtocolVersion pvString =
-    it (pvString ++ ": Test handleCatchUpRequest: Timeout in the middle of the chain") $ runTest @pv $ do
+catchupWithTimeoutsResponse sProtocolVersion =
+    it "Test handleCatchUpRequest: Timeout in the middle of the chain" $ runTest @pv $ do
         mapM_
             (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
             [TestBlocks.testBB1E, TestBlocks.testBB2E, TestBlocks.testBB3E, TestBlocks.testBB5E']
@@ -325,10 +325,9 @@ catchupWithOneTimeoutAtEndResponse ::
     forall pv.
     (IsConsensusV1 pv, IsProtocolVersion pv) =>
     SProtocolVersion pv ->
-    String ->
     Spec
-catchupWithOneTimeoutAtEndResponse sProtocolVersion pvString =
-    it (pvString ++ ": Test handleCatchUpRequest: One timeout certificate at end") $ runTest @pv $ do
+catchupWithOneTimeoutAtEndResponse sProtocolVersion =
+    it "Test handleCatchUpRequest: One timeout certificate at end" $ runTest @pv $ do
         mapM_
             (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
             [TestBlocks.testBB1, TestBlocks.testBB2, TestBlocks.testBB3]
@@ -370,9 +369,9 @@ catchupWithOneTimeoutAtEndResponse sProtocolVersion pvString =
         assertCatchupResponse expectedTerminalData expectedBlocksServed =<< handleCatchUpRequest request =<< get
 
 -- | There is a timeout for round 3 and round 4.
-catchupWithTwoTimeoutsAtEndResponse :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> String -> Spec
-catchupWithTwoTimeoutsAtEndResponse _ pvString =
-    it (pvString ++ ": Test handleCatchUpRequest: Two timeout certificates at end") $ runTest @pv $ do
+catchupWithTwoTimeoutsAtEndResponse :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> Spec
+catchupWithTwoTimeoutsAtEndResponse _ =
+    it "Test handleCatchUpRequest: Two timeout certificates at end" $ runTest @pv $ do
         mapM_
             (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
             [TestBlocks.testBB1, TestBlocks.testBB2, TestBlocks.testBB3]
@@ -416,10 +415,9 @@ catchupWithTwoBranchesResponse ::
     forall pv.
     (IsConsensusV1 pv, IsProtocolVersion pv) =>
     SProtocolVersion pv ->
-    String ->
     Spec
-catchupWithTwoBranchesResponse sProtocolVersion pvString =
-    it (pvString ++ ": Test handleCatchUpRequest: Two branches") $ runTest @pv $ do
+catchupWithTwoBranchesResponse sProtocolVersion =
+    it "Test handleCatchUpRequest: Two branches" $ runTest @pv $ do
         mapM_
             (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
             [TestBlocks.testBB1, TestBlocks.testBB2, TestBlocks.testBB3]
@@ -507,10 +505,9 @@ catchupWithEpochTransitionTimeout ::
     forall pv.
     (IsConsensusV1 pv, IsProtocolVersion pv) =>
     SProtocolVersion pv ->
-    String ->
     Spec
-catchupWithEpochTransitionTimeout sProtocolVersion pvString =
-    it (pvString ++ ": Test handleCatchUpRequest: Epoch transition with timeout") $ runTest @pv $ do
+catchupWithEpochTransitionTimeout sProtocolVersion =
+    it "Test handleCatchUpRequest: Epoch transition with timeout" $ runTest @pv $ do
         mapM_
             (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
             [TestBlocks.testBB1E, TestBlocks.testBB2E, TestBlocks.testBB3E]
@@ -550,10 +547,9 @@ testMakeCatchupStatus ::
     forall pv.
     (IsConsensusV1 pv, IsProtocolVersion pv) =>
     SProtocolVersion pv ->
-    String ->
     Spec
-testMakeCatchupStatus sProtocolVersion pvString =
-    it (pvString ++ ": Test makeCatchUpRequestMessage") $ runTest @pv $ do
+testMakeCatchupStatus sProtocolVersion =
+    it "Test makeCatchUpRequestMessage" $ runTest @pv $ do
         mapM_
             (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
             [TestBlocks.testBB1, TestBlocks.testBB2, TestBlocks.testBB3]
@@ -641,9 +637,9 @@ checkRoundStatus rs1 rs2 = do
 --  Hence this test serves as an integration test where
 --  catch-up status messages are generated and used to create responses,
 --  and the blocks from the response is received by the peer catching up.
-testCatchup :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> String -> Spec
-testCatchup sProtocolVersion pvString =
-    it (pvString ++ ": Test catch-up integration test") $ do
+testCatchup :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> Spec
+testCatchup sProtocolVersion =
+    it "Test catch-up integration test" $ do
         -- Responder to catchup
         (rStatus, responderState) <- runTest @pv $ do
             mapM_
@@ -698,9 +694,9 @@ testCatchup sProtocolVersion pvString =
             liftIO . assertEqual "Unexpected last finalization entry" respLfe =<< use latestFinalizationEntry
 
 -- | Test catch-up through an epoch transition.
-testCatchupEpochTransition :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> String -> Spec
-testCatchupEpochTransition _ pvString =
-    it (pvString ++ ": Test catch-up integration test with epoch transition") $ do
+testCatchupEpochTransition :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> Spec
+testCatchupEpochTransition _ =
+    it "Test catch-up integration test with epoch transition" $ do
         -- Responder to catchup
         (rStatus, responderState) <- runTest @pv $ do
             mapM_
@@ -740,10 +736,9 @@ testCatchupTCAtEnd ::
     forall pv.
     (IsConsensusV1 pv, IsProtocolVersion pv) =>
     SProtocolVersion pv ->
-    String ->
     Spec
-testCatchupTCAtEnd _ pvString =
-    it (pvString ++ ": Test catch-up integration test with TC at end") $ do
+testCatchupTCAtEnd _ =
+    it "Test catch-up integration test with TC at end" $ do
         -- Responder to catchup
         (rStatus, responderState) <- runTest $ do
             mapM_
@@ -788,10 +783,9 @@ testCatchupRequiredBehindLastFinalized ::
     forall pv.
     (IsConsensusV1 pv, IsProtocolVersion pv) =>
     SProtocolVersion pv ->
-    String ->
     Spec
-testCatchupRequiredBehindLastFinalized _ pvString =
-    it (pvString ++ ": Test isCatchUpRequired: Catch-up responder is behind last finalized") $ do
+testCatchupRequiredBehindLastFinalized _ =
+    it "Test isCatchUpRequired: Catch-up responder is behind last finalized" $ do
         -- Send a catch up status message
         (rStatus, responderState) <- runTest @pv $ do
             let b1 = TestBlocks.signedPB TestBlocks.testBB1
@@ -815,10 +809,9 @@ testCatchupRequiredBehind ::
     forall pv.
     (IsConsensusV1 pv, IsProtocolVersion pv) =>
     SProtocolVersion pv ->
-    String ->
     Spec
-testCatchupRequiredBehind _ pvString =
-    it (pvString ++ ": Test isCatchUpRequired: Catch-up responder is behind") $ do
+testCatchupRequiredBehind _ =
+    it "Test isCatchUpRequired: Catch-up responder is behind" $ do
         -- Send a catch up status message
         (rStatus, responderState) <- runTest @pv $ do
             let b1 = TestBlocks.signedPB TestBlocks.testBB1
@@ -843,10 +836,9 @@ testCatchupRequiredSameRound ::
     forall pv.
     (IsConsensusV1 pv, IsProtocolVersion pv) =>
     SProtocolVersion pv ->
-    String ->
     Spec
-testCatchupRequiredSameRound sProtocolVersion pvString =
-    it (pvString ++ ": Test isCatchUpRequired: Catch-up same round") $ do
+testCatchupRequiredSameRound sProtocolVersion =
+    it "Test isCatchUpRequired: Catch-up same round" $ do
         -- Send a catch up status message
         (rStatus, responderState) <- runTest @pv $ do
             mapM_
@@ -884,18 +876,19 @@ testCatchupRequiredSameRound sProtocolVersion pvString =
 
 tests :: Spec
 tests = describe "KonsensusV1.CatchUp" $ do
-    forEveryProtocolVersionConsensusV1 $ \spv pvString -> do
-        basicCatchupResponse spv pvString
-        catchupWithEpochTransitionResponse spv pvString
-        catchupWithTimeoutsResponse spv pvString
-        catchupWithOneTimeoutAtEndResponse spv pvString
-        catchupWithTwoTimeoutsAtEndResponse spv pvString
-        catchupWithTwoBranchesResponse spv pvString
-        testMakeCatchupStatus spv pvString
-        testCatchup spv pvString
-        testCatchupEpochTransition spv pvString
-        testCatchupTCAtEnd spv pvString
-        testCatchupRequiredBehindLastFinalized spv pvString
-        testCatchupRequiredBehind spv pvString
-        testCatchupRequiredSameRound spv pvString
-        catchupWithEpochTransitionTimeout spv pvString
+    Common.forEveryProtocolVersionConsensusV1 $ \spv pvString ->
+        describe pvString $ do
+            basicCatchupResponse spv
+            catchupWithEpochTransitionResponse spv
+            catchupWithTimeoutsResponse spv
+            catchupWithOneTimeoutAtEndResponse spv
+            catchupWithTwoTimeoutsAtEndResponse spv
+            catchupWithTwoBranchesResponse spv
+            testMakeCatchupStatus spv
+            testCatchup spv
+            testCatchupEpochTransition spv
+            testCatchupTCAtEnd spv
+            testCatchupRequiredBehindLastFinalized spv
+            testCatchupRequiredBehind spv
+            testCatchupRequiredSameRound spv
+            catchupWithEpochTransitionTimeout spv

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/CatchUp.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/CatchUp.hs
@@ -445,16 +445,14 @@ catchupWithTwoBranchesResponse sProtocolVersion =
                               bbTransactions = Vec.empty,
                               bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
                                 SBlockHashVersion0 ->
-                                    DBHashesV0 $
-                                        BlockDerivableHashesV0
-                                            { bdhv0TransactionOutcomesHash = emptyBlockTOH 3,
-                                              bdhv0BlockStateHash = read "cdf730c1b3fdc6d07f404c6b95a4f3417c19653b1299b92f59fcaffcc9745910"
-                                            }
+                                    DerivableBlockHashesV0
+                                        { dbhv0TransactionOutcomesHash = emptyBlockTOH 3,
+                                          dbhv0BlockStateHash = read "cdf730c1b3fdc6d07f404c6b95a4f3417c19653b1299b92f59fcaffcc9745910"
+                                        }
                                 SBlockHashVersion1 ->
-                                    DBHashesV1 $
-                                        BlockDerivableHashesV1
-                                            { bdhv1BlockResultHash = read "f36a049939054eac3e8662e4ab0310d8e12381ee2ba77a9c16fa19c205ea64b3"
-                                            }
+                                    DerivableBlockHashesV1
+                                        { dbhv1BlockResultHash = read "f36a049939054eac3e8662e4ab0310d8e12381ee2ba77a9c16fa19c205ea64b3"
+                                        }
                             }
         TestBlocks.succeedReceiveBlock b4
         -- There is one current timeout message and one current quorum message
@@ -582,16 +580,14 @@ testMakeCatchupStatus sProtocolVersion =
                               bbTransactions = Vec.empty,
                               bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
                                 SBlockHashVersion0 ->
-                                    DBHashesV0 $
-                                        BlockDerivableHashesV0
-                                            { bdhv0TransactionOutcomesHash = emptyBlockTOH 3,
-                                              bdhv0BlockStateHash = read "cdf730c1b3fdc6d07f404c6b95a4f3417c19653b1299b92f59fcaffcc9745910"
-                                            }
+                                    DerivableBlockHashesV0
+                                        { dbhv0TransactionOutcomesHash = emptyBlockTOH 3,
+                                          dbhv0BlockStateHash = read "cdf730c1b3fdc6d07f404c6b95a4f3417c19653b1299b92f59fcaffcc9745910"
+                                        }
                                 SBlockHashVersion1 ->
-                                    DBHashesV1 $
-                                        BlockDerivableHashesV1
-                                            { bdhv1BlockResultHash = read "f36a049939054eac3e8662e4ab0310d8e12381ee2ba77a9c16fa19c205ea64b3"
-                                            }
+                                    DerivableBlockHashesV1
+                                        { dbhv1BlockResultHash = read "f36a049939054eac3e8662e4ab0310d8e12381ee2ba77a9c16fa19c205ea64b3"
+                                        }
                             }
         TestBlocks.succeedReceiveBlock b4
         -- There is one current timeout message and one current quorum message

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/CatchUp.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/CatchUp.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -10,6 +11,8 @@ module ConcordiumTests.KonsensusV1.CatchUp where
 
 import Control.Monad.State.Strict
 
+import qualified Data.Map.Strict as Map
+import qualified Data.Vector as Vec
 import Lens.Micro.Platform
 import Test.HUnit
 import Test.Hspec
@@ -17,8 +20,7 @@ import Test.Hspec
 import Concordium.Types
 import Concordium.Types.BakerIdentity
 import Concordium.Types.HashableTo
-import qualified Data.Map.Strict as Map
-import qualified Data.Vector as Vec
+import Concordium.Types.Parameters
 
 import Concordium.KonsensusV1.Consensus
 import Concordium.KonsensusV1.Consensus.CatchUp
@@ -57,7 +59,10 @@ assertCatchupResponse term (x : xs) resp = case resp of
 
 -- | Receive and execute blocks served as part of the @CatchUpPartialResponse@.
 --  Return the terminal data when available.
-consumeResponse :: (MonadIO m, m ~ TestMonad 'P6) => CatchUpPartialResponse m -> TestMonad 'P6 CatchUpTerminalData
+consumeResponse ::
+    (IsProtocolVersion pv, IsConsensusV1 pv) =>
+    CatchUpPartialResponse (TestMonad pv) ->
+    TestMonad pv CatchUpTerminalData
 consumeResponse CatchUpPartialResponseBlock{..} = do
     succeedReceiveBlock
         PendingBlock
@@ -70,7 +75,7 @@ consumeResponse CatchUpPartialResponseBlock{..} = do
 consumeResponse CatchUpPartialResponseDone{..} = return cuprFinished
 
 -- | Receive and execute a timeout message.
-succeedReceiveExecuteTimeoutMessage :: TimeoutMessage -> TestMonad 'P6 ()
+succeedReceiveExecuteTimeoutMessage :: (IsProtocolVersion pv, IsConsensusV1 pv) => TimeoutMessage -> TestMonad pv ()
 succeedReceiveExecuteTimeoutMessage tm = do
     recvResult <- Timeout.receiveTimeoutMessage tm =<< get
     case recvResult of
@@ -81,7 +86,7 @@ succeedReceiveExecuteTimeoutMessage tm = do
         recvStatus -> liftIO . assertFailure $ "Expected timeout message was received, but was " <> show recvStatus
 
 -- | Receive and process a quorum message.
-succeedReceiveProcessQuorumMessage :: QuorumMessage -> TestMonad 'P6 ()
+succeedReceiveProcessQuorumMessage :: (IsProtocolVersion pv, IsConsensusV1 pv) => QuorumMessage -> TestMonad pv ()
 succeedReceiveProcessQuorumMessage qm = do
     recvResult <- Quorum.receiveQuorumMessage qm =<< get
     case recvResult of
@@ -89,8 +94,18 @@ succeedReceiveProcessQuorumMessage qm = do
         recvStatus -> liftIO . assertFailure $ "Expected quorum message was reveived, but was " <> show recvStatus
 
 -- | Create a valid timeout message with the provided data.
-testTimeoutMessage :: Int -> Round -> QuorumCertificate -> TimeoutMessage
-testTimeoutMessage finIndex rnd qc = signTimeoutMessage body TestBlocks.genesisHash (bakerSignKey . fst $ TestBlocks.bakers !! finIndex)
+testTimeoutMessage ::
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    Int ->
+    Round ->
+    QuorumCertificate ->
+    TimeoutMessage
+testTimeoutMessage sProtocolVersion finIndex rnd qc =
+    signTimeoutMessage
+        body
+        (TestBlocks.genesisHash sProtocolVersion)
+        (bakerSignKey . fst $ TestBlocks.bakers sProtocolVersion !! finIndex)
   where
     body =
         TimeoutMessageBody
@@ -100,26 +115,36 @@ testTimeoutMessage finIndex rnd qc = signTimeoutMessage body TestBlocks.genesisH
               tmQuorumCertificate = qc,
               tmAggregateSignature = timeoutSig
             }
-    timeoutSig = signTimeoutSignatureMessage timeoutSigMessage (bakerAggregationKey . fst $ TestBlocks.bakers !! finIndex)
+    timeoutSig =
+        signTimeoutSignatureMessage
+            timeoutSigMessage
+            (bakerAggregationKey . fst $ TestBlocks.bakers sProtocolVersion !! finIndex)
     timeoutSigMessage =
         TimeoutSignatureMessage
-            { tsmGenesis = TestBlocks.genesisHash,
+            { tsmGenesis = TestBlocks.genesisHash sProtocolVersion,
               tsmRound = rnd,
               tsmQCRound = qcRound qc,
               tsmQCEpoch = qcEpoch qc
             }
 
 -- | Create a valid quorum message with the provided data.
-testQuorumMessage :: Int -> Round -> Epoch -> BlockHash -> QuorumMessage
-testQuorumMessage finIndex rnd e ptr =
+testQuorumMessage ::
+    (IsProtocolVersion pv, IsConsensusV1 pv) =>
+    SProtocolVersion pv ->
+    Int ->
+    Round ->
+    Epoch ->
+    BlockHash ->
+    QuorumMessage
+testQuorumMessage sProtocolVersion finIndex rnd e ptr =
     let qsm =
             QuorumSignatureMessage
-                { qsmGenesis = genesisHash,
+                { qsmGenesis = genesisHash sProtocolVersion,
                   qsmBlock = ptr,
                   qsmRound = rnd,
                   qsmEpoch = e
                 }
-        qsig = signQuorumSignatureMessage qsm (bakerAggregationKey . fst $ bakers !! finIndex)
+        qsig = signQuorumSignatureMessage qsm (bakerAggregationKey . fst $ bakers sProtocolVersion !! finIndex)
     in  buildQuorumMessage qsm qsig (FinalizerIndex $ fromIntegral finIndex)
 
 -- | Create a finalization entry where the @QuorumCertificate@ denotes the block being finalized,
@@ -133,376 +158,468 @@ testFinalizationEntry finalizedBlock sucBlock =
         }
 
 -- | Timeout the provided round with a pointer to the proved block.
-mkTimeout :: Round -> BakedBlock 'P6 -> TestMonad 'P6 ()
+mkTimeout :: forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => Round -> BakedBlock pv -> TestMonad pv ()
 mkTimeout rnd bb =
     mapM_
         ( \bid ->
-            let x = testTimeoutMessage bid rnd $ validQCFor bb
+            let x = testTimeoutMessage (protocolVersion @pv) bid rnd $ validQCFor bb
             in  succeedReceiveExecuteTimeoutMessage x
         )
         [0 .. 3]
 
 -- | Run a TestMonad pv a action with a no-baker context,
 --  fixed 'genesisData' and fixed time.
-runTest :: TestMonad 'P6 a -> IO a
-runTest = runTestMonad @'P6 (BakerContext Nothing) (timestampToUTCTime 1_000) TestBlocks.genesisData
+runTest :: (IsConsensusV1 pv, IsProtocolVersion pv) => TestMonad pv a -> IO a
+runTest =
+    runTestMonad
+        (BakerContext Nothing)
+        (timestampToUTCTime 1_000)
+        (TestBlocks.genesisData protocolVersion)
 
 -- | Testing a basic test scenario where the node N knows
 --  of the block in round 1 and 2 and catches up the third block and a tm + qm for round 3.
-basicCatchupResponse :: Assertion
-basicCatchupResponse = runTest $ do
-    mapM_
-        (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
-        [TestBlocks.testBB1, TestBlocks.testBB2, TestBlocks.testBB3]
-    -- b2 has a qc for b1, b3 has a qc for b2 and
-    -- b1 and b2 is in consecutive rounds so b1 is finalized.
-    let b3QC = bbQuorumCertificate TestBlocks.testBB3
-        qsmR4 = QuorumSignatureMessage TestBlocks.genesisHash (getHash TestBlocks.testBB3) (Round 3) 0
-        qmR4Sig = signQuorumSignatureMessage qsmR4 (bakerAggregationKey . fst $ TestBlocks.bakers !! 1)
-        qmR4 = buildQuorumMessage qsmR4 qmR4Sig (FinalizerIndex 1)
-        tmR4 = head $ timeoutMessagesFor b3QC (Round 3) 0
-        finEntry = testFinalizationEntry TestBlocks.testBB2 TestBlocks.testBB3
-        request =
-            CatchUpStatus
-                { cusLastFinalizedBlock = genesisHash,
-                  cusLastFinalizedRound = Round 0,
-                  cusLeaves = [],
-                  cusBranches = [],
-                  cusCurrentRound = Round 0,
-                  cusCurrentRoundQuorum = Map.empty,
-                  cusCurrentRoundTimeouts = Absent
-                }
-        expectedTerminalData =
-            CatchUpTerminalData
-                { cutdHighestQuorumCertificate = Present $ bbQuorumCertificate TestBlocks.testBB3,
-                  cutdLatestFinalizationEntry = Present finEntry,
-                  cutdTimeoutCertificate = Absent,
-                  cutdCurrentRoundQuorumMessages = [qmR4],
-                  cutdCurrentRoundTimeoutMessages = [tmR4]
-                }
-        expectedBlocksServed = pbBlock . TestBlocks.signedPB <$> [TestBlocks.testBB1, TestBlocks.testBB2, TestBlocks.testBB3]
-        finToQMsgMap = Map.insert 1 qmR4 Map.empty
-        finToTMMap = Map.insert (FinalizerIndex 0) tmR4 Map.empty
-    -- Setting the current quorum, timeout message.
-    currentQuorumMessages .= QuorumMessages finToQMsgMap Map.empty
-    currentTimeoutMessages .= Present (TimeoutMessages 1 finToTMMap Map.empty)
-    assertCatchupResponse expectedTerminalData expectedBlocksServed =<< handleCatchUpRequest request =<< get
+basicCatchupResponse :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> String -> Spec
+basicCatchupResponse sProtocolVersion pvString =
+    it (pvString ++ ": Test handleCatchUpRequest: Basics") $ runTest @pv $ do
+        mapM_
+            (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
+            [TestBlocks.testBB1, TestBlocks.testBB2, TestBlocks.testBB3]
+        -- b2 has a qc for b1, b3 has a qc for b2 and
+        -- b1 and b2 is in consecutive rounds so b1 is finalized.
+        let b3QC = bbQuorumCertificate (TestBlocks.testBB3 @pv)
+            qsmR4 = QuorumSignatureMessage (TestBlocks.genesisHash sProtocolVersion) (getHash (TestBlocks.testBB3 @pv)) (Round 3) 0
+            qmR4Sig = signQuorumSignatureMessage qsmR4 (bakerAggregationKey . fst $ TestBlocks.bakers sProtocolVersion !! 1)
+            qmR4 = buildQuorumMessage qsmR4 qmR4Sig (FinalizerIndex 1)
+            tmR4 = head $ timeoutMessagesFor sProtocolVersion b3QC (Round 3) 0
+            finEntry = testFinalizationEntry (TestBlocks.testBB2 @pv) TestBlocks.testBB3
+            request =
+                CatchUpStatus
+                    { cusLastFinalizedBlock = genesisHash sProtocolVersion,
+                      cusLastFinalizedRound = Round 0,
+                      cusLeaves = [],
+                      cusBranches = [],
+                      cusCurrentRound = Round 0,
+                      cusCurrentRoundQuorum = Map.empty,
+                      cusCurrentRoundTimeouts = Absent
+                    }
+            expectedTerminalData =
+                CatchUpTerminalData
+                    { cutdHighestQuorumCertificate = Present $ bbQuorumCertificate (TestBlocks.testBB3 @pv),
+                      cutdLatestFinalizationEntry = Present finEntry,
+                      cutdTimeoutCertificate = Absent,
+                      cutdCurrentRoundQuorumMessages = [qmR4],
+                      cutdCurrentRoundTimeoutMessages = [tmR4]
+                    }
+            expectedBlocksServed = pbBlock . TestBlocks.signedPB <$> [TestBlocks.testBB1, TestBlocks.testBB2, TestBlocks.testBB3]
+            finToQMsgMap = Map.insert 1 qmR4 Map.empty
+            finToTMMap = Map.insert (FinalizerIndex 0) tmR4 Map.empty
+        -- Setting the current quorum, timeout message.
+        currentQuorumMessages .= QuorumMessages finToQMsgMap Map.empty
+        currentTimeoutMessages .= Present (TimeoutMessages 1 finToTMMap Map.empty)
+        assertCatchupResponse expectedTerminalData expectedBlocksServed =<< handleCatchUpRequest request =<< get
 
 -- | A test where the response covers an epoch transition.
-catchupWithEpochTransitionResponse :: Assertion
-catchupWithEpochTransitionResponse = runTest $ do
-    mapM_
-        (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
-        [TestBlocks.testBB1E, TestBlocks.testBB2E, TestBlocks.testBB3E]
-    -- b3 contains an epoch finalization entry and is in epoch 1.
-    let b3QC = bbQuorumCertificate TestBlocks.testBB3E
-        qsmR4 = QuorumSignatureMessage TestBlocks.genesisHash (getHash TestBlocks.testBB3E) (Round 4) 0
-        qmR4Sig = signQuorumSignatureMessage qsmR4 (bakerAggregationKey . fst $ TestBlocks.bakers !! 1)
-        qmR4 = buildQuorumMessage qsmR4 qmR4Sig (FinalizerIndex 1)
-        tmR4 = head $ timeoutMessagesFor b3QC (Round 4) 0
-        request =
-            CatchUpStatus
-                { cusLastFinalizedBlock = getHash TestBlocks.testBB1E,
-                  cusLastFinalizedRound = Round 1,
-                  cusLeaves = [],
-                  cusBranches = [],
-                  cusCurrentRound = Round 1,
-                  cusCurrentRoundQuorum = Map.empty,
-                  cusCurrentRoundTimeouts = Absent
-                }
-        expectedTerminalData =
-            CatchUpTerminalData
-                { cutdHighestQuorumCertificate = Present b3QC,
-                  cutdLatestFinalizationEntry = Absent,
-                  cutdTimeoutCertificate = Absent,
-                  cutdCurrentRoundQuorumMessages = [qmR4],
-                  cutdCurrentRoundTimeoutMessages = [tmR4]
-                }
-        expectedBlocksServed = pbBlock . TestBlocks.signedPB <$> [TestBlocks.testBB2E, TestBlocks.testBB3E]
-        finToQMsgMap = Map.insert 1 qmR4 Map.empty
-        finToTMMap = Map.insert (FinalizerIndex 0) tmR4 Map.empty
-    -- Setting the current quorum, timeout message and latest finalization entry.
-    currentQuorumMessages .= QuorumMessages finToQMsgMap Map.empty
-    currentTimeoutMessages .= Present (TimeoutMessages 1 finToTMMap Map.empty)
-    assertCatchupResponse expectedTerminalData expectedBlocksServed =<< handleCatchUpRequest request =<< get
+catchupWithEpochTransitionResponse :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> String -> Spec
+catchupWithEpochTransitionResponse sProtocolVersion pvString =
+    it (pvString ++ ": Test handleCatchUpRequest: Epoch transition") $ runTest @pv $ do
+        mapM_
+            (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
+            [TestBlocks.testBB1E, TestBlocks.testBB2E, TestBlocks.testBB3E]
+        -- b3 contains an epoch finalization entry and is in epoch 1.
+        let b3QC = bbQuorumCertificate (TestBlocks.testBB3E @pv)
+            qsmR4 =
+                QuorumSignatureMessage
+                    (TestBlocks.genesisHash sProtocolVersion)
+                    (getHash (TestBlocks.testBB3E @pv))
+                    (Round 4)
+                    0
+            qmR4Sig =
+                signQuorumSignatureMessage
+                    qsmR4
+                    ( bakerAggregationKey . fst $
+                        TestBlocks.bakers sProtocolVersion !! 1
+                    )
+            qmR4 = buildQuorumMessage qsmR4 qmR4Sig (FinalizerIndex 1)
+            tmR4 = head $ timeoutMessagesFor sProtocolVersion b3QC (Round 4) 0
+            request =
+                CatchUpStatus
+                    { cusLastFinalizedBlock = getHash (TestBlocks.testBB1E @pv),
+                      cusLastFinalizedRound = Round 1,
+                      cusLeaves = [],
+                      cusBranches = [],
+                      cusCurrentRound = Round 1,
+                      cusCurrentRoundQuorum = Map.empty,
+                      cusCurrentRoundTimeouts = Absent
+                    }
+            expectedTerminalData =
+                CatchUpTerminalData
+                    { cutdHighestQuorumCertificate = Present b3QC,
+                      cutdLatestFinalizationEntry = Absent,
+                      cutdTimeoutCertificate = Absent,
+                      cutdCurrentRoundQuorumMessages = [qmR4],
+                      cutdCurrentRoundTimeoutMessages = [tmR4]
+                    }
+            expectedBlocksServed = pbBlock . TestBlocks.signedPB <$> [TestBlocks.testBB2E, TestBlocks.testBB3E]
+            finToQMsgMap = Map.insert 1 qmR4 Map.empty
+            finToTMMap = Map.insert (FinalizerIndex 0) tmR4 Map.empty
+        -- Setting the current quorum, timeout message and latest finalization entry.
+        currentQuorumMessages .= QuorumMessages finToQMsgMap Map.empty
+        currentTimeoutMessages .= Present (TimeoutMessages 1 finToTMMap Map.empty)
+        assertCatchupResponse expectedTerminalData expectedBlocksServed =<< handleCatchUpRequest request =<< get
 
 -- | A response where there is a timeout in round 4,
 --  a quorum message for round 5 and a timeout message for round 5.
-catchupWithTimeoutsResponse :: Assertion
-catchupWithTimeoutsResponse = runTest $ do
-    mapM_
-        (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
-        [TestBlocks.testBB1E, TestBlocks.testBB2E, TestBlocks.testBB3E, TestBlocks.testBB5E']
-    -- round 4 timeouts
-    let b3QC = bbQuorumCertificate TestBlocks.testBB3E
-        qsmR5 = QuorumSignatureMessage TestBlocks.genesisHash (getHash TestBlocks.testBB3E) (Round 5) 0
-        qmR5Sig = signQuorumSignatureMessage qsmR5 (bakerAggregationKey . fst $ TestBlocks.bakers !! 1)
-        qmR5 = buildQuorumMessage qsmR5 qmR5Sig (FinalizerIndex 1)
-        tmR5 = head $ timeoutMessagesFor b3QC (Round 4) 0
-        finEntry = testFinalizationEntry TestBlocks.testBB2E TestBlocks.testBB3E
-        request =
-            CatchUpStatus
-                { cusLastFinalizedBlock = genesisHash,
-                  cusLastFinalizedRound = Round 0,
-                  cusLeaves = [],
-                  cusBranches = [],
-                  cusCurrentRound = Round 0,
-                  cusCurrentRoundQuorum = Map.empty,
-                  cusCurrentRoundTimeouts = Absent
-                }
-        expectedTerminalData =
-            CatchUpTerminalData
-                { cutdHighestQuorumCertificate = Present $ blockQuorumCertificate $ pbBlock $ TestBlocks.signedPB TestBlocks.testBB5E',
-                  cutdLatestFinalizationEntry = Present finEntry,
-                  cutdTimeoutCertificate = blockTimeoutCertificate $ pbBlock $ TestBlocks.signedPB TestBlocks.testBB5E',
-                  cutdCurrentRoundQuorumMessages = [qmR5],
-                  cutdCurrentRoundTimeoutMessages = [tmR5]
-                }
-        expectedBlocksServed = pbBlock . TestBlocks.signedPB <$> [TestBlocks.testBB1E, TestBlocks.testBB2E, TestBlocks.testBB3E, TestBlocks.testBB5E']
-        finToQMsgMap = Map.insert 1 qmR5 Map.empty
-        finToTMMap = Map.insert (FinalizerIndex 0) tmR5 Map.empty
-    -- Setting the current quorum, timeout message and finalization entry.
-    currentQuorumMessages .= QuorumMessages finToQMsgMap Map.empty
-    currentTimeoutMessages .= Present (TimeoutMessages 1 finToTMMap Map.empty)
-    assertCatchupResponse expectedTerminalData expectedBlocksServed =<< handleCatchUpRequest request =<< get
+catchupWithTimeoutsResponse ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+catchupWithTimeoutsResponse sProtocolVersion pvString =
+    it (pvString ++ ": Test handleCatchUpRequest: Timeout in the middle of the chain") $ runTest @pv $ do
+        mapM_
+            (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
+            [TestBlocks.testBB1E, TestBlocks.testBB2E, TestBlocks.testBB3E, TestBlocks.testBB5E']
+        -- round 4 timeouts
+        let b3QC = bbQuorumCertificate (TestBlocks.testBB3E @pv)
+            qsmR5 = QuorumSignatureMessage (TestBlocks.genesisHash sProtocolVersion) (getHash (TestBlocks.testBB3E @pv)) (Round 5) 0
+            qmR5Sig = signQuorumSignatureMessage qsmR5 (bakerAggregationKey . fst $ TestBlocks.bakers sProtocolVersion !! 1)
+            qmR5 = buildQuorumMessage qsmR5 qmR5Sig (FinalizerIndex 1)
+            tmR5 = head $ timeoutMessagesFor sProtocolVersion b3QC (Round 4) 0
+            finEntry = testFinalizationEntry (TestBlocks.testBB2E @pv) TestBlocks.testBB3E
+            request =
+                CatchUpStatus
+                    { cusLastFinalizedBlock = genesisHash sProtocolVersion,
+                      cusLastFinalizedRound = Round 0,
+                      cusLeaves = [],
+                      cusBranches = [],
+                      cusCurrentRound = Round 0,
+                      cusCurrentRoundQuorum = Map.empty,
+                      cusCurrentRoundTimeouts = Absent
+                    }
+            expectedTerminalData =
+                CatchUpTerminalData
+                    { cutdHighestQuorumCertificate =
+                        Present $
+                            blockQuorumCertificate $
+                                pbBlock $
+                                    TestBlocks.signedPB @pv TestBlocks.testBB5E',
+                      cutdLatestFinalizationEntry = Present finEntry,
+                      cutdTimeoutCertificate =
+                        blockTimeoutCertificate $
+                            pbBlock $
+                                TestBlocks.signedPB @pv TestBlocks.testBB5E',
+                      cutdCurrentRoundQuorumMessages = [qmR5],
+                      cutdCurrentRoundTimeoutMessages = [tmR5]
+                    }
+            expectedBlocksServed = pbBlock . TestBlocks.signedPB <$> [TestBlocks.testBB1E, TestBlocks.testBB2E, TestBlocks.testBB3E, TestBlocks.testBB5E']
+            finToQMsgMap = Map.insert 1 qmR5 Map.empty
+            finToTMMap = Map.insert (FinalizerIndex 0) tmR5 Map.empty
+        -- Setting the current quorum, timeout message and finalization entry.
+        currentQuorumMessages .= QuorumMessages finToQMsgMap Map.empty
+        currentTimeoutMessages .= Present (TimeoutMessages 1 finToTMMap Map.empty)
+        assertCatchupResponse expectedTerminalData expectedBlocksServed =<< handleCatchUpRequest request =<< get
 
 -- | There is a TC generated for the last round (round 3).
-catchupWithOneTimeoutAtEndResponse :: Assertion
-catchupWithOneTimeoutAtEndResponse = runTest $ do
-    mapM_
-        (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
-        [TestBlocks.testBB1, TestBlocks.testBB2, TestBlocks.testBB3]
-    -- Generate a TC for round 3.
-    mkTimeout (Round 3) TestBlocks.testBB2
-    -- b2 has a qc for b1, b3 has a qc for b2 and
-    -- b1 and b2 is in consecutive rounds so b1 is finalized.
-    let request =
-            CatchUpStatus
-                { cusLastFinalizedBlock = genesisHash,
-                  cusLastFinalizedRound = Round 0,
-                  cusLeaves = [],
-                  cusBranches = [],
-                  cusCurrentRound = Round 1,
-                  cusCurrentRoundQuorum = Map.empty,
-                  cusCurrentRoundTimeouts = Absent
-                }
-        finEntry = testFinalizationEntry TestBlocks.testBB2 TestBlocks.testBB3
-        expectedBlocksServed = pbBlock . TestBlocks.signedPB <$> [TestBlocks.testBB1, TestBlocks.testBB2, TestBlocks.testBB3]
-    expectedTerminalData <- do
-        sd <- get
-        case sd ^. roundStatus . rsPreviousRoundTimeout of
-            Absent -> liftIO . assertFailure $ "Expected timeout messages, but they were absent."
-            Present (RoundTimeout tc _) ->
-                return $
-                    CatchUpTerminalData
-                        { cutdHighestQuorumCertificate = Present $ blockQuorumCertificate $ pbBlock $ TestBlocks.signedPB TestBlocks.testBB3,
-                          cutdLatestFinalizationEntry = Present finEntry,
-                          cutdTimeoutCertificate = Present tc,
-                          cutdCurrentRoundQuorumMessages = [],
-                          cutdCurrentRoundTimeoutMessages = []
-                        }
-    assertCatchupResponse expectedTerminalData expectedBlocksServed =<< handleCatchUpRequest request =<< get
+catchupWithOneTimeoutAtEndResponse ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+catchupWithOneTimeoutAtEndResponse sProtocolVersion pvString =
+    it (pvString ++ ": Test handleCatchUpRequest: One timeout certificate at end") $ runTest @pv $ do
+        mapM_
+            (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
+            [TestBlocks.testBB1, TestBlocks.testBB2, TestBlocks.testBB3]
+        -- Generate a TC for round 3.
+        mkTimeout (Round 3) TestBlocks.testBB2
+        -- b2 has a qc for b1, b3 has a qc for b2 and
+        -- b1 and b2 is in consecutive rounds so b1 is finalized.
+        let request =
+                CatchUpStatus
+                    { cusLastFinalizedBlock = genesisHash sProtocolVersion,
+                      cusLastFinalizedRound = Round 0,
+                      cusLeaves = [],
+                      cusBranches = [],
+                      cusCurrentRound = Round 1,
+                      cusCurrentRoundQuorum = Map.empty,
+                      cusCurrentRoundTimeouts = Absent
+                    }
+            finEntry = testFinalizationEntry @pv TestBlocks.testBB2 TestBlocks.testBB3
+            expectedBlocksServed =
+                pbBlock . TestBlocks.signedPB @pv
+                    <$> [TestBlocks.testBB1, TestBlocks.testBB2, TestBlocks.testBB3]
+        expectedTerminalData <- do
+            sd <- get
+            case sd ^. roundStatus . rsPreviousRoundTimeout of
+                Absent -> liftIO . assertFailure $ "Expected timeout messages, but they were absent."
+                Present (RoundTimeout tc _) ->
+                    return $
+                        CatchUpTerminalData
+                            { cutdHighestQuorumCertificate =
+                                Present $
+                                    blockQuorumCertificate $
+                                        pbBlock $
+                                            TestBlocks.signedPB @pv TestBlocks.testBB3,
+                              cutdLatestFinalizationEntry = Present finEntry,
+                              cutdTimeoutCertificate = Present tc,
+                              cutdCurrentRoundQuorumMessages = [],
+                              cutdCurrentRoundTimeoutMessages = []
+                            }
+        assertCatchupResponse expectedTerminalData expectedBlocksServed =<< handleCatchUpRequest request =<< get
 
 -- | There is a timeout for round 3 and round 4.
-catchupWithTwoTimeoutsAtEndResponse :: Assertion
-catchupWithTwoTimeoutsAtEndResponse = runTest $ do
-    mapM_
-        (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
-        [TestBlocks.testBB1, TestBlocks.testBB2, TestBlocks.testBB3]
-    -- Generate a TC for round 3 and round 4.
-    mkTimeout (Round 3) TestBlocks.testBB2
-    mkTimeout (Round 4) TestBlocks.testBB2
-    -- b2 has a qc for b1, b3 has a qc for b2 and
-    -- b1 and b2 is in consecutive rounds so b1 is finalized.
-    let request =
-            CatchUpStatus
-                { cusLastFinalizedBlock = getHash TestBlocks.testBB1,
-                  cusLastFinalizedRound = Round 1,
-                  cusLeaves = [],
-                  cusBranches = [],
-                  cusCurrentRound = Round 3,
-                  cusCurrentRoundQuorum = Map.empty,
-                  cusCurrentRoundTimeouts = Absent
-                }
-        expectedBlocksServed = pbBlock . TestBlocks.signedPB <$> [TestBlocks.testBB2, TestBlocks.testBB3]
-    expectedTerminalData <- do
-        sd <- get
-        case sd ^. roundStatus . rsPreviousRoundTimeout of
-            Absent -> liftIO . assertFailure $ "Expected timeout messages, but they were absent."
-            -- todo: perhaps spell this tc out.
-            Present (RoundTimeout tc _) ->
-                return $
-                    CatchUpTerminalData
-                        { cutdHighestQuorumCertificate = Present $ blockQuorumCertificate $ pbBlock $ TestBlocks.signedPB TestBlocks.testBB3,
-                          cutdLatestFinalizationEntry = Absent,
-                          cutdTimeoutCertificate = Present tc,
-                          cutdCurrentRoundQuorumMessages = [],
-                          cutdCurrentRoundTimeoutMessages = []
-                        }
-    assertCatchupResponse expectedTerminalData expectedBlocksServed =<< handleCatchUpRequest request =<< get
+catchupWithTwoTimeoutsAtEndResponse :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> String -> Spec
+catchupWithTwoTimeoutsAtEndResponse _ pvString =
+    it (pvString ++ ": Test handleCatchUpRequest: Two timeout certificates at end") $ runTest @pv $ do
+        mapM_
+            (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
+            [TestBlocks.testBB1, TestBlocks.testBB2, TestBlocks.testBB3]
+        -- Generate a TC for round 3 and round 4.
+        mkTimeout (Round 3) TestBlocks.testBB2
+        mkTimeout (Round 4) TestBlocks.testBB2
+        -- b2 has a qc for b1, b3 has a qc for b2 and
+        -- b1 and b2 is in consecutive rounds so b1 is finalized.
+        let request =
+                CatchUpStatus
+                    { cusLastFinalizedBlock = getHash (TestBlocks.testBB1 @pv),
+                      cusLastFinalizedRound = Round 1,
+                      cusLeaves = [],
+                      cusBranches = [],
+                      cusCurrentRound = Round 3,
+                      cusCurrentRoundQuorum = Map.empty,
+                      cusCurrentRoundTimeouts = Absent
+                    }
+            expectedBlocksServed = pbBlock . TestBlocks.signedPB <$> [TestBlocks.testBB2, TestBlocks.testBB3]
+        expectedTerminalData <- do
+            sd <- get
+            case sd ^. roundStatus . rsPreviousRoundTimeout of
+                Absent -> liftIO . assertFailure $ "Expected timeout messages, but they were absent."
+                -- todo: perhaps spell this tc out.
+                Present (RoundTimeout tc _) ->
+                    return $
+                        CatchUpTerminalData
+                            { cutdHighestQuorumCertificate =
+                                Present $
+                                    blockQuorumCertificate $
+                                        pbBlock $
+                                            TestBlocks.signedPB @pv TestBlocks.testBB3,
+                              cutdLatestFinalizationEntry = Absent,
+                              cutdTimeoutCertificate = Present tc,
+                              cutdCurrentRoundQuorumMessages = [],
+                              cutdCurrentRoundTimeoutMessages = []
+                            }
+        assertCatchupResponse expectedTerminalData expectedBlocksServed =<< handleCatchUpRequest request =<< get
 
-catchupWithTwoBranchesResponse :: Assertion
-catchupWithTwoBranchesResponse = runTest $ do
-    mapM_
-        (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
-        [TestBlocks.testBB1, TestBlocks.testBB2, TestBlocks.testBB3]
-    -- block 1 is finalized as b2 has a qc for b1 and b3 has a qc for b2.
-    -- Timeout round 3.
-    mkTimeout (Round 3) TestBlocks.testBB1
-    -- we grab the timeout certificate for round 3 in the round status
-    -- so we can create a b4 with this tc.
-    -- todo: maybe just spell out this tc.
-    r3rt <- use $ roundStatus . rsPreviousRoundTimeout
-    b4 <- case r3rt of
-        Absent -> liftIO . assertFailure $ "There should be a previous round timeout"
-        Present rt ->
-            return $
-                TestBlocks.signedPB
-                    BakedBlock
-                        { bbRound = 4,
-                          bbEpoch = 0,
-                          bbTimestamp = 3_000,
-                          bbBaker = 3,
-                          bbQuorumCertificate = validQCFor testBB2,
-                          bbTimeoutCertificate = Present $ rtTimeoutCertificate rt,
-                          bbEpochFinalizationEntry = Absent,
-                          bbNonce = computeBlockNonce genesisLEN 4 (TestBlocks.bakerVRFKey (3 :: Int)),
-                          bbTransactions = Vec.empty,
-                          bbDerivableHashes =
-                            DBHashesV0 $
-                                BlockDerivableHashesV0
-                                    { bdhv0TransactionOutcomesHash = emptyBlockTOH 3,
-                                      bdhv0BlockStateHash = read "cdf730c1b3fdc6d07f404c6b95a4f3417c19653b1299b92f59fcaffcc9745910"
-                                    }
-                        }
-    TestBlocks.succeedReceiveBlock b4
-    -- There is one current timeout message and one current quorum message
-    let tm0_4 = testTimeoutMessage 0 (Round 4) $ blockQuorumCertificate $ pbBlock $ TestBlocks.signedPB TestBlocks.testBB2
-        qm1_4 = testQuorumMessage 1 (Round 4) 0 (getHash b4)
-    succeedReceiveExecuteTimeoutMessage tm0_4
-    succeedReceiveProcessQuorumMessage qm1_4
-    let request =
-            CatchUpStatus
-                { cusLastFinalizedBlock = getHash TestBlocks.testBB1,
-                  cusLastFinalizedRound = Round 1,
-                  cusLeaves = [],
-                  cusBranches = [],
-                  cusCurrentRound = Round 3,
-                  cusCurrentRoundQuorum = Map.empty,
-                  cusCurrentRoundTimeouts = Absent
-                }
-        -- The expected blocks. (b3 timed out)
-        expectedBlocksServed = pbBlock <$> [TestBlocks.signedPB TestBlocks.testBB2, b4]
-    expectedTerminalData <- do
-        sd <- get
-        case sd ^. roundStatus . rsPreviousRoundTimeout of
-            Absent -> liftIO . assertFailure $ "Expected timeout messages, but they were absent."
-            -- todo: perhaps spell this tc out.
-            Present (RoundTimeout tc _) ->
+catchupWithTwoBranchesResponse ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+catchupWithTwoBranchesResponse sProtocolVersion pvString =
+    it (pvString ++ ": Test handleCatchUpRequest: Two branches") $ runTest @pv $ do
+        mapM_
+            (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
+            [TestBlocks.testBB1, TestBlocks.testBB2, TestBlocks.testBB3]
+        -- block 1 is finalized as b2 has a qc for b1 and b3 has a qc for b2.
+        -- Timeout round 3.
+        mkTimeout (Round 3) TestBlocks.testBB1
+        -- we grab the timeout certificate for round 3 in the round status
+        -- so we can create a b4 with this tc.
+        -- todo: maybe just spell out this tc.
+        r3rt <- use $ roundStatus . rsPreviousRoundTimeout
+        b4 <- case r3rt of
+            Absent -> liftIO . assertFailure $ "There should be a previous round timeout"
+            Present rt ->
                 return $
-                    CatchUpTerminalData
-                        { cutdHighestQuorumCertificate = Present $ blockQuorumCertificate $ pbBlock $ TestBlocks.signedPB TestBlocks.testBB3,
-                          cutdLatestFinalizationEntry = Absent,
-                          cutdTimeoutCertificate = Present tc,
-                          cutdCurrentRoundQuorumMessages = [qm1_4],
-                          cutdCurrentRoundTimeoutMessages = [tm0_4]
-                        }
-    assertCatchupResponse expectedTerminalData expectedBlocksServed =<< handleCatchUpRequest request =<< get
+                    TestBlocks.signedPB
+                        BakedBlock
+                            { bbRound = 4,
+                              bbEpoch = 0,
+                              bbTimestamp = 3_000,
+                              bbBaker = 3,
+                              bbQuorumCertificate = validQCFor @pv testBB2,
+                              bbTimeoutCertificate = Present $ rtTimeoutCertificate rt,
+                              bbEpochFinalizationEntry = Absent,
+                              bbNonce = computeBlockNonce (genesisLEN sProtocolVersion) 4 (TestBlocks.bakerVRFKey sProtocolVersion (3 :: Int)),
+                              bbTransactions = Vec.empty,
+                              bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
+                                SBlockHashVersion0 ->
+                                    DBHashesV0 $
+                                        BlockDerivableHashesV0
+                                            { bdhv0TransactionOutcomesHash = emptyBlockTOH 3,
+                                              bdhv0BlockStateHash = read "cdf730c1b3fdc6d07f404c6b95a4f3417c19653b1299b92f59fcaffcc9745910"
+                                            }
+                                SBlockHashVersion1 ->
+                                    DBHashesV1 $
+                                        BlockDerivableHashesV1
+                                            { bdhv1BlockResultHash = read "f36a049939054eac3e8662e4ab0310d8e12381ee2ba77a9c16fa19c205ea64b3"
+                                            }
+                            }
+        TestBlocks.succeedReceiveBlock b4
+        -- There is one current timeout message and one current quorum message
+        let tm0_4 =
+                testTimeoutMessage sProtocolVersion 0 (Round 4) $
+                    blockQuorumCertificate $
+                        pbBlock $
+                            TestBlocks.signedPB @pv TestBlocks.testBB2
+            qm1_4 = testQuorumMessage sProtocolVersion 1 (Round 4) 0 (getHash b4)
+        succeedReceiveExecuteTimeoutMessage tm0_4
+        succeedReceiveProcessQuorumMessage qm1_4
+        let request =
+                CatchUpStatus
+                    { cusLastFinalizedBlock = getHash (TestBlocks.testBB1 @pv),
+                      cusLastFinalizedRound = Round 1,
+                      cusLeaves = [],
+                      cusBranches = [],
+                      cusCurrentRound = Round 3,
+                      cusCurrentRoundQuorum = Map.empty,
+                      cusCurrentRoundTimeouts = Absent
+                    }
+            -- The expected blocks. (b3 timed out)
+            expectedBlocksServed = pbBlock <$> [TestBlocks.signedPB TestBlocks.testBB2, b4]
+        expectedTerminalData <- do
+            sd <- get
+            case sd ^. roundStatus . rsPreviousRoundTimeout of
+                Absent -> liftIO . assertFailure $ "Expected timeout messages, but they were absent."
+                -- todo: perhaps spell this tc out.
+                Present (RoundTimeout tc _) ->
+                    return $
+                        CatchUpTerminalData
+                            { cutdHighestQuorumCertificate =
+                                Present $
+                                    blockQuorumCertificate $
+                                        pbBlock $
+                                            TestBlocks.signedPB @pv TestBlocks.testBB3,
+                              cutdLatestFinalizationEntry = Absent,
+                              cutdTimeoutCertificate = Present tc,
+                              cutdCurrentRoundQuorumMessages = [qm1_4],
+                              cutdCurrentRoundTimeoutMessages = [tm0_4]
+                            }
+        assertCatchupResponse expectedTerminalData expectedBlocksServed =<< handleCatchUpRequest request =<< get
 
 -- | Test case where we have a timeout and a QC for a round where the block starts the new epoch.
 --  The timeout refers to the old epoch. In this case, catch-up should send the highest certified
 --  at the time the timeout was generated, rather than the actual highest certified block.
-catchupWithEpochTransitionTimeout :: Assertion
-catchupWithEpochTransitionTimeout = runTest $ do
-    mapM_
-        (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
-        [TestBlocks.testBB1E, TestBlocks.testBB2E, TestBlocks.testBB3E]
-    -- Timeout round 3
-    mkTimeout (Round 3) TestBlocks.testBB2E
-    TestBlocks.succeedReceiveBlock . TestBlocks.signedPB $ TestBlocks.testBB4E
-    hcb <- use (roundStatus . rsHighestCertifiedBlock)
-    liftIO $ assertEqual "Highest certified block round" 3 (cbRound hcb)
-    let request =
-            CatchUpStatus
-                { cusLastFinalizedBlock = TestBlocks.genesisHash,
-                  cusLastFinalizedRound = Round 0,
-                  cusLeaves = [],
-                  cusBranches = [],
-                  cusCurrentRound = Round 1,
-                  cusCurrentRoundQuorum = Map.empty,
-                  cusCurrentRoundTimeouts = Absent
-                }
-    let expectedBlocksServed =
-            validSignBlock
-                <$> [TestBlocks.testBB1E, TestBlocks.testBB2E, TestBlocks.testBB3E, TestBlocks.testBB4E]
-    let expectedTerminalData =
-            CatchUpTerminalData
-                { cutdHighestQuorumCertificate = Present $ validQCFor testBB2E,
-                  cutdLatestFinalizationEntry = Present testEpochFinEntry,
-                  cutdTimeoutCertificate = Present $ validTimeoutForFinalizers [0 .. 3] (validQCFor testBB2E) 3,
-                  cutdCurrentRoundQuorumMessages = [],
-                  cutdCurrentRoundTimeoutMessages = []
-                }
-    assertCatchupResponse expectedTerminalData expectedBlocksServed =<< handleCatchUpRequest request =<< get
+catchupWithEpochTransitionTimeout ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+catchupWithEpochTransitionTimeout sProtocolVersion pvString =
+    it (pvString ++ ": Test handleCatchUpRequest: Epoch transition with timeout") $ runTest @pv $ do
+        mapM_
+            (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
+            [TestBlocks.testBB1E, TestBlocks.testBB2E, TestBlocks.testBB3E]
+        -- Timeout round 3
+        mkTimeout (Round 3) TestBlocks.testBB2E
+        TestBlocks.succeedReceiveBlock . TestBlocks.signedPB $ TestBlocks.testBB4E
+        hcb <- use (roundStatus . rsHighestCertifiedBlock)
+        liftIO $ assertEqual "Highest certified block round" 3 (cbRound hcb)
+        let request =
+                CatchUpStatus
+                    { cusLastFinalizedBlock = TestBlocks.genesisHash sProtocolVersion,
+                      cusLastFinalizedRound = Round 0,
+                      cusLeaves = [],
+                      cusBranches = [],
+                      cusCurrentRound = Round 1,
+                      cusCurrentRoundQuorum = Map.empty,
+                      cusCurrentRoundTimeouts = Absent
+                    }
+        let expectedBlocksServed =
+                validSignBlock
+                    <$> [TestBlocks.testBB1E, TestBlocks.testBB2E, TestBlocks.testBB3E, TestBlocks.testBB4E]
+        let expectedTerminalData =
+                CatchUpTerminalData
+                    { cutdHighestQuorumCertificate = Present $ validQCFor @pv testBB2E,
+                      cutdLatestFinalizationEntry = Present (testEpochFinEntry sProtocolVersion),
+                      cutdTimeoutCertificate = Present $ validTimeoutForFinalizers sProtocolVersion [0 .. 3] (validQCFor @pv testBB2E) 3,
+                      cutdCurrentRoundQuorumMessages = [],
+                      cutdCurrentRoundTimeoutMessages = []
+                    }
+        assertCatchupResponse expectedTerminalData expectedBlocksServed =<< handleCatchUpRequest request =<< get
 
 -- | Checking that the 'CatchUpStatus' is correctly generated from a state where:
 --  there are 3 blocks for round 1,2 and 3, where the first block is finalized.
 --  The block in round 3 never gets a 'QuorumCertificate' and hence round 3 times out.
 --  There is a block 4 for round 4
-testMakeCatchupStatus :: Assertion
-testMakeCatchupStatus = runTest $ do
-    mapM_
-        (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
-        [TestBlocks.testBB1, TestBlocks.testBB2, TestBlocks.testBB3]
-    -- block 1 is finalized as b2 has a qc for b1 and b3 has a qc for b2.
-    -- Now we time out round 3 with a reference to b1.
-    mkTimeout (Round 3) TestBlocks.testBB1
+testMakeCatchupStatus ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testMakeCatchupStatus sProtocolVersion pvString =
+    it (pvString ++ ": Test makeCatchUpRequestMessage") $ runTest @pv $ do
+        mapM_
+            (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
+            [TestBlocks.testBB1, TestBlocks.testBB2, TestBlocks.testBB3]
+        -- block 1 is finalized as b2 has a qc for b1 and b3 has a qc for b2.
+        -- Now we time out round 3 with a reference to b1.
+        mkTimeout (Round 3) TestBlocks.testBB1
 
-    -- we grab the timeout certificate for round 3 in the round status
-    -- so we can create a b4 with this tc.
-    -- todo: maybe just spell out this tc.
-    r3rt <- use $ roundStatus . rsPreviousRoundTimeout
-    b4 <- case r3rt of
-        Absent -> liftIO . assertFailure $ "There should be a previous round timeout"
-        Present rt ->
-            return $
-                TestBlocks.signedPB
-                    BakedBlock
-                        { bbRound = 4,
-                          bbEpoch = 0,
-                          bbTimestamp = 3_000,
-                          bbBaker = 3,
-                          bbQuorumCertificate = validQCFor testBB2,
-                          bbTimeoutCertificate = Present $ rtTimeoutCertificate rt,
-                          bbEpochFinalizationEntry = Absent,
-                          bbNonce = computeBlockNonce genesisLEN 4 (TestBlocks.bakerVRFKey (3 :: Int)),
-                          bbTransactions = Vec.empty,
-                          bbDerivableHashes =
-                            DBHashesV0 $
-                                BlockDerivableHashesV0
-                                    { bdhv0TransactionOutcomesHash = emptyBlockTOH 3,
-                                      bdhv0BlockStateHash = read "cdf730c1b3fdc6d07f404c6b95a4f3417c19653b1299b92f59fcaffcc9745910"
-                                    }
-                        }
-    TestBlocks.succeedReceiveBlock b4
-    -- There is one current timeout message and one current quorum message
-    let tm0_4 = testTimeoutMessage 0 (Round 4) $ blockQuorumCertificate $ pbBlock $ TestBlocks.signedPB TestBlocks.testBB2
-        qm1_4 = testQuorumMessage 1 (Round 4) 0 (getHash b4)
-    succeedReceiveExecuteTimeoutMessage tm0_4
-    succeedReceiveProcessQuorumMessage qm1_4
+        -- we grab the timeout certificate for round 3 in the round status
+        -- so we can create a b4 with this tc.
+        -- todo: maybe just spell out this tc.
+        r3rt <- use $ roundStatus . rsPreviousRoundTimeout
+        b4 <- case r3rt of
+            Absent -> liftIO . assertFailure $ "There should be a previous round timeout"
+            Present rt ->
+                return $
+                    TestBlocks.signedPB
+                        BakedBlock
+                            { bbRound = 4,
+                              bbEpoch = 0,
+                              bbTimestamp = 3_000,
+                              bbBaker = 3,
+                              bbQuorumCertificate = validQCFor @pv testBB2,
+                              bbTimeoutCertificate = Present $ rtTimeoutCertificate rt,
+                              bbEpochFinalizationEntry = Absent,
+                              bbNonce =
+                                computeBlockNonce
+                                    (genesisLEN sProtocolVersion)
+                                    4
+                                    (TestBlocks.bakerVRFKey sProtocolVersion (3 :: Int)),
+                              bbTransactions = Vec.empty,
+                              bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
+                                SBlockHashVersion0 ->
+                                    DBHashesV0 $
+                                        BlockDerivableHashesV0
+                                            { bdhv0TransactionOutcomesHash = emptyBlockTOH 3,
+                                              bdhv0BlockStateHash = read "cdf730c1b3fdc6d07f404c6b95a4f3417c19653b1299b92f59fcaffcc9745910"
+                                            }
+                                SBlockHashVersion1 ->
+                                    DBHashesV1 $
+                                        BlockDerivableHashesV1
+                                            { bdhv1BlockResultHash = read "f36a049939054eac3e8662e4ab0310d8e12381ee2ba77a9c16fa19c205ea64b3"
+                                            }
+                            }
+        TestBlocks.succeedReceiveBlock b4
+        -- There is one current timeout message and one current quorum message
+        let tm0_4 =
+                testTimeoutMessage sProtocolVersion 0 (Round 4) $
+                    blockQuorumCertificate $
+                        pbBlock $
+                            TestBlocks.signedPB @pv TestBlocks.testBB2
+            qm1_4 = testQuorumMessage sProtocolVersion 1 (Round 4) 0 (getHash b4)
+        succeedReceiveExecuteTimeoutMessage tm0_4
+        succeedReceiveProcessQuorumMessage qm1_4
 
-    let expectedCatchupStatus =
-            CatchUpStatus
-                { cusLastFinalizedBlock = getHash TestBlocks.testBB1,
-                  cusLastFinalizedRound = Round 1,
-                  cusLeaves = [getHash TestBlocks.testBB3, getHash b4],
-                  cusBranches = [getHash TestBlocks.testBB2],
-                  cusCurrentRound = Round 4,
-                  cusCurrentRoundQuorum = Map.insert (getHash b4) (finalizerSet [FinalizerIndex 1]) Map.empty,
-                  cusCurrentRoundTimeouts = Present (TimeoutSet 0 (finalizerSet [FinalizerIndex 0]) emptyFinalizerSet)
-                }
-    actualCatchupStatus <- makeCatchUpRequestMessage <$> get
-    liftIO $ assertEqual "Unexpected catchup status" expectedCatchupStatus $ cumStatus actualCatchupStatus
+        let expectedCatchupStatus =
+                CatchUpStatus
+                    { cusLastFinalizedBlock = getHash (TestBlocks.testBB1 @pv),
+                      cusLastFinalizedRound = Round 1,
+                      cusLeaves = [getHash (TestBlocks.testBB3 @pv), getHash b4],
+                      cusBranches = [getHash (TestBlocks.testBB2 @pv)],
+                      cusCurrentRound = Round 4,
+                      cusCurrentRoundQuorum = Map.insert (getHash b4) (finalizerSet [FinalizerIndex 1]) Map.empty,
+                      cusCurrentRoundTimeouts = Present (TimeoutSet 0 (finalizerSet [FinalizerIndex 0]) emptyFinalizerSet)
+                    }
+        actualCatchupStatus <- makeCatchUpRequestMessage <$> get
+        liftIO $ assertEqual "Unexpected catchup status" expectedCatchupStatus $ cumStatus actualCatchupStatus
 
 -- | Checks the expected 'RoundStatus' with the actual one.
 --  This checks the data of the round status that does not relate to
@@ -524,229 +641,261 @@ checkRoundStatus rs1 rs2 = do
 --  Hence this test serves as an integration test where
 --  catch-up status messages are generated and used to create responses,
 --  and the blocks from the response is received by the peer catching up.
-testCatchup :: Assertion
-testCatchup = do
-    -- Responder to catchup
-    (rStatus, responderState) <- runTest $ do
-        mapM_
-            (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
-            [TestBlocks.testBB1, TestBlocks.testBB2', TestBlocks.testBB3', TestBlocks.testBB4']
-        -- Some messages for the current round.
-        let b4QC = bbQuorumCertificate TestBlocks.testBB3
-            qsmR4 = QuorumSignatureMessage TestBlocks.genesisHash (getHash TestBlocks.testBB4') (Round 4) 0
-            qmR4Sig = signQuorumSignatureMessage qsmR4 (bakerAggregationKey . fst $ TestBlocks.bakers !! 1)
-            qmR4 = buildQuorumMessage qsmR4 qmR4Sig (FinalizerIndex 1)
-            tmR4 = head $ timeoutMessagesFor b4QC (Round 4) 0
-            finToQMsgMap = Map.insert 1 qmR4 Map.empty
-            finToTMMap = Map.insert (FinalizerIndex 0) tmR4 Map.empty
-        -- Setting the current quorum and timeout message.
-        currentQuorumMessages .= QuorumMessages finToQMsgMap Map.empty
-        currentTimeoutMessages .= Present (TimeoutMessages 1 finToTMMap Map.empty)
-        sd <- get
-        let statusMessage = makeCatchUpStatusMessage sd
-        return (statusMessage, sd)
-    -- Initiator of catchup
-    (req, initatorState) <- runTest $ do
-        let b1 = TestBlocks.signedPB TestBlocks.testBB1
-        TestBlocks.succeedReceiveBlock b1
-        let b2 = TestBlocks.signedPB TestBlocks.testBB2'
-        TestBlocks.succeedReceiveBlock b2
-        sd <- get
-        catchupRequired <- isCatchUpRequired (cumStatus rStatus) sd
-        liftIO $ assertBool "Catch-up should be required." catchupRequired
-        return (makeCatchUpRequestMessage sd, sd)
-    (resp, respRs, respLfe) <- runTest $ do
-        put responderState
-        resp <- handleCatchUpRequest (cumStatus req) =<< get
-        rs <- use roundStatus
-        lfe <- use latestFinalizationEntry
-        return (resp, rs, lfe)
-    -- Let the initiator catchup.
-    runTest $ do
-        -- Set the initiator state
-        put initatorState
-        termData <- consumeResponse resp
-        processCatchUpTerminalData termData >>= \case
-            TerminalDataResultValid stateProgessed -> liftIO $ assertBool "State should have progessed" stateProgessed
-            TerminalDataResultInvalid _ -> liftIO $ assertFailure "The terminal data should be valid."
-        -- Check that the round status is as expected.
-        liftIO . checkRoundStatus respRs =<< use roundStatus
-        -- Check that the latest finalization entry is as expected.
-        liftIO . assertEqual "Unexpected last finalization entry" respLfe =<< use latestFinalizationEntry
+testCatchup :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> String -> Spec
+testCatchup sProtocolVersion pvString =
+    it (pvString ++ ": Test catch-up integration test") $ do
+        -- Responder to catchup
+        (rStatus, responderState) <- runTest @pv $ do
+            mapM_
+                (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
+                [TestBlocks.testBB1, TestBlocks.testBB2', TestBlocks.testBB3', TestBlocks.testBB4']
+            -- Some messages for the current round.
+            let b4QC = bbQuorumCertificate (TestBlocks.testBB3 @pv)
+                qsmR4 =
+                    QuorumSignatureMessage
+                        (TestBlocks.genesisHash sProtocolVersion)
+                        (getHash (TestBlocks.testBB4' @pv))
+                        (Round 4)
+                        0
+                qmR4Sig = signQuorumSignatureMessage qsmR4 (bakerAggregationKey . fst $ TestBlocks.bakers sProtocolVersion !! 1)
+                qmR4 = buildQuorumMessage qsmR4 qmR4Sig (FinalizerIndex 1)
+                tmR4 = head $ timeoutMessagesFor sProtocolVersion b4QC (Round 4) 0
+                finToQMsgMap = Map.insert 1 qmR4 Map.empty
+                finToTMMap = Map.insert (FinalizerIndex 0) tmR4 Map.empty
+            -- Setting the current quorum and timeout message.
+            currentQuorumMessages .= QuorumMessages finToQMsgMap Map.empty
+            currentTimeoutMessages .= Present (TimeoutMessages 1 finToTMMap Map.empty)
+            sd <- get
+            let statusMessage = makeCatchUpStatusMessage sd
+            return (statusMessage, sd)
+        -- Initiator of catchup
+        (req, initatorState) <- runTest @pv $ do
+            let b1 = TestBlocks.signedPB TestBlocks.testBB1
+            TestBlocks.succeedReceiveBlock b1
+            let b2 = TestBlocks.signedPB TestBlocks.testBB2'
+            TestBlocks.succeedReceiveBlock b2
+            sd <- get
+            catchupRequired <- isCatchUpRequired (cumStatus rStatus) sd
+            liftIO $ assertBool "Catch-up should be required." catchupRequired
+            return (makeCatchUpRequestMessage sd, sd)
+        (resp, respRs, respLfe) <- runTest @pv $ do
+            put responderState
+            resp <- handleCatchUpRequest (cumStatus req) =<< get
+            rs <- use roundStatus
+            lfe <- use latestFinalizationEntry
+            return (resp, rs, lfe)
+        -- Let the initiator catchup.
+        runTest @pv $ do
+            -- Set the initiator state
+            put initatorState
+            termData <- consumeResponse resp
+            processCatchUpTerminalData termData >>= \case
+                TerminalDataResultValid stateProgessed -> liftIO $ assertBool "State should have progessed" stateProgessed
+                TerminalDataResultInvalid _ -> liftIO $ assertFailure "The terminal data should be valid."
+            -- Check that the round status is as expected.
+            liftIO . checkRoundStatus respRs =<< use roundStatus
+            -- Check that the latest finalization entry is as expected.
+            liftIO . assertEqual "Unexpected last finalization entry" respLfe =<< use latestFinalizationEntry
 
 -- | Test catch-up through an epoch transition.
-testCatchupEpochTransition :: Assertion
-testCatchupEpochTransition = do
-    -- Responder to catchup
-    (rStatus, responderState) <- runTest $ do
-        mapM_
-            (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
-            [TestBlocks.testBB1E, TestBlocks.testBB2E, TestBlocks.testBB3E, TestBlocks.testBB4E]
-        sd <- get
-        let statusMessage = makeCatchUpStatusMessage sd
-        return (statusMessage, sd)
-    -- Initiator of catchup
-    (req, initatorState) <- runTest $ do
-        TestBlocks.succeedReceiveBlock $ TestBlocks.signedPB TestBlocks.testBB1E
-        sd <- get
-        catchupRequired <- isCatchUpRequired (cumStatus rStatus) sd
-        liftIO $ assertBool "Catch-up should be required." catchupRequired
-        return (makeCatchUpRequestMessage sd, sd)
-    (resp, respRs, respLfe) <- runTest $ do
-        put responderState
-        response <- handleCatchUpRequest (cumStatus req) =<< get
-        rs <- use roundStatus
-        lfe <- use latestFinalizationEntry
-        return (response, rs, lfe)
-    -- Let the initiator catchup.
-    runTest $ do
-        -- Set the initiator state
-        put initatorState
-        termData <- consumeResponse resp
-        processCatchUpTerminalData termData >>= \case
-            TerminalDataResultValid stateProgessed -> liftIO $ assertBool "State should not have progessed" (not stateProgessed)
-            TerminalDataResultInvalid _ -> liftIO $ assertFailure "The terminal data should be valid."
-        -- Check that the round status is as expected.
-        liftIO . checkRoundStatus respRs =<< use roundStatus
-        -- Check that the latest finalization entry is as expected.
-        liftIO . assertEqual "Unexpected last finalization entry" respLfe =<< use latestFinalizationEntry
+testCatchupEpochTransition :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> String -> Spec
+testCatchupEpochTransition _ pvString =
+    it (pvString ++ ": Test catch-up integration test with epoch transition") $ do
+        -- Responder to catchup
+        (rStatus, responderState) <- runTest @pv $ do
+            mapM_
+                (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
+                [TestBlocks.testBB1E, TestBlocks.testBB2E, TestBlocks.testBB3E, TestBlocks.testBB4E]
+            sd <- get
+            let statusMessage = makeCatchUpStatusMessage sd
+            return (statusMessage, sd)
+        -- Initiator of catchup
+        (req, initatorState) <- runTest @pv $ do
+            TestBlocks.succeedReceiveBlock $ TestBlocks.signedPB TestBlocks.testBB1E
+            sd <- get
+            catchupRequired <- isCatchUpRequired (cumStatus rStatus) sd
+            liftIO $ assertBool "Catch-up should be required." catchupRequired
+            return (makeCatchUpRequestMessage sd, sd)
+        (resp, respRs, respLfe) <- runTest @pv $ do
+            put responderState
+            response <- handleCatchUpRequest (cumStatus req) =<< get
+            rs <- use roundStatus
+            lfe <- use latestFinalizationEntry
+            return (response, rs, lfe)
+        -- Let the initiator catchup.
+        runTest $ do
+            -- Set the initiator state
+            put initatorState
+            termData <- consumeResponse resp
+            processCatchUpTerminalData termData >>= \case
+                TerminalDataResultValid stateProgessed -> liftIO $ assertBool "State should not have progessed" (not stateProgessed)
+                TerminalDataResultInvalid _ -> liftIO $ assertFailure "The terminal data should be valid."
+            -- Check that the round status is as expected.
+            liftIO . checkRoundStatus respRs =<< use roundStatus
+            -- Check that the latest finalization entry is as expected.
+            liftIO . assertEqual "Unexpected last finalization entry" respLfe =<< use latestFinalizationEntry
 
 -- | Test catch up with a tc for last round.
-testCatchupTCAtEnd :: Assertion
-testCatchupTCAtEnd = do
-    -- Responder to catchup
-    (rStatus, responderState) <- runTest $ do
-        mapM_
-            (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
-            [TestBlocks.testBB1, TestBlocks.testBB2, TestBlocks.testBB3]
-        mkTimeout (Round 3) TestBlocks.testBB2
-        sd <- get
-        let statusMessage = makeCatchUpStatusMessage sd
-        return (statusMessage, sd)
-    -- Initiator of catchup
-    (req, initatorState) <- runTest $ do
-        let b1 = TestBlocks.signedPB TestBlocks.testBB1
-        TestBlocks.succeedReceiveBlock b1
-        sd <- get
-        catchupRequired <- isCatchUpRequired (cumStatus rStatus) sd
-        liftIO $ assertBool "Catch-up should be required." catchupRequired
-        return (makeCatchUpRequestMessage sd, sd)
-    (resp, respRs, respLfe) <- runTest $ do
-        put responderState
-        resp <- handleCatchUpRequest (cumStatus req) =<< get
-        rs <- use roundStatus
-        lfe <- use latestFinalizationEntry
-        return (resp, rs, lfe)
-    -- Let the initiator catchup.
-    runTest $ do
-        -- Set the initiator state
-        put initatorState
-        termData <- consumeResponse resp
-        processCatchUpTerminalData termData >>= \case
-            TerminalDataResultValid stateProgessed -> liftIO $ assertBool "State should have progessed" stateProgessed
-            TerminalDataResultInvalid _ -> liftIO $ assertFailure "The terminal data should be valid."
-        -- Check that the round status is as expected.
-        liftIO . checkRoundStatus respRs =<< use roundStatus
-        -- Check that the latest finalization entry is as expected.
-        liftIO . assertEqual "Unexpected last finalization entry" respLfe =<< use latestFinalizationEntry
+testCatchupTCAtEnd ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testCatchupTCAtEnd _ pvString =
+    it (pvString ++ ": Test catch-up integration test with TC at end") $ do
+        -- Responder to catchup
+        (rStatus, responderState) <- runTest $ do
+            mapM_
+                (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
+                [TestBlocks.testBB1, TestBlocks.testBB2, TestBlocks.testBB3]
+            mkTimeout (Round 3) TestBlocks.testBB2
+            sd <- get
+            let statusMessage = makeCatchUpStatusMessage sd
+            return (statusMessage, sd)
+        -- Initiator of catchup
+        (req, initatorState) <- runTest @pv $ do
+            let b1 = TestBlocks.signedPB TestBlocks.testBB1
+            TestBlocks.succeedReceiveBlock b1
+            sd <- get
+            catchupRequired <- isCatchUpRequired (cumStatus rStatus) sd
+            liftIO $ assertBool "Catch-up should be required." catchupRequired
+            return (makeCatchUpRequestMessage sd, sd)
+        (resp, respRs, respLfe) <- runTest $ do
+            put responderState
+            resp <- handleCatchUpRequest (cumStatus req) =<< get
+            rs <- use roundStatus
+            lfe <- use latestFinalizationEntry
+            return (resp, rs, lfe)
+        -- Let the initiator catchup.
+        runTest $ do
+            -- Set the initiator state
+            put initatorState
+            termData <- consumeResponse resp
+            processCatchUpTerminalData termData >>= \case
+                TerminalDataResultValid stateProgessed -> liftIO $ assertBool "State should have progessed" stateProgessed
+                TerminalDataResultInvalid _ -> liftIO $ assertFailure "The terminal data should be valid."
+            -- Check that the round status is as expected.
+            liftIO . checkRoundStatus respRs =<< use roundStatus
+            -- Check that the latest finalization entry is as expected.
+            liftIO . assertEqual "Unexpected last finalization entry" respLfe =<< use latestFinalizationEntry
 
 -- | Check that when receiving a catchup status message and
 --  "we" are behind their reported last finalized block then
 --  catchup should be required (and the other peer should not find
 --  that catching up is a requirement).
-testCatchupRequiredBehindLastFinalized :: Assertion
-testCatchupRequiredBehindLastFinalized = do
-    -- Send a catch up status message
-    (rStatus, responderState) <- runTest $ do
-        let b1 = TestBlocks.signedPB TestBlocks.testBB1
-        TestBlocks.succeedReceiveBlock b1
-        sd <- get
-        return (makeCatchUpStatusMessage sd, sd)
-    -- Send back a catch up status message as
-    -- this peer knows about TestBlocks.testBB2 and TestBlocks.testBB3.
-    (req, _) <- runTest $ do
-        mapM_
-            (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
-            [TestBlocks.testBB1, TestBlocks.testBB2, TestBlocks.testBB3]
-        sd <- get
-        catchupRequired <- isCatchUpRequired (cumStatus rStatus) sd
-        liftIO $ assertBool "Catch-up should not be required." $ not catchupRequired
-        return (makeCatchUpStatusMessage sd, sd)
-    required <- runTest $ isCatchUpRequired (cumStatus req) responderState
-    liftIO $ assertBool "Catch-up should be required." required
+testCatchupRequiredBehindLastFinalized ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testCatchupRequiredBehindLastFinalized _ pvString =
+    it (pvString ++ ": Test isCatchUpRequired: Catch-up responder is behind last finalized") $ do
+        -- Send a catch up status message
+        (rStatus, responderState) <- runTest @pv $ do
+            let b1 = TestBlocks.signedPB TestBlocks.testBB1
+            TestBlocks.succeedReceiveBlock b1
+            sd <- get
+            return (makeCatchUpStatusMessage sd, sd)
+        -- Send back a catch up status message as
+        -- this peer knows about TestBlocks.testBB2 and TestBlocks.testBB3.
+        (req, _) <- runTest @pv $ do
+            mapM_
+                (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
+                [TestBlocks.testBB1, TestBlocks.testBB2, TestBlocks.testBB3]
+            sd <- get
+            catchupRequired <- isCatchUpRequired (cumStatus rStatus) sd
+            liftIO $ assertBool "Catch-up should not be required." $ not catchupRequired
+            return (makeCatchUpStatusMessage sd, sd)
+        required <- runTest $ isCatchUpRequired (cumStatus req) responderState
+        liftIO $ assertBool "Catch-up should be required." required
 
-testCatchupRequiredBehind :: Assertion
-testCatchupRequiredBehind = do
-    -- Send a catch up status message
-    (rStatus, responderState) <- runTest $ do
-        let b1 = TestBlocks.signedPB TestBlocks.testBB1
-        TestBlocks.succeedReceiveBlock b1
-        sd <- get
-        return (makeCatchUpStatusMessage sd, sd)
-    (req, _) <- runTest $ do
-        mapM_
-            (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
-            [TestBlocks.testBB1, TestBlocks.testBB2]
-        sd <- get
-        catchupRequired <- isCatchUpRequired (cumStatus rStatus) sd
-        liftIO $ assertBool "Catch-up should not be required." $ not catchupRequired
-        return (makeCatchUpStatusMessage sd, sd)
-    required <- runTest $ isCatchUpRequired (cumStatus req) responderState
-    liftIO $ assertBool "Catch-up should be required." required
+testCatchupRequiredBehind ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testCatchupRequiredBehind _ pvString =
+    it (pvString ++ ": Test isCatchUpRequired: Catch-up responder is behind") $ do
+        -- Send a catch up status message
+        (rStatus, responderState) <- runTest @pv $ do
+            let b1 = TestBlocks.signedPB TestBlocks.testBB1
+            TestBlocks.succeedReceiveBlock b1
+            sd <- get
+            return (makeCatchUpStatusMessage sd, sd)
+        (req, _) <- runTest @pv $ do
+            mapM_
+                (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
+                [TestBlocks.testBB1, TestBlocks.testBB2]
+            sd <- get
+            catchupRequired <- isCatchUpRequired (cumStatus rStatus) sd
+            liftIO $ assertBool "Catch-up should not be required." $ not catchupRequired
+            return (makeCatchUpStatusMessage sd, sd)
+        required <- runTest $ isCatchUpRequired (cumStatus req) responderState
+        liftIO $ assertBool "Catch-up should be required." required
 
 -- | Checking 'isCatchUpRequired' where parties are in the same round.
 --  Each party has different timeout messages and as such they should be catching up
 --  with each other.
-testCatchupRequiredSameRound :: Assertion
-testCatchupRequiredSameRound = do
-    -- Send a catch up status message
-    (rStatus, responderState) <- runTest $ do
-        mapM_
-            (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
-            [TestBlocks.testBB1, TestBlocks.testBB2]
-        -- Add a timeout message for round 2 from baker 0.
-        succeedReceiveExecuteTimeoutMessage $
-            testTimeoutMessage 0 (Round 2) $
-                blockQuorumCertificate $
-                    pbBlock $
-                        TestBlocks.signedPB TestBlocks.testBB1
-        sd <- get
-        return (makeCatchUpStatusMessage sd, sd)
-    (req, _) <- runTest $ do
-        mapM_
-            (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
-            [TestBlocks.testBB1, TestBlocks.testBB2]
-        -- Add a timeout message for round 2 from baker 1 and 2.
-        succeedReceiveExecuteTimeoutMessage $
-            testTimeoutMessage 1 (Round 2) $
-                blockQuorumCertificate $
-                    pbBlock $
-                        TestBlocks.signedPB TestBlocks.testBB1
-        succeedReceiveExecuteTimeoutMessage $
-            testTimeoutMessage 2 (Round 2) $
-                blockQuorumCertificate $
-                    pbBlock $
-                        TestBlocks.signedPB TestBlocks.testBB1
-        sd <- get
-        catchupRequired <- isCatchUpRequired (cumStatus rStatus) sd
-        liftIO $ assertBool "Catch-up should be required." catchupRequired
-        return (makeCatchUpStatusMessage sd, sd)
-    required <- runTest $ isCatchUpRequired (cumStatus req) responderState
-    liftIO $ assertBool "Catch-up should be required." required
+testCatchupRequiredSameRound ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testCatchupRequiredSameRound sProtocolVersion pvString =
+    it (pvString ++ ": Test isCatchUpRequired: Catch-up same round") $ do
+        -- Send a catch up status message
+        (rStatus, responderState) <- runTest @pv $ do
+            mapM_
+                (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
+                [TestBlocks.testBB1, TestBlocks.testBB2]
+            -- Add a timeout message for round 2 from baker 0.
+            succeedReceiveExecuteTimeoutMessage $
+                testTimeoutMessage sProtocolVersion 0 (Round 2) $
+                    blockQuorumCertificate $
+                        pbBlock $
+                            TestBlocks.signedPB @pv TestBlocks.testBB1
+            sd <- get
+            return (makeCatchUpStatusMessage sd, sd)
+        (req, _) <- runTest @pv $ do
+            mapM_
+                (TestBlocks.succeedReceiveBlock . TestBlocks.signedPB)
+                [TestBlocks.testBB1, TestBlocks.testBB2]
+            -- Add a timeout message for round 2 from baker 1 and 2.
+            succeedReceiveExecuteTimeoutMessage $
+                testTimeoutMessage sProtocolVersion 1 (Round 2) $
+                    blockQuorumCertificate $
+                        pbBlock $
+                            TestBlocks.signedPB @pv TestBlocks.testBB1
+            succeedReceiveExecuteTimeoutMessage $
+                testTimeoutMessage sProtocolVersion 2 (Round 2) $
+                    blockQuorumCertificate $
+                        pbBlock $
+                            TestBlocks.signedPB @pv TestBlocks.testBB1
+            sd <- get
+            catchupRequired <- isCatchUpRequired (cumStatus rStatus) sd
+            liftIO $ assertBool "Catch-up should be required." catchupRequired
+            return (makeCatchUpStatusMessage sd, sd)
+        required <- runTest $ isCatchUpRequired (cumStatus req) responderState
+        liftIO $ assertBool "Catch-up should be required." required
 
 tests :: Spec
 tests = describe "KonsensusV1.CatchUp" $ do
-    it "Test handleCatchUpRequest: Basics" basicCatchupResponse
-    it "Test handleCatchUpRequest: Epoch transition" catchupWithEpochTransitionResponse
-    it "Test handleCatchUpRequest: Timeout in the middle of the chain" catchupWithTimeoutsResponse
-    it "Test handleCatchUpRequest: One timeout certificate at end" catchupWithOneTimeoutAtEndResponse
-    it "Test handleCatchUpRequest: Two timeout certificates at end" catchupWithTwoTimeoutsAtEndResponse
-    it "Test handleCatchUpRequest: Two branches" catchupWithTwoBranchesResponse
-    it "Test makeCatchUpRequestMessage" testMakeCatchupStatus
-    it "Test catch-up integration test" testCatchup
-    it "Test catch-up integration test with epoch transition" testCatchupEpochTransition
-    it "Test catch-up integration test with TC at end" testCatchupTCAtEnd
-    it "Test isCatchUpRequired: Catch-up responder is behind last finalized" testCatchupRequiredBehindLastFinalized
-    it "Test isCatchUpRequired: Catch-up responder is behind" testCatchupRequiredBehind
-    it "Test isCatchUpRequired: Catch-up same round" testCatchupRequiredSameRound
-    it "Test handleCatchUpRequest: Epoch transition with timeout" catchupWithEpochTransitionTimeout
+    forEveryProtocolVersionConsensusV1 $ \spv pvString -> do
+        basicCatchupResponse spv pvString
+        catchupWithEpochTransitionResponse spv pvString
+        catchupWithTimeoutsResponse spv pvString
+        catchupWithOneTimeoutAtEndResponse spv pvString
+        catchupWithTwoTimeoutsAtEndResponse spv pvString
+        catchupWithTwoBranchesResponse spv pvString
+        testMakeCatchupStatus spv pvString
+        testCatchup spv pvString
+        testCatchupEpochTransition spv pvString
+        testCatchupTCAtEnd spv pvString
+        testCatchupRequiredBehindLastFinalized spv pvString
+        testCatchupRequiredBehind spv pvString
+        testCatchupRequiredSameRound spv pvString
+        catchupWithEpochTransitionTimeout spv pvString

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Common.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Common.hs
@@ -12,6 +12,9 @@ import System.Random
 import qualified Concordium.Crypto.BlockSignature as Sig
 import qualified Concordium.Crypto.DummyData as Dummy
 import qualified Concordium.Crypto.SHA256 as Hash
+import qualified Concordium.Crypto.VRF as VRF
+import Concordium.GlobalState.Persistent.BlobStore (blobRefToBufferedRef, refNull)
+import Concordium.GlobalState.Persistent.BlockState (HashedPersistentBlockState (..), PersistentBlockState)
 import Concordium.KonsensusV1.TreeState.Types
 import Concordium.KonsensusV1.Types
 import Concordium.Types
@@ -19,12 +22,55 @@ import qualified Concordium.Types.Conditionally as Cond
 import Concordium.Types.Option
 import Concordium.Types.Parameters
 import Concordium.Types.Transactions
-import ConcordiumTests.KonsensusV1.TreeStateTest hiding (tests)
+import GHC.IO (unsafePerformIO)
+import GHC.IORef (newIORef)
 import Test.Hspec (Spec)
 
 -- | Just an arbitrary chosen block hash used for testing.
 myBlockHash :: BlockHash
 myBlockHash = BlockHash $ Hash.hash "my block hash"
+
+dummyStateHash :: StateHash
+dummyStateHash = StateHashV0 $ Hash.hash "DummyPersistentBlockState"
+
+dummyBlockResultHash :: BlockResultHash
+dummyBlockResultHash = BlockResultHash $ Hash.hash "DummyBlockResult"
+
+-- | A dummy block state that has no content.
+dummyBlockState :: HashedPersistentBlockState pv
+dummyBlockState = HashedPersistentBlockState{..}
+  where
+    hpbsPointers = dummyPersistentBlockState
+    hpbsHash = dummyStateHash
+
+-- | A dummy block state that is just a @BlobRef maxBound@.
+dummyPersistentBlockState :: PersistentBlockState pv
+{-# NOINLINE dummyPersistentBlockState #-}
+dummyPersistentBlockState = unsafePerformIO $ newIORef $ blobRefToBufferedRef refNull
+
+-- | A 'QuorumCertificate' pointing to the block provided.
+--  The certificate itself is inherently invalid as it is for round and epoch 0.
+--  Further no one signed it and it has an empty signature.
+--  However for the tests exposed here it is sufficient.
+dummyQuorumCertificate :: BlockHash -> QuorumCertificate
+dummyQuorumCertificate blockHash =
+    QuorumCertificate
+        { qcBlock = blockHash,
+          qcRound = 0,
+          qcEpoch = 0,
+          qcAggregateSignature = mempty,
+          qcSignatories = FinalizerSet 0
+        }
+
+-- | A BlockNonce consisting
+--  of a VRF proof on the empty string with the 'dummyVRFKeys'.
+dummyBlockNonce :: BlockNonce
+dummyBlockNonce = VRF.prove dummyVRFKeys ""
+
+-- | An arbitrary chosen 'VRF.KeyPair'.
+--  This is required to create the 'dummyBlockNonce'.
+dummyVRFKeys :: VRF.KeyPair
+dummyVRFKeys = fst $ VRF.randomKeyPair (mkStdGen 0)
 
 -- | A 'BlockPointer' which refers to a block with no meaningful state.
 someBlockPointer :: SProtocolVersion pv -> BlockHash -> Round -> Epoch -> BlockPointer pv
@@ -92,11 +138,8 @@ sigKeyPair = fst $ Dummy.randomBlockKeyPair $ mkStdGen 42
 sigPublicKey :: Sig.VerifyKey
 sigPublicKey = Sig.verifyKey sigKeyPair
 
--- | Call a function for each protocol version starting from P6 where the new conensus was
--- introduced, returning a list of results. Notice the return type for the function must be
--- independent of the protocol version.
---
---  This is used to run a test against every protocol version.
+-- | Run tests for each protocol version.
+-- The tests are provided with the protocol version and a string representation of the protocol version.
 forEveryProtocolVersion ::
     (forall pv. (IsProtocolVersion pv) => SProtocolVersion pv -> String -> Spec) ->
     Spec
@@ -111,7 +154,16 @@ forEveryProtocolVersion check =
           check SP7 "P7"
         ]
 
-forEveryProtocolVersionConsensusV1 :: (forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => SProtocolVersion pv -> String -> Spec) -> Spec
+-- | Run tests for each protocol version using consensus v1 (P6 and onwards).
+-- The tests are provided with the protocol version and a string representation of the protocol version.
+forEveryProtocolVersionConsensusV1 ::
+    ( forall pv.
+      (IsProtocolVersion pv, IsConsensusV1 pv) =>
+      SProtocolVersion pv ->
+      String ->
+      Spec
+    ) ->
+    Spec
 forEveryProtocolVersionConsensusV1 check =
     forEveryProtocolVersion $ \spv pvString -> case consensusVersionFor spv of
         ConsensusV0 -> return ()

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Common.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Common.hs
@@ -106,16 +106,14 @@ someBlockPointer sProtocolVersion bh r e =
               bbTransactions = Vec.empty,
               bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
                 SBlockHashVersion0 ->
-                    DBHashesV0 $
-                        BlockDerivableHashesV0
-                            { bdhv0TransactionOutcomesHash = emptyTransactionOutcomesHashV1,
-                              bdhv0BlockStateHash = stateHash
-                            }
+                    DerivableBlockHashesV0
+                        { dbhv0TransactionOutcomesHash = emptyTransactionOutcomesHashV1,
+                          dbhv0BlockStateHash = stateHash
+                        }
                 SBlockHashVersion1 ->
-                    DBHashesV1 $
-                        BlockDerivableHashesV1
-                            { bdhv1BlockResultHash = BlockResultHash $ Hash.hash "empty state hash"
-                            }
+                    DerivableBlockHashesV1
+                        { dbhv1BlockResultHash = BlockResultHash $ Hash.hash "empty state hash"
+                        }
             }
 
 -- | A block pointer with 'myBlockHash' as block hash.

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Consensus/Blocks.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Consensus/Blocks.hs
@@ -275,14 +275,8 @@ emptyBlockTOH bid = transactionOutcomesHash [] [BlockAccrueReward 0 0 0 0 0 0 bi
 
 setStateHash :: StateHash -> BakedBlock PV -> BakedBlock PV
 setStateHash newStateHash block = case bbDerivableHashes block of
-    DBHashesV0 hashes ->
-        block
-            { bbDerivableHashes =
-                DBHashesV0 $
-                    hashes
-                        { bdhv0BlockStateHash = newStateHash
-                        }
-            }
+    hashes@DerivableBlockHashesV0{} ->
+        block{bbDerivableHashes = hashes{dbhv0BlockStateHash = newStateHash}}
 
 -- | Valid block for round 1.
 testBB1 :: forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => BakedBlock pv
@@ -299,16 +293,14 @@ testBB1 =
           bbTransactions = Vec.empty,
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-                DBHashesV0 $
-                    BlockDerivableHashesV0
-                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
-                          bdhv0BlockStateHash = read "dee89435dba1609a84fa62283d2f63ec50f85b9c22f8815daf348df5428ccb65"
-                        }
+                DerivableBlockHashesV0
+                    { dbhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                      dbhv0BlockStateHash = read "dee89435dba1609a84fa62283d2f63ec50f85b9c22f8815daf348df5428ccb65"
+                    }
             SBlockHashVersion1 ->
-                DBHashesV1 $
-                    BlockDerivableHashesV1
-                        { bdhv1BlockResultHash = read "39a83a5c78db450c757b9d8c11c6911b7de5a4d2a8ce964a16f7fc87ed697b69"
-                        }
+                DerivableBlockHashesV1
+                    { dbhv1BlockResultHash = read "39a83a5c78db450c757b9d8c11c6911b7de5a4d2a8ce964a16f7fc87ed697b69"
+                    }
         }
   where
     bakerId = 2
@@ -329,16 +321,14 @@ testBB2 =
           bbTransactions = Vec.empty,
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-                DBHashesV0 $
-                    BlockDerivableHashesV0
-                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
-                          bdhv0BlockStateHash = read "d36974d10f1331559e396be5f8e31ecedc2042ebf941bc2fad6050e9e082f206"
-                        }
+                DerivableBlockHashesV0
+                    { dbhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                      dbhv0BlockStateHash = read "d36974d10f1331559e396be5f8e31ecedc2042ebf941bc2fad6050e9e082f206"
+                    }
             SBlockHashVersion1 ->
-                DBHashesV1 $
-                    BlockDerivableHashesV1
-                        { bdhv1BlockResultHash = read "2d988a0381670c7142ed81afe2b5745113d565e8de4b1656fcfafd27b0b22ecb"
-                        }
+                DerivableBlockHashesV1
+                    { dbhv1BlockResultHash = read "2d988a0381670c7142ed81afe2b5745113d565e8de4b1656fcfafd27b0b22ecb"
+                    }
         }
   where
     bakerId = 4
@@ -359,16 +349,14 @@ testBB3 =
           bbTransactions = Vec.empty,
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-                DBHashesV0 $
-                    BlockDerivableHashesV0
-                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
-                          bdhv0BlockStateHash = read "50998f735737ce13b35715a173efb7a3ad20cba597ba540985cd562a0b7bed74"
-                        }
+                DerivableBlockHashesV0
+                    { dbhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                      dbhv0BlockStateHash = read "50998f735737ce13b35715a173efb7a3ad20cba597ba540985cd562a0b7bed74"
+                    }
             SBlockHashVersion1 ->
-                DBHashesV1 $
-                    BlockDerivableHashesV1
-                        { bdhv1BlockResultHash = read "e3488977b88b8d2b9291f205145b8445deb5238af2526b6a3fd75f725dafef83"
-                        }
+                DerivableBlockHashesV1
+                    { dbhv1BlockResultHash = read "e3488977b88b8d2b9291f205145b8445deb5238af2526b6a3fd75f725dafef83"
+                    }
         }
   where
     bakerId = 4
@@ -382,16 +370,14 @@ testBB2' =
           bbTimeoutCertificate = Present (validTimeoutFor sProtocolVersion genQC 1),
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-                DBHashesV0 $
-                    BlockDerivableHashesV0
-                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
-                          bdhv0BlockStateHash = read "20cd8fe8689b17850e73e8322b53398a49df5e4723eaa77acaf5474e94915c0b"
-                        }
+                DerivableBlockHashesV0
+                    { dbhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                      dbhv0BlockStateHash = read "20cd8fe8689b17850e73e8322b53398a49df5e4723eaa77acaf5474e94915c0b"
+                    }
             SBlockHashVersion1 ->
-                DBHashesV1 $
-                    BlockDerivableHashesV1
-                        { bdhv1BlockResultHash = read "589c7ee85c2178f3ea9ba8be4bbd4e5946bb5b5ce757164c2dbe28551f354db5"
-                        }
+                DerivableBlockHashesV1
+                    { dbhv1BlockResultHash = read "589c7ee85c2178f3ea9ba8be4bbd4e5946bb5b5ce757164c2dbe28551f354db5"
+                    }
         }
   where
     bakerId :: BakerId
@@ -406,16 +392,14 @@ testBB3' =
         { bbQuorumCertificate = validQCFor @pv testBB2',
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-                DBHashesV0 $
-                    BlockDerivableHashesV0
-                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
-                          bdhv0BlockStateHash = read "784471f09f9678a2cf8208af45186f553406430b67e035ebf1b772e7c39fbd97"
-                        }
+                DerivableBlockHashesV0
+                    { dbhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                      dbhv0BlockStateHash = read "784471f09f9678a2cf8208af45186f553406430b67e035ebf1b772e7c39fbd97"
+                    }
             SBlockHashVersion1 ->
-                DBHashesV1 $
-                    BlockDerivableHashesV1
-                        { bdhv1BlockResultHash = read "51b39b40caa3b23e41e461177659cf0b6e24c98d0471fd59cf2de134645af87e"
-                        }
+                DerivableBlockHashesV1
+                    { dbhv1BlockResultHash = read "51b39b40caa3b23e41e461177659cf0b6e24c98d0471fd59cf2de134645af87e"
+                    }
         }
   where
     bakerId :: BakerId
@@ -437,16 +421,14 @@ testBB4' =
           bbTransactions = Vec.empty,
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-                DBHashesV0 $
-                    BlockDerivableHashesV0
-                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
-                          bdhv0BlockStateHash = read "3bb5b307d7abc6fad2464455f604d63512fff93d7fdeb2aa08d5a8f2720340fe"
-                        }
+                DerivableBlockHashesV0
+                    { dbhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                      dbhv0BlockStateHash = read "3bb5b307d7abc6fad2464455f604d63512fff93d7fdeb2aa08d5a8f2720340fe"
+                    }
             SBlockHashVersion1 ->
-                DBHashesV1 $
-                    BlockDerivableHashesV1
-                        { bdhv1BlockResultHash = read "c061123ab66c29dfb5c44be1f3fa62eff91bf27d1a7947e190cab98ee39eb367"
-                        }
+                DerivableBlockHashesV1
+                    { dbhv1BlockResultHash = read "c061123ab66c29dfb5c44be1f3fa62eff91bf27d1a7947e190cab98ee39eb367"
+                    }
         }
   where
     bakerId = 3
@@ -460,16 +442,14 @@ testBB3'' =
           bbTimeoutCertificate = Present (validTimeoutFor sProtocolVersion genQC 2),
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-                DBHashesV0 $
-                    BlockDerivableHashesV0
-                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
-                          bdhv0BlockStateHash = read "2b81e5943112b9a9916e57980a4b17b5b3b329eba0402d14201bfe1c9551a16d"
-                        }
+                DerivableBlockHashesV0
+                    { dbhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                      dbhv0BlockStateHash = read "2b81e5943112b9a9916e57980a4b17b5b3b329eba0402d14201bfe1c9551a16d"
+                    }
             SBlockHashVersion1 ->
-                DBHashesV1 $
-                    BlockDerivableHashesV1
-                        { bdhv1BlockResultHash = read "daa799010a8b4acb47fa97b876abed73621db292029360734d9c8978b5859e7b"
-                        }
+                DerivableBlockHashesV1
+                    { dbhv1BlockResultHash = read "daa799010a8b4acb47fa97b876abed73621db292029360734d9c8978b5859e7b"
+                    }
         }
   where
     sProtocolVersion = protocolVersion @pv
@@ -493,16 +473,14 @@ testBB1E =
           bbTransactions = Vec.empty,
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-                DBHashesV0 $
-                    BlockDerivableHashesV0
-                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
-                          bdhv0BlockStateHash = read "3ce2fe0d538434fa7677549a4acbdecea606bd47a61fa39735de1dc144c95eab"
-                        }
+                DerivableBlockHashesV0
+                    { dbhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                      dbhv0BlockStateHash = read "3ce2fe0d538434fa7677549a4acbdecea606bd47a61fa39735de1dc144c95eab"
+                    }
             SBlockHashVersion1 ->
-                DBHashesV1 $
-                    BlockDerivableHashesV1
-                        { bdhv1BlockResultHash = read "92c6d014d2d788845521445c299e85d16854f308397000fc64564ea7abe0e341"
-                        }
+                DerivableBlockHashesV1
+                    { dbhv1BlockResultHash = read "92c6d014d2d788845521445c299e85d16854f308397000fc64564ea7abe0e341"
+                    }
         }
   where
     bakerId = 2
@@ -523,16 +501,14 @@ testBB2E =
           bbTransactions = Vec.empty,
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-                DBHashesV0 $
-                    BlockDerivableHashesV0
-                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
-                          bdhv0BlockStateHash = read "df5d25b8ffbad7be62be0ae2ce1a4730018062c3bda6d6caa02ea03545a263fd"
-                        }
+                DerivableBlockHashesV0
+                    { dbhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                      dbhv0BlockStateHash = read "df5d25b8ffbad7be62be0ae2ce1a4730018062c3bda6d6caa02ea03545a263fd"
+                    }
             SBlockHashVersion1 ->
-                DBHashesV1 $
-                    BlockDerivableHashesV1
-                        { bdhv1BlockResultHash = read "be9c7f10dc2e649bbdd89e6ad97f6b72b3fc83fa3292aa62e1db558b17b9f0af"
-                        }
+                DerivableBlockHashesV1
+                    { dbhv1BlockResultHash = read "be9c7f10dc2e649bbdd89e6ad97f6b72b3fc83fa3292aa62e1db558b17b9f0af"
+                    }
         }
   where
     bakerId = 4
@@ -555,16 +531,14 @@ testBB3EX =
           bbTransactions = Vec.empty,
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-                DBHashesV0 $
-                    BlockDerivableHashesV0
-                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
-                          bdhv0BlockStateHash = read "81e1b33e20088562fcb48c619ea16e800d7fba58995fa6487a6209cf448c7d08"
-                        }
+                DerivableBlockHashesV0
+                    { dbhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                      dbhv0BlockStateHash = read "81e1b33e20088562fcb48c619ea16e800d7fba58995fa6487a6209cf448c7d08"
+                    }
             SBlockHashVersion1 ->
-                DBHashesV1 $
-                    BlockDerivableHashesV1
-                        { bdhv1BlockResultHash = read "9aee22a152f71ef811c017729d3bf47fc5eb110bb2853fe0b66f57091b18351a"
-                        }
+                DerivableBlockHashesV1
+                    { dbhv1BlockResultHash = read "9aee22a152f71ef811c017729d3bf47fc5eb110bb2853fe0b66f57091b18351a"
+                    }
         }
   where
     bakerId = 4
@@ -603,16 +577,14 @@ testBB3E =
           bbTransactions = Vec.empty,
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-                DBHashesV0 $
-                    BlockDerivableHashesV0
-                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
-                          bdhv0BlockStateHash = read "dc31a663a0bd166507e21cc641759018651c716b3571531672956abf24b0f4bc"
-                        }
+                DerivableBlockHashesV0
+                    { dbhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                      dbhv0BlockStateHash = read "dc31a663a0bd166507e21cc641759018651c716b3571531672956abf24b0f4bc"
+                    }
             SBlockHashVersion1 ->
-                DBHashesV1 $
-                    BlockDerivableHashesV1
-                        { bdhv1BlockResultHash = read "e95fc29d250c0fb4acb4e297ec0af49678442e9e2174c8ade12c0cc509995a9a"
-                        }
+                DerivableBlockHashesV1
+                    { dbhv1BlockResultHash = read "e95fc29d250c0fb4acb4e297ec0af49678442e9e2174c8ade12c0cc509995a9a"
+                    }
         }
   where
     bakerId = 5
@@ -644,16 +616,14 @@ testBB4E =
           bbTransactions = Vec.empty,
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-                DBHashesV0 $
-                    BlockDerivableHashesV0
-                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
-                          bdhv0BlockStateHash = read "daa799010a8b4acb47fa97b876abed73621db292029360734d9c8978b5859e7b"
-                        }
+                DerivableBlockHashesV0
+                    { dbhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                      dbhv0BlockStateHash = read "daa799010a8b4acb47fa97b876abed73621db292029360734d9c8978b5859e7b"
+                    }
             SBlockHashVersion1 ->
-                DBHashesV1 $
-                    BlockDerivableHashesV1
-                        { bdhv1BlockResultHash = read "6141bfe4eadcd557e42d4cc319a9855a26ea4ff37ecbb486d0244ad611bd4cba"
-                        }
+                DerivableBlockHashesV1
+                    { dbhv1BlockResultHash = read "6141bfe4eadcd557e42d4cc319a9855a26ea4ff37ecbb486d0244ad611bd4cba"
+                    }
         }
   where
     bakerId = 1
@@ -669,16 +639,14 @@ testBB4E' =
           bbEpochFinalizationEntry = Present (testEpochFinEntry sProtocolVersion),
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-                DBHashesV0 $
-                    BlockDerivableHashesV0
-                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
-                          bdhv0BlockStateHash = read "41b44dd4db52dae4021a0d71fbec00a423ffc9892cf97bf6e506d722cdaaeb0d"
-                        }
+                DerivableBlockHashesV0
+                    { dbhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                      dbhv0BlockStateHash = read "41b44dd4db52dae4021a0d71fbec00a423ffc9892cf97bf6e506d722cdaaeb0d"
+                    }
             SBlockHashVersion1 ->
-                DBHashesV1 $
-                    BlockDerivableHashesV1
-                        { bdhv1BlockResultHash = read "a2a7356e06ff00522c4d821cd497a253ef12f09912cc96615927ac98a71ecea4"
-                        }
+                DerivableBlockHashesV1
+                    { dbhv1BlockResultHash = read "a2a7356e06ff00522c4d821cd497a253ef12f09912cc96615927ac98a71ecea4"
+                    }
         }
   where
     bakerId :: BakerId
@@ -701,16 +669,14 @@ testBB5E' =
           bbTransactions = Vec.empty,
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-                DBHashesV0 $
-                    BlockDerivableHashesV0
-                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
-                          bdhv0BlockStateHash = read "ff8cd1198e3926f743e91a97484d75f1109534aaf9655e1c8c9507d4d0ebd8b3"
-                        }
+                DerivableBlockHashesV0
+                    { dbhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                      dbhv0BlockStateHash = read "ff8cd1198e3926f743e91a97484d75f1109534aaf9655e1c8c9507d4d0ebd8b3"
+                    }
             SBlockHashVersion1 ->
-                DBHashesV1 $
-                    BlockDerivableHashesV1
-                        { bdhv1BlockResultHash = read "c7eaff2141ade9ac6d5fd8513678d9c7f42e5915f0be7b7b94e89a88c816a9e9"
-                        }
+                DerivableBlockHashesV1
+                    { dbhv1BlockResultHash = read "c7eaff2141ade9ac6d5fd8513678d9c7f42e5915f0be7b7b94e89a88c816a9e9"
+                    }
         }
   where
     sProtocolVersion = protocolVersion @pv
@@ -746,16 +712,14 @@ testBB2Ex =
           bbTimeoutCertificate = Present (validTimeoutFor sProtocolVersion genQC 1),
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-                DBHashesV0 $
-                    BlockDerivableHashesV0
-                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
-                          bdhv0BlockStateHash = read "df76421871484a877532dc9b748fcf248bd186898def8bd40fee0a3cf9636b92"
-                        }
+                DerivableBlockHashesV0
+                    { dbhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                      dbhv0BlockStateHash = read "df76421871484a877532dc9b748fcf248bd186898def8bd40fee0a3cf9636b92"
+                    }
             SBlockHashVersion1 ->
-                DBHashesV1 $
-                    BlockDerivableHashesV1
-                        { bdhv1BlockResultHash = read "cde603d206bd3f3ac1534efbb648d70d237f277c79e6923e91485df68e2d861f"
-                        }
+                DerivableBlockHashesV1
+                    { dbhv1BlockResultHash = read "cde603d206bd3f3ac1534efbb648d70d237f277c79e6923e91485df68e2d861f"
+                    }
         }
   where
     sProtocolVersion = protocolVersion @pv
@@ -793,16 +757,14 @@ testBB3Ex =
           bbTransactions = Vec.empty,
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-                DBHashesV0 $
-                    BlockDerivableHashesV0
-                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
-                          bdhv0BlockStateHash = read "dc31a663a0bd166507e21cc641759018651c716b3571531672956abf24b0f4bc"
-                        }
+                DerivableBlockHashesV0
+                    { dbhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                      dbhv0BlockStateHash = read "dc31a663a0bd166507e21cc641759018651c716b3571531672956abf24b0f4bc"
+                    }
             SBlockHashVersion1 ->
-                DBHashesV1 $
-                    BlockDerivableHashesV1
-                        { bdhv1BlockResultHash = read "593789121ba54a59eeaa06fce6b694072dde26f8aec6830717fbc7ea6d4eb4fa"
-                        }
+                DerivableBlockHashesV1
+                    { dbhv1BlockResultHash = read "593789121ba54a59eeaa06fce6b694072dde26f8aec6830717fbc7ea6d4eb4fa"
+                    }
         }
   where
     sProtocolVersion = protocolVersion @pv
@@ -828,16 +790,14 @@ testBB3EA =
           bbTransactions = Vec.empty,
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-                DBHashesV0 $
-                    BlockDerivableHashesV0
-                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
-                          bdhv0BlockStateHash = read "df5d25b8ffbad7be62be0ae2ce1a4730018062c3bda6d6caa02ea03545a263fd"
-                        }
+                DerivableBlockHashesV0
+                    { dbhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                      dbhv0BlockStateHash = read "df5d25b8ffbad7be62be0ae2ce1a4730018062c3bda6d6caa02ea03545a263fd"
+                    }
             SBlockHashVersion1 ->
-                DBHashesV1 $
-                    BlockDerivableHashesV1
-                        { bdhv1BlockResultHash = read "be9c7f10dc2e649bbdd89e6ad97f6b72b3fc83fa3292aa62e1db558b17b9f0af"
-                        }
+                DerivableBlockHashesV1
+                    { dbhv1BlockResultHash = read "be9c7f10dc2e649bbdd89e6ad97f6b72b3fc83fa3292aa62e1db558b17b9f0af"
+                    }
         }
   where
     sProtocolVersion = protocolVersion @pv
@@ -863,16 +823,14 @@ testBB4EA =
           bbTransactions = Vec.empty,
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-                DBHashesV0 $
-                    BlockDerivableHashesV0
-                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
-                          bdhv0BlockStateHash = read "41b44dd4db52dae4021a0d71fbec00a423ffc9892cf97bf6e506d722cdaaeb0d"
-                        }
+                DerivableBlockHashesV0
+                    { dbhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                      dbhv0BlockStateHash = read "41b44dd4db52dae4021a0d71fbec00a423ffc9892cf97bf6e506d722cdaaeb0d"
+                    }
             SBlockHashVersion1 ->
-                DBHashesV1 $
-                    BlockDerivableHashesV1
-                        { bdhv1BlockResultHash = read "a2a7356e06ff00522c4d821cd497a253ef12f09912cc96615927ac98a71ecea4"
-                        }
+                DerivableBlockHashesV1
+                    { dbhv1BlockResultHash = read "a2a7356e06ff00522c4d821cd497a253ef12f09912cc96615927ac98a71ecea4"
+                    }
         }
   where
     sProtocolVersion = protocolVersion @pv
@@ -1129,16 +1087,14 @@ testReceiveInvalidDuplicate sProtocolVersion =
         (testBB1 @pv)
             { bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
                 SBlockHashVersion0 ->
-                    DBHashesV0 $
-                        BlockDerivableHashesV0
-                            { bdhv0TransactionOutcomesHash = emptyBlockTOH 2,
-                              bdhv0BlockStateHash = StateHashV0 minBound
-                            }
+                    DerivableBlockHashesV0
+                        { dbhv0TransactionOutcomesHash = emptyBlockTOH 2,
+                          dbhv0BlockStateHash = StateHashV0 minBound
+                        }
                 SBlockHashVersion1 ->
-                    DBHashesV1 $
-                        BlockDerivableHashesV1
-                            { bdhv1BlockResultHash = BlockResultHash minBound
-                            }
+                    DerivableBlockHashesV1
+                        { dbhv1BlockResultHash = BlockResultHash minBound
+                        }
             }
 
 testReceiveStale ::
@@ -1505,11 +1461,10 @@ testReceiveIncorrectTransactionOutcomesHash = runTestMonad noBaker testTime (gen
         signedPB
             (testBB1 @'P6)
                 { bbDerivableHashes =
-                    DBHashesV0 $
-                        BlockDerivableHashesV0
-                            { bdhv0TransactionOutcomesHash = read "0000000000000000000000000000000000000000000000000000000000000000",
-                              bdhv0BlockStateHash = read "dee89435dba1609a84fa62283d2f63ec50f85b9c22f8815daf348df5428ccb65"
-                            }
+                    DerivableBlockHashesV0
+                        { dbhv0TransactionOutcomesHash = read "0000000000000000000000000000000000000000000000000000000000000000",
+                          dbhv0BlockStateHash = read "dee89435dba1609a84fa62283d2f63ec50f85b9c22f8815daf348df5428ccb65"
+                        }
                 }
 
 testReceiveIncorrectStateHash :: Assertion

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Consensus/Blocks.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Consensus/Blocks.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- | This module tests block verification, processing, advancing round and baking.
 --  The below tests are intended to test the functionality exposed by the 'Concordium.KonsensusV1.Consensus.Blocks' module.
@@ -30,11 +32,13 @@ import Concordium.Types
 import Concordium.Types.BakerIdentity
 import qualified Concordium.Types.DummyData as Dummy
 import Concordium.Types.HashableTo
+import Concordium.Types.Parameters
 import Concordium.Types.SeedState
 import Concordium.Types.Transactions
 import qualified Concordium.Types.Transactions as Transactions
 
 import qualified Concordium.Genesis.Data.P6 as P6
+import qualified Concordium.Genesis.Data.P7 as P7
 import Concordium.GlobalState.BakerInfo
 import Concordium.GlobalState.Basic.BlockState.LFMBTree (hashAsLFMBT)
 import Concordium.GlobalState.BlockState (TransactionSummaryV1)
@@ -62,10 +66,13 @@ genTime = 0
 genEpochDuration :: Duration
 genEpochDuration = 3_600_000
 
-genesisData :: GenesisData 'P6
-bakers :: [(BakerIdentity, FullBakerInfo)]
-(genesisData, bakers, _) =
-    makeGenesisDataV1
+genesisDataV1 ::
+    forall pv.
+    (IsProtocolVersion pv, IsConsensusV1 pv) =>
+    SProtocolVersion pv ->
+    (GenesisData pv, [(BakerIdentity, FullBakerInfo)], Amount)
+genesisDataV1 sProtocolVersion =
+    makeGenesisDataV1 @pv
         genTime
         (maxBaker + 1)
         genEpochDuration
@@ -74,7 +81,7 @@ bakers :: [(BakerIdentity, FullBakerInfo)]
         Dummy.dummyArs
         [ foundationAcct
         ]
-        Dummy.dummyKeyCollection
+        (withIsAuthorizationsVersionForPV sProtocolVersion Dummy.dummyKeyCollection)
         Dummy.dummyChainParameters
   where
     foundationAcct =
@@ -82,6 +89,20 @@ bakers :: [(BakerIdentity, FullBakerInfo)]
             1_000_000_000_000
             foundationKeyPair
             foundationAccountAddress
+
+genesisData ::
+    forall pv.
+    (IsProtocolVersion pv, IsConsensusV1 pv) =>
+    SProtocolVersion pv ->
+    GenesisData pv
+genesisData sProtocolVersion = let (genData, _, _) = genesisDataV1 sProtocolVersion in genData
+
+bakers ::
+    forall pv.
+    (IsProtocolVersion pv, IsConsensusV1 pv) =>
+    SProtocolVersion pv ->
+    [(BakerIdentity, FullBakerInfo)]
+bakers sProtocolVersion = let (_, theBakers, _) = genesisDataV1 sProtocolVersion in theBakers
 
 -- | Key pair for the foundation account
 foundationKeyPair :: Sig.KeyPair
@@ -92,32 +113,34 @@ foundationAccountAddress :: AccountAddress
 foundationAccountAddress = Dummy.accountAddressFrom 0
 
 -- | Hash of the genesis block.
-genesisHash :: BlockHash
-genesisHash = genesisBlockHash genesisData
+genesisHash :: (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> BlockHash
+genesisHash sProtocolVersion = genesisBlockHash (genesisData sProtocolVersion)
 
 -- | Leadership election nonce at genesis
-genesisLEN :: LeadershipElectionNonce
-genesisLEN = genesisLeadershipElectionNonce $ P6.genesisInitialState $ unGDP6 genesisData
+genesisLEN :: (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> LeadershipElectionNonce
+genesisLEN sProtocolVersion = case sProtocolVersion of
+    SP6 -> genesisLeadershipElectionNonce $ P6.genesisInitialState $ unGDP6 $ genesisData sProtocolVersion
+    SP7 -> genesisLeadershipElectionNonce $ P7.genesisInitialState $ unGDP7 $ genesisData sProtocolVersion
 
 -- | Full bakers at genesis
-genesisFullBakers :: FullBakers
-genesisFullBakers = FullBakers{..}
+genesisFullBakers :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> FullBakers
+genesisFullBakers sProtocolVersion = FullBakers{..}
   where
-    fullBakerInfos = Vec.fromList $ snd <$> bakers
+    fullBakerInfos = Vec.fromList $ snd <$> bakers sProtocolVersion
     bakerTotalStake = sum $ _bakerStake <$> fullBakerInfos
 
 -- | Seed state at genesis
-genesisSeedState :: SeedState 'SeedStateVersion1
-genesisSeedState = initialSeedStateV1 genesisLEN (addDuration genTime genEpochDuration)
+genesisSeedState :: (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> SeedState 'SeedStateVersion1
+genesisSeedState sProtocolVersion = initialSeedStateV1 (genesisLEN sProtocolVersion) (addDuration genTime genEpochDuration)
 
-bakerKey :: (Integral a) => a -> BakerSignPrivateKey
-bakerKey i = bakerSignKey $ fst (bakers !! fromIntegral i)
+bakerKey :: forall a pv. (IsConsensusV1 pv, IsProtocolVersion pv, Integral a) => SProtocolVersion pv -> a -> BakerSignPrivateKey
+bakerKey sProtocolVersion i = bakerSignKey $ fst (bakers sProtocolVersion !! fromIntegral i)
 
-bakerVRFKey :: (Integral a) => a -> BakerElectionPrivateKey
-bakerVRFKey i = bakerElectionKey $ fst (bakers !! fromIntegral i)
+bakerVRFKey :: forall a pv. (IsConsensusV1 pv, IsProtocolVersion pv, Integral a) => SProtocolVersion pv -> a -> BakerElectionPrivateKey
+bakerVRFKey sProtocolVersion i = bakerElectionKey $ fst (bakers sProtocolVersion !! fromIntegral i)
 
-bakerAggKey :: (Integral a) => a -> BakerAggregationPrivateKey
-bakerAggKey i = bakerAggregationKey $ fst (bakers !! fromIntegral i)
+bakerAggKey :: forall a pv. (IsConsensusV1 pv, IsProtocolVersion pv, Integral a) => SProtocolVersion pv -> a -> BakerAggregationPrivateKey
+bakerAggKey sProtocolVersion i = bakerAggregationKey $ fst (bakers sProtocolVersion !! fromIntegral i)
 
 theFinalizers :: [Int]
 theFinalizers = [0 .. maxBaker]
@@ -126,7 +149,7 @@ theFinalizers = [0 .. maxBaker]
 allFinalizers :: FinalizerSet
 allFinalizers = finalizerSet $ FinalizerIndex <$> [0 .. maxBaker]
 
-validQCFor :: (IsProtocolVersion pv) => BakedBlock pv -> QuorumCertificate
+validQCFor :: forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => BakedBlock pv -> QuorumCertificate
 validQCFor bb =
     QuorumCertificate
         { qcSignatories = allFinalizers,
@@ -139,26 +162,43 @@ validQCFor bb =
     block = getHash bb
     qsm =
         QuorumSignatureMessage
-            { qsmGenesis = genesisHash,
+            { qsmGenesis = genesisHash (protocolVersion @pv),
               qsmBlock = block,
               qsmRound = bbRound bb,
               qsmEpoch = bbEpoch bb
             }
-    sig = fold [signQuorumSignatureMessage qsm (bakerAggKey i) | i <- theFinalizers]
+    sig = fold [signQuorumSignatureMessage qsm (bakerAggKey (protocolVersion @pv) i) | i <- theFinalizers]
 
-validSignBlock :: (IsProtocolVersion pv) => BakedBlock pv -> SignedBlock pv
-validSignBlock bb = signBlock (bakerKey (bbBaker bb)) genesisHash bb
+validSignBlock :: forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => BakedBlock pv -> SignedBlock pv
+validSignBlock bb =
+    let sProtocolVersion = protocolVersion @pv
+    in  signBlock (bakerKey sProtocolVersion (bbBaker bb)) (genesisHash sProtocolVersion) bb
 
-invalidSignBlock :: (IsProtocolVersion pv) => BakedBlock pv -> SignedBlock pv
-invalidSignBlock bb = signBlock (bakerKey (bbBaker bb)) (getHash bb) bb
+invalidSignBlock :: forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => BakedBlock pv -> SignedBlock pv
+invalidSignBlock bb =
+    let sProtocolVersion = protocolVersion @pv
+    in  signBlock (bakerKey sProtocolVersion (bbBaker bb)) (getHash bb) bb
 
 -- | Create a valid timeout message given a QC and a round.
 --  All finalizers sign the certificate and they all have the QC as their highest QC.
-validTimeoutFor :: QuorumCertificate -> Round -> TimeoutCertificate
-validTimeoutFor = validTimeoutForFinalizers theFinalizers
+validTimeoutFor ::
+    forall pv.
+    (IsProtocolVersion pv, IsConsensusV1 pv) =>
+    SProtocolVersion pv ->
+    QuorumCertificate ->
+    Round ->
+    TimeoutCertificate
+validTimeoutFor sProtocolVersion = validTimeoutForFinalizers sProtocolVersion theFinalizers
 
-validTimeoutForFinalizers :: [Int] -> QuorumCertificate -> Round -> TimeoutCertificate
-validTimeoutForFinalizers finalizers qc rnd =
+validTimeoutForFinalizers ::
+    forall pv.
+    (IsProtocolVersion pv, IsConsensusV1 pv) =>
+    SProtocolVersion pv ->
+    [Int] ->
+    QuorumCertificate ->
+    Round ->
+    TimeoutCertificate
+validTimeoutForFinalizers sProtocolVersion finalizers qc rnd =
     TimeoutCertificate
         { tcRound = rnd,
           tcMinEpoch = qcEpoch qc,
@@ -166,13 +206,13 @@ validTimeoutForFinalizers finalizers qc rnd =
           tcFinalizerQCRoundsSecondEpoch = FinalizerRounds Map.empty,
           tcAggregateSignature =
             fold
-                [signTimeoutSignatureMessage tsm (bakerAggKey i) | i <- finalizers]
+                [signTimeoutSignatureMessage tsm (bakerAggKey sProtocolVersion i) | i <- finalizers]
         }
   where
     finSet = finalizerSet $ FinalizerIndex . fromIntegral <$> finalizers
     tsm =
         TimeoutSignatureMessage
-            { tsmGenesis = genesisHash,
+            { tsmGenesis = genesisHash sProtocolVersion,
               tsmRound = rnd,
               tsmQCRound = qcRound qc,
               tsmQCEpoch = qcEpoch qc
@@ -181,11 +221,18 @@ validTimeoutForFinalizers finalizers qc rnd =
 -- | Produce properly-signed timeout message for the given QC, round and current epoch from each
 --  baker. (This assumes that all of the bakers are finalizers for the purposes of computing
 --  finalizer indexes.)
-timeoutMessagesFor :: QuorumCertificate -> Round -> Epoch -> [TimeoutMessage]
-timeoutMessagesFor qc curRound curEpoch = mkTm <$> bakers
+timeoutMessagesFor ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    QuorumCertificate ->
+    Round ->
+    Epoch ->
+    [TimeoutMessage]
+timeoutMessagesFor sProtocolVersion qc curRound curEpoch = mkTm <$> bakers sProtocolVersion
   where
     mkTm (BakerIdentity{..}, _) =
-        signTimeoutMessage (tmb bakerId bakerAggregationKey) genesisHash bakerSignKey
+        signTimeoutMessage (tmb bakerId bakerAggregationKey) (genesisHash sProtocolVersion) bakerSignKey
     tmb bid aggKey =
         TimeoutMessageBody
             { tmFinalizerIndex = FinalizerIndex (fromIntegral bid),
@@ -196,7 +243,7 @@ timeoutMessagesFor qc curRound curEpoch = mkTm <$> bakers
             }
     tsm =
         TimeoutSignatureMessage
-            { tsmGenesis = genesisHash,
+            { tsmGenesis = genesisHash sProtocolVersion,
               tsmRound = curRound,
               tsmQCRound = qcRound qc,
               tsmQCEpoch = qcEpoch qc
@@ -236,313 +283,439 @@ setStateHash newStateHash block = case bbDerivableHashes block of
             }
 
 -- | Valid block for round 1.
-testBB1 :: BakedBlock PV
+testBB1 :: forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => BakedBlock pv
 testBB1 =
     BakedBlock
         { bbRound = 1,
           bbEpoch = 0,
           bbTimestamp = 1_000,
           bbBaker = bakerId,
-          bbQuorumCertificate = genesisQuorumCertificate genesisHash,
+          bbQuorumCertificate = genesisQuorumCertificate (genesisHash sProtocolVersion),
           bbTimeoutCertificate = Absent,
           bbEpochFinalizationEntry = Absent,
-          bbNonce = computeBlockNonce genesisLEN 1 (bakerVRFKey bakerId),
+          bbNonce = computeBlockNonce (genesisLEN sProtocolVersion) 1 (bakerVRFKey sProtocolVersion bakerId),
           bbTransactions = Vec.empty,
-          bbDerivableHashes =
-            DBHashesV0 $
-                BlockDerivableHashesV0
-                    { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
-                      bdhv0BlockStateHash = read "dee89435dba1609a84fa62283d2f63ec50f85b9c22f8815daf348df5428ccb65"
-                    }
+          bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
+            SBlockHashVersion0 ->
+                DBHashesV0 $
+                    BlockDerivableHashesV0
+                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                          bdhv0BlockStateHash = read "dee89435dba1609a84fa62283d2f63ec50f85b9c22f8815daf348df5428ccb65"
+                        }
+            SBlockHashVersion1 ->
+                DBHashesV1 $
+                    BlockDerivableHashesV1
+                        { bdhv1BlockResultHash = read "39a83a5c78db450c757b9d8c11c6911b7de5a4d2a8ce964a16f7fc87ed697b69"
+                        }
         }
   where
     bakerId = 2
+    sProtocolVersion = protocolVersion @pv
 
 -- | Valid block for round 2, descended from 'testBB1'.
-testBB2 :: BakedBlock PV
+testBB2 :: forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => BakedBlock pv
 testBB2 =
     BakedBlock
         { bbRound = 2,
           bbEpoch = 0,
           bbTimestamp = 2_000,
           bbBaker = bakerId,
-          bbQuorumCertificate = validQCFor testBB1,
+          bbQuorumCertificate = validQCFor @pv testBB1,
           bbTimeoutCertificate = Absent,
           bbEpochFinalizationEntry = Absent,
-          bbNonce = computeBlockNonce genesisLEN 2 (bakerVRFKey bakerId),
+          bbNonce = computeBlockNonce (genesisLEN sProtocolVersion) 2 (bakerVRFKey sProtocolVersion bakerId),
           bbTransactions = Vec.empty,
-          bbDerivableHashes =
-            DBHashesV0 $
-                BlockDerivableHashesV0
-                    { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
-                      bdhv0BlockStateHash = read "d36974d10f1331559e396be5f8e31ecedc2042ebf941bc2fad6050e9e082f206"
-                    }
+          bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
+            SBlockHashVersion0 ->
+                DBHashesV0 $
+                    BlockDerivableHashesV0
+                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                          bdhv0BlockStateHash = read "d36974d10f1331559e396be5f8e31ecedc2042ebf941bc2fad6050e9e082f206"
+                        }
+            SBlockHashVersion1 ->
+                DBHashesV1 $
+                    BlockDerivableHashesV1
+                        { bdhv1BlockResultHash = read "2d988a0381670c7142ed81afe2b5745113d565e8de4b1656fcfafd27b0b22ecb"
+                        }
         }
   where
     bakerId = 4
+    sProtocolVersion = protocolVersion @pv
 
 -- | Valid block for round 3, descended from 'testBB2'.
-testBB3 :: BakedBlock PV
+testBB3 :: forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => BakedBlock pv
 testBB3 =
     BakedBlock
         { bbRound = 3,
           bbEpoch = 0,
           bbTimestamp = 3_000,
           bbBaker = bakerId,
-          bbQuorumCertificate = validQCFor testBB2,
+          bbQuorumCertificate = validQCFor @pv testBB2,
           bbTimeoutCertificate = Absent,
           bbEpochFinalizationEntry = Absent,
-          bbNonce = computeBlockNonce genesisLEN 3 (bakerVRFKey bakerId),
+          bbNonce = computeBlockNonce (genesisLEN sProtocolVersion) 3 (bakerVRFKey sProtocolVersion bakerId),
           bbTransactions = Vec.empty,
-          bbDerivableHashes =
-            DBHashesV0 $
-                BlockDerivableHashesV0
-                    { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
-                      bdhv0BlockStateHash = read "50998f735737ce13b35715a173efb7a3ad20cba597ba540985cd562a0b7bed74"
-                    }
+          bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
+            SBlockHashVersion0 ->
+                DBHashesV0 $
+                    BlockDerivableHashesV0
+                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                          bdhv0BlockStateHash = read "50998f735737ce13b35715a173efb7a3ad20cba597ba540985cd562a0b7bed74"
+                        }
+            SBlockHashVersion1 ->
+                DBHashesV1 $
+                    BlockDerivableHashesV1
+                        { bdhv1BlockResultHash = read "e3488977b88b8d2b9291f205145b8445deb5238af2526b6a3fd75f725dafef83"
+                        }
         }
   where
     bakerId = 4
+    sProtocolVersion = protocolVersion @pv
 
 -- | A valid block for round 2 where round 1 timed out.
-testBB2' :: BakedBlock PV
+testBB2' :: forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => BakedBlock pv
 testBB2' =
-    setStateHash
-        (read "20cd8fe8689b17850e73e8322b53398a49df5e4723eaa77acaf5474e94915c0b")
-        testBB2
-            { bbQuorumCertificate = genQC,
-              bbTimeoutCertificate = Present (validTimeoutFor genQC 1)
-            }
+    (testBB2 @pv)
+        { bbQuorumCertificate = genQC,
+          bbTimeoutCertificate = Present (validTimeoutFor sProtocolVersion genQC 1),
+          bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
+            SBlockHashVersion0 ->
+                DBHashesV0 $
+                    BlockDerivableHashesV0
+                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                          bdhv0BlockStateHash = read "20cd8fe8689b17850e73e8322b53398a49df5e4723eaa77acaf5474e94915c0b"
+                        }
+            SBlockHashVersion1 ->
+                DBHashesV1 $
+                    BlockDerivableHashesV1
+                        { bdhv1BlockResultHash = read "589c7ee85c2178f3ea9ba8be4bbd4e5946bb5b5ce757164c2dbe28551f354db5"
+                        }
+        }
   where
-    genQC = genesisQuorumCertificate genesisHash
+    bakerId :: BakerId
+    bakerId = 4
+    sProtocolVersion = protocolVersion @pv
+    genQC = genesisQuorumCertificate (genesisHash sProtocolVersion)
 
 -- | A valid block for round 3 descended from 'testBB2''.
-testBB3' :: BakedBlock PV
+testBB3' :: forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => BakedBlock pv
 testBB3' =
-    setStateHash
-        (read "784471f09f9678a2cf8208af45186f553406430b67e035ebf1b772e7c39fbd97")
-        testBB3
-            { bbQuorumCertificate = validQCFor testBB2'
-            }
+    (testBB3 @pv)
+        { bbQuorumCertificate = validQCFor @pv testBB2',
+          bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
+            SBlockHashVersion0 ->
+                DBHashesV0 $
+                    BlockDerivableHashesV0
+                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                          bdhv0BlockStateHash = read "784471f09f9678a2cf8208af45186f553406430b67e035ebf1b772e7c39fbd97"
+                        }
+            SBlockHashVersion1 ->
+                DBHashesV1 $
+                    BlockDerivableHashesV1
+                        { bdhv1BlockResultHash = read "51b39b40caa3b23e41e461177659cf0b6e24c98d0471fd59cf2de134645af87e"
+                        }
+        }
+  where
+    bakerId :: BakerId
+    bakerId = 4
+    sProtocolVersion = protocolVersion @pv
 
 -- | A valid block for round 4 descended from 'testBB3''.
-testBB4' :: BakedBlock PV
+testBB4' :: forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => BakedBlock pv
 testBB4' =
     BakedBlock
         { bbRound = 4,
           bbEpoch = 0,
           bbTimestamp = 4_000,
           bbBaker = bakerId,
-          bbQuorumCertificate = validQCFor testBB3',
+          bbQuorumCertificate = validQCFor @pv testBB3',
           bbTimeoutCertificate = Absent,
           bbEpochFinalizationEntry = Absent,
-          bbNonce = computeBlockNonce genesisLEN 4 (bakerVRFKey bakerId),
+          bbNonce = computeBlockNonce (genesisLEN sProtocolVersion) 4 (bakerVRFKey sProtocolVersion bakerId),
           bbTransactions = Vec.empty,
-          bbDerivableHashes =
-            DBHashesV0 $
-                BlockDerivableHashesV0
-                    { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
-                      bdhv0BlockStateHash = read "3bb5b307d7abc6fad2464455f604d63512fff93d7fdeb2aa08d5a8f2720340fe"
-                    }
+          bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
+            SBlockHashVersion0 ->
+                DBHashesV0 $
+                    BlockDerivableHashesV0
+                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                          bdhv0BlockStateHash = read "3bb5b307d7abc6fad2464455f604d63512fff93d7fdeb2aa08d5a8f2720340fe"
+                        }
+            SBlockHashVersion1 ->
+                DBHashesV1 $
+                    BlockDerivableHashesV1
+                        { bdhv1BlockResultHash = read "c061123ab66c29dfb5c44be1f3fa62eff91bf27d1a7947e190cab98ee39eb367"
+                        }
         }
   where
     bakerId = 3
+    sProtocolVersion = protocolVersion @pv
 
 -- | A valid block for round 3 descended from the genesis block with a timeout for round 2.
-testBB3'' :: BakedBlock PV
+testBB3'' :: forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => BakedBlock pv
 testBB3'' =
-    setStateHash
-        (read "2b81e5943112b9a9916e57980a4b17b5b3b329eba0402d14201bfe1c9551a16d")
-        testBB3
-            { bbQuorumCertificate = genQC,
-              bbTimeoutCertificate = Present (validTimeoutFor genQC 2)
-            }
+    (testBB3 @pv)
+        { bbQuorumCertificate = genQC,
+          bbTimeoutCertificate = Present (validTimeoutFor sProtocolVersion genQC 2),
+          bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
+            SBlockHashVersion0 ->
+                DBHashesV0 $
+                    BlockDerivableHashesV0
+                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                          bdhv0BlockStateHash = read "2b81e5943112b9a9916e57980a4b17b5b3b329eba0402d14201bfe1c9551a16d"
+                        }
+            SBlockHashVersion1 ->
+                DBHashesV1 $
+                    BlockDerivableHashesV1
+                        { bdhv1BlockResultHash = read "daa799010a8b4acb47fa97b876abed73621db292029360734d9c8978b5859e7b"
+                        }
+        }
   where
-    genQC = genesisQuorumCertificate genesisHash
+    sProtocolVersion = protocolVersion @pv
+    bakerId :: BakerId
+    bakerId = 4
+    genQC = genesisQuorumCertificate (genesisHash sProtocolVersion)
 
 -- | Valid block for round 1.
 --  This should be past the epoch transition trigger time.
-testBB1E :: BakedBlock PV
+testBB1E :: forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => BakedBlock pv
 testBB1E =
     BakedBlock
         { bbRound = 1,
           bbEpoch = 0,
           bbTimestamp = 3_600_000,
           bbBaker = bakerId,
-          bbQuorumCertificate = genesisQuorumCertificate genesisHash,
+          bbQuorumCertificate = genesisQuorumCertificate (genesisHash sProtocolVersion),
           bbTimeoutCertificate = Absent,
           bbEpochFinalizationEntry = Absent,
-          bbNonce = computeBlockNonce genesisLEN 1 (bakerVRFKey bakerId),
+          bbNonce = computeBlockNonce (genesisLEN sProtocolVersion) 1 (bakerVRFKey sProtocolVersion bakerId),
           bbTransactions = Vec.empty,
-          bbDerivableHashes =
-            DBHashesV0 $
-                BlockDerivableHashesV0
-                    { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
-                      bdhv0BlockStateHash = read "3ce2fe0d538434fa7677549a4acbdecea606bd47a61fa39735de1dc144c95eab"
-                    }
+          bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
+            SBlockHashVersion0 ->
+                DBHashesV0 $
+                    BlockDerivableHashesV0
+                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                          bdhv0BlockStateHash = read "3ce2fe0d538434fa7677549a4acbdecea606bd47a61fa39735de1dc144c95eab"
+                        }
+            SBlockHashVersion1 ->
+                DBHashesV1 $
+                    BlockDerivableHashesV1
+                        { bdhv1BlockResultHash = read "92c6d014d2d788845521445c299e85d16854f308397000fc64564ea7abe0e341"
+                        }
         }
   where
     bakerId = 2
+    sProtocolVersion = protocolVersion @pv
 
 -- | Valid block for round 2. Descends from 'testBB1E'.
-testBB2E :: BakedBlock PV
+testBB2E :: forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => BakedBlock pv
 testBB2E =
     BakedBlock
         { bbRound = 2,
           bbEpoch = 0,
           bbTimestamp = 3_601_000,
           bbBaker = bakerId,
-          bbQuorumCertificate = validQCFor testBB1E,
+          bbQuorumCertificate = validQCFor @pv testBB1E,
           bbTimeoutCertificate = Absent,
           bbEpochFinalizationEntry = Absent,
-          bbNonce = computeBlockNonce genesisLEN 2 (bakerVRFKey bakerId),
+          bbNonce = computeBlockNonce (genesisLEN sProtocolVersion) 2 (bakerVRFKey sProtocolVersion bakerId),
           bbTransactions = Vec.empty,
-          bbDerivableHashes =
-            DBHashesV0 $
-                BlockDerivableHashesV0
-                    { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
-                      bdhv0BlockStateHash = read "df5d25b8ffbad7be62be0ae2ce1a4730018062c3bda6d6caa02ea03545a263fd"
-                    }
+          bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
+            SBlockHashVersion0 ->
+                DBHashesV0 $
+                    BlockDerivableHashesV0
+                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                          bdhv0BlockStateHash = read "df5d25b8ffbad7be62be0ae2ce1a4730018062c3bda6d6caa02ea03545a263fd"
+                        }
+            SBlockHashVersion1 ->
+                DBHashesV1 $
+                    BlockDerivableHashesV1
+                        { bdhv1BlockResultHash = read "be9c7f10dc2e649bbdd89e6ad97f6b72b3fc83fa3292aa62e1db558b17b9f0af"
+                        }
         }
   where
     bakerId = 4
+    sProtocolVersion = protocolVersion @pv
 
 -- | A block that is valid for round 3, descending from 'testBB2E', but which should not be validated
 --  by a finalizer because it is in epoch 0. With the QC for 'testBB2E', a finalizer should move into
 --  epoch 1, and thus refuse to validate this block.
-testBB3EX :: BakedBlock PV
+testBB3EX :: forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => BakedBlock pv
 testBB3EX =
     BakedBlock
         { bbRound = 3,
           bbEpoch = 0,
           bbTimestamp = 3_602_000,
           bbBaker = bakerId,
-          bbQuorumCertificate = validQCFor testBB2E,
+          bbQuorumCertificate = validQCFor @pv testBB2E,
           bbTimeoutCertificate = Absent,
           bbEpochFinalizationEntry = Absent,
-          bbNonce = computeBlockNonce genesisLEN 3 (bakerVRFKey bakerId),
+          bbNonce = computeBlockNonce (genesisLEN sProtocolVersion) 3 (bakerVRFKey sProtocolVersion bakerId),
           bbTransactions = Vec.empty,
-          bbDerivableHashes =
-            DBHashesV0 $
-                BlockDerivableHashesV0
-                    { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
-                      bdhv0BlockStateHash = read "81e1b33e20088562fcb48c619ea16e800d7fba58995fa6487a6209cf448c7d08"
-                    }
+          bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
+            SBlockHashVersion0 ->
+                DBHashesV0 $
+                    BlockDerivableHashesV0
+                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                          bdhv0BlockStateHash = read "81e1b33e20088562fcb48c619ea16e800d7fba58995fa6487a6209cf448c7d08"
+                        }
+            SBlockHashVersion1 ->
+                DBHashesV1 $
+                    BlockDerivableHashesV1
+                        { bdhv1BlockResultHash = read "9aee22a152f71ef811c017729d3bf47fc5eb110bb2853fe0b66f57091b18351a"
+                        }
         }
   where
     bakerId = 4
+    sProtocolVersion = protocolVersion @pv
 
 -- | Epoch finalization entry based on QCs for 'testBB1E' and 'testBB2E'.
-testEpochFinEntry :: FinalizationEntry
-testEpochFinEntry =
+testEpochFinEntry :: forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => SProtocolVersion pv -> FinalizationEntry
+testEpochFinEntry _ =
     FinalizationEntry
-        { feFinalizedQuorumCertificate = validQCFor testBB1E,
-          feSuccessorQuorumCertificate = validQCFor testBB2E,
-          feSuccessorProof = getHash testBB2E
+        { feFinalizedQuorumCertificate = validQCFor @pv testBB1E,
+          feSuccessorQuorumCertificate = validQCFor @pv testBB2E,
+          feSuccessorProof = getHash (testBB2E @pv)
         }
 
 -- | Epoch leadership election nonce for epoch 1, assuming that block 'testBB1E' is finalized.
-testEpochLEN :: LeadershipElectionNonce
-testEpochLEN = nonceForNewEpoch genesisFullBakers $ upd testBB1E genesisSeedState
+testEpochLEN :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> LeadershipElectionNonce
+testEpochLEN sProtocolVersion =
+    nonceForNewEpoch (genesisFullBakers sProtocolVersion) $
+        upd (testBB1E @pv) (genesisSeedState sProtocolVersion)
   where
     upd b = updateSeedStateForBlock (bbTimestamp b) (bbNonce b) False
 
 -- | Valid block for round 3, epoch 1. Descends from 'testBB2E'. The finalization entry is
 --  'testEpochFinEntry'.
-testBB3E :: BakedBlock PV
+testBB3E :: forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => BakedBlock pv
 testBB3E =
     BakedBlock
         { bbRound = 3,
           bbEpoch = 1,
           bbTimestamp = 3_602_000,
           bbBaker = bakerId,
-          bbQuorumCertificate = validQCFor testBB2E,
+          bbQuorumCertificate = validQCFor @pv testBB2E,
           bbTimeoutCertificate = Absent,
-          bbEpochFinalizationEntry = Present testEpochFinEntry,
-          bbNonce = computeBlockNonce testEpochLEN 3 (bakerVRFKey bakerId),
+          bbEpochFinalizationEntry = Present (testEpochFinEntry sProtocolVersion),
+          bbNonce = computeBlockNonce (testEpochLEN sProtocolVersion) 3 (bakerVRFKey sProtocolVersion bakerId),
           bbTransactions = Vec.empty,
-          bbDerivableHashes =
-            DBHashesV0 $
-                BlockDerivableHashesV0
-                    { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
-                      bdhv0BlockStateHash = read "dc31a663a0bd166507e21cc641759018651c716b3571531672956abf24b0f4bc"
-                    }
+          bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
+            SBlockHashVersion0 ->
+                DBHashesV0 $
+                    BlockDerivableHashesV0
+                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                          bdhv0BlockStateHash = read "dc31a663a0bd166507e21cc641759018651c716b3571531672956abf24b0f4bc"
+                        }
+            SBlockHashVersion1 ->
+                DBHashesV1 $
+                    BlockDerivableHashesV1
+                        { bdhv1BlockResultHash = read "e95fc29d250c0fb4acb4e297ec0af49678442e9e2174c8ade12c0cc509995a9a"
+                        }
         }
   where
     bakerId = 5
+    sProtocolVersion = protocolVersion @pv
 
 -- | Invalid block for round 3, epoch 1. Descends from 'testBB1E', with finalization entry
 --  'testEpochFinEntry'. The block contains a valid timeout certificate for round 2.
 --  The block is not valid, because the highest round in the finalization entry is lower than the
 --  round of the parent block.
-testBB3E' :: BakedBlock PV
+testBB3E' :: forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => BakedBlock pv
 testBB3E' =
     testBB3E
-        { bbQuorumCertificate = validQCFor testBB1E,
-          bbTimeoutCertificate = Present (validTimeoutFor (validQCFor testBB1E) 2)
+        { bbQuorumCertificate = validQCFor @pv testBB1E,
+          bbTimeoutCertificate = Present (validTimeoutFor (protocolVersion @pv) (validQCFor @pv testBB1E) 2)
         }
 
 -- | Valid block for round 3, epoch 1. Descends from 'testBB3E'.
-testBB4E :: BakedBlock PV
+testBB4E :: forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => BakedBlock pv
 testBB4E =
     BakedBlock
         { bbRound = 4,
           bbEpoch = 1,
           bbTimestamp = 3_603_000,
           bbBaker = bakerId,
-          bbQuorumCertificate = validQCFor testBB3E,
+          bbQuorumCertificate = validQCFor @pv testBB3E,
           bbTimeoutCertificate = Absent,
           bbEpochFinalizationEntry = Absent,
-          bbNonce = computeBlockNonce testEpochLEN 4 (bakerVRFKey bakerId),
+          bbNonce = computeBlockNonce (testEpochLEN sProtocolVersion) 4 (bakerVRFKey sProtocolVersion bakerId),
           bbTransactions = Vec.empty,
-          bbDerivableHashes =
-            DBHashesV0 $
-                BlockDerivableHashesV0
-                    { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
-                      bdhv0BlockStateHash = read "daa799010a8b4acb47fa97b876abed73621db292029360734d9c8978b5859e7b"
-                    }
+          bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
+            SBlockHashVersion0 ->
+                DBHashesV0 $
+                    BlockDerivableHashesV0
+                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                          bdhv0BlockStateHash = read "daa799010a8b4acb47fa97b876abed73621db292029360734d9c8978b5859e7b"
+                        }
+            SBlockHashVersion1 ->
+                DBHashesV1 $
+                    BlockDerivableHashesV1
+                        { bdhv1BlockResultHash = read "6141bfe4eadcd557e42d4cc319a9855a26ea4ff37ecbb486d0244ad611bd4cba"
+                        }
         }
   where
     bakerId = 1
+    sProtocolVersion = protocolVersion @pv
 
 -- | Valid block for round 4 epoch 1. Descends from 'testBB2E', with finalization entry
 --  'testEpochFinEntry'. The block contains a valid timeout for round 3.
-testBB4E' :: BakedBlock PV
+testBB4E' :: forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => BakedBlock pv
 testBB4E' =
-    setStateHash
-        (read "41b44dd4db52dae4021a0d71fbec00a423ffc9892cf97bf6e506d722cdaaeb0d")
-        testBB4E
-            { bbQuorumCertificate = validQCFor testBB2E,
-              bbTimeoutCertificate = Present (validTimeoutFor (validQCFor testBB1E) 3),
-              bbEpochFinalizationEntry = Present testEpochFinEntry
-            }
+    (testBB4E @pv)
+        { bbQuorumCertificate = validQCFor @pv testBB2E,
+          bbTimeoutCertificate = Present (validTimeoutFor sProtocolVersion (validQCFor @pv testBB1E) 3),
+          bbEpochFinalizationEntry = Present (testEpochFinEntry sProtocolVersion),
+          bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
+            SBlockHashVersion0 ->
+                DBHashesV0 $
+                    BlockDerivableHashesV0
+                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                          bdhv0BlockStateHash = read "41b44dd4db52dae4021a0d71fbec00a423ffc9892cf97bf6e506d722cdaaeb0d"
+                        }
+            SBlockHashVersion1 ->
+                DBHashesV1 $
+                    BlockDerivableHashesV1
+                        { bdhv1BlockResultHash = read "a2a7356e06ff00522c4d821cd497a253ef12f09912cc96615927ac98a71ecea4"
+                        }
+        }
+  where
+    bakerId :: BakerId
+    bakerId = 1
+    sProtocolVersion = protocolVersion @pv
 
 -- | Valid block for round 5, epoch 1. Descends from 'testBB3E'. The timeout certificate for round
 --  4 spans epoch 0 and 1.
-testBB5E' :: BakedBlock PV
+testBB5E' :: forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => BakedBlock pv
 testBB5E' =
     BakedBlock
         { bbRound = rnd,
           bbEpoch = 1,
           bbTimestamp = 3_604_000,
           bbBaker = bakerId,
-          bbQuorumCertificate = validQCFor testBB3E,
+          bbQuorumCertificate = validQCFor @pv testBB3E,
           bbTimeoutCertificate = Present tc,
           bbEpochFinalizationEntry = Absent,
-          bbNonce = computeBlockNonce testEpochLEN rnd (bakerVRFKey bakerId),
+          bbNonce = computeBlockNonce (testEpochLEN sProtocolVersion) rnd (bakerVRFKey sProtocolVersion bakerId),
           bbTransactions = Vec.empty,
-          bbDerivableHashes =
-            DBHashesV0 $
-                BlockDerivableHashesV0
-                    { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
-                      bdhv0BlockStateHash = read "ff8cd1198e3926f743e91a97484d75f1109534aaf9655e1c8c9507d4d0ebd8b3"
-                    }
+          bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
+            SBlockHashVersion0 ->
+                DBHashesV0 $
+                    BlockDerivableHashesV0
+                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                          bdhv0BlockStateHash = read "ff8cd1198e3926f743e91a97484d75f1109534aaf9655e1c8c9507d4d0ebd8b3"
+                        }
+            SBlockHashVersion1 ->
+                DBHashesV1 $
+                    BlockDerivableHashesV1
+                        { bdhv1BlockResultHash = read "c7eaff2141ade9ac6d5fd8513678d9c7f42e5915f0be7b7b94e89a88c816a9e9"
+                        }
         }
   where
+    sProtocolVersion = protocolVersion @pv
     bakerId = 2
     rnd = 5
-    qc1 = validQCFor testBB2E
-    qc2 = validQCFor testBB3E
+    qc1 = validQCFor @pv testBB2E
+    qc2 = validQCFor @pv testBB3E
     tc =
         TimeoutCertificate
             { tcRound = rnd - 1,
@@ -551,12 +724,12 @@ testBB5E' =
               tcFinalizerQCRoundsSecondEpoch = FinalizerRounds (Map.singleton (qcRound qc2) (finalizerSet $ FinalizerIndex <$> finsB)),
               tcAggregateSignature =
                 fold $
-                    [signTimeoutSignatureMessage (tsm qc1) (bakerAggKey i) | i <- finsA]
-                        ++ [signTimeoutSignatureMessage (tsm qc2) (bakerAggKey i) | i <- finsB]
+                    [signTimeoutSignatureMessage (tsm qc1) (bakerAggKey sProtocolVersion i) | i <- finsA]
+                        ++ [signTimeoutSignatureMessage (tsm qc2) (bakerAggKey sProtocolVersion i) | i <- finsB]
             }
     tsm qc =
         TimeoutSignatureMessage
-            { tsmGenesis = genesisHash,
+            { tsmGenesis = genesisHash sProtocolVersion,
               tsmRound = rnd - 1,
               tsmQCRound = qcRound qc,
               tsmQCEpoch = qcEpoch qc
@@ -564,93 +737,146 @@ testBB5E' =
     finsA = take 3 [0 .. maxBaker]
     finsB = drop 3 [0 .. maxBaker]
 
-testBB2Ex :: BakedBlock PV
+testBB2Ex :: forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => BakedBlock pv
 testBB2Ex =
-    setStateHash
-        (read "df76421871484a877532dc9b748fcf248bd186898def8bd40fee0a3cf9636b92")
-        testBB2E
-            { bbQuorumCertificate = genQC,
-              bbTimeoutCertificate = Present (validTimeoutFor genQC 1)
-            }
+    (testBB2E @pv)
+        { bbQuorumCertificate = genQC,
+          bbTimeoutCertificate = Present (validTimeoutFor sProtocolVersion genQC 1),
+          bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
+            SBlockHashVersion0 ->
+                DBHashesV0 $
+                    BlockDerivableHashesV0
+                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                          bdhv0BlockStateHash = read "df76421871484a877532dc9b748fcf248bd186898def8bd40fee0a3cf9636b92"
+                        }
+            SBlockHashVersion1 ->
+                DBHashesV1 $
+                    BlockDerivableHashesV1
+                        { bdhv1BlockResultHash = read "cde603d206bd3f3ac1534efbb648d70d237f277c79e6923e91485df68e2d861f"
+                        }
+        }
   where
-    genQC = genesisQuorumCertificate genesisHash
+    sProtocolVersion = protocolVersion @pv
+    bakerId :: BakerId
+    bakerId = 4
+    genQC = genesisQuorumCertificate (genesisHash sProtocolVersion)
 
 -- | Epoch leadership election nonce for epoch 1, assuming that block 'testBB2Ex' is finalized.
-testEpochLENx :: LeadershipElectionNonce
-testEpochLENx = nonceForNewEpoch genesisFullBakers $ upd testBB2Ex genesisSeedState
+testEpochLENx ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    LeadershipElectionNonce
+testEpochLENx sProtocolVersion =
+    nonceForNewEpoch (genesisFullBakers sProtocolVersion) $
+        upd (testBB2Ex @pv) (genesisSeedState sProtocolVersion)
   where
     upd b = updateSeedStateForBlock (bbTimestamp b) (bbNonce b) False
 
-testBB3Ex :: BakedBlock PV
+testBB3Ex :: forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => BakedBlock pv
 testBB3Ex =
     BakedBlock
         { bbRound = 3,
           bbEpoch = 1,
           bbTimestamp = 3_602_000,
           bbBaker = bakerId,
-          bbQuorumCertificate = validQCFor testBB2Ex,
+          bbQuorumCertificate = validQCFor @pv testBB2Ex,
           bbTimeoutCertificate = Absent,
-          bbEpochFinalizationEntry = Present testEpochFinEntry,
-          bbNonce = computeBlockNonce testEpochLENx 3 (bakerVRFKey bakerId),
+          bbEpochFinalizationEntry = Present (testEpochFinEntry sProtocolVersion),
+          bbNonce =
+            computeBlockNonce
+                (testEpochLENx sProtocolVersion)
+                3
+                (bakerVRFKey sProtocolVersion bakerId),
           bbTransactions = Vec.empty,
-          bbDerivableHashes =
-            DBHashesV0 $
-                BlockDerivableHashesV0
-                    { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
-                      bdhv0BlockStateHash = read "dc31a663a0bd166507e21cc641759018651c716b3571531672956abf24b0f4bc"
-                    }
+          bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
+            SBlockHashVersion0 ->
+                DBHashesV0 $
+                    BlockDerivableHashesV0
+                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                          bdhv0BlockStateHash = read "dc31a663a0bd166507e21cc641759018651c716b3571531672956abf24b0f4bc"
+                        }
+            SBlockHashVersion1 ->
+                DBHashesV1 $
+                    BlockDerivableHashesV1
+                        { bdhv1BlockResultHash = read "593789121ba54a59eeaa06fce6b694072dde26f8aec6830717fbc7ea6d4eb4fa"
+                        }
         }
   where
+    sProtocolVersion = protocolVersion @pv
     bakerId = 2
 
 -- | Valid block in round 3 descended from 'testBB1E' with a timeout.
-testBB3EA :: BakedBlock PV
+testBB3EA :: forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => BakedBlock pv
 testBB3EA =
     BakedBlock
         { bbRound = 3,
           bbEpoch = 0,
           bbTimestamp = 3_603_000,
           bbBaker = bakerId,
-          bbQuorumCertificate = validQCFor testBB1E,
-          bbTimeoutCertificate = Present (validTimeoutFor (validQCFor testBB1E) 2),
+          bbQuorumCertificate = validQCFor @pv testBB1E,
+          bbTimeoutCertificate =
+            Present $
+                validTimeoutFor
+                    sProtocolVersion
+                    (validQCFor @pv testBB1E)
+                    2,
           bbEpochFinalizationEntry = Absent,
-          bbNonce = computeBlockNonce genesisLEN 3 (bakerVRFKey bakerId),
+          bbNonce = computeBlockNonce (genesisLEN sProtocolVersion) 3 (bakerVRFKey sProtocolVersion bakerId),
           bbTransactions = Vec.empty,
-          bbDerivableHashes =
-            DBHashesV0 $
-                BlockDerivableHashesV0
-                    { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
-                      bdhv0BlockStateHash = read "df5d25b8ffbad7be62be0ae2ce1a4730018062c3bda6d6caa02ea03545a263fd"
-                    }
+          bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
+            SBlockHashVersion0 ->
+                DBHashesV0 $
+                    BlockDerivableHashesV0
+                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                          bdhv0BlockStateHash = read "df5d25b8ffbad7be62be0ae2ce1a4730018062c3bda6d6caa02ea03545a263fd"
+                        }
+            SBlockHashVersion1 ->
+                DBHashesV1 $
+                    BlockDerivableHashesV1
+                        { bdhv1BlockResultHash = read "be9c7f10dc2e649bbdd89e6ad97f6b72b3fc83fa3292aa62e1db558b17b9f0af"
+                        }
         }
   where
+    sProtocolVersion = protocolVersion @pv
     bakerId = 4
 
 -- | Valid block in round 4, epoch 1, descended from 'testBB3EA', with a finalization proof based on
 --  'testBB2E'.
-testBB4EA :: BakedBlock PV
+testBB4EA :: forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => BakedBlock pv
 testBB4EA =
     BakedBlock
         { bbRound = 4,
           bbEpoch = 1,
           bbTimestamp = 3_604_000,
           bbBaker = bakerId,
-          bbQuorumCertificate = validQCFor testBB3EA,
+          bbQuorumCertificate = validQCFor @pv testBB3EA,
           bbTimeoutCertificate = Absent,
-          bbEpochFinalizationEntry = Present testEpochFinEntry,
-          bbNonce = computeBlockNonce testEpochLEN 4 (bakerVRFKey bakerId),
+          bbEpochFinalizationEntry = Present (testEpochFinEntry sProtocolVersion),
+          bbNonce =
+            computeBlockNonce
+                (testEpochLEN sProtocolVersion)
+                4
+                (bakerVRFKey sProtocolVersion bakerId),
           bbTransactions = Vec.empty,
-          bbDerivableHashes =
-            DBHashesV0 $
-                BlockDerivableHashesV0
-                    { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
-                      bdhv0BlockStateHash = read "41b44dd4db52dae4021a0d71fbec00a423ffc9892cf97bf6e506d722cdaaeb0d"
-                    }
+          bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
+            SBlockHashVersion0 ->
+                DBHashesV0 $
+                    BlockDerivableHashesV0
+                        { bdhv0TransactionOutcomesHash = emptyBlockTOH bakerId,
+                          bdhv0BlockStateHash = read "41b44dd4db52dae4021a0d71fbec00a423ffc9892cf97bf6e506d722cdaaeb0d"
+                        }
+            SBlockHashVersion1 ->
+                DBHashesV1 $
+                    BlockDerivableHashesV1
+                        { bdhv1BlockResultHash = read "a2a7356e06ff00522c4d821cd497a253ef12f09912cc96615927ac98a71ecea4"
+                        }
         }
   where
+    sProtocolVersion = protocolVersion @pv
     bakerId = 1
 
-succeedReceiveBlock :: PendingBlock 'P6 -> TestMonad 'P6 ()
+succeedReceiveBlock :: (IsProtocolVersion pv, IsConsensusV1 pv) => PendingBlock pv -> TestMonad pv ()
 succeedReceiveBlock pb = do
     res <- uponReceivingBlock pb
     case res of
@@ -669,7 +895,7 @@ succeedReceiveBlock pb = do
                 _ -> liftIO . assertFailure $ "Expected OnBlock event on executeBlock, but saw: " ++ show events
         _ -> liftIO . assertFailure $ "Expected BlockResultSuccess after uponReceivingBlock, but found: " ++ show res ++ "\n" ++ show pb
 
-duplicateReceiveBlock :: PendingBlock 'P6 -> TestMonad 'P6 ()
+duplicateReceiveBlock :: (IsProtocolVersion pv, IsConsensusV1 pv) => PendingBlock pv -> TestMonad pv ()
 duplicateReceiveBlock pb = do
     res <- uponReceivingBlock pb
     case res of
@@ -681,7 +907,10 @@ duplicateReceiveBlock pb = do
                 _ -> liftIO . assertFailure $ "Expected BlockAlive after executeBlock, but found: " ++ show status ++ "\n" ++ show pb
         _ -> liftIO . assertFailure $ "Expected BlockResultDoubleSign after uponReceivingBlock, but found: " ++ show res ++ "\n" ++ show pb
 
-succeedReceiveBlockFailExecute :: PendingBlock 'P6 -> TestMonad 'P6 ()
+succeedReceiveBlockFailExecute ::
+    (IsProtocolVersion pv, IsConsensusV1 pv) =>
+    PendingBlock pv ->
+    TestMonad pv ()
 succeedReceiveBlockFailExecute pb = do
     res <- uponReceivingBlock pb
     case res of
@@ -691,10 +920,23 @@ succeedReceiveBlockFailExecute pb = do
             case status of
                 BlockUnknown -> return ()
                 BlockDead -> return ()
-                _ -> liftIO . assertFailure $ "Expected BlockUnknown or BlockDead after executeBlock, but found: " ++ show status ++ "\n" ++ show pb
-        _ -> liftIO . assertFailure $ "Expected BlockResultSuccess after uponReceivingBlock, but found: " ++ show res ++ "\n" ++ show pb
+                _ ->
+                    liftIO . assertFailure $
+                        "Expected BlockUnknown or BlockDead after executeBlock, but found: "
+                            ++ show status
+                            ++ "\n"
+                            ++ show pb
+        _ ->
+            liftIO . assertFailure $
+                "Expected BlockResultSuccess after uponReceivingBlock, but found: "
+                    ++ show res
+                    ++ "\n"
+                    ++ show pb
 
-duplicateReceiveBlockFailExecute :: PendingBlock 'P6 -> TestMonad 'P6 ()
+duplicateReceiveBlockFailExecute ::
+    (IsProtocolVersion pv, IsConsensusV1 pv) =>
+    PendingBlock pv ->
+    TestMonad pv ()
 duplicateReceiveBlockFailExecute pb = do
     res <- uponReceivingBlock pb
     case res of
@@ -704,32 +946,44 @@ duplicateReceiveBlockFailExecute pb = do
             case status of
                 BlockUnknown -> return ()
                 BlockDead -> return ()
-                _ -> liftIO . assertFailure $ "Expected BlockUnknown or BlockDead after executeBlock, but found: " ++ show status ++ "\n" ++ show pb
-        _ -> liftIO . assertFailure $ "Expected BlockResultDoubleSign after uponReceivingBlock, but found: " ++ show res ++ "\n" ++ show pb
+                _ ->
+                    liftIO . assertFailure $
+                        "Expected BlockUnknown or BlockDead after executeBlock, but found: "
+                            ++ show status
+                            ++ "\n"
+                            ++ show pb
+        _ ->
+            liftIO . assertFailure $
+                "Expected BlockResultDoubleSign after uponReceivingBlock, but found: "
+                    ++ show res
+                    ++ "\n"
+                    ++ show pb
 
-pendingReceiveBlock :: PendingBlock 'P6 -> TestMonad 'P6 ()
+pendingReceiveBlock :: (IsProtocolVersion pv, IsConsensusV1 pv) => PendingBlock pv -> TestMonad pv ()
 pendingReceiveBlock pb = do
     res <- uponReceivingBlock pb
     case res of
         BlockResultPending -> return ()
-        _ -> liftIO . assertFailure $ "Expected BlockResultPending after uponReceivingBlock, but found: " ++ show res
+        _ ->
+            liftIO . assertFailure $
+                "Expected BlockResultPending after uponReceivingBlock, but found: " ++ show res
 
-staleReceiveBlock :: PendingBlock 'P6 -> TestMonad 'P6 ()
+staleReceiveBlock :: (IsProtocolVersion pv, IsConsensusV1 pv) => PendingBlock pv -> TestMonad pv ()
 staleReceiveBlock sb = do
     res <- uponReceivingBlock sb
     liftIO $ res `shouldBe` BlockResultStale
 
-invalidReceiveBlock :: PendingBlock 'P6 -> TestMonad 'P6 ()
+invalidReceiveBlock :: (IsProtocolVersion pv, IsConsensusV1 pv) => PendingBlock pv -> TestMonad pv ()
 invalidReceiveBlock sb = do
     res <- uponReceivingBlock sb
     liftIO $ res `shouldBe` BlockResultInvalid
 
-earlyReceiveBlock :: PendingBlock 'P6 -> TestMonad 'P6 ()
+earlyReceiveBlock :: (IsProtocolVersion pv, IsConsensusV1 pv) => PendingBlock pv -> TestMonad pv ()
 earlyReceiveBlock sb = do
     res <- uponReceivingBlock sb
     liftIO $ res `shouldBe` BlockResultEarly
 
-checkLive :: (HashableTo BlockHash b) => b -> TestMonad 'P6 ()
+checkLive :: (IsProtocolVersion pv, IsConsensusV1 pv, HashableTo BlockHash b) => b -> TestMonad pv ()
 checkLive b =
     get >>= getBlockStatus bh >>= \case
         BlockAlive _ -> return ()
@@ -742,7 +996,7 @@ checkLive b =
   where
     bh = getHash b
 
-checkFinalized :: (HashableTo BlockHash b) => b -> TestMonad 'P6 ()
+checkFinalized :: (HashableTo BlockHash b, IsProtocolVersion pv) => b -> TestMonad pv ()
 checkFinalized b =
     get >>= getBlockStatus bh >>= \case
         BlockFinalized _ -> return ()
@@ -755,7 +1009,7 @@ checkFinalized b =
   where
     bh = getHash b
 
-checkDead :: (HashableTo BlockHash b) => b -> TestMonad 'P6 ()
+checkDead :: (IsProtocolVersion pv, HashableTo BlockHash b) => b -> TestMonad pv ()
 checkDead b =
     get >>= getBlockStatus bh >>= \case
         BlockDead -> return ()
@@ -768,7 +1022,7 @@ checkDead b =
   where
     bh = getHash b
 
-signedPB :: (IsProtocolVersion pv) => BakedBlock pv -> PendingBlock pv
+signedPB :: forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => BakedBlock pv -> PendingBlock pv
 signedPB bb =
     PendingBlock
         { pbReceiveTime = timestampToUTCTime $ bbTimestamp bb,
@@ -780,300 +1034,497 @@ noBaker :: BakerContext
 noBaker = BakerContext Nothing
 
 -- | Baker context with baker @i@.
-baker :: Int -> BakerContext
-baker i = BakerContext $ Just $ fst $ bakers !! i
+baker :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> Int -> BakerContext
+baker sProtocolVersion i = BakerContext $ Just $ fst $ bakers sProtocolVersion !! i
 
 -- | Current time used for running (some) tests. 5 seconds after genesis.
 testTime :: UTCTime
 testTime = timestampToUTCTime 5_000
 
 -- | Receive 3 valid blocks in consecutive rounds.
-testReceive3 :: Assertion
-testReceive3 = runTestMonad noBaker testTime genesisData $ do
-    let b1 = signedPB testBB1
-    succeedReceiveBlock b1
-    let b2 = signedPB testBB2
-    succeedReceiveBlock b2
-    let b3 = signedPB testBB3
-    succeedReceiveBlock b3
-    -- b3's QC is for b2, which has QC for b1, so b1 should now be finalized.
-    checkFinalized b1
+testReceive3 :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> String -> Spec
+testReceive3 sProtocolVersion pvString =
+    it (pvString ++ ": receive 3 consecutive blocks") $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            let b1 = signedPB testBB1
+            succeedReceiveBlock b1
+            let b2 = signedPB testBB2
+            succeedReceiveBlock b2
+            let b3 = signedPB testBB3
+            succeedReceiveBlock b3
+            -- b3's QC is for b2, which has QC for b1, so b1 should now be finalized.
+            checkFinalized b1
 
 -- | Receive 3 valid blocks in consecutive rounds, but with the block for round 2 being received first.
-testReceive3Reordered :: Assertion
-testReceive3Reordered = runTestMonad noBaker testTime genesisData $ do
-    let b2 = signedPB testBB2
-    pendingReceiveBlock b2
-    let b1 = signedPB testBB1
-    succeedReceiveBlock b1
-    let b3 = signedPB testBB3
-    pendingReceiveBlock b3
-    succeedReceiveBlock b2
-    succeedReceiveBlock b3
-    -- b3's QC is for b2, which has QC for b1, so b1 should now be finalized.
-    checkFinalized b1
+testReceive3Reordered :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> String -> Spec
+testReceive3Reordered sProtocolVersion pvString =
+    it (pvString ++ ": receive 3 blocks reordered") $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            let b2 = signedPB testBB2
+            pendingReceiveBlock b2
+            let b1 = signedPB testBB1
+            succeedReceiveBlock b1
+            let b3 = signedPB testBB3
+            pendingReceiveBlock b3
+            succeedReceiveBlock b2
+            succeedReceiveBlock b3
+            -- b3's QC is for b2, which has QC for b1, so b1 should now be finalized.
+            checkFinalized b1
 
 -- | Receive 4 valid blocks reordered across epochs.
-testReceive4Reordered :: Assertion
-testReceive4Reordered = runTestMonad noBaker testTime genesisData $ do
-    -- We get block 4, but we don't know the parent (BB3E)
-    pendingReceiveBlock (signedPB testBB4E)
-    -- so we "catch up" and get BB1E
-    succeedReceiveBlock (signedPB testBB1E)
-    -- Now we see block 3, but we don't know the parent (BB2E)
-    pendingReceiveBlock (signedPB testBB3E)
-    -- so we "catch up" again and get BB2E
-    succeedReceiveBlock (signedPB testBB2E)
-    -- We get the rest via catch-up
-    succeedReceiveBlock (signedPB testBB3E)
-    succeedReceiveBlock (signedPB testBB4E)
-    checkFinalized testBB1E
-    -- Note: testBB2E is not finalized because it is in a different epoch from testBB3E.
-    checkLive testBB2E
-    checkLive testBB3E
-    checkLive testBB4E
+testReceive4Reordered :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> String -> Spec
+testReceive4Reordered sProtocolVersion pvString =
+    it (pvString ++ ": receive 4 blocks reordered, multiple epochs") $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            -- We get block 4, but we don't know the parent (BB3E)
+            pendingReceiveBlock (signedPB testBB4E)
+            -- so we "catch up" and get BB1E
+            succeedReceiveBlock (signedPB testBB1E)
+            -- Now we see block 3, but we don't know the parent (BB2E)
+            pendingReceiveBlock (signedPB testBB3E)
+            -- so we "catch up" again and get BB2E
+            succeedReceiveBlock (signedPB testBB2E)
+            -- We get the rest via catch-up
+            succeedReceiveBlock (signedPB testBB3E)
+            succeedReceiveBlock (signedPB testBB4E)
+            checkFinalized (testBB1E @pv)
+            -- Note: testBB2E is not finalized because it is in a different epoch from testBB3E.
+            checkLive (testBB2E @pv)
+            checkLive (testBB3E @pv)
+            checkLive (testBB4E @pv)
 
 -- | Receive 3 blocks where the first round is skipped due to timeout.
-testReceiveWithTimeout :: Assertion
-testReceiveWithTimeout = runTestMonad noBaker testTime genesisData $ do
-    let b2' = signedPB testBB2'
-    succeedReceiveBlock b2'
-    succeedReceiveBlock $ signedPB testBB3'
-    succeedReceiveBlock $ signedPB testBB4'
-    checkFinalized b2'
+testReceiveWithTimeout :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> String -> Spec
+testReceiveWithTimeout sProtocolVersion pvString =
+    it (pvString ++ ": skip round 1, receive rounds 2,3,4") $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            let b2' = signedPB testBB2'
+            succeedReceiveBlock b2'
+            succeedReceiveBlock $ signedPB testBB3'
+            succeedReceiveBlock $ signedPB testBB4'
+            checkFinalized b2'
 
 -- | Receive a block twice.
-testReceiveDuplicate :: Assertion
-testReceiveDuplicate = runTestMonad noBaker testTime genesisData $ do
-    succeedReceiveBlock $ signedPB testBB1
-    res <- uponReceivingBlock $ signedPB testBB1
-    liftIO $ res `shouldBe` BlockResultDuplicate
+testReceiveDuplicate :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> String -> Spec
+testReceiveDuplicate sProtocolVersion pvString =
+    it (pvString ++ ": receive duplicate block") $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            succeedReceiveBlock $ signedPB testBB1
+            res <- uponReceivingBlock $ signedPB testBB1
+            liftIO $ res `shouldBe` BlockResultDuplicate
 
 -- | Receive an invalid block twice.
-testReceiveInvalidDuplicate :: Assertion
-testReceiveInvalidDuplicate = runTestMonad noBaker testTime genesisData $ do
-    let badBlock = signedPB (setStateHash (StateHashV0 minBound) testBB1)
-    succeedReceiveBlockFailExecute badBlock
-    res <- uponReceivingBlock $ badBlock
-    liftIO $ res `shouldBe` BlockResultDuplicate
+testReceiveInvalidDuplicate :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> String -> Spec
+testReceiveInvalidDuplicate sProtocolVersion pvString =
+    it (pvString ++ ": receive invalid duplicate block") $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            let badBlock = signedPB badBakedBlock
+            succeedReceiveBlockFailExecute badBlock
+            res <- uponReceivingBlock badBlock
+            liftIO $ res `shouldBe` BlockResultDuplicate
+  where
+    badBakedBlock =
+        (testBB1 @pv)
+            { bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
+                SBlockHashVersion0 ->
+                    DBHashesV0 $
+                        BlockDerivableHashesV0
+                            { bdhv0TransactionOutcomesHash = emptyBlockTOH 2,
+                              bdhv0BlockStateHash = StateHashV0 minBound
+                            }
+                SBlockHashVersion1 ->
+                    DBHashesV1 $
+                        BlockDerivableHashesV1
+                            { bdhv1BlockResultHash = BlockResultHash minBound
+                            }
+            }
 
-testReceiveStale :: Assertion
-testReceiveStale = runTestMonad noBaker testTime genesisData $ do
-    mapM_ (succeedReceiveBlock . signedPB) [testBB2', testBB3', testBB4']
-    res <- uponReceivingBlock (signedPB testBB1)
-    liftIO $ res `shouldBe` BlockResultStale
+testReceiveStale ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testReceiveStale sProtocolVersion pvString =
+    it (pvString ++ ": receive stale round") $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            mapM_ (succeedReceiveBlock . signedPB) [testBB2', testBB3', testBB4']
+            res <- uponReceivingBlock (signedPB testBB1)
+            liftIO $ res `shouldBe` BlockResultStale
 
-testReceiveEpoch :: Assertion
-testReceiveEpoch = runTestMonad noBaker testTime genesisData $ do
-    mapM_ (succeedReceiveBlock . signedPB) [testBB1E, testBB2E, testBB3E, testBB4E]
+testReceiveEpoch ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testReceiveEpoch sProtocolVersion pvString =
+    it (pvString ++ ": epoch transition") $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            mapM_ (succeedReceiveBlock . signedPB) [testBB1E, testBB2E, testBB3E, testBB4E]
 
 -- | Test that blocks are correctly marked dead when a block gets finalized.
 --  Test that blocks arriving on dead branches are handled as stale.
-testReceiveBlockDies :: Assertion
-testReceiveBlockDies = runTestMonad noBaker testTime genesisData $ do
-    -- Receive blocks testBB1, testBB2', testBB2 and testBB3.
-    mapM_ (succeedReceiveBlock . signedPB) [testBB1, testBB2']
-    -- (testBB2 and testBB2' are both in round 2, so the second is handled as a duplicate)
-    duplicateReceiveBlock $ signedPB testBB2
-    succeedReceiveBlock $ signedPB testBB3
-    -- Receiving testBB3 finalizes testBB1, so testBB2' should now be dead
-    checkDead testBB2'
-    -- Check that blocks descending from a dead block (testBB3') and an old finalized block
-    -- (testBB3'') fail.
-    mapM_ (staleReceiveBlock . signedPB) [testBB3', testBB3'']
+testReceiveBlockDies ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testReceiveBlockDies sProtocolVersion pvString =
+    it (pvString ++ ": block dies on old branch") $
+        runTestMonad @pv noBaker testTime (genesisData sProtocolVersion) $ do
+            -- Receive blocks testBB1, testBB2', testBB2 and testBB3.
+            mapM_ (succeedReceiveBlock . signedPB) [testBB1, testBB2']
+            -- (testBB2 and testBB2' are both in round 2, so the second is handled as a duplicate)
+            duplicateReceiveBlock $ signedPB testBB2
+            succeedReceiveBlock $ signedPB testBB3
+            -- Receiving testBB3 finalizes testBB1, so testBB2' should now be dead
+            checkDead (testBB2' @pv)
+            -- Check that blocks descending from a dead block (testBB3') and an old finalized block
+            -- (testBB3'') fail.
+            mapM_ (staleReceiveBlock . signedPB) [testBB3', testBB3'']
 
 -- | Test receiving a block from future epochs.
-testReceiveBadFutureEpoch :: Assertion
-testReceiveBadFutureEpoch = runTestMonad noBaker testTime genesisData $ do
-    invalidReceiveBlock $ signedPB (testBB1{bbEpoch = 500})
-    invalidReceiveBlock $ signedPB (testBB1{bbEpoch = 2})
+testReceiveBadFutureEpoch ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testReceiveBadFutureEpoch sProtocolVersion pvString =
+    it (pvString ++ ": receive a block in a bad future epoch") $
+        runTestMonad @pv noBaker testTime (genesisData sProtocolVersion) $ do
+            invalidReceiveBlock $ signedPB (testBB1{bbEpoch = 500})
+            invalidReceiveBlock $ signedPB (testBB1{bbEpoch = 2})
 
 -- | Test receiving a block from a past epoch.
-testReceiveBadPastEpoch :: Assertion
-testReceiveBadPastEpoch = runTestMonad noBaker testTime genesisData $ do
-    mapM_ (succeedReceiveBlock . signedPB) [testBB1E, testBB2E, testBB3E]
-    invalidReceiveBlock $ signedPB testBB4'{bbQuorumCertificate = bbQuorumCertificate testBB4E}
+testReceiveBadPastEpoch ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testReceiveBadPastEpoch sProtocolVersion pvString =
+    it (pvString ++ ": receive a block in a bad past epoch") $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            mapM_ (succeedReceiveBlock . signedPB) [testBB1E, testBB2E, testBB3E]
+            invalidReceiveBlock $ signedPB testBB4'{bbQuorumCertificate = bbQuorumCertificate (testBB4E @pv)}
 
 -- | Test receiving a block from future epochs.
-testReceiveBadEpochTransition :: Assertion
-testReceiveBadEpochTransition = runTestMonad noBaker testTime genesisData $ do
-    invalidReceiveBlock $ signedPB (testBB1{bbEpoch = 1})
+testReceiveBadEpochTransition ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testReceiveBadEpochTransition sProtocolVersion pvString =
+    it (pvString ++ ": receive a block in the next epoch where the transition is not allowed") $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            invalidReceiveBlock $ signedPB (testBB1{bbEpoch = 1})
 
 -- | Test receiving a block with an incorrect signature, followed by the same block with the
 --  correct signature.
-testReceiveBadSignature :: Assertion
-testReceiveBadSignature = runTestMonad noBaker testTime genesisData $ do
-    invalidReceiveBlock $
-        PendingBlock
-            { pbBlock = invalidSignBlock testBB1,
-              pbReceiveTime = testTime
-            }
-    -- Receiving the same block with the correct signature should still succeed afterwards.
-    succeedReceiveBlock $ signedPB testBB1
+testReceiveBadSignature ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testReceiveBadSignature sProtocolVersion pvString =
+    it (pvString ++ ": receive a block with a bad signature") $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            invalidReceiveBlock $
+                PendingBlock
+                    { pbBlock = invalidSignBlock testBB1,
+                      pbReceiveTime = testTime
+                    }
+            -- Receiving the same block with the correct signature should still succeed afterwards.
+            succeedReceiveBlock $ signedPB testBB1
 
 -- | Test receiving a block baked by the wrong baker.
-testReceiveWrongBaker :: Assertion
-testReceiveWrongBaker = runTestMonad noBaker testTime genesisData $ do
-    let claimedBakerId = 0
-    invalidReceiveBlock $
-        signedPB
-            testBB1
-                { bbBaker = claimedBakerId,
-                  bbNonce = computeBlockNonce genesisLEN 1 (bakerVRFKey claimedBakerId)
-                }
+testReceiveWrongBaker ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testReceiveWrongBaker sProtocolVersion pvString =
+    it (pvString ++ ": receive a block from a baker that did not win the round") $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            let claimedBakerId = 0
+            invalidReceiveBlock $
+                signedPB
+                    testBB1
+                        { bbBaker = claimedBakerId,
+                          bbNonce =
+                            computeBlockNonce
+                                (genesisLEN sProtocolVersion)
+                                1
+                                (bakerVRFKey sProtocolVersion claimedBakerId)
+                        }
 
 -- | Test receiving an (out-of-order) block from the far future.
-testReceiveEarlyUnknownParent :: Assertion
-testReceiveEarlyUnknownParent = runTestMonad noBaker testTime genesisData $ do
-    res <- uponReceivingBlock $ (signedPB testBB2E){pbReceiveTime = testTime}
-    liftIO $ res `shouldBe` BlockResultEarly
+testReceiveEarlyUnknownParent ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testReceiveEarlyUnknownParent sProtocolVersion pvString =
+    it (pvString ++ ": receive a block from the future with an unknown parent") $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            res <- uponReceivingBlock $ (signedPB testBB2E){pbReceiveTime = testTime}
+            liftIO $ res `shouldBe` BlockResultEarly
 
 -- | Test receiving a block with an unknown parent and incorrect signature, followed by the parent
 --  block and the same block with the correct signature.
-testReceiveBadSignatureUnknownParent :: Assertion
-testReceiveBadSignatureUnknownParent = runTestMonad noBaker testTime genesisData $ do
-    pendingReceiveBlock $
-        PendingBlock
-            { pbBlock = invalidSignBlock testBB2,
-              pbReceiveTime = testTime
-            }
-    -- Receiving the same block with the correct signature should still succeed afterwards.
-    mapM_ (succeedReceiveBlock . signedPB) [testBB1, testBB2]
+testReceiveBadSignatureUnknownParent ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testReceiveBadSignatureUnknownParent sProtocolVersion pvString =
+    it (pvString ++ ": receive a block with a bad signature and unknown parent") $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            pendingReceiveBlock $
+                PendingBlock
+                    { pbBlock = invalidSignBlock testBB2,
+                      pbReceiveTime = testTime
+                    }
+            -- Receiving the same block with the correct signature should still succeed afterwards.
+            mapM_ (succeedReceiveBlock . signedPB) [testBB1, testBB2]
 
 -- | Test receiving a block with an unknown parent from a far distant epoch. (But the timestamp
 --  is still in the present.)
-testReceiveFutureEpochUnknownParent :: Assertion
-testReceiveFutureEpochUnknownParent = runTestMonad noBaker testTime genesisData $ do
-    pendingReceiveBlock $ signedPB testBB2{bbEpoch = 30}
+testReceiveFutureEpochUnknownParent ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testReceiveFutureEpochUnknownParent sProtocolVersion pvString =
+    it (pvString ++ ": receive a block with an unknown parent and epoch") $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            pendingReceiveBlock $ signedPB testBB2{bbEpoch = 30}
 
 -- | Test receiving a block where the QC is not consistent with the round of the parent block.
-testReceiveInconsistentQCRound :: Assertion
-testReceiveInconsistentQCRound = runTestMonad noBaker testTime genesisData $ do
-    succeedReceiveBlock $ signedPB testBB1
-    succeedReceiveBlockFailExecute $
-        signedPB
-            testBB2
-                { bbQuorumCertificate = (bbQuorumCertificate testBB2){qcRound = 0}
-                }
+testReceiveInconsistentQCRound ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testReceiveInconsistentQCRound sProtocolVersion pvString =
+    it (pvString ++ ": receive a block with QC round inconsistent with the parent block") $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            succeedReceiveBlock $ signedPB testBB1
+            succeedReceiveBlockFailExecute $
+                signedPB
+                    testBB2
+                        { bbQuorumCertificate = (bbQuorumCertificate (testBB2 @pv)){qcRound = 0}
+                        }
 
 -- | Test receiving a block where the QC is not consistent with the epoch of the parent block.
-testReceiveInconsistentQCEpoch :: Assertion
-testReceiveInconsistentQCEpoch = runTestMonad noBaker testTime genesisData $ do
-    succeedReceiveBlock $ signedPB testBB1
-    succeedReceiveBlockFailExecute $
-        signedPB
-            testBB2{bbQuorumCertificate = (bbQuorumCertificate testBB2){qcEpoch = 1}}
+testReceiveInconsistentQCEpoch ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testReceiveInconsistentQCEpoch sProtocolVersion pvString =
+    it (pvString ++ ": receive a block with QC epoch inconsistent with the parent block") $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            succeedReceiveBlock $ signedPB testBB1
+            succeedReceiveBlockFailExecute $
+                signedPB
+                    testBB2{bbQuorumCertificate = (bbQuorumCertificate (testBB2 @pv)){qcEpoch = 1}}
 
 -- | Test receiving a block where the round is earlier than or equal to the round of the parent
 --  block.
-testReceiveRoundInconsistent :: Assertion
-testReceiveRoundInconsistent = runTestMonad noBaker testTime genesisData $ do
-    succeedReceiveBlock $ signedPB testBB2'
-    -- Earlier round
-    succeedReceiveBlockFailExecute $
-        signedPB
-            testBB1{bbQuorumCertificate = validQCFor testBB2'}
-    -- Equal round
-    duplicateReceiveBlockFailExecute $ signedPB testBB2{bbQuorumCertificate = validQCFor testBB2'}
+testReceiveRoundInconsistent ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testReceiveRoundInconsistent sProtocolVersion pvString =
+    it (pvString ++ ": receive a block with round before parent block round") $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            succeedReceiveBlock $ signedPB testBB2'
+            -- Earlier round
+            succeedReceiveBlockFailExecute $
+                signedPB
+                    testBB1{bbQuorumCertificate = validQCFor @pv testBB2'}
+            -- Equal round
+            duplicateReceiveBlockFailExecute $ signedPB testBB2{bbQuorumCertificate = validQCFor @pv testBB2'}
 
 -- | Test processing a block where the epoch is inconsistent with the parent block's epoch.
-testProcessEpochInconsistent :: Assertion
-testProcessEpochInconsistent = runTestMonad noBaker testTime genesisData $ do
-    mapM_ (succeedReceiveBlock . signedPB) [testBB1E, testBB2E, testBB3E]
-    -- We skip 'uponReceivingBlock' and go straight to processing, because the condition would be
-    -- caught in 'uponReceivingBlock'.
-    let pb = signedPB testBB4'{bbQuorumCertificate = bbQuorumCertificate testBB4E}
-    bf <- use $ epochBakers . currentEpochBakers
-    executeBlock $
-        VerifiedBlock
-            { vbBlock = pb,
-              vbBakersAndFinalizers = bf,
-              vbBakerInfo = fromJust $ fullBaker genesisFullBakers (blockBaker pb),
-              vbLeadershipElectionNonce = genesisLEN
-            }
-    status <- getBlockStatus (getHash pb) =<< get
-    case status of
-        BlockUnknown -> return ()
-        BlockDead -> return ()
-        _ -> liftIO . assertFailure $ "Expected BlockUnknown or BlockDead after executeBlock, but found: " ++ show status ++ "\n" ++ show pb
+testProcessEpochInconsistent ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testProcessEpochInconsistent sProtocolVersion pvString =
+    it (pvString ++ ": process a block with epoch before parent block epoch") $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            mapM_ (succeedReceiveBlock . signedPB) [testBB1E, testBB2E, testBB3E]
+            -- We skip 'uponReceivingBlock' and go straight to processing, because the condition would be
+            -- caught in 'uponReceivingBlock'.
+            let pb = signedPB testBB4'{bbQuorumCertificate = bbQuorumCertificate (testBB4E @pv)}
+            bf <- use $ epochBakers . currentEpochBakers
+            executeBlock $
+                VerifiedBlock
+                    { vbBlock = pb,
+                      vbBakersAndFinalizers = bf,
+                      vbBakerInfo = fromJust $ fullBaker (genesisFullBakers sProtocolVersion) (blockBaker pb),
+                      vbLeadershipElectionNonce = genesisLEN sProtocolVersion
+                    }
+            status <- getBlockStatus (getHash pb) =<< get
+            case status of
+                BlockUnknown -> return ()
+                BlockDead -> return ()
+                _ -> liftIO . assertFailure $ "Expected BlockUnknown or BlockDead after executeBlock, but found: " ++ show status ++ "\n" ++ show pb
 
 -- | Test receiving a block where the block nonce is incorrect.
-testReceiveIncorrectNonce :: Assertion
-testReceiveIncorrectNonce = runTestMonad noBaker testTime genesisData $ do
-    succeedReceiveBlockFailExecute $
-        signedPB
-            testBB1{bbNonce = computeBlockNonce genesisLEN 0 (bakerVRFKey (0 :: Int))}
+testReceiveIncorrectNonce ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testReceiveIncorrectNonce sProtocolVersion pvString =
+    it (pvString ++ ": receive a block with incorrect block nonce") $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            succeedReceiveBlockFailExecute $
+                signedPB
+                    testBB1{bbNonce = computeBlockNonce (genesisLEN sProtocolVersion) 0 (bakerVRFKey sProtocolVersion (0 :: Int))}
 
 -- | Test receiving a block where the block nonce is incorrect.
-testReceiveTooFast :: Assertion
-testReceiveTooFast = runTestMonad noBaker testTime genesisData $ do
-    succeedReceiveBlockFailExecute $
-        signedPB
-            testBB1{bbTimestamp = 10}
+testReceiveTooFast ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testReceiveTooFast sProtocolVersion pvString =
+    it (pvString ++ ": receive a block with timestamp too soon after parent") $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            succeedReceiveBlockFailExecute $
+                signedPB
+                    testBB1{bbTimestamp = 10}
 
 -- | Test receiving a block that should have a timeout certificate, but doesn't.
-testReceiveMissingTC :: Assertion
-testReceiveMissingTC = runTestMonad noBaker testTime genesisData $ do
-    succeedReceiveBlockFailExecute $
-        signedPB
-            testBB2'{bbTimeoutCertificate = Absent}
+testReceiveMissingTC ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testReceiveMissingTC sProtocolVersion pvString =
+    it (pvString ++ ": receive a block with a missing TC") $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            succeedReceiveBlockFailExecute $
+                signedPB
+                    testBB2'{bbTimeoutCertificate = Absent}
 
 -- | Test receiving a block with a timeout certificate for an incorrect round.
-testReceiveTCIncorrectRound :: Assertion
-testReceiveTCIncorrectRound = runTestMonad noBaker testTime genesisData $ do
-    succeedReceiveBlockFailExecute $
-        signedPB
-            testBB2'{bbTimeoutCertificate = Present (validTimeoutFor genQC 2)}
+testReceiveTCIncorrectRound ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testReceiveTCIncorrectRound sProtocolVersion pvString =
+    it (pvString ++ ": receive a block with a TC for incorrect round") $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            succeedReceiveBlockFailExecute $
+                signedPB
+                    testBB2'{bbTimeoutCertificate = Present (validTimeoutFor sProtocolVersion genQC 2)}
   where
-    genQC = genesisQuorumCertificate genesisHash
+    genQC = genesisQuorumCertificate (genesisHash sProtocolVersion)
 
 -- | Test receiving a block with a timeout certificate where none is expected.
-testReceiveTCUnexpected :: Assertion
-testReceiveTCUnexpected = runTestMonad noBaker testTime genesisData $ do
-    succeedReceiveBlockFailExecute $
-        signedPB
-            testBB1{bbTimeoutCertificate = Present (validTimeoutFor genQC 0)}
+testReceiveTCUnexpected ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testReceiveTCUnexpected sProtocolVersion pvString =
+    it (pvString ++ ": receive a block with an unexpected TC") $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            succeedReceiveBlockFailExecute $
+                signedPB
+                    testBB1{bbTimeoutCertificate = Present (validTimeoutFor sProtocolVersion genQC 0)}
   where
-    genQC = genesisQuorumCertificate genesisHash
+    genQC = genesisQuorumCertificate (genesisHash sProtocolVersion)
 
 -- | Test receiving a block with a timeout certificate that is inconsistent with the QC, in that
 --  it has a more recent QC.
-testReceiveTCInconsistent1 :: Assertion
-testReceiveTCInconsistent1 = runTestMonad noBaker testTime genesisData $ do
-    succeedReceiveBlockFailExecute $
-        signedPB
-            testBB2'{bbTimeoutCertificate = Present (validTimeoutFor (validQCFor testBB1) 1)}
+testReceiveTCInconsistent1 ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testReceiveTCInconsistent1 sProtocolVersion pvString =
+    it (pvString ++ ": receive a block with a QC behind the max QC of the TC") $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            succeedReceiveBlockFailExecute $
+                signedPB
+                    testBB2'{bbTimeoutCertificate = Present (validTimeoutFor sProtocolVersion (validQCFor @pv testBB1) 1)}
 
 -- | Test receiving a block that is the start of a new epoch, but with the previous round
 --  timing out.
-testReceiveTimeoutPastEpoch :: Assertion
-testReceiveTimeoutPastEpoch = runTestMonad noBaker testTime genesisData $ do
-    mapM_ (succeedReceiveBlock . signedPB) [testBB1E, testBB2E, testBB4E']
+testReceiveTimeoutPastEpoch ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testReceiveTimeoutPastEpoch sProtocolVersion pvString =
+    it (pvString ++ ": receive a block with a timeout where the block is in a new epoch") $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            mapM_ (succeedReceiveBlock . signedPB) [testBB1E, testBB2E, testBB4E']
 
 -- | Test receiving a block that is the start of a new epoch, but with the previous round
 --  timing out, but where the high QC in the finalization entry is higher than the QC of the parent
 --  block.
-testReceiveTimeoutPastEpochInvalid :: Assertion
-testReceiveTimeoutPastEpochInvalid = runTestMonad noBaker testTime genesisData $ do
-    succeedReceiveBlock $ signedPB testBB1E
-    succeedReceiveBlockFailExecute $ signedPB testBB3E'
+testReceiveTimeoutPastEpochInvalid ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testReceiveTimeoutPastEpochInvalid sProtocolVersion pvString =
+    it (pvString ++ ": receive a block with an invalid timeout where the block is in a new epoch") $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            succeedReceiveBlock $ signedPB testBB1E
+            succeedReceiveBlockFailExecute $ signedPB testBB3E'
 
 -- | Test receiving a block that is the start of a new epoch, but with an epoch finalization entry
 --  for a different branch.
-testReceiveFinalizationBranch :: Assertion
-testReceiveFinalizationBranch = runTestMonad noBaker testTime genesisData $ do
-    mapM_ (succeedReceiveBlock . signedPB) [testBB1E, testBB2Ex]
-    succeedReceiveBlockFailExecute $ signedPB testBB3Ex
+testReceiveFinalizationBranch :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> String -> Spec
+testReceiveFinalizationBranch sProtocolVersion pvString =
+    it (pvString ++ ": receive a block with an epoch finalization certificate for a different branch") $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            mapM_ (succeedReceiveBlock . signedPB) [testBB1E, testBB2Ex]
+            succeedReceiveBlockFailExecute $ signedPB testBB3Ex
 
-testReceiveEpochTransitionTimeout :: Assertion
-testReceiveEpochTransitionTimeout = runTestMonad noBaker testTime genesisData $ do
-    mapM_ (succeedReceiveBlock . signedPB) [testBB1E, testBB2E, testBB3E, testBB5E']
+testReceiveEpochTransitionTimeout :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> String -> Spec
+testReceiveEpochTransitionTimeout sProtocolVersion pvString =
+    it (pvString ++ ": receive a block with a timeout spanning epochs") $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            mapM_ (succeedReceiveBlock . signedPB) [testBB1E, testBB2E, testBB3E, testBB5E']
 
 testReceiveIncorrectTransactionOutcomesHash :: Assertion
-testReceiveIncorrectTransactionOutcomesHash = runTestMonad noBaker testTime genesisData $ do
+testReceiveIncorrectTransactionOutcomesHash = runTestMonad noBaker testTime (genesisData SP6) $ do
     succeedReceiveBlockFailExecute $
         signedPB
-            testBB1
+            (testBB1 @'P6)
                 { bbDerivableHashes =
                     DBHashesV0 $
                         BlockDerivableHashesV0
@@ -1083,57 +1534,86 @@ testReceiveIncorrectTransactionOutcomesHash = runTestMonad noBaker testTime gene
                 }
 
 testReceiveIncorrectStateHash :: Assertion
-testReceiveIncorrectStateHash = runTestMonad noBaker testTime genesisData $ do
+testReceiveIncorrectStateHash = runTestMonad noBaker testTime (genesisData SP6) $ do
     succeedReceiveBlockFailExecute $
         signedPB $
             setStateHash (read "0000000000000000000000000000000000000000000000000000000000000000") testBB1
 
 -- | Test receiving a block where the QC signature is invalid.
-testReceiveInvalidQC :: Assertion
-testReceiveInvalidQC = runTestMonad noBaker testTime genesisData $ do
-    succeedReceiveBlock $ signedPB testBB1
-    succeedReceiveBlockFailExecute $
-        signedPB
-            testBB2
-                { bbQuorumCertificate = (bbQuorumCertificate testBB2){qcAggregateSignature = mempty}
-                }
+testReceiveInvalidQC ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testReceiveInvalidQC sProtocolVersion pvString =
+    it (pvString ++ ": receive a block with an invalid QC signature") $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            succeedReceiveBlock $ signedPB testBB1
+            succeedReceiveBlockFailExecute $
+                signedPB
+                    testBB2
+                        { bbQuorumCertificate = (bbQuorumCertificate (testBB2 @pv)){qcAggregateSignature = mempty}
+                        }
 
 -- | Test receiving the first block in a new epoch where the parent block is not descended from
 --  the successor block in the finalization entry for the trigger block.
-testReceiveTimeoutEpochTransition1 :: Assertion
-testReceiveTimeoutEpochTransition1 = runTestMonad noBaker testTime genesisData $ do
-    mapM_ (succeedReceiveBlock . signedPB) [testBB1E, testBB3EA, testBB4EA]
-    checkFinalized testBB1E
+testReceiveTimeoutEpochTransition1 ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testReceiveTimeoutEpochTransition1 sProtocolVersion pvString =
+    it (pvString ++ ": receive blocks with a timeout before an epoch transition") $
+        runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
+            mapM_
+                (succeedReceiveBlock . signedPB)
+                [ testBB1E,
+                  testBB3EA,
+                  testBB4EA
+                ]
+            checkFinalized (testBB1E @pv)
 
 -- | Test calling 'makeBlock' in the first round for a baker that should produce a block.
-testMakeFirstBlock :: Assertion
-testMakeFirstBlock = runTestMonad (baker bakerId) testTime genesisData $ do
-    ((), r) <- listen makeBlock
-    let expectBlock = validSignBlock testBB1{bbTimestamp = utcTimeToTimestamp testTime}
-    let qsm =
-            QuorumSignatureMessage
-                { qsmGenesis = genesisHash,
-                  qsmBlock = getHash expectBlock,
-                  qsmRound = blockRound expectBlock,
-                  qsmEpoch = blockEpoch expectBlock
-                }
-    let qsig = signQuorumSignatureMessage qsm (bakerAggregationKey . fst $ bakers !! bakerId)
-    let expectQM = buildQuorumMessage qsm qsig (FinalizerIndex $ fromIntegral bakerId)
-    liftIO $ assertEqual "Produced events (makeBlock)" [OnBlock (NormalBlock expectBlock)] r
-    timers <- getPendingTimers
-    case Map.toAscList timers of
-        [(0, (DelayUntil t, a))]
-            | t == testTime -> do
-                clearPendingTimers
-                ((), r2) <- listen a
-                liftIO $
-                    assertEqual
-                        "Produced events (after first timer)"
-                        [SendBlock expectBlock, SendQuorumMessage expectQM]
-                        r2
-                timers2 <- getPendingTimers
-                liftIO $ assertBool "Timers should not be pending" (null timers2)
-        _ -> timerFail timers
+testMakeFirstBlock ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testMakeFirstBlock sProtocolVersion pvString =
+    it (pvString ++ ": make a block as baker 2") $
+        runTestMonad (baker sProtocolVersion bakerId) testTime (genesisData sProtocolVersion) $ do
+            ((), r) <- listen makeBlock
+            let expectBlock = validSignBlock testBB1{bbTimestamp = utcTimeToTimestamp testTime}
+            let qsm =
+                    QuorumSignatureMessage
+                        { qsmGenesis = genesisHash sProtocolVersion,
+                          qsmBlock = getHash expectBlock,
+                          qsmRound = blockRound expectBlock,
+                          qsmEpoch = blockEpoch expectBlock
+                        }
+            let qsig =
+                    signQuorumSignatureMessage
+                        qsm
+                        (bakerAggregationKey . fst $ bakers sProtocolVersion !! bakerId)
+            let expectQM = buildQuorumMessage qsm qsig (FinalizerIndex $ fromIntegral bakerId)
+            liftIO $ assertEqual "Produced events (makeBlock)" [OnBlock (NormalBlock expectBlock)] r
+            timers <- getPendingTimers
+            case Map.toAscList timers of
+                [(0, (DelayUntil t, a))]
+                    | t == testTime -> do
+                        clearPendingTimers
+                        ((), r2) <- listen a
+                        liftIO $
+                            assertEqual
+                                "Produced events (after first timer)"
+                                [SendBlock expectBlock, SendQuorumMessage expectQM]
+                                r2
+                        timers2 <- getPendingTimers
+                        liftIO $ assertBool "Timers should not be pending" (null timers2)
+                _ -> timerFail timers
   where
     bakerId = 2
     timerFail timers =
@@ -1147,36 +1627,51 @@ testMakeFirstBlock = runTestMonad (baker bakerId) testTime genesisData $ do
 -- | Test calling 'makeBlock' in the first round for a baker that should produce a block.
 --  We try to make the block earlier than it should be, which should succeed, but delay sending
 --  the block.
-testMakeFirstBlockEarly :: Assertion
-testMakeFirstBlockEarly = runTestMonad (baker bakerId) curTime genesisData $ do
-    ((), r) <- listen makeBlock
-    let expectBlock = validSignBlock testBB1{bbTimestamp = utcTimeToTimestamp blkTime}
-    let qsm =
-            QuorumSignatureMessage
-                { qsmGenesis = genesisHash,
-                  qsmBlock = getHash expectBlock,
-                  qsmRound = blockRound expectBlock,
-                  qsmEpoch = blockEpoch expectBlock
-                }
-    let qsig = signQuorumSignatureMessage qsm (bakerAggregationKey . fst $ bakers !! bakerId)
-    let expectQM = buildQuorumMessage qsm qsig (FinalizerIndex $ fromIntegral bakerId)
-    liftIO $ assertEqual "Produced events (makeBlock)" [OnBlock (NormalBlock expectBlock)] r
-    timers <- getPendingTimers
-    case Map.toAscList timers of
-        [(0, (DelayUntil t, a))]
-            | t == blkTime -> do
-                clearPendingTimers
-                ((), r2) <- listen a
-                liftIO $ assertEqual "Produced events (after first timer)" [SendBlock expectBlock] r2
-                timers2 <- getPendingTimers
-                case Map.toAscList timers2 of
-                    [(0, (DelayUntil t2, a2))]
-                        | t2 == blkTime -> do
-                            ((), r3) <- listen a2
-                            liftIO $ assertEqual "Produced events (after second timer)" [SendQuorumMessage expectQM] r3
-                    _ -> timerFail timers2
-                return ()
-        _ -> timerFail timers
+testMakeFirstBlockEarly ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testMakeFirstBlockEarly sProtocolVersion pvString =
+    it (pvString ++ ": make a block as baker 2 early") $
+        runTestMonad (baker sProtocolVersion bakerId) curTime (genesisData sProtocolVersion) $ do
+            ((), r) <- listen makeBlock
+            let expectBlock = validSignBlock testBB1{bbTimestamp = utcTimeToTimestamp blkTime}
+            let qsm =
+                    QuorumSignatureMessage
+                        { qsmGenesis = genesisHash sProtocolVersion,
+                          qsmBlock = getHash expectBlock,
+                          qsmRound = blockRound expectBlock,
+                          qsmEpoch = blockEpoch expectBlock
+                        }
+            let qsig = signQuorumSignatureMessage qsm (bakerAggregationKey . fst $ bakers sProtocolVersion !! bakerId)
+            let expectQM = buildQuorumMessage qsm qsig (FinalizerIndex $ fromIntegral bakerId)
+            liftIO $ assertEqual "Produced events (makeBlock)" [OnBlock (NormalBlock expectBlock)] r
+            timers <- getPendingTimers
+            case Map.toAscList timers of
+                [(0, (DelayUntil t, a))]
+                    | t == blkTime -> do
+                        clearPendingTimers
+                        ((), r2) <- listen a
+                        liftIO $
+                            assertEqual
+                                "Produced events (after first timer)"
+                                [SendBlock expectBlock]
+                                r2
+                        timers2 <- getPendingTimers
+                        case Map.toAscList timers2 of
+                            [(0, (DelayUntil t2, a2))]
+                                | t2 == blkTime -> do
+                                    ((), r3) <- listen a2
+                                    liftIO $
+                                        assertEqual
+                                            "Produced events (after second timer)"
+                                            [SendQuorumMessage expectQM]
+                                            r3
+                            _ -> timerFail timers2
+                        return ()
+                _ -> timerFail timers
   where
     curTime = timestampToUTCTime 250
     blkTime = timestampToUTCTime 1_000
@@ -1190,56 +1685,72 @@ testMakeFirstBlockEarly = runTestMonad (baker bakerId) curTime genesisData $ do
                     ++ show (fst <$> timers)
 
 -- | Test calling 'makeBlock' in the first round for a baker that should not produce a block.
-testNoMakeFirstBlock :: Assertion
-testNoMakeFirstBlock = runTestMonad (baker 0) testTime genesisData $ do
-    ((), r) <- listen makeBlock
-    liftIO $ assertEqual "Produced events" [] r
-    timers <- getPendingTimers
-    liftIO $ assertBool "Pending timers should be empty" (null timers)
+testNoMakeFirstBlock ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testNoMakeFirstBlock sProtocolVersion pvString =
+    it (pvString ++ ": fail to make a block as baker 0") $
+        runTestMonad (baker sProtocolVersion 0) testTime (genesisData sProtocolVersion) $ do
+            ((), r) <- listen makeBlock
+            liftIO $ assertEqual "Produced events" [] r
+            timers <- getPendingTimers
+            liftIO $ assertBool "Pending timers should be empty" (null timers)
 
 -- | Test making a block in the second round, after sending timeout messages to time out the
 --  first round, where the baker should win the second round.
-testTimeoutMakeBlock :: Assertion
-testTimeoutMakeBlock = runTestMonad (baker bakerId) testTime genesisData $ do
-    let genQC = genesisQuorumCertificate genesisHash
-    -- Once the timeout certificate is generated, 'processTimeout' calls 'makeBlock'.
-    ((), r) <- listen $ mapM_ processTimeout $ timeoutMessagesFor genQC 1 0
-    let expectBlock =
-            validSignBlock
-                testBB2'
-                    { bbTimestamp = utcTimeToTimestamp testTime,
-                      bbTimeoutCertificate = Present $ validTimeoutForFinalizers [0 .. 3] genQC 1
-                    }
-    let qsm =
-            QuorumSignatureMessage
-                { qsmGenesis = genesisHash,
-                  qsmBlock = getHash expectBlock,
-                  qsmRound = blockRound expectBlock,
-                  qsmEpoch = blockEpoch expectBlock
-                }
-    let qsig = signQuorumSignatureMessage qsm (bakerAggregationKey . fst $ bakers !! bakerId)
-    let expectQM = buildQuorumMessage qsm qsig (FinalizerIndex $ fromIntegral bakerId)
-    liftIO $
-        assertEqual
-            "Produced events (processTimeout)"
-            [ ResetTimer 10_000,
-              OnBlock (NormalBlock expectBlock)
-            ]
-            r
-    timers1 <- getPendingTimers
-    case Map.toAscList timers1 of
-        [(0, (DelayUntil t, a))]
-            | t == testTime -> do
-                clearPendingTimers
-                ((), r2) <- listen a
-                liftIO $
-                    assertEqual
-                        "Produced events (after first timer)"
-                        [SendBlock expectBlock, SendQuorumMessage expectQM]
-                        r2
-                timers2 <- getPendingTimers
-                liftIO $ assertBool "Timers should not be pending" (null timers2)
-        _ -> timerFail timers1
+testTimeoutMakeBlock ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testTimeoutMakeBlock sProtocolVersion pvString =
+    it (pvString ++ ": make a block after first round timeout") $
+        runTestMonad (baker sProtocolVersion bakerId) testTime (genesisData sProtocolVersion) $ do
+            let genQC = genesisQuorumCertificate (genesisHash sProtocolVersion)
+            -- Once the timeout certificate is generated, 'processTimeout' calls 'makeBlock'.
+            ((), r) <- listen $ mapM_ processTimeout $ timeoutMessagesFor sProtocolVersion genQC 1 0
+            let expectBlock =
+                    validSignBlock
+                        testBB2'
+                            { bbTimestamp = utcTimeToTimestamp testTime,
+                              bbTimeoutCertificate =
+                                Present $
+                                    validTimeoutForFinalizers sProtocolVersion [0 .. 3] genQC 1
+                            }
+            let qsm =
+                    QuorumSignatureMessage
+                        { qsmGenesis = genesisHash sProtocolVersion,
+                          qsmBlock = getHash expectBlock,
+                          qsmRound = blockRound expectBlock,
+                          qsmEpoch = blockEpoch expectBlock
+                        }
+            let qsig = signQuorumSignatureMessage qsm (bakerAggregationKey . fst $ bakers sProtocolVersion !! bakerId)
+            let expectQM = buildQuorumMessage qsm qsig (FinalizerIndex $ fromIntegral bakerId)
+            liftIO $
+                assertEqual
+                    "Produced events (processTimeout)"
+                    [ ResetTimer 10_000,
+                      OnBlock (NormalBlock expectBlock)
+                    ]
+                    r
+            timers1 <- getPendingTimers
+            case Map.toAscList timers1 of
+                [(0, (DelayUntil t, a))]
+                    | t == testTime -> do
+                        clearPendingTimers
+                        ((), r2) <- listen a
+                        liftIO $
+                            assertEqual
+                                "Produced events (after first timer)"
+                                [SendBlock expectBlock, SendQuorumMessage expectQM]
+                                r2
+                        timers2 <- getPendingTimers
+                        liftIO $ assertBool "Timers should not be pending" (null timers2)
+                _ -> timerFail timers1
   where
     bakerId = 4
     timerFail timers =
@@ -1252,159 +1763,187 @@ testTimeoutMakeBlock = runTestMonad (baker bakerId) testTime genesisData $ do
 
 -- | Test that if we receive three blocks such that the QC contained in the last one justifies
 --  transitioning to a new epoch, we do not sign the third block, since it is in an old epoch.
-testNoSignIncorrectEpoch :: Assertion
-testNoSignIncorrectEpoch = runTestMonad (baker 0) testTime genesisData $ do
-    let blocks = [testBB1E, testBB2E, testBB3EX]
-    ((), r) <- listen $ mapM_ (succeedReceiveBlock . signedPB) blocks
-    let onblock = OnBlock . NormalBlock . validSignBlock
-        expectEvents =
-            [ onblock testBB1E,
-              onblock testBB2E,
-              ResetTimer 10_000, -- Advance to round 2 from the QC in testBB2E
-              onblock testBB3EX,
-              OnFinalize testEpochFinEntry, -- Finalize from the QC in testBB3EX
-              ResetTimer 10_000 -- Advance to round 3
-            ]
-    liftIO $
-        assertEqual
-            "Produced events (receive/execute block)"
-            expectEvents
-            r
-    timers <- getPendingTimers
-    case Map.toAscList timers of
-        [(0, (DelayUntil to0, a0)), (1, (DelayUntil to1, a1)), (2, (DelayUntil to2, a2))]
-            | to0 == timestampToUTCTime (bbTimestamp testBB1E),
-              to1 == timestampToUTCTime (bbTimestamp testBB2E),
-              to2 == timestampToUTCTime (bbTimestamp testBB3EX) ->
-                do
-                    clearPendingTimers
-                    ((), r0) <- listen a0
-                    liftIO $ assertEqual "Timer 0 events" [] r0
-                    ((), r1) <- listen a1
-                    liftIO $ assertEqual "Timer 1 events" [] r1
-                    ((), r2) <- listen a2
-                    liftIO $ assertEqual "Timer 2 events" [] r2
-        _ -> liftIO $ assertFailure $ "Unexpected timers: " ++ show (fst <$> timers)
+testNoSignIncorrectEpoch ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testNoSignIncorrectEpoch sProtocolVersion pvString =
+    it (pvString ++ ": refuse to sign a block in old epoch after epoch transition") $
+        runTestMonad (baker sProtocolVersion 0) testTime (genesisData sProtocolVersion) $ do
+            let blocks = [testBB1E, testBB2E, testBB3EX]
+            ((), r) <- listen $ mapM_ (succeedReceiveBlock . signedPB) blocks
+            let onblock = OnBlock . NormalBlock . validSignBlock
+                expectEvents =
+                    [ onblock testBB1E,
+                      onblock testBB2E,
+                      ResetTimer 10_000, -- Advance to round 2 from the QC in testBB2E
+                      onblock testBB3EX,
+                      OnFinalize (testEpochFinEntry sProtocolVersion), -- Finalize from the QC in testBB3EX
+                      ResetTimer 10_000 -- Advance to round 3
+                    ]
+            liftIO $
+                assertEqual
+                    "Produced events (receive/execute block)"
+                    expectEvents
+                    r
+            timers <- getPendingTimers
+            case Map.toAscList timers of
+                [(0, (DelayUntil to0, a0)), (1, (DelayUntil to1, a1)), (2, (DelayUntil to2, a2))]
+                    | to0 == timestampToUTCTime (bbTimestamp (testBB1E @pv)),
+                      to1 == timestampToUTCTime (bbTimestamp (testBB2E @pv)),
+                      to2 == timestampToUTCTime (bbTimestamp (testBB3EX @pv)) ->
+                        do
+                            clearPendingTimers
+                            ((), r0) <- listen a0
+                            liftIO $ assertEqual "Timer 0 events" [] r0
+                            ((), r1) <- listen a1
+                            liftIO $ assertEqual "Timer 1 events" [] r1
+                            ((), r2) <- listen a2
+                            liftIO $ assertEqual "Timer 2 events" [] r2
+                _ -> liftIO $ assertFailure $ "Unexpected timers: " ++ show (fst <$> timers)
 
 -- | Test that if we receive 3 blocks that transition into a new epoch as a finalizer, we
 --  will sign the last of the blocks.
-testSignCorrectEpoch :: Assertion
-testSignCorrectEpoch = runTestMonad (baker bakerId) testTime genesisData $ do
-    ((), r) <- listen $ mapM_ (succeedReceiveBlock . signedPB) blocks
-    let onblock = OnBlock . NormalBlock . validSignBlock
-        expectEvents =
-            [ onblock testBB1E,
-              onblock testBB2E,
-              ResetTimer 10_000, -- Advance to round 2 from the QC in testBB2E
-              onblock testBB3E,
-              OnFinalize testEpochFinEntry, -- Finalize from the epoch finalization entry in testBB3E
-              ResetTimer 10_000 -- Advance to round 3
-            ]
-    liftIO $
-        assertEqual
-            "Produced events (receive/execute block)"
-            expectEvents
-            r
-    timers <- getPendingTimers
-    case Map.toAscList timers of
-        [(0, (DelayUntil to0, a0)), (1, (DelayUntil to1, a1)), (2, (DelayUntil to2, a2))]
-            | to0 == timestampToUTCTime (bbTimestamp testBB1E),
-              to1 == timestampToUTCTime (bbTimestamp testBB2E),
-              to2 == timestampToUTCTime (bbTimestamp testBB3E) ->
-                do
-                    clearPendingTimers
-                    ((), r0) <- listen a0
-                    liftIO $ assertEqual "Timer 0 events" [] r0
-                    ((), r1) <- listen a1
-                    liftIO $ assertEqual "Timer 1 events" [] r1
-                    ((), r2) <- listen a2
+testSignCorrectEpoch ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testSignCorrectEpoch sProtocolVersion pvString =
+    it (pvString ++ ": sign a block in a new epoch") $
+        runTestMonad (baker sProtocolVersion bakerId) testTime (genesisData sProtocolVersion) $ do
+            ((), r) <- listen $ mapM_ (succeedReceiveBlock . signedPB) blocks
+            let onblock = OnBlock . NormalBlock . validSignBlock
+                expectEvents =
+                    [ onblock testBB1E,
+                      onblock testBB2E,
+                      ResetTimer 10_000, -- Advance to round 2 from the QC in testBB2E
+                      onblock testBB3E,
+                      OnFinalize (testEpochFinEntry sProtocolVersion), -- Finalize from the epoch finalization entry in testBB3E
+                      ResetTimer 10_000 -- Advance to round 3
+                    ]
+            liftIO $
+                assertEqual
+                    "Produced events (receive/execute block)"
+                    expectEvents
+                    r
+            timers <- getPendingTimers
+            case Map.toAscList timers of
+                [(0, (DelayUntil to0, a0)), (1, (DelayUntil to1, a1)), (2, (DelayUntil to2, a2))]
+                    | to0 == timestampToUTCTime (bbTimestamp (testBB1E @pv)),
+                      to1 == timestampToUTCTime (bbTimestamp (testBB2E @pv)),
+                      to2 == timestampToUTCTime (bbTimestamp (testBB3E @pv)) ->
+                        do
+                            clearPendingTimers
+                            ((), r0) <- listen a0
+                            liftIO $ assertEqual "Timer 0 events" [] r0
+                            ((), r1) <- listen a1
+                            liftIO $ assertEqual "Timer 1 events" [] r1
+                            ((), r2) <- listen a2
 
-                    liftIO $ assertEqual "Timer 2 events" [SendQuorumMessage expectQM] r2
-        _ -> liftIO $ assertFailure $ "Unexpected timers: " ++ show (fst <$> timers)
+                            liftIO $ assertEqual "Timer 2 events" [SendQuorumMessage expectQM] r2
+                _ -> liftIO $ assertFailure $ "Unexpected timers: " ++ show (fst <$> timers)
   where
     bakerId = 0
     blocks = [testBB1E, testBB2E, testBB3E]
     qsm =
         QuorumSignatureMessage
-            { qsmGenesis = genesisHash,
-              qsmBlock = getHash testBB3E,
-              qsmRound = bbRound testBB3E,
-              qsmEpoch = bbEpoch testBB3E
+            { qsmGenesis = genesisHash sProtocolVersion,
+              qsmBlock = getHash (testBB3E @pv),
+              qsmRound = bbRound (testBB3E @pv),
+              qsmEpoch = bbEpoch (testBB3E @pv)
             }
-    qsig = signQuorumSignatureMessage qsm (bakerAggregationKey . fst $ bakers !! bakerId)
+    qsig = signQuorumSignatureMessage qsm (bakerAggregationKey . fst $ bakers sProtocolVersion !! bakerId)
     expectQM = buildQuorumMessage qsm qsig (FinalizerIndex $ fromIntegral bakerId)
 
 -- | Test that if we receive 3 blocks that transition into a new epoch as a finalizer, we
 --  will sign the last of the blocks. Here, the blocks arrive in reverse order to begin with.
-testSignCorrectEpochReordered :: Assertion
-testSignCorrectEpochReordered = runTestMonad (baker bakerId) testTime genesisData $ do
-    ((), events0) <- listen $ pendingReceiveBlock $ signedPB testBB3E
-    liftIO $ assertEqual "Events after receiving testBB3E" [] events0
-    ((), events1) <- listen $ pendingReceiveBlock $ signedPB testBB2E
-    liftIO $ assertEqual "Events after receiving testBB2E" [] events1
-    ((), events2) <- listen $ succeedReceiveBlock $ signedPB testBB1E
-    let onblock = OnBlock . NormalBlock . validSignBlock
-        expectEvents3 = [onblock testBB2E, ResetTimer 10_000]
-        expectEvents4 = [onblock testBB3E, OnFinalize testEpochFinEntry, ResetTimer 10_000]
-    liftIO $ assertEqual "Events after receiving testBB1E" [onblock testBB1E] events2
-    ((), events3) <- listen $ succeedReceiveBlock $ signedPB testBB2E
-    liftIO $ assertEqual "Events after receiving testBB2E" expectEvents3 events3
-    ((), events4) <- listen $ succeedReceiveBlock $ signedPB testBB3E
-    liftIO $ assertEqual "Events after receiving testBB3E" expectEvents4 events4
-    timers <- getPendingTimers
-    case Map.toAscList timers of
-        [(0, (DelayUntil to0, a0)), (1, (DelayUntil to1, a1)), (2, (DelayUntil to2, a2))]
-            | to0 == timestampToUTCTime (bbTimestamp testBB1E),
-              to1 == timestampToUTCTime (bbTimestamp testBB2E),
-              to2 == timestampToUTCTime (bbTimestamp testBB3E) ->
-                do
-                    clearPendingTimers
-                    ((), r0) <- listen a0
-                    liftIO $ assertEqual "Timer 0 events" [] r0
-                    ((), r1) <- listen a1
-                    liftIO $ assertEqual "Timer 1 events" [] r1
-                    ((), r2) <- listen a2
+testSignCorrectEpochReordered ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testSignCorrectEpochReordered sProtocolVersion pvString =
+    it (pvString ++ ": sign a block in a new epoch where blocks are reordered") $
+        runTestMonad (baker sProtocolVersion bakerId) testTime (genesisData sProtocolVersion) $ do
+            ((), events0) <- listen $ pendingReceiveBlock $ signedPB testBB3E
+            liftIO $ assertEqual "Events after receiving testBB3E" [] events0
+            ((), events1) <- listen $ pendingReceiveBlock $ signedPB testBB2E
+            liftIO $ assertEqual "Events after receiving testBB2E" [] events1
+            ((), events2) <- listen $ succeedReceiveBlock $ signedPB testBB1E
+            let onblock = OnBlock . NormalBlock . validSignBlock
+                expectEvents3 = [onblock testBB2E, ResetTimer 10_000]
+                expectEvents4 = [onblock testBB3E, OnFinalize (testEpochFinEntry sProtocolVersion), ResetTimer 10_000]
+            liftIO $ assertEqual "Events after receiving testBB1E" [onblock testBB1E] events2
+            ((), events3) <- listen $ succeedReceiveBlock $ signedPB testBB2E
+            liftIO $ assertEqual "Events after receiving testBB2E" expectEvents3 events3
+            ((), events4) <- listen $ succeedReceiveBlock $ signedPB testBB3E
+            liftIO $ assertEqual "Events after receiving testBB3E" expectEvents4 events4
+            timers <- getPendingTimers
+            case Map.toAscList timers of
+                [(0, (DelayUntil to0, a0)), (1, (DelayUntil to1, a1)), (2, (DelayUntil to2, a2))]
+                    | to0 == timestampToUTCTime (bbTimestamp (testBB1E @pv)),
+                      to1 == timestampToUTCTime (bbTimestamp (testBB2E @pv)),
+                      to2 == timestampToUTCTime (bbTimestamp (testBB3E @pv)) ->
+                        do
+                            clearPendingTimers
+                            ((), r0) <- listen a0
+                            liftIO $ assertEqual "Timer 0 events" [] r0
+                            ((), r1) <- listen a1
+                            liftIO $ assertEqual "Timer 1 events" [] r1
+                            ((), r2) <- listen a2
 
-                    liftIO $ assertEqual "Timer 2 events" [SendQuorumMessage expectQM] r2
-        _ -> liftIO $ assertFailure $ "Unexpected timers: " ++ show (fst <$> timers)
+                            liftIO $ assertEqual "Timer 2 events" [SendQuorumMessage expectQM] r2
+                _ -> liftIO $ assertFailure $ "Unexpected timers: " ++ show (fst <$> timers)
   where
     bakerId = 0
     qsm =
         QuorumSignatureMessage
-            { qsmGenesis = genesisHash,
-              qsmBlock = getHash testBB3E,
-              qsmRound = bbRound testBB3E,
-              qsmEpoch = bbEpoch testBB3E
+            { qsmGenesis = genesisHash sProtocolVersion,
+              qsmBlock = getHash (testBB3E @pv),
+              qsmRound = bbRound (testBB3E @pv),
+              qsmEpoch = bbEpoch (testBB3E @pv)
             }
-    qsig = signQuorumSignatureMessage qsm (bakerAggregationKey . fst $ bakers !! bakerId)
+    qsig = signQuorumSignatureMessage qsm (bakerAggregationKey . fst $ bakers sProtocolVersion !! bakerId)
     expectQM = buildQuorumMessage qsm qsig (FinalizerIndex $ fromIntegral bakerId)
 
 -- | Test calling 'makeBlock' to construct the first block in a new epoch.
-testMakeBlockNewEpoch :: Assertion
-testMakeBlockNewEpoch = runTestMonad (baker bakerId) testTime genesisData $ do
-    -- We use 'testBB3EX' because it contains a QC that finalizes the trigger block.
-    mapM_ (succeedReceiveBlock . signedPB) [testBB1E, testBB2E, testBB3EX]
-    clearPendingTimers
-    ((), r) <- listen makeBlock
-    let expectBlock = validSignBlock testBB3E
-    liftIO $ assertEqual "Produced events (makeBlock)" [OnBlock (NormalBlock expectBlock)] r
-    timers <- getPendingTimers
-    let bb3Time = timestampToUTCTime $ bbTimestamp testBB3E
-    case Map.toAscList timers of
-        [(0, (DelayUntil t, a))]
-            | t == bb3Time -> do
-                clearPendingTimers
-                ((), r2) <- listen a
-                liftIO $ assertEqual "Produced events (after first timer)" [SendBlock expectBlock] r2
-                timers2 <- getPendingTimers
-                case Map.toAscList timers2 of
-                    [(0, (DelayUntil t2, a2))]
-                        | t2 == bb3Time -> do
-                            ((), r3) <- listen a2
-                            liftIO $ assertEqual "Produced events (after second timer)" [SendQuorumMessage expectQM] r3
-                    _ -> timerFail timers2
-                return ()
-        _ -> timerFail timers
+testMakeBlockNewEpoch ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testMakeBlockNewEpoch sProtocolVersion pvString =
+    it (pvString ++ ": make first block in a new epoch") $
+        runTestMonad (baker sProtocolVersion bakerId) testTime (genesisData sProtocolVersion) $ do
+            -- We use 'testBB3EX' because it contains a QC that finalizes the trigger block.
+            mapM_ (succeedReceiveBlock . signedPB) [testBB1E, testBB2E, testBB3EX]
+            clearPendingTimers
+            ((), r) <- listen makeBlock
+            let expectBlock = validSignBlock testBB3E
+            liftIO $ assertEqual "Produced events (makeBlock)" [OnBlock (NormalBlock expectBlock)] r
+            timers <- getPendingTimers
+            let bb3Time = timestampToUTCTime $ bbTimestamp (testBB3E @pv)
+            case Map.toAscList timers of
+                [(0, (DelayUntil t, a))]
+                    | t == bb3Time -> do
+                        clearPendingTimers
+                        ((), r2) <- listen a
+                        liftIO $ assertEqual "Produced events (after first timer)" [SendBlock expectBlock] r2
+                        timers2 <- getPendingTimers
+                        case Map.toAscList timers2 of
+                            [(0, (DelayUntil t2, a2))]
+                                | t2 == bb3Time -> do
+                                    ((), r3) <- listen a2
+                                    liftIO $ assertEqual "Produced events (after second timer)" [SendQuorumMessage expectQM] r3
+                            _ -> timerFail timers2
+                        return ()
+                _ -> timerFail timers
   where
     bakerId = 5
     timerFail timers =
@@ -1416,57 +1955,84 @@ testMakeBlockNewEpoch = runTestMonad (baker bakerId) testTime genesisData $ do
                     ++ show (fst <$> timers)
     qsm =
         QuorumSignatureMessage
-            { qsmGenesis = genesisHash,
-              qsmBlock = getHash testBB3E,
-              qsmRound = bbRound testBB3E,
-              qsmEpoch = bbEpoch testBB3E
+            { qsmGenesis = genesisHash sProtocolVersion,
+              qsmBlock = getHash (testBB3E @pv),
+              qsmRound = bbRound (testBB3E @pv),
+              qsmEpoch = bbEpoch (testBB3E @pv)
             }
-    qsig = signQuorumSignatureMessage qsm (bakerAggregationKey . fst $ bakers !! bakerId)
+    qsig = signQuorumSignatureMessage qsm (bakerAggregationKey . fst $ bakers sProtocolVersion !! bakerId)
     expectQM = buildQuorumMessage qsm qsig (FinalizerIndex $ fromIntegral bakerId)
+
+-- | Call a function for each protocol version starting from P6 where the new conensus was
+-- introduced, returning a list of results. Notice the return type for the function must be
+-- independent of the protocol version.
+--
+--  This is used to run a test against every protocol version.
+forEveryProtocolVersion ::
+    (forall pv. (IsProtocolVersion pv) => SProtocolVersion pv -> String -> Spec) ->
+    Spec
+forEveryProtocolVersion check =
+    sequence_
+        [ check SP1 "P1",
+          check SP2 "P2",
+          check SP3 "P3",
+          check SP4 "P4",
+          check SP5 "P5",
+          check SP6 "P6",
+          check SP7 "P7"
+        ]
+
+forEveryProtocolVersionConsensusV1 :: (forall pv. (IsProtocolVersion pv, IsConsensusV1 pv) => SProtocolVersion pv -> String -> Spec) -> Spec
+forEveryProtocolVersionConsensusV1 check = forEveryProtocolVersion $ \spv pvString -> case consensusVersionFor spv of
+    ConsensusV0 -> return ()
+    ConsensusV1 -> check spv pvString
 
 tests :: Spec
 tests = describe "KonsensusV1.Consensus.Blocks" $ do
-    describe "uponReceiveingBlock" $ do
-        it "receive 3 consecutive blocks" testReceive3
-        it "receive 3 blocks reordered" testReceive3Reordered
-        it "receive 4 blocks reordered, multiple epochs" testReceive4Reordered
-        it "skip round 1, receive rounds 2,3,4" testReceiveWithTimeout
-        it "receive duplicate block" testReceiveDuplicate
-        it "receive invalid duplicate block" testReceiveInvalidDuplicate
-        it "receive stale round" testReceiveStale
-        it "epoch transition" testReceiveEpoch
-        it "block dies on old branch" testReceiveBlockDies
-        it "receive a block in a bad future epoch" testReceiveBadFutureEpoch
-        it "receive a block in a bad past epoch" testReceiveBadPastEpoch
-        it "receive a block in the next epoch where the transition is not allowed" testReceiveBadEpochTransition
-        it "receive a block with a bad signature" testReceiveBadSignature
-        it "receive a block from a baker that did not win the round" testReceiveWrongBaker
-        it "receive a block from the future with an unknown parent" testReceiveEarlyUnknownParent
-        it "receive a block with a bad signature and unknown parent" testReceiveBadSignatureUnknownParent
-        it "receive a block with an unknown parent and epoch" testReceiveFutureEpochUnknownParent
-        it "receive a block with QC round inconsistent with the parent block" testReceiveInconsistentQCRound
-        it "receive a block with QC epoch inconsistent with the parent block" testReceiveInconsistentQCEpoch
-        it "receive a block with round before parent block round" testReceiveRoundInconsistent
-        it "process a block with epoch before parent block epoch" testProcessEpochInconsistent
-        it "receive a block with incorrect block nonce" testReceiveIncorrectNonce
-        it "receive a block with timestamp too soon after parent" testReceiveTooFast
-        it "receive a block with a missing TC" testReceiveMissingTC
-        it "receive a block with a TC for incorrect round" testReceiveTCIncorrectRound
-        it "receive a block with an unexpected TC" testReceiveTCUnexpected
-        it "receive a block with a QC behind the max QC of the TC" testReceiveTCInconsistent1
-        it "receive a block with a timeout where the block is in a new epoch" testReceiveTimeoutPastEpoch
-        it "receive a block with an invalid timeout where the block is in a new epoch" testReceiveTimeoutPastEpochInvalid
-        it "receive a block with an epoch finalization certificate for a different branch" testReceiveFinalizationBranch
-        it "receive a block with a timeout spanning epochs" testReceiveEpochTransitionTimeout
+    describe "uponReceiveingBlockPV" $ do
+        forEveryProtocolVersionConsensusV1 $ \spv pvString -> do
+            testReceive3 spv pvString
+            testReceive3Reordered spv pvString
+            testReceive4Reordered spv pvString
+            testReceiveWithTimeout spv pvString
+            testReceiveDuplicate spv pvString
+            testReceiveInvalidDuplicate spv pvString
+            testReceiveStale spv pvString
+            testReceiveEpoch spv pvString
+            testReceiveBlockDies spv pvString
+            testReceiveBadFutureEpoch spv pvString
+            testReceiveBadPastEpoch spv pvString
+            testReceiveBadEpochTransition spv pvString
+            testReceiveBadSignature spv pvString
+            testReceiveWrongBaker spv pvString
+            testReceiveEarlyUnknownParent spv pvString
+            testReceiveBadSignatureUnknownParent spv pvString
+            testReceiveFutureEpochUnknownParent spv pvString
+            testReceiveInconsistentQCRound spv pvString
+            testReceiveInconsistentQCEpoch spv pvString
+            testReceiveRoundInconsistent spv pvString
+            testProcessEpochInconsistent spv pvString
+            testReceiveIncorrectNonce spv pvString
+            testReceiveTooFast spv pvString
+            testReceiveMissingTC spv pvString
+            testReceiveTCIncorrectRound spv pvString
+            testReceiveTCUnexpected spv pvString
+            testReceiveTCInconsistent1 spv pvString
+            testReceiveTimeoutPastEpoch spv pvString
+            testReceiveTimeoutPastEpochInvalid spv pvString
+            testReceiveFinalizationBranch spv pvString
+            testReceiveEpochTransitionTimeout spv pvString
+            testReceiveInvalidQC spv pvString
+            testMakeFirstBlock spv pvString
+            testMakeFirstBlockEarly spv pvString
+            testNoMakeFirstBlock spv pvString
+            testTimeoutMakeBlock spv pvString
+            testNoSignIncorrectEpoch spv pvString
+            testSignCorrectEpoch spv pvString
+            testSignCorrectEpochReordered spv pvString
+            testMakeBlockNewEpoch spv pvString
+            testReceiveTimeoutEpochTransition1 spv pvString
+
+    describe "uponReceiveingBlock (P6 only)" $ do
         it "receive a block with an incorrect transaction outcomes hash" testReceiveIncorrectTransactionOutcomesHash
         it "receive a block with an incorrect state hash" testReceiveIncorrectStateHash
-        it "receive a block with an invalid QC signature" testReceiveInvalidQC
-        it "make a block as baker 2" testMakeFirstBlock
-        it "make a block as baker 2 early" testMakeFirstBlockEarly
-        it "fail to make a block as baker 0" testNoMakeFirstBlock
-        it "make a block after first round timeout" testTimeoutMakeBlock
-        it "refuse to sign a block in old epoch after epoch transition" testNoSignIncorrectEpoch
-        it "sign a block in a new epoch" testSignCorrectEpoch
-        it "sign a block in a new epoch where blocks are reordered" testSignCorrectEpochReordered
-        it "make first block in a new epoch" testMakeBlockNewEpoch
-        it "receive blocks with a timeout before an epoch transition" testReceiveTimeoutEpochTransition1

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/LMDB.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/LMDB.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module ConcordiumTests.KonsensusV1.LMDB (tests) where
@@ -34,6 +35,8 @@ import qualified Concordium.Types.Conditionally as Cond
 import Concordium.Types.HashableTo
 import Concordium.Types.Option
 import Concordium.Types.Transactions
+
+import qualified ConcordiumTests.KonsensusV1.Common as Common
 
 -- | A dummy UTCTime used for tests where the actual value is not significant.
 dummyTime :: UTCTime
@@ -87,8 +90,8 @@ dummyBlockSig = Block.sign dummyKP "someMessage"
 -- | A helper function for creating a 'BakedBlock' given a round. Used by 'dummyBlock' to create blocks.
 --  The block is well-formed and contains the supplied transactions and is for the specified round.
 --  Beyond that, there should be no expectation on the data in the block.
-dummyBakedBlock :: Round -> Vector.Vector BlockItem -> BakedBlock 'P6
-dummyBakedBlock n ts =
+dummyBakedBlock :: SProtocolVersion pv -> Round -> Vector.Vector BlockItem -> BakedBlock pv
+dummyBakedBlock sProtocolVersion n ts =
     BakedBlock
         { bbRound = n,
           bbEpoch = 1,
@@ -99,12 +102,18 @@ dummyBakedBlock n ts =
           bbEpochFinalizationEntry = Absent,
           bbNonce = dummyProof,
           bbTransactions = ts,
-          bbDerivableHashes =
-            DBHashesV0 $
-                BlockDerivableHashesV0
-                    { bdhv0TransactionOutcomesHash = TransactionOutcomesHash dummyHash,
-                      bdhv0BlockStateHash = StateHashV0 dummyHash
-                    }
+          bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
+            SBlockHashVersion0 ->
+                DBHashesV0 $
+                    BlockDerivableHashesV0
+                        { bdhv0TransactionOutcomesHash = TransactionOutcomesHash dummyHash,
+                          bdhv0BlockStateHash = StateHashV0 dummyHash
+                        }
+            SBlockHashVersion1 ->
+                DBHashesV1 $
+                    BlockDerivableHashesV1
+                        { bdhv1BlockResultHash = BlockResultHash dummyHash
+                        }
         }
 
 -- | A helper function for creating an account address given a seed.
@@ -142,37 +151,63 @@ dummyBlockItem =
 -- | A helper function for creating a block with the given round and block items.
 --  Blocks with different hashes can then be constructed by calling this function with different rounds.
 --  The blocks are derived from 'dummyBakedBlock' with the supplied round and block items.
-dummyBlock :: Round -> Vector.Vector BlockItem -> Block 'P6
-dummyBlock n ts = NormalBlock $ SignedBlock b h dummyBlockSig
+dummyBlock :: SProtocolVersion pv -> Round -> Vector.Vector BlockItem -> Block pv
+dummyBlock sProtocolVersion n ts = NormalBlock $ SignedBlock b h dummyBlockSig
   where
-    b = dummyBakedBlock n ts
+    b = dummyBakedBlock sProtocolVersion n ts
     h = getHash b
 
 -- | A helper function for creating a StoredBlock with the given block height and round, and with no transactions.
 --  Empty 'StoredBlock's with different hashes can then be constructed by calling this function with different rounds.
 --  The blocks are derived from 'dummyBlock' with the supplied height and round, but no block items.
-dummyStoredBlockEmpty :: BlockHeight -> Round -> StoredBlock 'P6
-dummyStoredBlockEmpty h n = StoredBlock (BlockMetadata h dummyTime dummyTime 0 0 Cond.CFalse) (dummyBlock n Vector.empty) (BlobRef 0)
+dummyStoredBlockEmpty :: SProtocolVersion pv -> BlockHeight -> Round -> StoredBlock pv
+dummyStoredBlockEmpty sProtocolVersion h n = StoredBlock blockMeta (dummyBlock sProtocolVersion n Vector.empty) (BlobRef 0)
+  where
+    blockMeta =
+        BlockMetadata
+            { bmHeight = h,
+              bmReceiveTime = dummyTime,
+              bmArriveTime = dummyTime,
+              bmEnergyCost = 0,
+              bmTransactionsSize = 0,
+              bmBlockStateHash =
+                Cond.conditionally
+                    (sBlockStateHashInMetadata (sBlockHashVersionFor sProtocolVersion))
+                    (StateHashV0 dummyHash)
+            }
 
 -- | A helper function for creating a StoredBlock with the given block height and round, and with one transaction.
 --  'StoredBlock's (with one transaction) with different hashes can then be constructed by calling this function with different rounds.
 --  The blocks are derived from 'dummyBlock' with the supplied height and round, and a singular 'dummyBlockItem'.
-dummyStoredBlockOneTransaction :: BlockHeight -> Round -> StoredBlock 'P6
-dummyStoredBlockOneTransaction h n = StoredBlock (BlockMetadata h dummyTime dummyTime 200 200 Cond.CFalse) (dummyBlock n $ Vector.singleton dummyBlockItem) (BlobRef 0)
+dummyStoredBlockOneTransaction :: SProtocolVersion pv -> BlockHeight -> Round -> StoredBlock pv
+dummyStoredBlockOneTransaction sProtocolVersion height n = StoredBlock blockMeta (dummyBlock sProtocolVersion n $ Vector.singleton dummyBlockItem) (BlobRef 0)
+  where
+    blockMeta =
+        BlockMetadata
+            { bmHeight = height,
+              bmReceiveTime = dummyTime,
+              bmArriveTime = dummyTime,
+              bmEnergyCost = 200,
+              bmTransactionsSize = 200,
+              bmBlockStateHash =
+                Cond.conditionally
+                    (sBlockStateHashInMetadata (sBlockHashVersionFor sProtocolVersion))
+                    (StateHashV0 dummyHash)
+            }
 
 -- | List of stored blocks used for testing. The heights are chosen so it is tested that the endianness of the stored block heights are correct.
-dummyStoredBlocks :: [StoredBlock 'P6]
-dummyStoredBlocks =
-    [ dummyStoredBlockEmpty 1 1,
-      dummyStoredBlockEmpty 0x100 2,
-      dummyStoredBlockEmpty 0x10000 3,
-      dummyStoredBlockEmpty 0x1000000 4,
-      dummyStoredBlockEmpty 0x100000000 5,
-      dummyStoredBlockEmpty 0x10000000000 6,
-      dummyStoredBlockEmpty 0x1000000000000 7,
-      dummyStoredBlockEmpty 0x100000000000000 8,
-      dummyStoredBlockEmpty 0 9,
-      dummyStoredBlockOneTransaction 5 10
+dummyStoredBlocks :: SProtocolVersion pv -> [StoredBlock pv]
+dummyStoredBlocks sProtocolVersion =
+    [ dummyStoredBlockEmpty sProtocolVersion 1 1,
+      dummyStoredBlockEmpty sProtocolVersion 0x100 2,
+      dummyStoredBlockEmpty sProtocolVersion 0x10000 3,
+      dummyStoredBlockEmpty sProtocolVersion 0x1000000 4,
+      dummyStoredBlockEmpty sProtocolVersion 0x100000000 5,
+      dummyStoredBlockEmpty sProtocolVersion 0x10000000000 6,
+      dummyStoredBlockEmpty sProtocolVersion 0x1000000000000 7,
+      dummyStoredBlockEmpty sProtocolVersion 0x100000000000000 8,
+      dummyStoredBlockEmpty sProtocolVersion 0 9,
+      dummyStoredBlockOneTransaction sProtocolVersion 5 10
     ]
 
 -- | A FinalizationEntry. Both used by 'writeBlocks' and used when testing 'lookupLatestFinalizationEntry'.
@@ -196,18 +231,18 @@ dummyFinalizationEntry =
 --  serves the disk based lmdb implementation the computation.
 runLLMDBTest ::
     String ->
-    DiskLLDBM pv (ReaderT (DatabaseHandlers 'P6) (LoggerT IO)) a ->
+    DiskLLDBM pv (ReaderT (DatabaseHandlers pv) (LoggerT IO)) a ->
     IO a
 runLLMDBTest name action = withTempDirectory "" name $ \path ->
     bracket
-        (openDatabase path :: IO (DatabaseHandlers 'P6))
+        (openDatabase path :: IO (DatabaseHandlers pv))
         closeDatabase
         (\dbhandlers -> runSilentLogger $ runReaderT (runDiskLLDBM action) dbhandlers)
 
 -- | Set up the database with the 'dummyStoredBlocks' finalized.
-setupDummy :: DiskLLDBM 'P6 (ReaderT (DatabaseHandlers 'P6) (LoggerT IO)) ()
-setupDummy = do
-    forM_ dummyStoredBlocks $ \sb ->
+setupDummy :: (IsProtocolVersion pv) => SProtocolVersion pv -> DiskLLDBM pv (ReaderT (DatabaseHandlers pv) (LoggerT IO)) ()
+setupDummy sProtocolVersion = do
+    forM_ (dummyStoredBlocks sProtocolVersion) $ \sb ->
         writeCertifiedBlock
             sb
             dummyQC
@@ -215,66 +250,66 @@ setupDummy = do
                   qcRound = blockRound sb,
                   qcEpoch = blockEpoch sb
                 }
-    writeFinalizedBlocks dummyStoredBlocks dummyFinalizationEntry
+    writeFinalizedBlocks (dummyStoredBlocks sProtocolVersion) dummyFinalizationEntry
 
 -- | Test that 'lookupLastBlock' returns the block with the greatest height among the dummy blocks.
 --  The dummy blocks are chosen to have a wide range of blockheights to catch possible endianness
 --  errors.
-testLookupLastBlock :: Assertion
-testLookupLastBlock = runLLMDBTest "lookupLastBlockTest" $ do
-    setupDummy
+testLookupLastBlock :: (IsProtocolVersion pv) => SProtocolVersion pv -> Assertion
+testLookupLastBlock sProtocolVersion = runLLMDBTest "lookupLastBlockTest" $ do
+    setupDummy sProtocolVersion
     lastBlock <- lookupLastFinalizedBlock
     case lastBlock of
         Nothing -> liftIO $ assertFailure "Block should be Just"
         Just sb -> liftIO $ assertEqual "BlockHeight should be 0x100000000000000" 0x100000000000000 (blockHeight sb)
 
 -- | Test that the function 'LookupFirstBlock' returns the block with height '0' from the dummy blocks.
-testLookupFirstBlock :: Assertion
-testLookupFirstBlock = runLLMDBTest "lookupFirstBlockTest" $ do
-    setupDummy
+testLookupFirstBlock :: (IsProtocolVersion pv) => SProtocolVersion pv -> Assertion
+testLookupFirstBlock sProtocolVersion = runLLMDBTest "lookupFirstBlockTest" $ do
+    setupDummy sProtocolVersion
     lastBlock <- lookupFirstBlock
     case lastBlock of
         Nothing -> liftIO $ assertFailure "Block should be Just"
         Just sb -> liftIO $ assertEqual "BlockHeight should be 0" 0 (blockHeight sb)
 
 -- | Test that the function 'LookupBlockByHeight' retrieves the correct block at height 0x10000.
-testLookupBlockByHeight :: Assertion
-testLookupBlockByHeight = runLLMDBTest "lookupBlockByHeightTest" $ do
-    setupDummy
+testLookupBlockByHeight :: (IsProtocolVersion pv) => SProtocolVersion pv -> Assertion
+testLookupBlockByHeight sProtocolVersion = runLLMDBTest "lookupBlockByHeightTest" $ do
+    setupDummy sProtocolVersion
     lastBlock <- lookupBlockByHeight 0x10000
     case lastBlock of
         Nothing -> liftIO $ assertFailure "Block should be Just"
         Just sb -> liftIO $ assertEqual "BlockHeight should be 0x10000" 0x10000 (blockHeight sb)
 
 -- | Test that the function 'memberBlock' returns 'True' for a selected block.
-testMemberBlock :: Assertion
-testMemberBlock = runLLMDBTest "memberBlockTest" $ do
-    setupDummy
-    isMember <- memberBlock $ getHash $ dummyBakedBlock 1 Vector.empty
+testMemberBlock :: (IsProtocolVersion pv) => SProtocolVersion pv -> Assertion
+testMemberBlock sProtocolVersion = runLLMDBTest "memberBlockTest" $ do
+    setupDummy sProtocolVersion
+    isMember <- memberBlock $ getHash $ dummyBakedBlock sProtocolVersion 1 Vector.empty
     liftIO $ assertBool "isMember should be True" isMember
 
 -- | Test that the function 'lookupBlock' retrieves a selected block.
-testLookupBlock :: Assertion
-testLookupBlock = runLLMDBTest "lookupBlockTest" $ do
-    setupDummy
-    block <- lookupBlock $ getHash $ dummyBakedBlock 5 Vector.empty
+testLookupBlock :: (IsProtocolVersion pv) => SProtocolVersion pv -> Assertion
+testLookupBlock sProtocolVersion = runLLMDBTest "lookupBlockTest" $ do
+    setupDummy sProtocolVersion
+    block <- lookupBlock $ getHash $ dummyBakedBlock sProtocolVersion 5 Vector.empty
     case block of
         Nothing -> liftIO $ assertFailure "Block should be Just"
         Just sb -> liftIO $ assertEqual "BlockHeight should be 0x100000000" 0x100000000 (blockHeight sb)
 
 -- | Test that the function 'lookupFinalizationEntry' retrieves a written expected finalization entry.
-testLookupLatestFinalizationEntry :: Assertion
-testLookupLatestFinalizationEntry = runLLMDBTest "lookupFinalizationEntryTest" $ do
-    setupDummy
+testLookupLatestFinalizationEntry :: (IsProtocolVersion pv) => SProtocolVersion pv -> Assertion
+testLookupLatestFinalizationEntry sProtocolVersion = runLLMDBTest "lookupFinalizationEntryTest" $ do
+    setupDummy sProtocolVersion
     fe <- lookupLatestFinalizationEntry
     case fe of
         Nothing -> liftIO $ assertFailure "Finalization entry should be Just"
         Just f -> liftIO $ assertEqual "Finalization entry should match" dummyFinalizationEntry f
 
 -- | Test that the function 'lookupTransaction' retrieves the expected transaction status.
-testLookupTransaction :: Assertion
-testLookupTransaction = runLLMDBTest "lookupTransactionTest" $ do
-    setupDummy
+testLookupTransaction :: (IsProtocolVersion pv) => SProtocolVersion pv -> Assertion
+testLookupTransaction sProtocolVersion = runLLMDBTest "lookupTransactionTest" $ do
+    setupDummy sProtocolVersion
     ft <- lookupTransaction $ wmdHash $ dummyBlockItem
     case ft of
         Nothing -> liftIO $ assertFailure "Finalized transaction status should be Just"
@@ -283,19 +318,21 @@ testLookupTransaction = runLLMDBTest "lookupTransactionTest" $ do
             liftIO $ assertEqual "Transaction index should be 0" 0 ftsIndex
 
 -- | Test that the function 'memberTransaction' identifies the presence of a known transaction.
-testMemberTransaction :: Assertion
-testMemberTransaction = runLLMDBTest "memberTransactionTest" $ do
-    setupDummy
+testMemberTransaction :: (IsProtocolVersion pv) => SProtocolVersion pv -> Assertion
+testMemberTransaction sProtocolVersion = runLLMDBTest "memberTransactionTest" $ do
+    setupDummy sProtocolVersion
     isMember <- memberTransaction $ wmdHash $ dummyBlockItem
     liftIO $ assertBool "memberTransaction should be True" isMember
 
 tests :: Spec
 tests = describe "KonsensusV2.LMDB" $ do
-    it "Test lookupLastBlock" testLookupLastBlock
-    it "Test lookupFirstBlock" testLookupFirstBlock
-    it "Test lookupBlockByHeight" testLookupBlockByHeight
-    it "Test memberBlock" testMemberBlock
-    it "Test lookupBlock" testLookupBlock
-    it "Test lookupLatestFinalizationEntry" testLookupLatestFinalizationEntry
-    it "Test lookupTransaction" testLookupTransaction
-    it "Test memberTransaction" testMemberTransaction
+    Common.forEveryProtocolVersionConsensusV1 $ \spv pvString ->
+        describe pvString $ do
+            it "Test lookupLastBlock" $ testLookupLastBlock spv
+            it "Test lookupFirstBlock" $ testLookupFirstBlock spv
+            it "Test lookupBlockByHeight" $ testLookupBlockByHeight spv
+            it "Test memberBlock" $ testMemberBlock spv
+            it "Test lookupBlock" $ testLookupBlock spv
+            it "Test lookupLatestFinalizationEntry" $ testLookupLatestFinalizationEntry spv
+            it "Test lookupTransaction" $ testLookupTransaction spv
+            it "Test memberTransaction" $ testMemberTransaction spv

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/LMDB.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/LMDB.hs
@@ -104,16 +104,14 @@ dummyBakedBlock sProtocolVersion n ts =
           bbTransactions = ts,
           bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
             SBlockHashVersion0 ->
-                DBHashesV0 $
-                    BlockDerivableHashesV0
-                        { bdhv0TransactionOutcomesHash = TransactionOutcomesHash dummyHash,
-                          bdhv0BlockStateHash = StateHashV0 dummyHash
-                        }
+                DerivableBlockHashesV0
+                    { dbhv0TransactionOutcomesHash = TransactionOutcomesHash dummyHash,
+                      dbhv0BlockStateHash = StateHashV0 dummyHash
+                    }
             SBlockHashVersion1 ->
-                DBHashesV1 $
-                    BlockDerivableHashesV1
-                        { bdhv1BlockResultHash = BlockResultHash dummyHash
-                        }
+                DerivableBlockHashesV1
+                    { dbhv1BlockResultHash = BlockResultHash dummyHash
+                    }
         }
 
 -- | A helper function for creating an account address given a seed.

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Timeout.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Timeout.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
 -- | Module testing functions from the 'Concordium.KonsensusV1.Consensus.Timeout' module.
@@ -41,6 +43,7 @@ import Concordium.Types
 import Concordium.Types.BakerIdentity
 import qualified Concordium.Types.DummyData as Dummy
 import Concordium.Types.Option
+import Concordium.Types.Parameters
 import ConcordiumTests.KonsensusV1.Common
 import ConcordiumTests.KonsensusV1.TreeStateTest hiding (tests)
 import ConcordiumTests.KonsensusV1.Types hiding (tests)
@@ -54,9 +57,12 @@ testUpdateCurrentTimeout baseTimeout timeoutIncrease expectedTimeout = do
     let actualTimeout = updateCurrentTimeout timeoutIncrease baseTimeout
     assertEqual "Timeout duration should be correct" expectedTimeout actualTimeout
 
-genesisData :: GenesisData 'P6
-bakers :: [(BakerIdentity, FullBakerInfo)]
-(genesisData, bakers, _) =
+genesisDataV1 ::
+    forall pv.
+    (IsProtocolVersion pv, IsConsensusV1 pv) =>
+    SProtocolVersion pv ->
+    (GenesisData pv, [(BakerIdentity, FullBakerInfo)], Amount)
+genesisDataV1 sProtocolVersion =
     makeGenesisDataV1
         0
         5
@@ -66,7 +72,7 @@ bakers :: [(BakerIdentity, FullBakerInfo)]
         Dummy.dummyArs
         [ foundationAcct
         ]
-        Dummy.dummyKeyCollection
+        (withIsAuthorizationsVersionForPV sProtocolVersion Dummy.dummyKeyCollection)
         Dummy.dummyChainParameters
   where
     foundationAcct =
@@ -75,20 +81,34 @@ bakers :: [(BakerIdentity, FullBakerInfo)]
             (Dummy.deterministicKP 0)
             (Dummy.accountAddressFrom 0)
 
-genesisHash :: BlockHash
-genesisHash = genesisBlockHash genesisData
+genesisData ::
+    forall pv.
+    (IsProtocolVersion pv, IsConsensusV1 pv) =>
+    SProtocolVersion pv ->
+    GenesisData pv
+genesisData sProtocolVersion = let (genData, _, _) = genesisDataV1 sProtocolVersion in genData
+
+bakers ::
+    forall pv.
+    (IsProtocolVersion pv, IsConsensusV1 pv) =>
+    SProtocolVersion pv ->
+    [(BakerIdentity, FullBakerInfo)]
+bakers sProtocolVersion = let (_, theBakers, _) = genesisDataV1 sProtocolVersion in theBakers
+
+genesisHash :: (IsProtocolVersion pv, IsConsensusV1 pv) => SProtocolVersion pv -> BlockHash
+genesisHash = genesisBlockHash . genesisData
 
 sigThreshold :: Rational
 sigThreshold = 2 % 3
 
 -- | Generate a timeout message signed by the finalizer with the finalizer index @fid@ from
 --  'bakers' above in epoch @e@ with a qc epoch @qce@.
-dummyTimeoutMessage' :: Int -> Epoch -> Epoch -> TimeoutMessage
-dummyTimeoutMessage' fid e qce =
-    signTimeoutMessage timeoutMessageBody genesisHash $
+dummyTimeoutMessage' :: (IsProtocolVersion pv, IsConsensusV1 pv) => SProtocolVersion pv -> Int -> Epoch -> Epoch -> TimeoutMessage
+dummyTimeoutMessage' sProtocolVersion fid e qce =
+    signTimeoutMessage timeoutMessageBody (genesisHash sProtocolVersion) $
         bakerSignKey $
             fst $
-                bakers !! fid
+                bakers sProtocolVersion !! fid
   where
     timeoutMessageBody =
         TimeoutMessageBody
@@ -102,20 +122,25 @@ dummyTimeoutMessage' fid e qce =
         signTimeoutSignatureMessage dummyTimeoutSigMessage $
             bakerAggregationKey $
                 fst $
-                    bakers !! fid
+                    bakers sProtocolVersion !! fid
     dummyTimeoutSigMessage =
         TimeoutSignatureMessage
-            { tsmGenesis = genesisBlockHash genesisData,
+            { tsmGenesis = genesisBlockHash (genesisData sProtocolVersion),
               tsmRound = 1,
               tsmQCRound = 0,
               tsmQCEpoch = 0
             }
-    quorumCert = QuorumCertificate genesisHash 0 qce mempty $ FinalizerSet 0
+    quorumCert = QuorumCertificate (genesisHash sProtocolVersion) 0 qce mempty $ FinalizerSet 0
 
 -- | Generate a timeout message signed by the finalizer index @fid@ from
 --  'bakers' above in epoch @e@ and qc epoch @e@.
-dummyTimeoutMessage :: Int -> Epoch -> TimeoutMessage
-dummyTimeoutMessage fid e = dummyTimeoutMessage' fid e e
+dummyTimeoutMessage ::
+    (IsProtocolVersion pv, IsConsensusV1 pv) =>
+    SProtocolVersion pv ->
+    Int ->
+    Epoch ->
+    TimeoutMessage
+dummyTimeoutMessage sProtocolVersion fid e = dummyTimeoutMessage' sProtocolVersion fid e e
 
 -- | Test the function 'uponTimeoutEvent' using the baker context of the finalizer with index 0 from
 --  @bakers@. This tests the following:
@@ -124,9 +149,14 @@ dummyTimeoutMessage fid e = dummyTimeoutMessage' fid e e
 --  * that 'sendTimeoutMessage' has been called with the expected timeout message.
 --  * that the field @receivedTimeoutMessages@ of 'SkovData' has been updated with
 --    expected timeout message (via the call to 'processTimeout').
-testUponTimeoutEvent :: Assertion
-testUponTimeoutEvent = do
-    runTestMonad baker testTime genesisData $ do
+testUponTimeoutEvent ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testUponTimeoutEvent sProtocolVersion pvString = it (pvString ++ ": Test uponTimeoutEvent") $ do
+    runTestMonad @pv baker testTime (genesisData sProtocolVersion) $ do
         lastSigned <- use $ persistentRoundStatus . prsLastSignedTimeoutMessage
         liftIO $ assertEqual "last signed timeout message should be absent" Absent lastSigned
         (_, events) <- listen uponTimeoutEvent
@@ -150,12 +180,12 @@ testUponTimeoutEvent = do
                 expectedMessages
                 receivedMessages
   where
-    baker = BakerContext $ Just $ fst $ head bakers
+    baker = BakerContext $ Just $ fst $ head (bakers sProtocolVersion)
     testTime = timestampToUTCTime 1_000
     expectedMessages =
         Present $
             TimeoutMessages 0 (Map.singleton (FinalizerIndex 0) expectedMessage) Map.empty
-    expectedMessage = dummyTimeoutMessage 0 0
+    expectedMessage = dummyTimeoutMessage sProtocolVersion 0 0
 
 -- | Test 'processTimeout'.
 --  The following is tested before receival of enough timeout messages to form a valid TC:
@@ -167,14 +197,14 @@ testUponTimeoutEvent = do
 --  * that the round is indeed advanced
 --  * that the field @rsPreviousRoundTC@ is set with a valid TC
 --  * that the field @receivedTimeoutMessages@ of 'SkovData' is now @Absent@
-testProcessTimeout :: Assertion
-testProcessTimeout = do
-    runTestMonad noBaker testTime genesisData $ do
+testProcessTimeout :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> String -> Spec
+testProcessTimeout sProtocolVersion pvString = it (pvString ++ ": Test processTimeout") $ do
+    runTestMonad noBaker testTime (genesisData sProtocolVersion) $ do
         currentRound <- use $ roundStatus . rsCurrentRound
         liftIO $ assertEqual "Round should be 1" 1 currentRound
-        let message1 = dummyTimeoutMessage 0 0
-        let message2 = dummyTimeoutMessage 2 0
-        let message3 = dummyTimeoutMessage 4 0
+        let message1 = dummyTimeoutMessage sProtocolVersion 0 0
+        let message2 = dummyTimeoutMessage sProtocolVersion 2 0
+        let message3 = dummyTimeoutMessage sProtocolVersion 4 0
         processTimeout message1
 
         actualMessages <- use currentTimeoutMessages
@@ -238,128 +268,128 @@ testProcessTimeout = do
                 finComm <- use $ skovEpochBakers . currentEpochBakers . bfFinalizers
                 liftIO $
                     assertBool "TC should be valid" $
-                        checkTimeoutCertificate genesisHash sigThreshold finComm finComm finComm tc
+                        checkTimeoutCertificate (genesisHash sProtocolVersion) sigThreshold finComm finComm finComm tc
   where
     noBaker = BakerContext Nothing
     testTime = timestampToUTCTime 1_000
 
 -- | Test 'updateTimeoutMessages'.
-testUpdateTimeoutMessages :: Spec
-testUpdateTimeoutMessages =
-    describe "Test updateTimeoutMessages" $ do
+testUpdateTimeoutMessages :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> String -> Spec
+testUpdateTimeoutMessages sProtocolVersion pvString =
+    describe (pvString ++ ": Test updateTimeoutMessages") $ do
         it "Adding message, no messages already stored" $
             assertEqual "Should get stored" (Just messages1) $
                 updateTimeoutMessages Absent $
-                    dummyTimeoutMessage 0 0
+                    dummyTimeoutMessage sProtocolVersion 0 0
         it "Adding message in first epoch, where one message is already stored in first epoch." $
             assertEqual "Should get stored" (Just messages2) $
                 updateTimeoutMessages (Present messages1) $
-                    dummyTimeoutMessage 1 0
+                    dummyTimeoutMessage sProtocolVersion 1 0
         it "Adding message in first epoch + 1, where the qc is in epoch." $
             assertEqual "Should get stored" (Just messages3') $
                 updateTimeoutMessages (Present messages1) $
-                    dummyTimeoutMessage' 1 1 0
+                    dummyTimeoutMessage' sProtocolVersion 1 1 0
         it "Adding message in first epoch + 1, where one message is already stored in first epoch." $
             assertEqual "Should get stored" (Just messages3) $
                 updateTimeoutMessages (Present messages1) $
-                    dummyTimeoutMessage 1 1
+                    dummyTimeoutMessage sProtocolVersion 1 1
         it "Adding message in first epoch, where messages are already stored in both epochs." $
             assertEqual "Should get stored" (Just messages4) $
                 updateTimeoutMessages (Present messages3) $
-                    dummyTimeoutMessage 2 0
+                    dummyTimeoutMessage sProtocolVersion 2 0
         it "Adding message in first epoch + 1 = second epoch, where messages are already stored in both epochs." $
             assertEqual "Should get stored" (Just messages4') $
                 updateTimeoutMessages (Present messages3) $
-                    dummyTimeoutMessage 2 1
+                    dummyTimeoutMessage sProtocolVersion 2 1
         it "Adding message in first epoch + 2, where one message is already stored in first epoch." $
             assertEqual "Should get stored" (Just messages5) $
                 updateTimeoutMessages (Present messages1) $
-                    dummyTimeoutMessage 1 2
+                    dummyTimeoutMessage sProtocolVersion 1 2
         it "Adding message in first epoch + 2, where messages are already stored in both epochs." $
             assertEqual "Should get stored" (Just messages5') $
                 updateTimeoutMessages (Present messages3) $
-                    dummyTimeoutMessage 2 2
+                    dummyTimeoutMessage sProtocolVersion 2 2
         it "Adding message in first epoch + 3, where one message is already stored in first epoch." $
             assertEqual "Should get stored" (Just messages5'') $
                 updateTimeoutMessages (Present messages1) $
-                    dummyTimeoutMessage 3 3
+                    dummyTimeoutMessage sProtocolVersion 3 3
         it "Adding message in first epoch + 3, where messages are already stored in both epochs." $
             assertEqual "Should get stored" (Just messages5'') $
                 updateTimeoutMessages (Present messages3) $
-                    dummyTimeoutMessage 3 3
+                    dummyTimeoutMessage sProtocolVersion 3 3
         it "Adding message in first epoch - 1, where one message is already stored in first epoch." $
             assertEqual "Should get stored" (Just messages6) $
                 updateTimeoutMessages (Present messages5) $
-                    dummyTimeoutMessage 0 1
+                    dummyTimeoutMessage sProtocolVersion 0 1
         it "Adding message in first epoch - 1, where messages are already stored in both epochs." $
             assertEqual "Should not get stored" Nothing $
                 updateTimeoutMessages (Present messages5') $
-                    dummyTimeoutMessage 0 0
+                    dummyTimeoutMessage sProtocolVersion 0 0
         it "Adding message in first epoch - 2, where messages are already stored in both epochs." $
             assertEqual "Should not get stored" Nothing $
                 updateTimeoutMessages (Present messages5) $
-                    dummyTimeoutMessage 0 0
+                    dummyTimeoutMessage sProtocolVersion 0 0
   where
     messages6 =
         TimeoutMessages
-            { tmSecondEpochTimeouts = Map.fromList [(FinalizerIndex 1, dummyTimeoutMessage 1 2)],
-              tmFirstEpochTimeouts = Map.fromList [(FinalizerIndex 0, dummyTimeoutMessage 0 1)],
+            { tmSecondEpochTimeouts = Map.fromList [(FinalizerIndex 1, dummyTimeoutMessage sProtocolVersion 1 2)],
+              tmFirstEpochTimeouts = Map.fromList [(FinalizerIndex 0, dummyTimeoutMessage sProtocolVersion 0 1)],
               tmFirstEpoch = 1
             }
     messages5'' =
         TimeoutMessages
             { tmSecondEpochTimeouts = Map.empty,
-              tmFirstEpochTimeouts = Map.fromList [(FinalizerIndex 3, dummyTimeoutMessage 3 3)],
+              tmFirstEpochTimeouts = Map.fromList [(FinalizerIndex 3, dummyTimeoutMessage sProtocolVersion 3 3)],
               tmFirstEpoch = 3
             }
     messages5' =
         TimeoutMessages
-            { tmSecondEpochTimeouts = Map.fromList [(FinalizerIndex 2, dummyTimeoutMessage 2 2)],
-              tmFirstEpochTimeouts = Map.fromList [(FinalizerIndex 1, dummyTimeoutMessage 1 1)],
+            { tmSecondEpochTimeouts = Map.fromList [(FinalizerIndex 2, dummyTimeoutMessage sProtocolVersion 2 2)],
+              tmFirstEpochTimeouts = Map.fromList [(FinalizerIndex 1, dummyTimeoutMessage sProtocolVersion 1 1)],
               tmFirstEpoch = 1
             }
     messages5 =
         TimeoutMessages
             { tmSecondEpochTimeouts = Map.empty,
-              tmFirstEpochTimeouts = Map.fromList [(FinalizerIndex 1, dummyTimeoutMessage 1 2)],
+              tmFirstEpochTimeouts = Map.fromList [(FinalizerIndex 1, dummyTimeoutMessage sProtocolVersion 1 2)],
               tmFirstEpoch = 2
             }
     messages4' =
         TimeoutMessages
-            { tmSecondEpochTimeouts = Map.fromList [(FinalizerIndex 1, dummyTimeoutMessage 1 1), (FinalizerIndex 2, dummyTimeoutMessage 2 1)],
-              tmFirstEpochTimeouts = Map.fromList [(FinalizerIndex 0, dummyTimeoutMessage 0 0)],
+            { tmSecondEpochTimeouts = Map.fromList [(FinalizerIndex 1, dummyTimeoutMessage sProtocolVersion 1 1), (FinalizerIndex 2, dummyTimeoutMessage sProtocolVersion 2 1)],
+              tmFirstEpochTimeouts = Map.fromList [(FinalizerIndex 0, dummyTimeoutMessage sProtocolVersion 0 0)],
               tmFirstEpoch = 0
             }
     messages4 =
         TimeoutMessages
-            { tmSecondEpochTimeouts = Map.fromList [(FinalizerIndex 1, dummyTimeoutMessage 1 1)],
-              tmFirstEpochTimeouts = Map.fromList [(FinalizerIndex 0, dummyTimeoutMessage 0 0), (FinalizerIndex 2, dummyTimeoutMessage 2 0)],
+            { tmSecondEpochTimeouts = Map.fromList [(FinalizerIndex 1, dummyTimeoutMessage sProtocolVersion 1 1)],
+              tmFirstEpochTimeouts = Map.fromList [(FinalizerIndex 0, dummyTimeoutMessage sProtocolVersion 0 0), (FinalizerIndex 2, dummyTimeoutMessage sProtocolVersion 2 0)],
               tmFirstEpoch = 0
             }
     messages3' =
         TimeoutMessages
             { tmSecondEpochTimeouts = Map.empty,
-              tmFirstEpochTimeouts = Map.fromList [(FinalizerIndex 0, dummyTimeoutMessage 0 0), (FinalizerIndex 1, dummyTimeoutMessage' 1 1 0)],
+              tmFirstEpochTimeouts = Map.fromList [(FinalizerIndex 0, dummyTimeoutMessage sProtocolVersion 0 0), (FinalizerIndex 1, dummyTimeoutMessage' sProtocolVersion 1 1 0)],
               tmFirstEpoch = 0
             }
     messages3 =
         TimeoutMessages
-            { tmSecondEpochTimeouts = Map.fromList [(FinalizerIndex 1, dummyTimeoutMessage 1 1)],
-              tmFirstEpochTimeouts = Map.fromList [(FinalizerIndex 0, dummyTimeoutMessage 0 0)],
+            { tmSecondEpochTimeouts = Map.fromList [(FinalizerIndex 1, dummyTimeoutMessage sProtocolVersion 1 1)],
+              tmFirstEpochTimeouts = Map.fromList [(FinalizerIndex 0, dummyTimeoutMessage sProtocolVersion 0 0)],
               tmFirstEpoch = 0
             }
     messages2 =
         TimeoutMessages
             { tmSecondEpochTimeouts = Map.empty,
-              tmFirstEpochTimeouts = Map.fromList [(FinalizerIndex 0, dummyTimeoutMessage 0 0), (FinalizerIndex 1, dummyTimeoutMessage 1 0)],
+              tmFirstEpochTimeouts = Map.fromList [(FinalizerIndex 0, dummyTimeoutMessage sProtocolVersion 0 0), (FinalizerIndex 1, dummyTimeoutMessage sProtocolVersion 1 0)],
               tmFirstEpoch = 0
             }
-    messages1 = TimeoutMessages 0 (Map.singleton (FinalizerIndex 0) $ dummyTimeoutMessage 0 0) Map.empty
+    messages1 = TimeoutMessages 0 (Map.singleton (FinalizerIndex 0) $ dummyTimeoutMessage sProtocolVersion 0 0) Map.empty
 
 -- | Test the 'receiveTimeoutMessage' function which partially verifies
 --  a 'TimeoutMessage'.
-testReceiveTimeoutMessage :: Spec
-testReceiveTimeoutMessage = describe "Receive timeout message" $ do
+testReceiveTimeoutMessage :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> String -> Spec
+testReceiveTimeoutMessage sProtocolVersion pvString = describe (pvString ++ ": Receive timeout message") $ do
     it "rejects obsolete round" $ receiveAndCheck sd obsoleteRoundMessage $ Rejected ObsoleteRound
     it "rejects obsolete qc" $ receiveAndCheck sd obsoleteQCMessage $ Rejected ObsoleteQC
     it "initializes catch-up upon future epoch" $ receiveAndCheck sd futureEpochTM CatchupRequired
@@ -376,7 +406,7 @@ testReceiveTimeoutMessage = describe "Receive timeout message" $ do
     it "received a valid timeout message" $
         receiveAndCheck sd validTimeoutMessage $
             Received $
-                PartiallyVerifiedTimeoutMessage validTimeoutMessage finalizers True (Present $ someBlockPointer liveBlockHash 1 0)
+                PartiallyVerifiedTimeoutMessage validTimeoutMessage finalizers True (Present $ someBlockPointer sProtocolVersion liveBlockHash 1 0)
   where
     -- A valid timeout message that should pass the initial verification.
     -- This is sent from finalizer with index 2.
@@ -461,7 +491,7 @@ testReceiveTimeoutMessage = describe "Receive timeout message" $ do
     -- @liveBlockHash@.
     anotherLiveBlock = BlockHash $ Hash.hash "another live block"
     -- A block that is recorded as live in the tree state
-    liveBlock = someBlockPointer liveBlockHash 3 0
+    liveBlock = someBlockPointer sProtocolVersion liveBlockHash 3 0
     -- FinalizerInfo for the finalizer index provided.
     -- All finalizers has the same keys attached.
     fi :: Word32 -> FinalizerInfo
@@ -484,7 +514,7 @@ testReceiveTimeoutMessage = describe "Receive timeout message" $ do
             & roundStatus . rsCurrentRound .~ Round 2
             & roundStatus . rsCurrentEpoch .~ 0
             & genesisMetadata %~ (\existingGenesis -> existingGenesis{gmCurrentGenesisHash = genesisBlkHash, gmFirstGenesisHash = genesisBlkHash})
-            & lastFinalized .~ myBlockPointer (Round 1) 0
+            & lastFinalized .~ myBlockPointer sProtocolVersion (Round 1) 0
             & skovEpochBakers . currentEpochBakers .~ bakersAndFinalizers
             & skovEpochBakers . previousEpochBakers .~ bakersAndFinalizers
             & blockTable . deadBlocks %~ insertDeadCache deadBlockHash
@@ -495,10 +525,11 @@ testReceiveTimeoutMessage = describe "Receive timeout message" $ do
             & currentTimeoutMessages .~ Present (TimeoutMessages 0 (Map.singleton (FinalizerIndex 1) duplicateMessage) Map.empty)
     -- A low level database which consists of a finalized block for height 0 otherwise empty.
     lldb =
-        let myLLDB = lldbWithGenesis
+        let myLLDB = lldbWithGenesis @pv
         in  myLLDB{lldbBlocks = HM.singleton someOldFinalizedBlockHash $ toStoredBlock (dummyBlock 20)}
     -- receive the timeout message in the provided tree state context and
     -- check that the result is as expected.
+    receiveAndCheck :: SkovData pv -> TimeoutMessage -> ReceiveTimeoutMessageResult pv -> Expectation
     receiveAndCheck skovData tm expect = do
         resultCode <- runTestLLDB lldb $ receiveTimeoutMessage tm skovData
         resultCode `shouldBe` expect
@@ -506,8 +537,8 @@ testReceiveTimeoutMessage = describe "Receive timeout message" $ do
 -- | Tests for executing timeout messages.
 --  The @executeTimeoutMessage@ executes a 'TimeoutMessage' which is partially verified
 --  by @receiveTimeoutMessage@.
-testExecuteTimeoutMessages :: Spec
-testExecuteTimeoutMessages = describe "execute timeout messages" $ do
+testExecuteTimeoutMessages :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> String -> Spec
+testExecuteTimeoutMessages sProtocolVersion pvString = describe (pvString ++ ": execute timeout messages") $ do
     it "rejects message with invalid bls signature" $ execute invalidAggregateSignature InvalidAggregateSignature
     it "accepts message where there is already checked a valid qc for the round" $ execute validMessageAbsentQCPointer ExecutionSuccess
     it "rejects message with invalid qc signature (qc round is better than recorded highest qc)" $ execute invalidQCTimeoutMessage $ InvalidQC $ someInvalidQC 2 0
@@ -523,12 +554,18 @@ testExecuteTimeoutMessages = describe "execute timeout messages" $ do
     -- - current round is 2
     -- - highest QC seen is round 1 and epoch 0
     -- - a qc for round 1 epoch 0 has been checked (witnessed)
-    execute timeoutMessage expect = runTestMonad @'P6 noBaker time myGenesisData $ do
+    execute :: PartiallyVerifiedTimeoutMessage pv -> ExecuteTimeoutMessageResult -> Assertion
+    execute timeoutMessage expect = runTestMonad @pv noBaker time myGenesisData $ do
         -- Set the highest qc to round 1 epoch 0.
         roundStatus . rsHighestCertifiedBlock
             .= CertifiedBlock
                 { cbQuorumCertificate = someQC (Round 1) 0,
-                  cbQuorumBlock = someBlockPointer (BlockHash $ Hash.hash "quorum block hash") 0 1
+                  cbQuorumBlock =
+                    someBlockPointer
+                        sProtocolVersion
+                        (BlockHash $ Hash.hash "quorum block hash")
+                        0
+                        1
                 }
         -- Set the current round to round 2.
         roundStatus . rsCurrentRound .= Round 2
@@ -558,7 +595,7 @@ testExecuteTimeoutMessages = describe "execute timeout messages" $ do
             { pvtmTimeoutMessage = mkTimeoutMessage $! mkTimeoutMessageBody 2 2 0 (someInvalidQC 2 0),
               pvtmQuorumFinalizers = finalizers,
               pvtmAggregateSignatureValid = True,
-              pvtmBlock = Present $ myBlockPointer 1 0
+              pvtmBlock = Present $ myBlockPointer sProtocolVersion 1 0
             }
     -- wrong epoch
     wrongEpochMessage =
@@ -566,7 +603,7 @@ testExecuteTimeoutMessages = describe "execute timeout messages" $ do
             { pvtmTimeoutMessage = mkTimeoutMessage $! mkTimeoutMessageBody 2 0 0 (someInvalidQC 0 0),
               pvtmQuorumFinalizers = finalizers,
               pvtmAggregateSignatureValid = True,
-              pvtmBlock = Present $ myBlockPointer 1 0
+              pvtmBlock = Present $ myBlockPointer sProtocolVersion 1 0
             }
     -- the finalization committee.
     finalizers = FinalizationCommittee (Vec.fromList [fi 0, fi 1, fi 2]) 3
@@ -609,7 +646,7 @@ testExecuteTimeoutMessages = describe "execute timeout messages" $ do
     -- the genesis data for composing the monad that the computations are run within.
     -- it consists of 3 finalizers with indices 0,1,2
     (myGenesisData, _, _) =
-        makeGenesisDataV1 @'P6
+        makeGenesisDataV1 @pv
             (Timestamp 0)
             3
             3_600_000
@@ -618,16 +655,22 @@ testExecuteTimeoutMessages = describe "execute timeout messages" $ do
             Dummy.dummyArs
             [ foundationAcct
             ]
-            Dummy.dummyKeyCollection
+            (withIsAuthorizationsVersionForPV sProtocolVersion Dummy.dummyKeyCollection)
             Dummy.dummyChainParameters
 
 -- | Tests the 'checkTimeoutCertificate' function.
-testCheckTimeoutCertificate :: Spec
-testCheckTimeoutCertificate = describe "check timeout certificate" $ do
-    it "accepts timeout certificate" checkOkTC
-    it "rejects with wrong genesis" wrongGenesis
-    it "rejects when there is not enough weight" insufficientWeight
-    it "rejects when the signature is invalid" invalidSignature
+testCheckTimeoutCertificate ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testCheckTimeoutCertificate sProtocolVersion pvString =
+    describe (pvString ++ ": check timeout certificate") $ do
+        it "accepts timeout certificate" checkOkTC
+        it "rejects with wrong genesis" wrongGenesis
+        it "rejects when there is not enough weight" insufficientWeight
+        it "rejects when the signature is invalid" invalidSignature
   where
     checkOkTC = runTest $ do
         finComm <- use $ skovEpochBakers . currentEpochBakers . bfFinalizers
@@ -648,26 +691,28 @@ testCheckTimeoutCertificate = describe "check timeout certificate" $ do
         checkNotOk $ checkTimeoutCertificate okGenesisHash sigThreshold finComm finComm finComm $ invalidSignatureInTC qc
     checkOk = liftIO . assertBool "Check failed"
     checkNotOk b = liftIO . assertBool "Check failed" $ not b
-    runTest = runTestMonad (BakerContext Nothing) (timestampToUTCTime 1_000) TestBlocks.genesisData
-    okGenesisHash = TestBlocks.genesisHash
-    invalidGenesisHash = genesisHash
-    validTCFor qc = TestBlocks.validTimeoutFor qc (Round 1)
+    runTest = runTestMonad (BakerContext Nothing) (timestampToUTCTime 1_000) (TestBlocks.genesisData sProtocolVersion)
+    okGenesisHash = TestBlocks.genesisHash sProtocolVersion
+    invalidGenesisHash = genesisHash sProtocolVersion
+    validTCFor qc = TestBlocks.validTimeoutFor sProtocolVersion qc (Round 1)
     invalidSignatureInTC qc =
         let tc = validTCFor qc
         in  tc{tcAggregateSignature = TimeoutSignature Bls.emptySignature}
 
 tests :: Spec
 tests = describe "KonsensusV1.Timeout" $ do
-    testReceiveTimeoutMessage
-    testExecuteTimeoutMessages
-    it "Test updateCurrentTimeout" $ do
-        testUpdateCurrentTimeout 10_000 (3 % 2) 15_000
-        testUpdateCurrentTimeout 10_000 (4 % 3) 13_333
-        testUpdateCurrentTimeout 10_000 (5 % 3) 16_666
-        testUpdateCurrentTimeout 3_000 (4 % 3) 4_000
-        testUpdateCurrentTimeout 80_000 (10 % 9) 88_888
-        testUpdateCurrentTimeout 8_000 (8 % 7) 9_142
-    it "Test processTimeout" testProcessTimeout
-    it "Test uponTimeoutEvent" testUponTimeoutEvent
-    testUpdateTimeoutMessages
-    testCheckTimeoutCertificate
+    TestBlocks.forEveryProtocolVersionConsensusV1 $ \spv pvString -> do
+        testReceiveTimeoutMessage spv pvString
+        testExecuteTimeoutMessages spv pvString
+        testProcessTimeout spv pvString
+        testUponTimeoutEvent spv pvString
+        testUpdateTimeoutMessages spv pvString
+        testCheckTimeoutCertificate spv pvString
+
+        it "Test updateCurrentTimeout" $ do
+            testUpdateCurrentTimeout 10_000 (3 % 2) 15_000
+            testUpdateCurrentTimeout 10_000 (4 % 3) 13_333
+            testUpdateCurrentTimeout 10_000 (5 % 3) 16_666
+            testUpdateCurrentTimeout 3_000 (4 % 3) 4_000
+            testUpdateCurrentTimeout 80_000 (10 % 9) 88_888
+            testUpdateCurrentTimeout 8_000 (8 % 7) 9_142

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/TransactionProcessingTest.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/TransactionProcessingTest.hs
@@ -506,16 +506,14 @@ testProcessBlockItems sProtocolVersion = describe "processBlockItems" $ do
             bbTransactions = Vec.fromList txs
             bbDerivableHashes = case sBlockHashVersionFor sProtocolVersion of
                 SBlockHashVersion0 ->
-                    DBHashesV0 $
-                        BlockDerivableHashesV0
-                            { bdhv0TransactionOutcomesHash = TransactionOutcomesHash minBound,
-                              bdhv0BlockStateHash = StateHashV0 $ Hash.hash "DummyStateHash"
-                            }
+                    DerivableBlockHashesV0
+                        { dbhv0TransactionOutcomesHash = TransactionOutcomesHash minBound,
+                          dbhv0BlockStateHash = StateHashV0 $ Hash.hash "DummyStateHash"
+                        }
                 SBlockHashVersion1 ->
-                    DBHashesV1 $
-                        BlockDerivableHashesV1
-                            { bdhv1BlockResultHash = BlockResultHash $ Hash.hash "DummyBlockResultHash"
-                            }
+                    DerivableBlockHashesV1
+                        { dbhv1BlockResultHash = BlockResultHash $ Hash.hash "DummyBlockResultHash"
+                        }
         in  BakedBlock
                 { bbQuorumCertificate =
                     QuorumCertificate

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/TreeStateTest.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/TreeStateTest.hs
@@ -155,16 +155,14 @@ dummyBakedBlock parentHash bbRound bbTimestamp = BakedBlock{..}
     bbTransactions = mempty
     bbDerivableHashes = case sBlockHashVersionFor (protocolVersion @pv) of
         SBlockHashVersion0 ->
-            DBHashesV0 $
-                BlockDerivableHashesV0
-                    { bdhv0TransactionOutcomesHash = TransactionOutcomesHash minBound,
-                      bdhv0BlockStateHash = Common.dummyStateHash
-                    }
+            DerivableBlockHashesV0
+                { dbhv0TransactionOutcomesHash = TransactionOutcomesHash minBound,
+                  dbhv0BlockStateHash = Common.dummyStateHash
+                }
         SBlockHashVersion1 ->
-            DBHashesV1 $
-                BlockDerivableHashesV1
-                    { bdhv1BlockResultHash = dummyBlockResultHash
-                    }
+            DerivableBlockHashesV1
+                { dbhv1BlockResultHash = dummyBlockResultHash
+                }
 
 -- | Create a 'SignedBlock' by signing the
 --  'dummyBakedBlock' with 'dummySignKeys'

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Types.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Types.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
 -- | Testing of 'Concordium.KonsensusV1.Types' and 'Concordium.KonsensusV1.TreeState.Types' modules.
@@ -21,15 +22,16 @@ import Concordium.Crypto.DummyData
 import qualified Concordium.Crypto.SHA256 as Hash
 import qualified Concordium.Crypto.SignatureScheme as SigScheme
 import qualified Concordium.Crypto.VRF as VRF
+import Concordium.KonsensusV1.TreeState.Types
+import Concordium.KonsensusV1.Types
 import Concordium.Types
 import qualified Concordium.Types.DummyData as Dummy
+import Concordium.Types.Option
 import Concordium.Types.Transactions
 import qualified Concordium.Types.Transactions as Transactions
 import qualified Data.FixedByteString as FBS
 
-import Concordium.KonsensusV1.TreeState.Types
-import Concordium.KonsensusV1.Types
-import Concordium.Types.Option
+import qualified ConcordiumTests.KonsensusV1.Common as Common
 
 -- | Generate a 'FinalizerSet'. The size parameter determines the size of the committee that
 --  the finalizers are (nominally) sampled from.
@@ -304,18 +306,22 @@ propSerializeTimeoutMessage :: Property
 propSerializeTimeoutMessage = forAll genTimeoutMessage serCheck
 
 -- | Test that serializing then deserializing a baked block is the identity.
-propSerializeBakedBlock :: Property
-propSerializeBakedBlock =
-    forAll (genBakedBlock SP6) $ \bb ->
-        case runGet (getBakedBlock SP6 (TransactionTime 42)) $! runPut (putBakedBlock bb) of
+propSerializeBakedBlock :: SProtocolVersion pv -> Property
+propSerializeBakedBlock sProtocolVersion =
+    forAll (genBakedBlock sProtocolVersion) $ \bb ->
+        case runGet (getBakedBlock sProtocolVersion (TransactionTime 42)) $! runPut (putBakedBlock bb) of
             Left _ -> False
             Right bb' -> bb == bb'
 
 -- | Test that serializing then deserializing a signed block is the identity.
-propSerializeSignedBlock :: Property
-propSerializeSignedBlock =
-    forAll (genSignedBlock @'P6) $ \sb ->
-        case runGet (getSignedBlock SP6 (TransactionTime 42)) $! runPut (putSignedBlock sb) of
+propSerializeSignedBlock ::
+    forall pv.
+    (IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    Property
+propSerializeSignedBlock sProtocolVersion =
+    forAll (genSignedBlock @pv) $ \sb ->
+        case runGet (getSignedBlock sProtocolVersion (TransactionTime 42)) $! runPut (putSignedBlock sb) of
             Left _ -> False
             Right sb' -> sb == sb'
 
@@ -402,16 +408,16 @@ propSignQuorumSignatureMessageDiffBody =
                     pubKeys = [(Bls.derivePublicKey someBlsSecretKey), (Bls.derivePublicKey (someOtherBlsSecretKey 1))]
                 in  not (checkQuorumSignature qsm1 pubKeys qs')
 
-propSignBakedBlock :: Property
-propSignBakedBlock =
-    forAll (genBakedBlock SP6) $ \bb ->
+propSignBakedBlock :: SProtocolVersion pv -> Property
+propSignBakedBlock sProtocolVersion =
+    forAll (genBakedBlock sProtocolVersion) $ \bb ->
         forAll genBlockHash $ \genesisHash ->
             forAll genBlockKeyPair $ \kp@(Sig.KeyPair _ pk) ->
                 (verifyBlockSignature pk genesisHash (signBlock kp genesisHash bb))
 
-propSignBakedBlockDiffKey :: Property
-propSignBakedBlockDiffKey =
-    forAll (genBakedBlock SP6) $ \bb ->
+propSignBakedBlockDiffKey :: SProtocolVersion pv -> Property
+propSignBakedBlockDiffKey sProtocolVersion =
+    forAll (genBakedBlock sProtocolVersion) $ \bb ->
         forAll genBlockHash $ \genesisHash ->
             forAll genBlockKeyPair $ \kp ->
                 forAll genBlockKeyPair $ \(Sig.KeyPair _ pk1) ->
@@ -434,8 +440,6 @@ tests = describe "KonsensusV1.Types" $ do
     it "TimeoutCertificate serialization" propSerializeTimeoutCertificate
     it "TimeoutMessageBody serialization" propSerializeTimeoutMessageBody
     it "TimeoutMessage serialization" propSerializeTimeoutMessage
-    it "BakedBlock serialization" propSerializeBakedBlock
-    it "SignedBlock serialization" propSerializeSignedBlock
     it "RoundStatus serialization" propSerializePersistentRoundStatus
     it "TimeoutMessage signature check positive" propSignTimeoutMessagePositive
     it "TimeoutMessage signature check fails with different key" propSignTimeoutMessageDiffKey
@@ -446,6 +450,10 @@ tests = describe "KonsensusV1.Types" $ do
     it "QuorumSignatureMessage signature check positive" propSignQuorumSignatureMessage
     it "QuorumSignatureMessage signature check fails with different key" propSignQuorumSignatureMessageDiffKey
     it "QuorumSignatureMessage signature check fails with different body" propSignQuorumSignatureMessageDiffBody
-    it "SignedBlock signature check positive" propSignBakedBlock
-    it "SignedBlock signature fails with different key" propSignBakedBlockDiffKey
     it "Conversion to and from FinalizerSet" propFinalizerListIsInverseOfFinalizerSet
+    Common.forEveryProtocolVersionConsensusV1 $ \spv pvString -> do
+        describe pvString $ do
+            it "SignedBlock serialization" $ propSerializeSignedBlock spv
+            it "BakedBlock serialization" $ propSerializeBakedBlock spv
+            it "SignedBlock signature fails with different key" $ propSignBakedBlockDiffKey spv
+            it "SignedBlock signature check positive" $ propSignBakedBlock spv

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Types.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Types.hs
@@ -242,18 +242,16 @@ genBakedBlock sProtocolVersion = do
         SBlockHashVersion0 -> do
             bbStateHash <- StateHashV0 . Hash.Hash . FBS.pack <$> vector 32
             return $
-                DBHashesV0 $
-                    BlockDerivableHashesV0
-                        { bdhv0TransactionOutcomesHash = Transactions.emptyTransactionOutcomesHashV1,
-                          bdhv0BlockStateHash = bbStateHash
-                        }
+                DerivableBlockHashesV0
+                    { dbhv0TransactionOutcomesHash = Transactions.emptyTransactionOutcomesHashV1,
+                      dbhv0BlockStateHash = bbStateHash
+                    }
         SBlockHashVersion1 -> do
             blockResultHash <- BlockResultHash . Hash.Hash . FBS.pack <$> vector 32
             return $
-                DBHashesV1 $
-                    BlockDerivableHashesV1
-                        { bdhv1BlockResultHash = blockResultHash
-                        }
+                DerivableBlockHashesV1
+                    { dbhv1BlockResultHash = blockResultHash
+                    }
 
     return
         BakedBlock


### PR DESCRIPTION
## Purpose

Prior to this PR, numerous of our tests are only targeting protocol version 6, this PR changes this such that these tests are generalized to run against every protocol version starting from P6 and onwards.

## Changes

- No changes are intended by this PR besides generalizing the tests, the only exception is a test related to account nonce https://github.com/Concordium/concordium-node/pull/1111/files#diff-176f6e3e32412c792f8e0873ce966e99076d1be8da6a228d9226d6b87301fbefR760

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
