### PR TITLE
Fix tests by checking block state invariants in the same state context

### DIFF
--- a/concordium-consensus/tests/scheduler/SchedulerTests/BakerTransactions.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/BakerTransactions.hs
@@ -32,7 +32,6 @@ import qualified Concordium.Crypto.SignatureScheme as SigScheme
 import qualified Concordium.Crypto.VRF as VRF
 import Concordium.GlobalState.DummyData
 import Concordium.Scheduler.DummyData
-import System.IO.Unsafe
 
 import qualified SchedulerTests.Helpers as Helpers
 import SchedulerTests.TestUtils

--- a/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
@@ -358,15 +358,11 @@ runSchedulerTestWithIntermediateStates ::
     PersistentBSM pv (BS.HashedPersistentBlockState pv) ->
     (SchedulerResult -> BS.PersistentBlockState pv -> PersistentBSM pv a) ->
     Types.GroupedTransactions ->
-    IO (IntermediateResults a, BS.HashedPersistentBlockState pv)
-runSchedulerTestWithIntermediateStates config constructState extractor transactions =
-    runTestBlockState blockStateComputation
+    PersistentBSM pv (IntermediateResults a, BS.HashedPersistentBlockState pv)
+runSchedulerTestWithIntermediateStates config constructState extractor transactions = do
+    blockStateBefore <- constructState
+    foldM transactionRunner ([], blockStateBefore) transactions
   where
-    blockStateComputation :: PersistentBSM pv (IntermediateResults a, BS.HashedPersistentBlockState pv)
-    blockStateComputation = do
-        blockStateBefore <- constructState
-        foldM transactionRunner ([], blockStateBefore) transactions
-
     transactionRunner ::
         (IntermediateResults a, BS.HashedPersistentBlockState pv) ->
         Types.TransactionGroup ->


### PR DESCRIPTION
## Purpose

Fix tests.

Checking state invariants, it is crucial that the invariant checking function is executed in the same context as the state is constructed, since, for example, LMDB database must be available for looking up accounts.

Other uses of `assertBlockStateInvariants` are correct already.

It's unclear why this test ever worked but possibly it sometimes worked due to unsafePerformIO usage. It did not work on my machine though, it caused an LMDB error.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.