### PR TITLE
Integrate new cost assignment version.

### DIFF
--- a/concordium-consensus/src/Concordium/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler.hs
@@ -1103,6 +1103,7 @@ checkAndGetBalanceInstanceV0 ownerAccount istance transferAmount = do
 handleContractUpdateV1 ::
     forall r m.
     (StaticInformation m, AccountOperations m, ContractStateOperations m, ModuleQuery m, MonadProtocolVersion m) =>
+    -- | Current call depth. This call is being made in the context of this many interrupted contracts.
     Word ->
     -- | The address that was used to send the top-level transaction.
     AccountAddress ->

--- a/concordium-consensus/src/Concordium/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler.hs
@@ -811,7 +811,7 @@ handleInitContract wtc initAmount modref initName param =
         case viface of
             GSWasm.ModuleInterfaceV0 iface -> do
                 let iSize = GSWasm.miModuleSize iface
-                tickEnergy $ Cost.lookupModule iSize
+                tickEnergy $ Cost.lookupModule (protocolVersion @(MPV m)) iSize
 
                 -- Then get the particular contract interface (in particular the type of the init method).
                 unless (Set.member initName (GSWasm.miExposedInit iface)) $ rejectTransaction $ InvalidInitMethod modref initName
@@ -842,7 +842,7 @@ handleInitContract wtc initAmount modref initName param =
                 return (Left (iface, result))
             GSWasm.ModuleInterfaceV1 iface -> do
                 let iSize = GSWasm.miModuleSize iface
-                tickEnergy $ Cost.lookupModule iSize
+                tickEnergy $ Cost.lookupModule (protocolVersion @(MPV m)) iSize
 
                 -- Then get the particular contract interface (in particular the type of the init method).
                 unless (Set.member initName (GSWasm.miExposedInit iface)) $ rejectTransaction $ InvalidInitMethod modref initName
@@ -1009,6 +1009,7 @@ handleUpdateContract wtc uAmount uAddress uReceiveName uMessage =
             InstanceInfoV0 ins ->
                 -- Now invoke the general handler for contract messages.
                 handleContractUpdateV0
+                    0
                     senderAddress
                     ins
                     checkAndGetBalanceV0
@@ -1016,7 +1017,7 @@ handleUpdateContract wtc uAmount uAddress uReceiveName uMessage =
                     uReceiveName
                     uMessage
             InstanceInfoV1 ins -> do
-                handleContractUpdateV1 senderAddress ins checkAndGetBalanceV1 uAmount uReceiveName uMessage >>= \case
+                handleContractUpdateV1 0 senderAddress ins checkAndGetBalanceV1 uAmount uReceiveName uMessage >>= \case
                     Left cer -> do
                         transactionReturnValue .= WasmV1.ccfToReturnValue cer
                         rejectTransaction (WasmV1.cerToRejectReasonReceive uAddress uReceiveName uMessage cer)
@@ -1102,6 +1103,7 @@ checkAndGetBalanceInstanceV0 ownerAccount istance transferAmount = do
 handleContractUpdateV1 ::
     forall r m.
     (StaticInformation m, AccountOperations m, ContractStateOperations m, ModuleQuery m, MonadProtocolVersion m) =>
+    Word ->
     -- | The address that was used to send the top-level transaction.
     AccountAddress ->
     -- | The current state of the target contract of the transaction, which must exist.
@@ -1122,7 +1124,9 @@ handleContractUpdateV1 ::
     -- | The events resulting from processing the message and all recursively processed messages. For efficiency
     --  reasons the events are in **reverse order** of the actual effects.
     LocalT r m (Either WasmV1.ContractCallFailure (WasmV1.ReturnValue, [Event]))
-handleContractUpdateV1 originAddr istance checkAndGetSender transferAmount receiveName parameter = do
+handleContractUpdateV1 depth originAddr istance checkAndGetSender transferAmount receiveName parameter = do
+    unless (Cost.allowedContractCallDepth (protocolVersion @(MPV m)) depth) $
+        rejectTransaction RuntimeFailure
     -- Cover administrative costs.
     tickEnergy Cost.updateContractInstanceBaseCost
     let model = iiState istance
