### PR TITLE
Change severity of logs for certain gRPC status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased changes
 
+- Change the logs for gRPC API to only consider the following [gRPC status codes](https://github.com/grpc/grpc/blob/master/doc/statuscodes.md#status-codes-and-their-use-in-grpc) as errors:
+  UNKNOWN, DEADLINE_EXCEEDED, RESOURCE_EXHAUSTED, FAILED_PRECONDITION, ABORTED, OUT_OF_RANGE, INTERNAL and DATA_LOSS.
+  The remaining status codes are now logged at DEBUG level.
 - Add support for new `invoke` calls from smart contracts in protocol version 7:
   - query the contract module reference for a given contract address
   - query the contract name for a given contract address

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,7 @@
 
 ## Unreleased changes
 
-- Change the logs for gRPC API to only consider the following [gRPC status codes](https://github.com/grpc/grpc/blob/master/doc/statuscodes.md#status-codes-and-their-use-in-grpc) as errors:
-  UNKNOWN, DEADLINE_EXCEEDED, RESOURCE_EXHAUSTED, FAILED_PRECONDITION, ABORTED, OUT_OF_RANGE, INTERNAL and DATA_LOSS.
-  The remaining status codes are now logged at DEBUG level.
+- Change the severity of logs for failed gRPC API requests to DEBUG level.
 - Add support for new `invoke` calls from smart contracts in protocol version 7:
   - query the contract module reference for a given contract address
   - query the contract name for a given contract address

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -851,6 +851,7 @@ dependencies = [
  "tonic-web",
  "tower",
  "tower-http",
+ "tracing",
  "twox-hash",
  "url",
  "walkdir",

--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -84,6 +84,7 @@ prost = "0.12"
 tokio = { version = "1.35", features = ["macros", "rt-multi-thread", "signal", "io-util", "time"] }
 tokio-stream = "0.1"
 num_cpus = "1.16"
+tracing = "0.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 macos_logger_wrapper = { version = "*", path = "../macos_logger_wrapper/"}


### PR DESCRIPTION
## Purpose

Fixes https://github.com/Concordium/concordium-node/issues/1057

## Changes

- Using DEBUG severity for logging of failed gRPC API requests.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
