### PR TITLE
Disable encrypted transfers in P7.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
   the node's database to the new format is done on-demand, which means node
   startup can be a bit slower when a lot of modules exist. All Wasm modules will
   be migrated to the new format when the protocol is updated to P7.
+- Remove support for encrypted transfers in protocol version 7. Transactions with
+  payload types `TransferToEncrypted`, `EncryptedAmountTransfer` and
+  `EncryptedAmountTransferWithMemo` are disabled in this protocol version, which
+  prevents encrypting further CCDs or transferring encrypted CCDs.
+  `TransferToPublic` remains enabled, allowing existing encrypted balances to be
+  decrypted.
 
 ## 6.3.0
 

--- a/concordium-consensus/src/Concordium/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler.hs
@@ -268,12 +268,10 @@ dispatchTransactionBody msg senderAccount checkHeaderCost = do
     -- Hence we can increase the account nonce of the sender account.
     increaseAccountNonce senderAccount
 
-    let psize = payloadSize (transactionPayload msg)
-
     tsIndex <- bumpTransactionIndex
     -- Payload is not parametrised by the protocol version, but decodePayload only returns
     -- payloads appropriate to the protocol version.
-    case decodePayload (protocolVersion @(MPV m)) psize (transactionPayload msg) of
+    case decodePayload (protocolVersion @(MPV m)) (transactionPayload msg) of
         Left _ -> do
             -- In case of serialization failure we charge the sender for checking
             -- the header and reject the transaction; we have checked that the amount

--- a/concordium-consensus/tests/scheduler/SchedulerTests/EncryptedTransfersTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/EncryptedTransfersTest.hs
@@ -1389,7 +1389,8 @@ tests :: Spec
 tests =
     describe "Encrypted transfers:" $
         sequence_ $
-            Helpers.forEveryProtocolVersion $ \spv pvString -> do
-                testCase0 spv pvString
-                testCase1 spv pvString
-                testCase2 spv pvString
+            Helpers.forEveryProtocolVersion $ \spv pvString ->
+                when (Types.supportsEncryptedTransfers spv) $ do
+                    testCase0 spv pvString
+                    testCase1 spv pvString
+                    testCase2 spv pvString

--- a/concordium-consensus/tests/scheduler/SchedulerTests/MaxIncomingAmountsTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/MaxIncomingAmountsTest.hs
@@ -20,6 +20,7 @@ actually combined and the amounts are right.
 For now `numberOfTransactions == maxNumIncoming + 2`.
 -}
 
+import Control.Monad
 import Data.Foldable
 import Data.Maybe (fromJust)
 import qualified Data.Sequence as Seq
@@ -51,8 +52,9 @@ testCase0 ::
     Types.SProtocolVersion pv ->
     String ->
     Spec
-testCase0 _ pvString = specify
-    (pvString ++ ": Makes a chain of encrypted transfers testing maxNumIncoming")
+testCase0 spv pvString = when (supportsEncryptedTransfers spv)
+    $ specify
+        (pvString ++ ": Makes a chain of encrypted transfers testing maxNumIncoming")
     $ do
         transactionsAndAssertions <- makeTransactionsAndAssertions
         Helpers.runSchedulerTestAssertIntermediateStates

--- a/concordium-consensus/tests/scheduler/SchedulerTests/RandomBakerTransactions.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/RandomBakerTransactions.hs
@@ -258,7 +258,7 @@ testTransactions spv = forAll makeTransactions (ioProperty . tt)
         let Sch.FilteredTransactions{..} = Helpers.srTransactions result
 
         let rejs =
-                [ (z, decodePayload spv (thPayloadSize . atrHeader $ z) (atrPayload z), rr)
+                [ (z, decodePayload spv (atrPayload z), rr)
                   | ((WithMetadata{wmdData = NormalTransaction z}, _), TxReject rr) <-
                         Helpers.getResults ftAdded
                 ]


### PR DESCRIPTION
## Purpose

Closes #1170 

Disable encrypted transfers in protocol version 7. This is primarily done by `decodePayload` in concordium-base not allowing the relevant payload types to be deserialized in P7.

## Changes

- Update base.
- `decodePayload` no longer takes payload length as a separate argument.
- Disable encrypted transfer tests where they are no longer relevant.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