@@ -1163,7 +1167,7 @@ handleContractUpdateV1 originAddr istance checkAndGetSender transferAmount recei
             -- Now run the receive function on the message. This ticks energy during execution, failing when running out of energy.
 
             -- Charge for looking up the module.
-            tickEnergy $ Cost.lookupModule (GSWasm.miModuleSize moduleInterface)
+            tickEnergy $ Cost.lookupModule (protocolVersion @(MPV m)) (GSWasm.miModuleSize moduleInterface)
 
             -- we've covered basic administrative costs now.
             -- The @go@ function iterates until the end of execution, handling any interrupts by dispatching
@@ -1259,7 +1263,7 @@ handleContractUpdateV1 originAddr istance checkAndGetSender transferAmount recei
                                                 -- in this case we essentially treat this as a top-level transaction invoking that contract.
                                                 -- That is, we execute the entire tree that is potentially generated.
                                                 let rName = Wasm.uncheckedMakeReceiveName (instanceInitName (iiParameters targetInstance)) imcName
-                                                    runSuccess = handleContractUpdateV0 originAddr targetInstance (checkAndGetBalanceInstanceV0 ownerAccount istance) imcAmount rName imcParam
+                                                    runSuccess = handleContractUpdateV0 (depth + 1) originAddr targetInstance (checkAndGetBalanceInstanceV0 ownerAccount istance) imcAmount rName imcParam
                                                 -- If execution of the contract succeeds resume.
                                                 -- Otherwise rollback the state and report that to the caller.
                                                 runInnerTransaction runSuccess >>= \case
@@ -1283,7 +1287,7 @@ handleContractUpdateV1 originAddr istance checkAndGetSender transferAmount recei
                                                 -- to the caller.
                                                 -- Otherwise we roll back all the changes and return the return value, and the error code to the caller.
                                                 let rName = Wasm.uncheckedMakeReceiveName (instanceInitName (iiParameters targetInstance)) imcName
-                                                withRollback (handleContractUpdateV1 originAddr targetInstance (checkAndGetBalanceInstanceV1 ownerAccount istance) imcAmount rName imcParam) >>= \case
+                                                withRollback (handleContractUpdateV1 (depth + 1) originAddr targetInstance (checkAndGetBalanceInstanceV1 ownerAccount istance) imcAmount rName imcParam) >>= \case
                                                     Left cer ->
                                                         go (resumeEvent False : interruptEvent : events) =<< runInterpreter (return . WasmV1.resumeReceiveFun rrdInterruptedConfig rrdCurrentState False entryBalance (WasmV1.Error cer) (WasmV1.ccfToReturnValue cer))
                                                     Right (rVal, callEvents) -> do
@@ -1308,7 +1312,7 @@ handleContractUpdateV1 originAddr istance checkAndGetSender transferAmount recei
                                                 GSWasm.ModuleInterfaceV0 _ -> go (resumeEvent False : interruptEvent : events) =<< runInterpreter (return . WasmV1.resumeReceiveFun rrdInterruptedConfig rrdCurrentState False entryBalance (WasmV1.UpgradeInvalidVersion imuModRef GSWasm.V0) Nothing)
                                                 GSWasm.ModuleInterfaceV1 newModuleInterfaceAV1 -> do
                                                     -- Charge for the lookup of the new module.
-                                                    tickEnergy $ Cost.lookupModule $ GSWasm.miModuleSize newModuleInterfaceAV1
+                                                    tickEnergy $ Cost.lookupModule (protocolVersion @(MPV m)) $ GSWasm.miModuleSize newModuleInterfaceAV1
                                                     -- The contract must exist in the new module.
                                                     -- I.e. It must be the case that there exists an init function for the new module that matches the caller.
                                                     if Set.notMember (instanceInitName iParams) (GSWasm.miExposedInit newModuleInterfaceAV1)
