### PR TITLE
Add basic cooldown queue type and testing.

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/CooldownQueue.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/CooldownQueue.hs
@@ -1,0 +1,217 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Concordium.GlobalState.CooldownQueue where
+
+import qualified Data.Bits as Bits
+import qualified Data.Map.Strict as Map
+import Data.Serialize
+
+import qualified Concordium.Crypto.SHA256 as Hash
+import Concordium.Types
+import Concordium.Types.Accounts (Cooldown (..), CooldownStatus (..))
+import Concordium.Types.HashableTo
+import Concordium.Utils.Serialization
+
+import Concordium.GlobalState.Persistent.BlobStore
+import Concordium.Types.Option
+import Data.Foldable
+
+-- | The amounts that are currently in cooldown and any pre-cooldown and pre-pre-cooldown target
+-- balances.
+data Cooldowns = Cooldowns
+    { -- | Amounts currently in cooldown, indexed by their expiry timestamp.
+      --  (Must have fewer than 2^62 entries.)
+      inCooldown :: !(Map.Map Timestamp Amount),
+      -- | The amount in pre-cooldown.
+      --  This will enter cooldown at the next payday.
+      --  If 'Nothing', there is no pre-cooldown.
+      preCooldown :: !(Option Amount),
+      -- | The amount in pre-pre-cooldown.
+      --  This will enter pre-cooldown at the next epoch transition that is one epoch before a
+      --  payday.
+      --  If 'Nothing', there is no pre-pre-cooldown.
+      prePreCooldown :: !(Option Amount)
+    }
+    deriving (Eq, Show)
+
+instance Serialize Cooldowns where
+    put Cooldowns{..} = do
+        putWord64be tag
+        putSafeSizedMapOf put put inCooldown
+        mapM_ put preCooldown
+        mapM_ put prePreCooldown
+      where
+        -- The two highest order bits encode whether there is a preCooldown and a
+        -- prePreCooldown
+        tag = fromIntegral (Map.size inCooldown) Bits..|. preCooldownBit Bits..|. prePreCooldownBit
+        preCooldownBit
+            | isPresent preCooldown = Bits.bit 62
+            | otherwise = 0
+        prePreCooldownBit
+            | isPresent prePreCooldown = Bits.bit 63
+            | otherwise = 0
+    get :: Get Cooldowns
+    get = do
+        tag <- getWord64be
+        inCooldown <- getSafeSizedMapOf (tag Bits..&. sizeMask) get get
+        preCooldown <- if Bits.testBit tag 62 then Present <$> get else return Absent
+        prePreCooldown <- if Bits.testBit tag 63 then Present <$> get else return Absent
+        return Cooldowns{..}
+      where
+        sizeMask = Bits.bit 62 - 1
+
+instance (MonadBlobStore m) => BlobStorable m Cooldowns
+
+-- | Check if a 'Cooldowns' is empty (i.e. has no stake in cooldown, pre-cooldown or
+--  pre-pre-cooldown).
+isEmptyCooldowns :: Cooldowns -> Bool
+isEmptyCooldowns Cooldowns{..} =
+    Map.null inCooldown
+        && null preCooldown
+        && null prePreCooldown
+
+-- | A 'Cooldowns' with no stake in cooldown, pre-cooldown or pre-pre-cooldown.
+emptyCooldowns :: Cooldowns
+emptyCooldowns =
+    Cooldowns
+        { inCooldown = Map.empty,
+          preCooldown = Absent,
+          prePreCooldown = Absent
+        }
+
+-- | The total amount in cooldown, pre-cooldown and pre-pre-cooldown.
+cooldownTotal :: Cooldowns -> Amount
+cooldownTotal Cooldowns{..} =
+    sum (Map.elems inCooldown)
+        + fromOption 0 preCooldown
+        + fromOption 0 prePreCooldown
+
+-- FIXME: Decide if we want to use the serialization for hashing.
+instance HashableTo Hash.Hash Cooldowns where
+    getHash = getHash . encode
+
+-- | Add the given amount to the pre-pre-cooldown.
+addPrePreCooldown :: Amount -> Cooldowns -> Cooldowns
+addPrePreCooldown amt Cooldowns{..} =
+    Cooldowns
+        { prePreCooldown = Present (ofOption amt (+ amt) prePreCooldown),
+          ..
+        }
+
+-- | Remove up to the given amount from the cooldowns, starting with pre-pre-cooldown, then
+--  pre-cooldown, and finally from the amounts in cooldown, in decreasing order of timestamp.
+reactivateCooldownAmount :: Amount -> Cooldowns -> Cooldowns
+reactivateCooldownAmount = reactivatePrePre
+  where
+    reactivateHelper more update available amt cd = case available of
+        Absent -> more amt cd
+        Present availableAmt -> case availableAmt `compare` amt of
+            LT -> more (amt - availableAmt) $ update Absent
+            EQ -> update Absent
+            GT -> update (Present (availableAmt - amt))
+    reactivatePrePre amt cd =
+        reactivateHelper reactivatePre (\pp -> cd{prePreCooldown = pp}) (prePreCooldown cd) amt cd
+    reactivatePre amt cd =
+        reactivateHelper reactivateInCooldown (\p -> cd{preCooldown = p}) (preCooldown cd) amt cd
+    reactivateInCooldown amt cd = reactivateCooldown (Map.toDescList $ inCooldown cd) amt cd
+    reactivateCooldown [] _ cd = cd
+    reactivateCooldown ((ts, availableAmount) : rest) amt cd =
+        case availableAmount `compare` amt of
+            LT -> reactivateCooldown rest (amt - availableAmount) cd{inCooldown = Map.delete ts (inCooldown cd)}
+            EQ -> cd{inCooldown = Map.delete ts (inCooldown cd)}
+            GT -> cd{inCooldown = Map.insert ts (availableAmount - amt) (inCooldown cd)}
+
+-- | Remove any amounts in cooldown with timestamp before or equal to the given timestamp.
+processCooldowns :: Timestamp -> Cooldowns -> Cooldowns
+processCooldowns ts Cooldowns{..} =
+    Cooldowns
+        { inCooldown = snd $ Map.split ts inCooldown,
+          ..
+        }
+
+-- | Transfer the pre-cooldown to cooldown with the specified expiry timestamp.
+processPreCooldown :: Timestamp -> Cooldowns -> Cooldowns
+processPreCooldown _ c@Cooldowns{preCooldown = Absent} = c
+processPreCooldown expiry Cooldowns{preCooldown = Present preAmt, ..} =
+    Cooldowns
+        { inCooldown = Map.insertWith (+) expiry preAmt inCooldown,
+          preCooldown = Absent,
+          ..
+        }
+
+-- | Transfer the pre-pre-cooldown to pre-cooldown.
+-- If there is already an amount in pre-cooldown, the two amounts are combined.
+processPrePreCooldown :: Cooldowns -> Cooldowns
+processPrePreCooldown c@Cooldowns{prePreCooldown = Absent} = c
+processPrePreCooldown Cooldowns{preCooldown = Absent, ..} =
+    Cooldowns
+        { preCooldown = prePreCooldown,
+          prePreCooldown = Absent,
+          ..
+        }
+processPrePreCooldown Cooldowns{preCooldown = Present preAmt, prePreCooldown = Present prePreAmt, ..} =
+    Cooldowns
+        { preCooldown = Present (preAmt + prePreAmt),
+          prePreCooldown = Absent,
+          ..
+        }
+
+-- | Get the timestamp of the first cooldown that will expire, if any.
+-- (This ignores pre-cooldown and pre-pre-cooldown.)
+firstCooldownTimestamp :: Cooldowns -> Maybe Timestamp
+firstCooldownTimestamp Cooldowns{..} = fst <$> Map.lookupMin inCooldown
+
+-- | Parameters that are used to calculate the timestamps at which stake in pre-cooldown and
+--  pre-pre-cooldown is expected to be released from cooldown.
+data CooldownCalculationParameters = CooldownCalculationParameters
+    { -- | The duration of an epoch.
+      ccpEpochDuration :: Duration,
+      -- | The current epoch number.
+      ccpCurrentEpoch :: Epoch,
+      -- | The time of the next epoch transition (i.e. trigger block time).
+      ccpTriggerTime :: Timestamp,
+      -- | The epoch number of the next payday. (Must be after the current epoch.)
+      ccpNextPayday :: Epoch,
+      -- | The length of a reward period in epochs.
+      ccpRewardPeriodLength :: RewardPeriodLength,
+      -- | The current duration to for cooldowns.
+      ccpCooldownDuration :: DurationSeconds
+    }
+
+-- | Calculate the timestamp at which stake in pre-cooldown is expected to be released from
+--  cooldown. This is computed by adding the cooldown duration to the time of the next payday,
+--  where the time of the next payday is the time of the next epoch transition (i.e trigger
+--  block time) plus the duration of an epoch for each epoch between the current epoch and the
+--  payday.
+preCooldownTimestamp :: CooldownCalculationParameters -> Timestamp
+preCooldownTimestamp CooldownCalculationParameters{..} =
+    ccpTriggerTime
+        `addDuration` (fromIntegral (ccpNextPayday - ccpCurrentEpoch - 1) * ccpEpochDuration)
+        `addDurationSeconds` ccpCooldownDuration
+
+-- | Calculate the timestamp at which stake in pre-pre-cooldown is expected to be released from
+--  cooldown. If the next epoch is the next payday, this is the time of the payday after that.
+--  Otherwise, this is the same as the 'preCooldownTimestamp'.
+prePreCooldownTimestamp :: CooldownCalculationParameters -> Timestamp
+prePreCooldownTimestamp ccp@CooldownCalculationParameters{..}
+    | ccpNextPayday - ccpCurrentEpoch == 1 =
+        ccpTriggerTime
+            `addDuration` (ccpEpochDuration * fromIntegral ccpRewardPeriodLength)
+            `addDurationSeconds` ccpCooldownDuration
+    | otherwise = preCooldownTimestamp ccp
+
+-- | Convert a 'Cooldowns' to a list of 'Cooldown's.
+toCooldownList :: CooldownCalculationParameters -> Cooldowns -> [Cooldown]
+toCooldownList ccp Cooldowns{..} = cooldowns ++ preCooldowns ++ prePreCooldowns
+  where
+    cooldowns = (\(ts, amt) -> Cooldown ts amt StatusCooldown) <$> Map.toAscList inCooldown
+    preCooldowns =
+        (\amt -> Cooldown (preCooldownTimestamp ccp) amt StatusPreCooldown) <$> toList preCooldown
+    prePreCooldowns =
+        (\amt -> Cooldown (prePreCooldownTimestamp ccp) amt StatusPrePreCooldown)
+            <$> toList prePreCooldown

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/CooldownQueue.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/CooldownQueue.hs
@@ -1,0 +1,273 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | This module tests the 'CooldownQueue' structure, and the various functions that operate on it.
+module GlobalStateTests.CooldownQueue where
+
+import qualified Data.Map.Strict as Map
+import Data.Serialize
+import Test.HUnit
+import Test.Hspec
+import Test.QuickCheck
+
+import qualified Concordium.Crypto.SHA256 as Hash
+import Concordium.Types
+import Concordium.Types.Accounts
+import Concordium.Types.HashableTo
+import Concordium.Types.Option
+
+import Concordium.GlobalState.CooldownQueue
+
+-- | Generate a 'Cooldowns' with arbitrary values.
+genCooldowns :: Gen Cooldowns
+genCooldowns = do
+    inCooldown <- Map.fromList <$> listOf (((,) . Timestamp <$> arbitrary) <*> arbitrary)
+    preCooldown <- oneof [return Absent, Present <$> arbitrary]
+    prePreCooldown <- oneof [return Absent, Present <$> arbitrary]
+    return Cooldowns{..}
+
+-- | Test that serializing and deserializing 'Cooldowns' is the identity.
+testSerialize :: Property
+testSerialize = property $ forAll genCooldowns $ \cds -> decode (encode cds) === Right cds
+
+-- | Test that 'isEmptyCooldowns' only holds for the empty cooldowns.
+testIsEmptyCooldowns :: Property
+testIsEmptyCooldowns = property $ forAll genCooldowns $ \cds ->
+    isEmptyCooldowns cds === (cds == emptyCooldowns)
+
+-- | Test that hashing two different cooldowns gives different hashes.
+testHashCooldowns :: Property
+testHashCooldowns = property $ forAll genCooldowns $ \cds1 -> forAll genCooldowns $ \cds2 ->
+    cds1 /= cds2 ==> getHash @Hash.Hash cds1 /= getHash cds2
+
+-- | An example 'Cooldowns' structure with 3 amounts in cooldown, a pre-cooldown of 150, and a
+-- pre-pre-cooldown of 2000.
+cooldown1 :: Cooldowns
+cooldown1 =
+    Cooldowns
+        { inCooldown = Map.fromList [(Timestamp 10, 1), (Timestamp 20, 15), (Timestamp 30, 100)],
+          preCooldown = Present 150,
+          prePreCooldown = Present 2000
+        }
+
+-- | An example 'Cooldowns' structure with 3 amounts in cooldown, no pre-cooldown, and a
+-- pre-pre-cooldown of 2000.
+cooldown2 :: Cooldowns
+cooldown2 = cooldown1{preCooldown = Absent}
+
+-- | An example 'Cooldowns' structure with 3 amounts in cooldown, no pre-cooldown, and no
+-- pre-pre-cooldown.
+cooldown3 :: Cooldowns
+cooldown3 = cooldown2{prePreCooldown = Absent}
+
+testReactivateCooldownAmount :: Assertion
+testReactivateCooldownAmount = do
+    assertEqual "reactivate 0" cooldown1 (reactivateCooldownAmount 0 cooldown1)
+    assertEqual
+        "reactivate 10"
+        cooldown1{prePreCooldown = Present 1990}
+        (reactivateCooldownAmount 10 cooldown1)
+    assertEqual
+        "reactivate 2000"
+        cooldown1{prePreCooldown = Absent}
+        (reactivateCooldownAmount 2000 cooldown1)
+    assertEqual
+        "reactivate 2010"
+        cooldown1{prePreCooldown = Absent, preCooldown = Present 140}
+        (reactivateCooldownAmount 2010 cooldown1)
+    assertEqual
+        "reactivate 2150"
+        cooldown3
+        (reactivateCooldownAmount 2150 cooldown1)
+    assertEqual
+        "reactivate 2200"
+        cooldown3{inCooldown = Map.fromList [(Timestamp 10, 1), (Timestamp 20, 15), (Timestamp 30, 50)]}
+        (reactivateCooldownAmount 2200 cooldown1)
+    assertEqual
+        "reactivate 2250"
+        cooldown3{inCooldown = Map.fromList [(Timestamp 10, 1), (Timestamp 20, 15)]}
+        (reactivateCooldownAmount 2250 cooldown1)
+    assertEqual
+        "reactivate 2255"
+        cooldown3{inCooldown = Map.fromList [(Timestamp 10, 1), (Timestamp 20, 10)]}
+        (reactivateCooldownAmount 2255 cooldown1)
+    assertEqual
+        "reactivate 2265"
+        cooldown3{inCooldown = Map.fromList [(Timestamp 10, 1)]}
+        (reactivateCooldownAmount 2265 cooldown1)
+    assertEqual
+        "reactivate 2266"
+        emptyCooldowns
+        (reactivateCooldownAmount 2266 cooldown1)
+    assertEqual
+        "reactivate 5000"
+        emptyCooldowns
+        (reactivateCooldownAmount 5000 cooldown1)
+    assertEqual
+        "reactivate 2050 (cooldown2)"
+        cooldown3{inCooldown = Map.fromList [(Timestamp 10, 1), (Timestamp 20, 15), (Timestamp 30, 50)]}
+        (reactivateCooldownAmount 2050 cooldown2)
+    assertEqual
+        "reactivate 50 (cooldown 3)"
+        cooldown3{inCooldown = Map.fromList [(Timestamp 10, 1), (Timestamp 20, 15), (Timestamp 30, 50)]}
+        (reactivateCooldownAmount 50 cooldown3)
+
+-- | Unit test for 'processCooldowns'.
+testProcessCooldowns :: Assertion
+testProcessCooldowns = do
+    assertEqual
+        "after 5"
+        cooldown1
+        (processCooldowns 5 cooldown1)
+    assertEqual
+        "after 10"
+        cooldown1{inCooldown = Map.fromList [(Timestamp 20, 15), (Timestamp 30, 100)]}
+        (processCooldowns 10 cooldown1)
+    assertEqual
+        "after 20"
+        cooldown1{inCooldown = Map.fromList [(Timestamp 30, 100)]}
+        (processCooldowns 20 cooldown1)
+    assertEqual
+        "after 25"
+        cooldown1{inCooldown = Map.fromList [(Timestamp 30, 100)]}
+        (processCooldowns 25 cooldown1)
+    assertEqual
+        "after 30"
+        cooldown1{inCooldown = Map.empty}
+        (processCooldowns 30 cooldown1)
+    assertEqual
+        "after 30000"
+        cooldown1{inCooldown = Map.empty}
+        (processCooldowns 30_000 cooldown1)
+
+-- | Unit test for 'processPreCooldown'.
+testProcessPreCooldown :: Assertion
+testProcessPreCooldown = do
+    assertEqual "no pre-cooldown" cooldown2 (processPreCooldown 25 cooldown2)
+    assertEqual
+        "at 4000"
+        cooldown2{inCooldown = Map.insert (Timestamp 4000) 150 (inCooldown cooldown1)}
+        (processPreCooldown 4000 cooldown1)
+    assertEqual
+        "at 25"
+        cooldown2{inCooldown = Map.insert (Timestamp 25) 150 (inCooldown cooldown1)}
+        (processPreCooldown 25 cooldown1)
+    assertEqual
+        "at 20"
+        cooldown2{inCooldown = Map.insert (Timestamp 20) 165 (inCooldown cooldown1)}
+        (processPreCooldown 20 cooldown1)
+
+-- | Unit test for 'processPrePreCooldown'.
+testProcessPrePreCooldown :: Assertion
+testProcessPrePreCooldown = do
+    assertEqual "no pre-pre-cooldown" (processPrePreCooldown cooldown3) cooldown3
+    assertEqual
+        "no pre-cooldown"
+        cooldown3{preCooldown = Present 2000}
+        (processPrePreCooldown cooldown2)
+    assertEqual
+        "with pre-cooldown"
+        cooldown3{preCooldown = Present 2150}
+        (processPrePreCooldown cooldown1)
+
+-- | Example 'CooldownCalculationParameters' for testing.
+ccp1 :: CooldownCalculationParameters
+ccp1 =
+    CooldownCalculationParameters
+        { ccpEpochDuration = Duration 1000,
+          ccpCurrentEpoch = 10,
+          ccpTriggerTime = Timestamp 1_000_000,
+          ccpNextPayday = 20,
+          ccpRewardPeriodLength = RewardPeriodLength 20,
+          ccpCooldownDuration = DurationSeconds 1000
+        }
+
+-- | Example 'CooldownCalculationParameters' for testing, where the next epoch is a payday.
+ccp2 :: CooldownCalculationParameters
+ccp2 = ccp1{ccpCurrentEpoch = 19}
+
+-- | Test that 'preCooldownTimestamp' calculates the correct timestamp.
+testPreCooldownTimestamp :: Assertion
+testPreCooldownTimestamp = do
+    assertEqual
+        "pre-cooldown timestamp 1"
+        ( 1_000_000 -- Trigger time
+            + 9 * 1000 -- 10 epochs till next payday
+            + 1_000_000 -- Cooldown duration
+        )
+        (preCooldownTimestamp ccp1)
+    assertEqual
+        "pre-cooldown timestamp 2"
+        ( 1_000_000 -- Trigger time
+            + 0 * 1000 -- 1 epoch till next payday
+            + 1_000_000 -- Cooldown duration
+        )
+        (preCooldownTimestamp ccp2)
+
+-- | Test that 'prePreCooldownTimestamp' calculates the correct timestamp.
+testPrePreCooldownTimestamp :: Assertion
+testPrePreCooldownTimestamp = do
+    assertEqual
+        "pre-pre-cooldown timestamp 1"
+        ( 1_000_000 -- Trigger time
+            + 9 * 1000 -- 10 epochs till next payday
+            + 1_000_000 -- Cooldown duration
+        )
+        (prePreCooldownTimestamp ccp1)
+    assertEqual
+        "pre-pre-cooldown timestamp 2"
+        ( 1_000_000 -- Trigger time
+            + 20 * 1000 -- Next epoch is payday; 20 epochs till next payday after that
+            + 1_000_000 -- Cooldown duration
+        )
+        (prePreCooldownTimestamp ccp2)
+
+-- | Unit test for 'toCooldownList'.
+testToCooldownList :: Assertion
+testToCooldownList = do
+    assertEqual
+        "empty cooldowns"
+        []
+        (toCooldownList ccp1 emptyCooldowns)
+    assertEqual
+        "cooldowns"
+        [ Cooldown 10 1 StatusCooldown,
+          Cooldown 20 15 StatusCooldown,
+          Cooldown 30 100 StatusCooldown,
+          Cooldown 2_000_000 150 StatusPreCooldown,
+          Cooldown 2_020_000 2000 StatusPrePreCooldown
+        ]
+        (toCooldownList ccp2 cooldown1)
+
+testAddPrePreCooldownEmpty :: Assertion
+testAddPrePreCooldownEmpty = do
+    let amount = 100
+    let newCooldowns = addPrePreCooldown amount emptyCooldowns
+    assertEqual "pre-pre-cooldown" (Present amount) (prePreCooldown newCooldowns)
+    assertEqual "pre-cooldown" Absent (preCooldown newCooldowns)
+    assertEqual "in-cooldown" Map.empty (inCooldown newCooldowns)
+
+testAddPrePreCooldownNonEmpty :: Assertion
+testAddPrePreCooldownNonEmpty = do
+    let amount = 100
+    let newCooldowns = addPrePreCooldown amount cooldown1
+    assertEqual "pre-pre-cooldown" (Present $ 2000 + amount) (prePreCooldown newCooldowns)
+    assertEqual "pre-cooldown" (preCooldown cooldown1) (preCooldown newCooldowns)
+    assertEqual "in-cooldown" (inCooldown cooldown1) (inCooldown newCooldowns)
+
+tests :: Spec
+tests = describe "GlobalStateTests.CooldownQueue" $ parallel $ do
+    it "Cooldowns serialization" $ withMaxSuccess 1000 testSerialize
+    it "Empty cooldowns is empty" $ isEmptyCooldowns emptyCooldowns
+    it "isEmptyCooldowns" testIsEmptyCooldowns
+    it "Hashing cooldowns" $ withMaxSuccess 10_000 testHashCooldowns
+    it "cooldownTotal" $ cooldownTotal cooldown1 == 2266
+    it "processCooldowns" testProcessCooldowns
+    it "processPreCooldown" testProcessPreCooldown
+    it "processPrePrecooldown" testProcessPrePreCooldown
+    it "preCooldownTimestamp" testPreCooldownTimestamp
+    it "prePreCooldownTimestamp" testPrePreCooldownTimestamp
+    it "toCooldownList" testToCooldownList
+    it "addPrePreCooldown empty" testAddPrePreCooldownEmpty
+    it "addPrePreCooldown non-empty" testAddPrePreCooldownNonEmpty
+    it "reactivateCooldownAmount" testReactivateCooldownAmount

--- a/concordium-consensus/tests/globalstate/Spec.hs
+++ b/concordium-consensus/tests/globalstate/Spec.hs
@@ -9,6 +9,7 @@ import qualified GlobalStateTests.Accounts (tests)
 import qualified GlobalStateTests.BlobStore (tests)
 import qualified GlobalStateTests.BlockHash (tests)
 import qualified GlobalStateTests.Cache (tests)
+import qualified GlobalStateTests.CooldownQueue (tests)
 import qualified GlobalStateTests.DifferenceMap (tests)
 import qualified GlobalStateTests.EnduringDataFlags (tests)
 import qualified GlobalStateTests.FinalizationSerializationSpec (tests)
@@ -51,3 +52,4 @@ main = atLevel $ \lvl -> hspec $ do
     GlobalStateTests.UpdateQueues.tests
     GlobalStateTests.LMDBAccountMap.tests
     GlobalStateTests.DifferenceMap.tests
+    GlobalStateTests.CooldownQueue.tests


### PR DESCRIPTION
## Purpose

Implement a basic type that represents cooldowns associated with an account.

## Changes

- Define `Cooldowns` and basic operations.
- Operations for calculating how to present `Cooldowns` in response to GRPC queries.
- Testing for the operations.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
