### PR TITLE
Improve logging around protocol update events.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   prevents encrypting further CCDs or transferring encrypted CCDs.
   `TransferToPublic` remains enabled, allowing existing encrypted balances to be
   decrypted.
+- Improve logging around protocol update events.
 
 ## 6.3.1
 


### PR DESCRIPTION
## Purpose

Addresses #1172 
This improves how protocol update events are logged for the new consensus. In particular, if a protocol update is already scheduled, but a new protocol update is scheduled earlier (replacing the old update) then the new update will now be noted in the log, where it wasn't before.

## Changes

- When considering logging a pending protocol update, check if it's the same as the last notified protocol update.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