@@ -1693,6 +1697,8 @@ handleContractUpdateV1 originAddr istance checkAndGetSender transferAmount recei
 handleContractUpdateV0 ::
     forall r m.
     (StaticInformation m, AccountOperations m, ContractStateOperations m, ModuleQuery m, MonadProtocolVersion m) =>
+    -- | Current call depth.
+    Word ->
     -- | The address that was used to send the top-level transaction.
     AccountAddress ->
     -- | The current state of the target contract of the transaction, which must exist.
@@ -1710,7 +1716,9 @@ handleContractUpdateV0 ::
     Wasm.Parameter ->
     -- | The events resulting from processing the message and all recursively processed messages.
     LocalT r m [Event]
-handleContractUpdateV0 originAddr istance checkAndGetSender transferAmount receiveName parameter = do
+handleContractUpdateV0 depth originAddr istance checkAndGetSender transferAmount receiveName parameter = do
+    unless (Cost.allowedContractCallDepth (protocolVersion @(MPV m)) depth) $
+        rejectTransaction RuntimeFailure
     -- Cover administrative costs.
     tickEnergy Cost.updateContractInstanceBaseCost
 
@@ -1749,7 +1757,7 @@ handleContractUpdateV0 originAddr istance checkAndGetSender transferAmount recei
     -- FIXME: Once errors can be caught in smart contracts update this to not terminate the transaction.
     let iface = instanceModuleInterface iParams
     -- charge for looking up the module
-    tickEnergy $ Cost.lookupModule (GSWasm.miModuleSize iface)
+    tickEnergy $ Cost.lookupModule (protocolVersion @(MPV m)) (GSWasm.miModuleSize iface)
 
     model <- getRuntimeReprV0 (iiState istance)
     artifact <- liftLocal $ getModuleArtifact (GSWasm.miModule iface)
@@ -1784,7 +1792,7 @@ handleContractUpdateV0 originAddr istance checkAndGetSender transferAmount recei
                           euContractVersion = Wasm.V0,
                           euEvents = Wasm.logs result
                         }
-            foldEvents originAddr (ownerAccount, istance) initEvent txOut
+            foldEvents depth originAddr (ownerAccount, istance) initEvent txOut
 
 -- Cost of a step in the traversal of the actions tree. We need to charge for
 -- this separately to prevent problems with exponentially sized trees
@@ -1799,6 +1807,8 @@ traversalStepCost = 10
 
 foldEvents ::
     (StaticInformation m, AccountOperations m, ContractStateOperations m, ModuleQuery m, MonadProtocolVersion m) =>
+    -- | Current call depth.
+    Word ->
     -- | Address that was used in the top-level transaction.
     AccountAddress ->
     -- | Instance that generated the events.
@@ -1809,12 +1819,13 @@ foldEvents ::
     Wasm.ActionsTree ->
     -- | List of events in order that transactions were traversed.
     LocalT r m [Event]
-foldEvents originAddr istance initEvent = fmap (initEvent :) . go
+foldEvents depth originAddr istance initEvent = fmap (initEvent :) . go
   where
     go Wasm.TSend{..} = do
         getCurrentContractInstanceTicking erAddr >>= \case
             InstanceInfoV0 cinstance ->
                 handleContractUpdateV0
+                    depth
                     originAddr
                     cinstance
                     (uncurry checkAndGetBalanceInstanceV0 istance)
@@ -1824,6 +1835,7 @@ foldEvents originAddr istance initEvent = fmap (initEvent :) . go
             InstanceInfoV1 cinstance ->
                 let c =
                         handleContractUpdateV1
+                            depth
                             originAddr
                             cinstance
                             (uncurry checkAndGetBalanceInstanceV1 istance)

--- a/concordium-consensus/src/Concordium/Scheduler/InvokeContract.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/InvokeContract.hs
@@ -166,8 +166,8 @@ invokeContract ContractContext{..} cm bs
                     Left err -> return (Left err, ccEnergy)
                     Right (invoker, addr, ai) -> do
                         let comp = do
