### PR TITLE
Query contract module

### DIFF
--- a/concordium-consensus/src/Concordium/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler.hs
@@ -1659,7 +1659,8 @@ handleContractUpdateV1 originAddr istance checkAndGetSender transferAmount recei
               -- Check whether the number of logs and the size of return values are limited in the current protocol version.
               rcLimitLogsAndRvs = Wasm.limitLogsAndReturnValues $ protocolVersion @(MPV m),
               rcFixRollbacks = demoteProtocolVersion (protocolVersion @(MPV m)) >= P6,
-              rcSupportAccountSignatureChecks = supportsAccountSignatureChecks $ protocolVersion @(MPV m)
+              rcSupportAccountSignatureChecks = supportsAccountSignatureChecks $ protocolVersion @(MPV m),
+              rcSupportContractInspectionQueries = supportsContractInspectionQueries $ protocolVersion @(MPV m)
             }
     transferAccountSync ::
         AccountAddress -> -- The target account address.

--- a/concordium-consensus/src/Concordium/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler.hs
@@ -1565,7 +1565,7 @@ handleContractUpdateV1 originAddr istance checkAndGetSender transferAmount recei
                                                                         )
                                     WasmV1.QueryContractModuleReference{..} -> do
                                         -- Charge for querying the balance of a contract.
-                                        tickEnergy Cost.contractInstanceQueryContractBalanceCost
+                                        tickEnergy Cost.contractInstanceQueryContractModuleReferenceCost
                                         -- Lookup contract balances.
                                         maybeInstanceInfo <- getCurrentContractInstance imqcmrAddress
                                         case maybeInstanceInfo of
@@ -1604,7 +1604,7 @@ handleContractUpdateV1 originAddr istance checkAndGetSender transferAmount recei
                                                         )
                                     WasmV1.QueryContractName{..} -> do
                                         -- Charge for querying the balance of a contract.
-                                        tickEnergy Cost.contractInstanceQueryContractBalanceCost
+                                        tickEnergy Cost.contractInstanceQueryContractNameCost
                                         -- Lookup contract balances.
                                         maybeInstanceInfo <- getCurrentContractInstance imqcnAddress
                                         case maybeInstanceInfo of

--- a/concordium-consensus/src/Concordium/Scheduler/WasmIntegration/V1.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/WasmIntegration/V1.hs
@@ -287,6 +287,8 @@ foreign import ccall "call_receive_v1"
         Word8 ->
         -- | Non-zero to enable support for account keys query and signature checks.
         Word8 ->
+        -- | Non-zero to enable support for contract module reference and name queries.
+        Word8 ->
         -- | New state, logs, and actions, if applicable, or null, signalling out-of-energy.
         IO (Ptr Word8)
 
@@ -678,7 +680,9 @@ data RuntimeConfig = RuntimeConfig
       rcLimitLogsAndRvs :: Bool,
       -- | Whether to support account key queries and account signature checks.
       --  Supported in P6 onward.
-      rcSupportAccountSignatureChecks :: Bool
+      rcSupportAccountSignatureChecks :: Bool,
+      -- | Whether to support querying smart contract module reference and name.
+      rcSupportContractInspectionQueries :: Bool
     }
 
 -- | Apply a receive function which is assumed to be part of the given module.
@@ -738,6 +742,7 @@ applyReceiveFun miface cm receiveCtx rName useFallback param amnt initialState R
                                     stateWrittenToPtr
                                     (if rcSupportChainQueries then 1 else 0)
                                     (if rcSupportAccountSignatureChecks then 1 else 0)
+                                    (if rcSupportContractInspectionQueries then 1 else 0)
                             if outPtr == nullPtr
                                 then return (Just (Left Trap, 0)) -- this case should not happen
                                 else do

--- a/concordium-consensus/src/Concordium/Scheduler/WasmIntegration/V1.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/WasmIntegration/V1.hs
@@ -424,6 +424,14 @@ data InvokeMethod
       QueryAccountKeys
         { imqakAddress :: !AccountAddress
         }
+    | -- | Query the module reference of a contract.
+      QueryContractModuleReference
+        { imqcmrAddress :: !ContractAddress
+        }
+    | -- | Query the constructor name of a contract.
+      QueryContractName
+        { imqcnAddress :: !ContractAddress
+        }
 
 getInvokeMethod :: Get InvokeMethod
 getInvokeMethod =
@@ -436,6 +444,8 @@ getInvokeMethod =
         5 -> return QueryExchangeRates
         6 -> CheckAccountSignature <$> get <*> getByteStringLen
         7 -> QueryAccountKeys <$> get
+        8 -> QueryContractModuleReference <$> get
+        9 -> QueryContractName <$> get
         n -> fail $ "Unsupported invoke method tag: " ++ show n
 
 -- | Data return from the contract in case of successful initialization.


### PR DESCRIPTION
## Purpose

Closes #1124
Depends on https://github.com/Concordium/concordium-base/pull/511

Adds support for smart contracts to query the module reference and contract name of smart contract instances.

## Changes

- Add constructors to the `InvokeMethod` type for the new queries.
- Add implementation for the new queries.


## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