-                                let onV0 i = handleContractUpdateV0 addr i invoker ccAmount ccMethod ccParameter
-                                let onV1 i = handleContractUpdateV1 addr i (fmap Right . invoker) ccAmount ccMethod ccParameter
+                                let onV0 i = handleContractUpdateV0 0 addr i invoker ccAmount ccMethod ccParameter
+                                let onV1 i = handleContractUpdateV1 0 addr i (fmap Right . invoker) ccAmount ccMethod ccParameter
                                 istance <- getCurrentContractInstanceTicking ccContract
                                 result <- case istance of
                                     BS.InstanceInfoV0 i -> Left <$> onV0 i

--- a/concordium-consensus/src/Concordium/Scheduler/WasmIntegration.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/WasmIntegration.hs
@@ -30,7 +30,7 @@ foreign import ccall "validate_and_process_v0"
         Ptr Word8 ->
         -- | Length of the module source.
         CSize ->
-        -- |Metering (cost assignment) version.
+        -- | Metering (cost assignment) version.
         Word8 ->
         -- | Total length of the output.
         Ptr CSize ->
@@ -313,5 +313,5 @@ compileModule csv modl = unsafePerformIO $ do
                                     (fromIntegral artifactLen)
                                     (rs_free_array_len artifactPtr (fromIntegral artifactLen))
                             return (Just (bs, instrumentedModuleFromBytes SV0 moduleArtifact))
-   
-    where meteringVersion = costSemanticsVersionToWord8 csv
+  where
+    meteringVersion = costSemanticsVersionToWord8 csv

--- a/concordium-consensus/src/Concordium/Scheduler/WasmIntegration.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/WasmIntegration.hs
@@ -314,6 +314,4 @@ compileModule csv modl = unsafePerformIO $ do
                                     (rs_free_array_len artifactPtr (fromIntegral artifactLen))
                             return (Just (bs, instrumentedModuleFromBytes SV0 moduleArtifact))
    
-    where meteringVersion = case csv of
-            CSV0 -> 0
-            CSV1 -> 1
+    where meteringVersion = costSemanticsVersionToWord8 csv

--- a/concordium-consensus/src/Concordium/Scheduler/WasmIntegration.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/WasmIntegration.hs
@@ -30,6 +30,8 @@ foreign import ccall "validate_and_process_v0"
         Ptr Word8 ->
         -- | Length of the module source.
         CSize ->
+        -- |Metering (cost assignment) version.
+        Word8 ->
         -- | Total length of the output.
         Ptr CSize ->
         -- | Length of the artifact.
@@ -292,13 +294,12 @@ processModule spv modl = do
 -- | Validate and compile a module. If successful return the artifact and serialization of module exports.
 {-# NOINLINE compileModule #-}
 compileModule :: CostSemanticsVersion -> WasmModuleV V0 -> Maybe (BS.ByteString, InstrumentedModuleV V0)
--- TODO: The unused spv argument will be used when new cost semantics are introduced.
-compileModule _spv modl = unsafePerformIO $ do
+compileModule csv modl = unsafePerformIO $ do
     unsafeUseModuleSourceAsCStringLen (wmvSource modl) $ \(wasmBytesPtr, wasmBytesLen) ->
         alloca $ \outputLenPtr ->
             alloca $ \artifactLenPtr ->
                 alloca $ \outputModuleArtifactPtr -> do
-                    outPtr <- validate_and_process (castPtr wasmBytesPtr) (fromIntegral wasmBytesLen) outputLenPtr artifactLenPtr outputModuleArtifactPtr
+                    outPtr <- validate_and_process (castPtr wasmBytesPtr) (fromIntegral wasmBytesLen) meteringVersion outputLenPtr artifactLenPtr outputModuleArtifactPtr
                     if outPtr == nullPtr
                         then return Nothing
                         else do
@@ -312,3 +313,7 @@ compileModule _spv modl = unsafePerformIO $ do
                                     (fromIntegral artifactLen)
                                     (rs_free_array_len artifactPtr (fromIntegral artifactLen))
                             return (Just (bs, instrumentedModuleFromBytes SV0 moduleArtifact))
+   
+    where meteringVersion = case csv of
+            CSV0 -> 0
+            CSV1 -> 1

--- a/concordium-consensus/src/Concordium/Scheduler/WasmIntegration/V1.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/WasmIntegration/V1.hs
@@ -944,6 +944,4 @@ compileModule ValidationConfig{..} modl =
                                         (rs_free_array_len artifactPtr (fromIntegral artifactLen))
                                 return (Just (bs, instrumentedModuleFromBytes SV1 moduleArtifact))
   where
-    meteringVersion = case vcCostSemantics of
-        CSV0 -> 0
-        CSV1 -> 1
+    meteringVersion = costSemanticsVersionToWord8 vcCostSemantics

--- a/concordium-consensus/src/Concordium/Scheduler/WasmIntegration/V1.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/WasmIntegration/V1.hs
@@ -85,6 +85,8 @@ foreign import ccall "validate_and_process_v1"
         Ptr Word8 ->
         -- | Length of the module source.
         CSize ->
+        -- | Metering (cost semantics) version.
+        Word8 ->
         -- | Total length of the output.
         Ptr CSize ->
         -- | Length of the artifact.
@@ -927,7 +929,7 @@ compileModule ValidationConfig{..} modl =
             alloca $ \outputLenPtr ->
                 alloca $ \artifactLenPtr ->
                     alloca $ \outputModuleArtifactPtr -> do
-                        outPtr <- validate_and_process (if vcSupportUpgrade then 1 else 0) (if vcAllowGlobals then 1 else 0) (if vcAllowSignExtensionInstr then 1 else 0) (castPtr wasmBytesPtr) (fromIntegral wasmBytesLen) outputLenPtr artifactLenPtr outputModuleArtifactPtr
+                        outPtr <- validate_and_process (if vcSupportUpgrade then 1 else 0) (if vcAllowGlobals then 1 else 0) (if vcAllowSignExtensionInstr then 1 else 0) (castPtr wasmBytesPtr) (fromIntegral wasmBytesLen) meteringVersion outputLenPtr artifactLenPtr outputModuleArtifactPtr
                         if outPtr == nullPtr
                             then return Nothing
                             else do
@@ -941,3 +943,7 @@ compileModule ValidationConfig{..} modl =
                                         (fromIntegral artifactLen)
                                         (rs_free_array_len artifactPtr (fromIntegral artifactLen))
                                 return (Just (bs, instrumentedModuleFromBytes SV1 moduleArtifact))
+  where
+    meteringVersion = case vcCostSemantics of
+        CSV0 -> 0
+        CSV1 -> 1

--- a/concordium-consensus/tests/scheduler/SchedulerTests/FibonacciSelfMessageTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/FibonacciSelfMessageTest.hs
@@ -89,6 +89,7 @@ testCase1 _ pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         fibSourceFile
                         (InitName "init_fib")
                         (Parameter "")
@@ -138,7 +139,7 @@ testCase1 _ pvString =
                         -- lower bound on the cost of the transaction, assuming no interpreter energy and the instance is not created.
                         -- the number of invocations of the smart contract is fibOne 10, see below for the definition of fibOne
                         -- the size of the contract state is 8 bytes (one u64)
-                        costLowerBound = baseTxCost + (fibOne 10) * Cost.updateContractInstanceCost 0 modLen 8 (Just 8)
+                        costLowerBound = baseTxCost + (fibOne 10) * Cost.updateContractInstanceCost (Types.protocolVersion @pv) 0 modLen 8 (Just 8)
                     unless (srUsedEnergy >= costLowerBound) $
                         assertFailure $
                             "Actual update cost " ++ show srUsedEnergy ++ " not more than lower bound " ++ show costLowerBound

--- a/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
@@ -57,6 +57,7 @@ import qualified Concordium.Scheduler.EnvironmentImplementation as EI
 import qualified Concordium.Scheduler.Runner as SchedTest
 import qualified Concordium.Scheduler.Types as Types
 import Concordium.TimeMonad
+import Concordium.Types (SProtocolVersion)
 
 getResults :: [(a, Types.TransactionSummary)] -> [(a, Types.ValidResult)]
 getResults = map (\(x, r) -> (x, Types.tsResult r))
@@ -822,13 +823,14 @@ assertUsedEnergyDeploymentV1 sourceFile result = do
 --  It is not practical to check the exact cost because the execution cost of the init function is hard to
 --  have an independent number for, other than executing.
 assertUsedEnergyInitialization ::
+    SProtocolVersion pv ->
     FilePath ->
     Wasm.InitName ->
     Wasm.Parameter ->
     Maybe Wasm.ByteSize ->
     SchedulerResult ->
     Assertion
-assertUsedEnergyInitialization sourceFile initName parameter initialStateSize result = do
+assertUsedEnergyInitialization spv sourceFile initName parameter initialStateSize result = do
     moduleSource <- ByteString.readFile sourceFile
     let modLen = fromIntegral $ ByteString.length moduleSource
         modRef = Types.ModuleRef (Hash.hash moduleSource)
@@ -839,7 +841,7 @@ assertUsedEnergyInitialization sourceFile initName parameter initialStateSize re
         -- transaction is signed with 1 signature
         baseTxCost = Cost.baseCost txSize 1
         -- lower bound on the cost of the transaction, assuming no interpreter energy
-        costLowerBound = baseTxCost + Cost.initializeContractInstanceCost 0 modLen initialStateSize
+        costLowerBound = baseTxCost + Cost.initializeContractInstanceCost spv 0 modLen initialStateSize
     unless (srUsedEnergy result >= costLowerBound) $
         assertFailure $
             "Actual initialization cost "

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V0/RelaxedRestrictions.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V0/RelaxedRestrictions.hs
@@ -221,7 +221,7 @@ newLogLimitTest spv pvString =
                ]
 
 -- | Transactions and assertions for deploying and initializing the "relax" contract.
-deployAndInitTransactions :: [Helpers.TransactionAndAssertion pv]
+deployAndInitTransactions :: forall pv. (Types.IsProtocolVersion pv) => [Helpers.TransactionAndAssertion pv]
 deployAndInitTransactions =
     [ Helpers.TransactionAndAssertion
         { taaTransaction =
@@ -246,6 +246,7 @@ deployAndInitTransactions =
             return $ do
                 Helpers.assertSuccess result
                 Helpers.assertUsedEnergyInitialization
+                    (Types.protocolVersion @pv)
                     sourceFile
                     (InitName "init_relax")
                     (Parameter "")

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V0/SmartContractTests.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V0/SmartContractTests.hs
@@ -88,6 +88,7 @@ runInitTestsFromFile _ testCaseDescription testFile testCases =
                       taaAssertion = \result _ ->
                         return $ do
                             Helpers.assertUsedEnergyInitialization
+                                (Types.protocolVersion @pv)
                                 testFile
                                 (InitName testName)
                                 (Parameter initParam)
@@ -142,6 +143,7 @@ runReceiveTestsFromFile _ testCaseDescription testFile testCases =
                         return $ do
                             Helpers.assertSuccess result
                             Helpers.assertUsedEnergyInitialization
+                                (Types.protocolVersion @pv)
                                 testFile
                                 (InitName "init_test")
                                 (Parameter "")

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Checkpointing.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Checkpointing.hs
@@ -104,6 +104,7 @@ checkpointingTest1 spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         checkpointingSourceFile
                         (InitName "init_a")
                         (Parameter "")
@@ -121,6 +122,7 @@ checkpointingTest1 spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         checkpointingSourceFile
                         (InitName "init_b")
                         (Parameter "")
@@ -208,6 +210,7 @@ checkpointingTest2 spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         checkpointingSourceFile
                         (InitName "init_a")
                         (Parameter "")
@@ -225,6 +228,7 @@ checkpointingTest2 spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         checkpointingSourceFile
                         (InitName "init_b")
                         (Parameter "")
@@ -310,6 +314,7 @@ checkpointingTest3 spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         checkpointingSourceFile
                         (InitName "init_a")
                         (Parameter "")
@@ -327,6 +332,7 @@ checkpointingTest3 spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         checkpointingSourceFile
                         (InitName "init_b")
                         (Parameter "")
@@ -397,6 +403,7 @@ checkpointingTest4 spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         checkpointingSourceFile
                         (InitName "init_a")
                         (Parameter "")
@@ -414,6 +421,7 @@ checkpointingTest4 spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         checkpointingSourceFile
                         (InitName "init_b")
                         (Parameter "")
@@ -515,6 +523,7 @@ checkpointingTest5 spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         checkpointingSourceFile
                         (InitName "init_a")
                         (Parameter "")
@@ -532,6 +541,7 @@ checkpointingTest5 spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         checkpointingSourceFile
                         (InitName "init_b")
                         (Parameter "")
@@ -549,6 +559,7 @@ checkpointingTest5 spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         v0ProxySourceFile
                         (InitName "init_proxy")
                         (Parameter "")
@@ -659,6 +670,7 @@ checkpointingTest6 spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         checkpointingSourceFile
                         (InitName "init_a")
                         (Parameter "")
@@ -676,6 +688,7 @@ checkpointingTest6 spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         checkpointingSourceFile
                         (InitName "init_b")
                         (Parameter "")
@@ -693,6 +706,7 @@ checkpointingTest6 spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         v0ProxySourceFile
                         (InitName "init_proxy")
                         (Parameter "")
@@ -794,6 +808,7 @@ checkpointingTest7 spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         checkpointing2SourceFile
                         (InitName "init_test")
                         (Parameter "")
@@ -871,6 +886,7 @@ checkpointingTest8 spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         checkpointing2SourceFile
                         (InitName "init_test")
                         (Parameter "")
@@ -945,6 +961,7 @@ checkpointingTest9 spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         checkpointing2SourceFile
                         (InitName "init_test")
                         (Parameter "")

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Counter.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Counter.hs
@@ -88,6 +88,7 @@ test1 spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         counterSourceFile
                         (InitName "init_counter")
                         (Parameter "")

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/CrossMessaging.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/CrossMessaging.hs
@@ -110,6 +110,7 @@ test1 spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         counterSourceFile
                         (InitName "init_counter")
                         (Parameter "")
@@ -128,6 +129,7 @@ test1 spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         proxySourceFile
                         (InitName "init_proxy")
                         (Parameter "")

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Iterator.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Iterator.hs
@@ -83,6 +83,7 @@ test1 spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         iteratorSourceFile
                         (InitName "init_iterator")
                         (Parameter "")

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Queries.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Queries.hs
@@ -126,6 +126,7 @@ accountBalanceTestCase spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         accountBalanceSourceFile
                         (InitName "init_contract")
                         (Parameter "")
@@ -200,6 +201,7 @@ accountBalanceInvokerTestCase spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         accountBalanceSourceFile
                         (InitName "init_contract")
                         (Parameter "")
@@ -269,6 +271,7 @@ accountBalanceTransferTestCase spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         accountBalanceTransferSourceFile
                         (InitName "init_contract")
                         (Parameter "")
@@ -339,6 +342,7 @@ accountBalanceMissingAccountTestCase spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         accountBalanceMissingAccountSourceFile
                         (InitName "init_contract")
                         (Parameter "")
@@ -404,6 +408,7 @@ contractBalanceTestCase spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         contractBalanceSourceFile
                         (InitName "init_contract")
                         (Parameter "")
@@ -479,6 +484,7 @@ contractBalanceSelfTestCase spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         contractBalanceSourceFile
                         (InitName "init_contract")
                         (Parameter "")
@@ -548,6 +554,7 @@ contractBalanceTransferTestCase spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         contractBalanceTransferSourceFile
                         (InitName "init_contract")
                         (Parameter "")
@@ -622,6 +629,7 @@ contractBalanceMissingContractTestCase spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         contractBalanceMissingContractSourceFile
                         (InitName "init_contract")
                         (Parameter "")
@@ -688,6 +696,7 @@ exchangeRatesTestCase spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         exchangeRatesSourceFile
                         (InitName "init_contract")
                         (Parameter "")
@@ -758,6 +767,7 @@ allTestCase spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         allSourceFile
                         (InitName "init_contract")
                         (Parameter "")

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Recorder.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Recorder.hs
@@ -87,6 +87,7 @@ testCase spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         recorderSourceFile
                         (InitName "init_recorder")
                         (Parameter "")

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/RelaxedRestrictions.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/RelaxedRestrictions.hs
@@ -301,7 +301,7 @@ newLogLimitTest spv pvString =
                ]
 
 -- | Transactions and assertions for deploying and initializing the "relax" contract.
-deployAndInitTransactions :: [Helpers.TransactionAndAssertion pv]
+deployAndInitTransactions :: forall pv. (Types.IsProtocolVersion pv) => [Helpers.TransactionAndAssertion pv]
 deployAndInitTransactions =
     [ Helpers.TransactionAndAssertion
         { taaTransaction =
@@ -326,6 +326,7 @@ deployAndInitTransactions =
             return $ do
                 Helpers.assertSuccess result
                 Helpers.assertUsedEnergyInitialization
+                    (Types.protocolVersion @pv)
                     sourceFile
                     (InitName "init_relax")
                     (Parameter "")

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Transfer.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Transfer.hs
@@ -84,6 +84,7 @@ testCase spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         transferSourceFile
                         (InitName "init_transfer")
                         (Parameter "")

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Upgrading.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Upgrading.hs
@@ -116,6 +116,7 @@ upgradingTestCase spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         upgrading0SourceFile
                         (InitName "init_a")
                         (Parameter "")
@@ -234,6 +235,7 @@ selfInvokeTestCase spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         selfInvokeSourceFile0
                         (InitName "init_contract")
                         (Parameter "")
@@ -331,6 +333,7 @@ missingModuleTestCase spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         missingModuleSourceFile
                         (InitName "init_contract")
                         (Parameter "")
@@ -404,6 +407,7 @@ missingContractTestCase spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         missingContractSourceFile0
                         (InitName "init_contract")
                         (Parameter "")
@@ -490,6 +494,7 @@ unsupportedVersionTestCase spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         unsupportedVersionSourceFile0
                         (InitName "init_contract")
                         (Parameter "")
@@ -578,6 +583,7 @@ twiceTestCase spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         upgrading0SourceFile
                         (InitName "init_contract")
                         (Parameter "")
@@ -683,6 +689,7 @@ chainedTestCase spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         chainedSourceFile0
                         (InitName "init_contract")
                         (Parameter "")
@@ -766,6 +773,7 @@ rejectTestCase spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         upgrading0SourceFile
                         (InitName "init_contract")
                         (Parameter "")
@@ -862,6 +870,7 @@ changingEntrypointsTestCase spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         changingEntrypointsSourceFile0
                         (InitName "init_contract")
                         (Parameter "")
@@ -1003,6 +1012,7 @@ persistingStateTestCase spv pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         persistingStateSourceFile0
                         (InitName "init_contract")
                         (Parameter "")

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TrySendTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TrySendTest.hs
@@ -86,6 +86,7 @@ errorHandlingTest _ pvString =
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
+                        (Types.protocolVersion @pv)
                         contractSourceFile
                         (InitName "init_try")
                         (Parameter "")


### PR DESCRIPTION
## Purpose

Integrate reduce costs for P7.

This is a very minor change compared to #1135 . The main annoyance is that tests needed to be updated because of the both cost changes in P7 and parametrization of module lookup by protocol version.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.