### PR TITLE
Add cooldowns to account structure.

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Account.hs
@@ -224,13 +224,21 @@ instance Serialize PersistingAccountData where
 newtype AccountHash (av :: AccountVersion) = AccountHash {theAccountHash :: Hash.Hash}
     deriving newtype (Eq, Ord, Show, Serialize)
 
--- | Inputs for computing the hash of an account.
+-- | Inputs for computing the hash of an account, used for 'AccountV0' and 'AccountV1'.
+--  While the structure is common across both versions, the 'AccountStakeHash' is version-specific.
+--  (In particular, the 'AccountStakeHash' for 'AccountV1' allows for delegation.)
 data AccountHashInputsV0 (av :: AccountVersion) = AccountHashInputsV0
-    { ahiNextNonce :: !Nonce,
+    { -- | The next nonce for the account.
+      ahiNextNonce :: !Nonce,
+      -- | The account balance.
       ahiAccountAmount :: !Amount,
+      -- | The account's encrypted balance.
       ahiAccountEncryptedAmount :: !AccountEncryptedAmount,
+      -- | The account's release schedule.
       ahiAccountReleaseScheduleHash :: !ARSV0.AccountReleaseScheduleHashV0,
+      -- | Hash of the persisting account data.
       ahiPersistingAccountDataHash :: !PersistingAccountDataHash,
+      -- | Hash of the account's stake details.
       ahiAccountStakeHash :: !(AccountStakeHash av)
     }
 
@@ -307,10 +315,17 @@ instance HashableTo (AccountMerkleHash av) (AccountMerkleHashInputs av) where
                     )
                 )
 
+-- | The data used to compute an 'AccountHash' from 'AccountV2' onwards.
+--  While this is common between account versions, the 'AccountMerkleHash' is version-specific,
+--  as is the mode of computing the account hash.
 data AccountHashInputsV2 (av :: AccountVersion) = AccountHashInputsV2
-    { ahi2NextNonce :: !Nonce,
+    { -- | The next nonce for the account.
+      ahi2NextNonce :: !Nonce,
+      -- | The account balance.
       ahi2AccountBalance :: !Amount,
+      -- | The actively staked balance.
       ahi2StakedBalance :: !Amount,
+      -- | Hash derived from the seldom-updated parts of the account.
       ahi2MerkleHash :: !(AccountMerkleHash av)
     }
 

--- a/concordium-consensus/src/Concordium/GlobalState/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Account.hs
@@ -31,6 +31,10 @@ import Concordium.Types.Execution
 import Concordium.Types.HashableTo
 import Concordium.Utils.Serialization
 
+-- | The hash derived from an account's cooldown queue.
+newtype CooldownQueueHash (av :: AccountVersion) = CooldownQueueHash {theCooldownQueueHash :: Hash.Hash}
+    deriving (Eq, Ord, Show, Serialize)
+
 -- | A list of credential IDs that have been removed from an account.
 data RemovedCredentials
     = EmptyRemovedCredentials
@@ -249,13 +253,26 @@ data AccountMerkleHashInputs (av :: AccountVersion) where
         { -- | Hash of the persisting account data.
           amhi2PersistingAccountDataHash :: !PersistingAccountDataHash,
           -- | Hash of the account stake.
-          amhi2AccountStakeHash :: !(AccountStakeHash av),
+          amhi2AccountStakeHash :: !(AccountStakeHash 'AccountV2),
           -- | Hash of the account's encrypted amount.
           amhi2EncryptedAmountHash :: !EncryptedAmountHash,
           -- | Hash of the account's release schedule.
           amhi2AccountReleaseScheduleHash :: !ARSV1.AccountReleaseScheduleHashV1
         } ->
         AccountMerkleHashInputs 'AccountV2
+    AccountMerkleHashInputsV3 ::
+        { -- | Hash of the persisting account data.
+          amhi3PersistingAccountDataHash :: !PersistingAccountDataHash,
+          -- | Hash of the account stake.
+          amhi3AccountStakeHash :: !(AccountStakeHash 'AccountV3),
+          -- | Hash of the account's encrypted amount.
+          amhi3EncryptedAmountHash :: !EncryptedAmountHash,
+          -- | Hash of the account's release schedule.
+          amhi3AccountReleaseScheduleHash :: !ARSV1.AccountReleaseScheduleHashV1,
+          -- | Hash of the account's cooldown queue.
+          amhi3Cooldown :: !(CooldownQueueHash 'AccountV3)
+        } ->
+        AccountMerkleHashInputs 'AccountV3
 
 -- | The Merkle hash derived from the seldom-updated parts of an account, namely the persisting
 --  account data, account stake, encrypted amount, and account release schedule.
@@ -275,6 +292,20 @@ instance HashableTo (AccountMerkleHash av) (AccountMerkleHashInputs av) where
                     (theEncryptedAmountHash amhi2EncryptedAmountHash)
                     (ARSV1.theAccountReleaseScheduleHashV1 amhi2AccountReleaseScheduleHash)
                 )
+    getHash AccountMerkleHashInputsV3{..} =
+        AccountMerkleHash $
+            Hash.hashOfHashes
+                ( Hash.hashOfHashes
+                    (thePersistingAccountDataHash amhi3PersistingAccountDataHash)
+                    (theAccountStakeHash amhi3AccountStakeHash)
+                )
+                ( Hash.hashOfHashes
+                    (theEncryptedAmountHash amhi3EncryptedAmountHash)
+                    ( Hash.hashOfHashes
+                        (ARSV1.theAccountReleaseScheduleHashV1 amhi3AccountReleaseScheduleHash)
+                        (theCooldownQueueHash amhi3Cooldown)
+                    )
+                )
 
 data AccountHashInputsV2 (av :: AccountVersion) = AccountHashInputsV2
     { ahi2NextNonce :: !Nonce,
@@ -293,17 +324,30 @@ makeAccountHashV2 AccountHashInputsV2{..} = Hash.hashLazy $ runPutLazy $ do
     put ahi2StakedBalance
     put ahi2MerkleHash
 
+-- | Generate the hash for an account (for 'AccountV3'), given the
+--  'AccountHashInputsV2'. 'makeAccountHash' should be used in preference to this function.
+makeAccountHashV3 :: AccountHashInputsV2 av -> Hash.Hash
+makeAccountHashV3 AccountHashInputsV2{..} = Hash.hashLazy $ runPutLazy $ do
+    putShortByteString "AC03"
+    put ahi2NextNonce
+    put ahi2AccountBalance
+    put ahi2StakedBalance
+    put ahi2MerkleHash
+
 -- | Inputs for computing the 'AccountHash' for an account.
 data AccountHashInputs (av :: AccountVersion) where
     AHIV0 :: AccountHashInputsV0 'AccountV0 -> AccountHashInputs 'AccountV0
     AHIV1 :: AccountHashInputsV0 'AccountV1 -> AccountHashInputs 'AccountV1
     AHIV2 :: AccountHashInputsV2 'AccountV2 -> AccountHashInputs 'AccountV2
+    AHIV3 :: AccountHashInputsV2 'AccountV3 -> AccountHashInputs 'AccountV3
 
+-- | Generate the hash for an account, given the 'AccountHashInputs'.
 makeAccountHash :: AccountHashInputs av -> AccountHash av
 {-# INLINE makeAccountHash #-}
 makeAccountHash (AHIV0 ahi) = AccountHash $ makeAccountHashV0 ahi
 makeAccountHash (AHIV1 ahi) = AccountHash $ makeAccountHashV0 ahi
 makeAccountHash (AHIV2 ahi) = AccountHash $ makeAccountHashV2 ahi
+makeAccountHash (AHIV3 ahi) = AccountHash $ makeAccountHashV3 ahi
 
 data EncryptedAmountUpdate
     = -- | Replace encrypted amounts less than the given index,

--- a/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/Account.hs
@@ -22,12 +22,14 @@ import Lens.Micro.Platform
 import qualified Concordium.Crypto.SHA256 as Hash
 import Concordium.GlobalState.Account
 import Concordium.GlobalState.Basic.BlockState.AccountReleaseSchedule
+import Concordium.GlobalState.CooldownQueue
 import Concordium.ID.Parameters
 import Concordium.ID.Types
 import Concordium.Types.HashableTo
 
 import Concordium.Types
 import Concordium.Types.Accounts
+import Concordium.Types.Conditionally
 
 -- | Type for how a 'PersistingAccountData' value is stored as part of
 --  an account. This is stored with its hash.
@@ -54,7 +56,9 @@ data Account (av :: AccountVersion) = Account
       -- | Locked-up amounts and their release schedule.
       _accountReleaseSchedule :: !(AccountReleaseSchedule av),
       -- | The baker or delegation associated with the account (if any).
-      _accountStaking :: !(AccountStake av)
+      _accountStaking :: !(AccountStake av),
+      -- | The cooldown on the account.
+      _accountStakeCooldown :: !(Conditionally (SupportsFlexibleCooldown av) Cooldowns)
     }
     deriving (Eq, Show)
 
@@ -126,15 +130,43 @@ accountHashInputsV2 Account{..} =
               amhi2AccountReleaseScheduleHash = getHash _accountReleaseSchedule
             }
 
+-- | Generate hash inputs from an account for 'AccountV2'.
+accountHashInputsV3 :: Account 'AccountV3 -> AccountHashInputsV2 'AccountV3
+accountHashInputsV3 Account{..} =
+    AccountHashInputsV2
+        { ahi2NextNonce = _accountNonce,
+          ahi2AccountBalance = _accountAmount,
+          ahi2StakedBalance = stakedBalance,
+          ahi2MerkleHash = getHash merkleInputs
+        }
+  where
+    stakedBalance = case _accountStaking of
+        AccountStakeNone -> 0
+        AccountStakeBaker AccountBaker{..} -> _stakedAmount
+        AccountStakeDelegate AccountDelegationV1{..} -> _delegationStakedAmount
+    merkleInputs :: AccountMerkleHashInputs 'AccountV3
+    merkleInputs =
+        AccountMerkleHashInputsV3
+            { amhi3PersistingAccountDataHash = getHash _accountPersisting,
+              amhi3AccountStakeHash = getHash _accountStaking :: AccountStakeHash 'AccountV3,
+              amhi3EncryptedAmountHash = getHash _accountEncryptedAmount,
+              amhi3AccountReleaseScheduleHash = getHash _accountReleaseSchedule,
+              amhi3Cooldown = CooldownQueueHash $ getHash $ uncond _accountStakeCooldown
+            }
+
 instance (IsAccountVersion av) => HashableTo (AccountHash av) (Account av) where
     getHash acc = makeAccountHash $ case accountVersion @av of
         SAccountV0 -> AHIV0 (accountHashInputsV0 acc)
         SAccountV1 -> AHIV1 (accountHashInputsV0 acc)
         SAccountV2 -> AHIV2 (accountHashInputsV2 acc)
-        SAccountV3 -> undefined -- TODO: Implement account version 3
+        SAccountV3 -> AHIV3 (accountHashInputsV3 acc)
 
 instance forall av. (IsAccountVersion av) => HashableTo Hash.Hash (Account av) where
     getHash = coerce @(AccountHash av) . getHash
+
+-- | An empty cooldown queue for a given account version.
+emptyCooldownQueue :: SAccountVersion av -> Conditionally (SupportsFlexibleCooldown av) Cooldowns
+emptyCooldownQueue sav = conditionally (sSupportsFlexibleCooldown sav) emptyCooldowns
 
 -- | Create an empty account with the given public key, address and credentials.
 newAccountMultiCredential ::
@@ -164,7 +196,8 @@ newAccountMultiCredential cryptoParams threshold _accountAddress cs =
           _accountAmount = 0,
           _accountEncryptedAmount = initialAccountEncryptedAmount,
           _accountReleaseSchedule = emptyAccountReleaseSchedule,
-          _accountStaking = AccountStakeNone
+          _accountStaking = AccountStakeNone,
+          _accountStakeCooldown = emptyCooldownQueue (accountVersion @av)
         }
 
 -- | Create an empty account with the given public key, address and credential.

--- a/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/Account.hs
@@ -125,7 +125,7 @@ accountHashInputsV2 Account{..} =
     merkleInputs =
         AccountMerkleHashInputsV2
             { amhi2PersistingAccountDataHash = getHash _accountPersisting,
-              amhi2AccountStakeHash = getHash _accountStaking :: AccountStakeHash 'AccountV2,
+              amhi2AccountStakeHash = getHash _accountStaking,
               amhi2EncryptedAmountHash = getHash _accountEncryptedAmount,
               amhi2AccountReleaseScheduleHash = getHash _accountReleaseSchedule
             }
@@ -148,7 +148,7 @@ accountHashInputsV3 Account{..} =
     merkleInputs =
         AccountMerkleHashInputsV3
             { amhi3PersistingAccountDataHash = getHash _accountPersisting,
-              amhi3AccountStakeHash = getHash _accountStaking :: AccountStakeHash 'AccountV3,
+              amhi3AccountStakeHash = getHash _accountStaking,
               amhi3EncryptedAmountHash = getHash _accountEncryptedAmount,
               amhi3AccountReleaseScheduleHash = getHash _accountReleaseSchedule,
               amhi3Cooldown = CooldownQueueHash $ getHash $ uncond _accountStakeCooldown

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
@@ -27,6 +27,7 @@ import Concordium.GlobalState.Account
 import Concordium.GlobalState.BakerInfo
 import qualified Concordium.GlobalState.Basic.BlockState.Account as Transient
 import Concordium.GlobalState.BlockState (AccountAllowance)
+import Concordium.GlobalState.CooldownQueue
 import qualified Concordium.GlobalState.Persistent.Account.StructureV0 as V0
 import qualified Concordium.GlobalState.Persistent.Account.StructureV1 as V1
 import Concordium.GlobalState.Persistent.BlobStore
@@ -40,26 +41,30 @@ data PersistentAccount (av :: AccountVersion) where
     PAV0 :: !(V0.PersistentAccount 'AccountV0) -> PersistentAccount 'AccountV0
     PAV1 :: !(V0.PersistentAccount 'AccountV1) -> PersistentAccount 'AccountV1
     PAV2 :: !(V1.PersistentAccount 'AccountV2) -> PersistentAccount 'AccountV2
+    PAV3 :: !(V1.PersistentAccount 'AccountV3) -> PersistentAccount 'AccountV3
 
 instance (MonadBlobStore m) => MHashableTo m (AccountHash av) (PersistentAccount av) where
     getHashM (PAV0 acc) = getHashM acc
     getHashM (PAV1 acc) = getHashM acc
     getHashM (PAV2 acc) = getHashM acc
+    getHashM (PAV3 acc) = getHashM acc
 
 instance (MonadBlobStore m) => MHashableTo m Hash.Hash (PersistentAccount av) where
     getHashM (PAV0 acc) = getHashM acc
     getHashM (PAV1 acc) = getHashM acc
     getHashM (PAV2 acc) = getHashM acc
+    getHashM (PAV3 acc) = getHashM acc
 
 instance (IsAccountVersion av, MonadBlobStore m) => BlobStorable m (PersistentAccount av) where
     storeUpdate (PAV0 acct) = second PAV0 <$!> storeUpdate acct
     storeUpdate (PAV1 acct) = second PAV1 <$!> storeUpdate acct
     storeUpdate (PAV2 acct) = second PAV2 <$!> storeUpdate acct
+    storeUpdate (PAV3 acct) = second PAV3 <$!> storeUpdate acct
     load = case accountVersion @av of
         SAccountV0 -> fmap PAV0 <$> load
         SAccountV1 -> fmap PAV1 <$> load
         SAccountV2 -> fmap PAV2 <$> load
-        SAccountV3 -> undefined -- TODO: Implement account version 3
+        SAccountV3 -> fmap PAV3 <$> load
 
 -- | Type of references to persistent accounts.
 type AccountRef (av :: AccountVersion) = HashedCachedRef (AccountCache av) (PersistentAccount av)
@@ -69,21 +74,24 @@ data PersistentBakerInfoRef (av :: AccountVersion) where
     PBIRV0 :: !(V0.PersistentBakerInfoEx 'AccountV0) -> PersistentBakerInfoRef 'AccountV0
     PBIRV1 :: !(V0.PersistentBakerInfoEx 'AccountV1) -> PersistentBakerInfoRef 'AccountV1
     PBIRV2 :: !(V1.PersistentBakerInfoEx 'AccountV2) -> PersistentBakerInfoRef 'AccountV2
+    PBIRV3 :: !(V1.PersistentBakerInfoEx 'AccountV3) -> PersistentBakerInfoRef 'AccountV3
 
 instance Show (PersistentBakerInfoRef av) where
     show (PBIRV0 pibr) = show pibr
     show (PBIRV1 pibr) = show pibr
     show (PBIRV2 pibr) = show pibr
+    show (PBIRV3 pibr) = show pibr
 
 instance (IsAccountVersion av, MonadBlobStore m) => BlobStorable m (PersistentBakerInfoRef av) where
     storeUpdate (PBIRV0 bir) = second PBIRV0 <$!> storeUpdate bir
     storeUpdate (PBIRV1 bir) = second PBIRV1 <$!> storeUpdate bir
     storeUpdate (PBIRV2 bir) = second PBIRV2 <$!> storeUpdate bir
+    storeUpdate (PBIRV3 bir) = second PBIRV3 <$!> storeUpdate bir
     load = case accountVersion @av of
         SAccountV0 -> fmap PBIRV0 <$!> load
         SAccountV1 -> fmap PBIRV1 <$!> load
         SAccountV2 -> fmap PBIRV2 <$!> load
-        SAccountV3 -> undefined -- TODO: Implement account version 3
+        SAccountV3 -> fmap PBIRV3 <$!> load
 
 -- * Account cache
 
@@ -101,30 +109,45 @@ accountCanonicalAddress :: (MonadBlobStore m) => PersistentAccount av -> m Accou
 accountCanonicalAddress (PAV0 acc) = V0.getCanonicalAddress acc
 accountCanonicalAddress (PAV1 acc) = V0.getCanonicalAddress acc
 accountCanonicalAddress (PAV2 acc) = V1.getCanonicalAddress acc
+accountCanonicalAddress (PAV3 acc) = V1.getCanonicalAddress acc
 
 -- | Get the current public account balance.
 accountAmount :: (MonadBlobStore m) => PersistentAccount av -> m Amount
 accountAmount (PAV0 acc) = V0.getAmount acc
 accountAmount (PAV1 acc) = V0.getAmount acc
 accountAmount (PAV2 acc) = V1.getAmount acc
+accountAmount (PAV3 acc) = V1.getAmount acc
 
 -- | Gets the amount of a baker's stake, or 'Nothing' if the account is not a baker.
+--  This consists only of the active stake, and does not include any inactive stake.
 accountBakerStakeAmount :: (MonadBlobStore m) => PersistentAccount av -> m (Maybe Amount)
 accountBakerStakeAmount (PAV0 acc) = V0.getBakerStakeAmount acc
 accountBakerStakeAmount (PAV1 acc) = V0.getBakerStakeAmount acc
 accountBakerStakeAmount (PAV2 acc) = V1.getBakerStakeAmount acc
+accountBakerStakeAmount (PAV3 acc) = V1.getBakerStakeAmount acc
 
--- | Get the amount that is staked on the account.
-accountStakedAmount :: (MonadBlobStore m) => PersistentAccount av -> m Amount
-accountStakedAmount (PAV0 acc) = V0.getStakedAmount acc
-accountStakedAmount (PAV1 acc) = V0.getStakedAmount acc
-accountStakedAmount (PAV2 acc) = V1.getStakedAmount acc
+-- | Get the amount that is actively staked on an account as a baker or delegator.
+accountActiveStakedAmount :: (MonadBlobStore m) => PersistentAccount av -> m Amount
+accountActiveStakedAmount (PAV0 acc) = V0.getStakedAmount acc
+accountActiveStakedAmount (PAV1 acc) = V0.getStakedAmount acc
+accountActiveStakedAmount (PAV2 acc) = V1.getActiveStakedAmount acc
+accountActiveStakedAmount (PAV3 acc) = V1.getActiveStakedAmount acc
+
+-- | Get the amount that is staked on the account (both active and inactive).
+accountTotalStakedAmount :: (MonadBlobStore m) => PersistentAccount av -> m Amount
+accountTotalStakedAmount (PAV0 acc) = V0.getStakedAmount acc
+accountTotalStakedAmount (PAV1 acc) = V0.getStakedAmount acc
+accountTotalStakedAmount (PAV2 acc) =
+    -- This is the same as the total staked amount in account version 2.
+    V1.getActiveStakedAmount acc
+accountTotalStakedAmount (PAV3 acc) = V1.getTotalStakedAmount acc
 
 -- | Get the amount that is locked in scheduled releases on the account.
 accountLockedAmount :: (MonadBlobStore m) => PersistentAccount av -> m Amount
 accountLockedAmount (PAV0 acc) = V0.getLockedAmount acc
 accountLockedAmount (PAV1 acc) = V0.getLockedAmount acc
 accountLockedAmount (PAV2 acc) = V1.getLockedAmount acc
+accountLockedAmount (PAV3 acc) = V1.getLockedAmount acc
 
 -- | Get the current public account available balance.
 -- This accounts for lock-up and staked amounts.
@@ -133,12 +156,14 @@ accountAvailableAmount :: (MonadBlobStore m) => PersistentAccount av -> m Amount
 accountAvailableAmount (PAV0 acc) = V0.getAvailableAmount acc
 accountAvailableAmount (PAV1 acc) = V0.getAvailableAmount acc
 accountAvailableAmount (PAV2 acc) = V1.getAvailableAmount acc
+accountAvailableAmount (PAV3 acc) = V1.getAvailableAmount acc
 
 -- | Get the next account nonce for transactions from this account.
 accountNonce :: (MonadBlobStore m) => PersistentAccount av -> m Nonce
 accountNonce (PAV0 acc) = V0.getNonce acc
 accountNonce (PAV1 acc) = V0.getNonce acc
 accountNonce (PAV2 acc) = V1.getNonce acc
+accountNonce (PAV3 acc) = V1.getNonce acc
 
 -- | Determine if a given operation is permitted for the account.
 --
@@ -149,6 +174,7 @@ accountIsAllowed :: (MonadBlobStore m) => PersistentAccount av -> AccountAllowan
 accountIsAllowed (PAV0 acc) = V0.isAllowed acc
 accountIsAllowed (PAV1 acc) = V0.isAllowed acc
 accountIsAllowed (PAV2 acc) = V1.isAllowed acc
+accountIsAllowed (PAV3 acc) = V1.isAllowed acc
 
 -- | Get the credentials deployed on the account. This map is always non-empty and (presently)
 --  will have a credential at index 'initialCredentialIndex' (0) that cannot be changed.
@@ -156,84 +182,115 @@ accountCredentials :: (MonadBlobStore m) => PersistentAccount av -> m (Map.Map C
 accountCredentials (PAV0 acc) = V0.getCredentials acc
 accountCredentials (PAV1 acc) = V0.getCredentials acc
 accountCredentials (PAV2 acc) = V1.getCredentials acc
+accountCredentials (PAV3 acc) = V1.getCredentials acc
 
 -- | Get the key used to verify transaction signatures, it records the signature scheme used as well.
 accountVerificationKeys :: (MonadBlobStore m) => PersistentAccount av -> m AccountInformation
 accountVerificationKeys (PAV0 acc) = V0.getVerificationKeys acc
 accountVerificationKeys (PAV1 acc) = V0.getVerificationKeys acc
 accountVerificationKeys (PAV2 acc) = V1.getVerificationKeys acc
+accountVerificationKeys (PAV3 acc) = V1.getVerificationKeys acc
 
 -- | Get the current encrypted amount on the account.
 accountEncryptedAmount :: (MonadBlobStore m) => PersistentAccount av -> m AccountEncryptedAmount
 accountEncryptedAmount (PAV0 acc) = V0.getEncryptedAmount acc
 accountEncryptedAmount (PAV1 acc) = V0.getEncryptedAmount acc
 accountEncryptedAmount (PAV2 acc) = V1.getEncryptedAmount acc
+accountEncryptedAmount (PAV3 acc) = V1.getEncryptedAmount acc
 
 -- | Get the public key used to receive encrypted amounts.
 accountEncryptionKey :: (MonadBlobStore m) => PersistentAccount av -> m AccountEncryptionKey
 accountEncryptionKey (PAV0 acc) = V0.getEncryptionKey acc
 accountEncryptionKey (PAV1 acc) = V0.getEncryptionKey acc
 accountEncryptionKey (PAV2 acc) = V1.getEncryptionKey acc
+accountEncryptionKey (PAV3 acc) = V1.getEncryptionKey acc
 
 -- | Get the 'AccountReleaseSummary' summarising scheduled releases for an account.
 accountReleaseSummary :: (MonadBlobStore m) => PersistentAccount av -> m AccountReleaseSummary
 accountReleaseSummary (PAV0 acc) = V0.getReleaseSummary acc
 accountReleaseSummary (PAV1 acc) = V0.getReleaseSummary acc
 accountReleaseSummary (PAV2 acc) = V1.getReleaseSummary acc
+accountReleaseSummary (PAV3 acc) = V1.getReleaseSummary acc
 
 -- | Get the timestamp at which the next scheduled release will occur (if any).
 accountNextReleaseTimestamp :: (MonadBlobStore m) => PersistentAccount av -> m (Maybe Timestamp)
 accountNextReleaseTimestamp (PAV0 acc) = V0.getNextReleaseTimestamp acc
 accountNextReleaseTimestamp (PAV1 acc) = V0.getNextReleaseTimestamp acc
 accountNextReleaseTimestamp (PAV2 acc) = V1.getNextReleaseTimestamp acc
+accountNextReleaseTimestamp (PAV3 acc) = V1.getNextReleaseTimestamp acc
 
 -- | Get the baker (if any) attached to an account.
 accountBaker :: (MonadBlobStore m) => PersistentAccount av -> m (Maybe (AccountBaker av))
 accountBaker (PAV0 acc) = V0.getBaker acc
 accountBaker (PAV1 acc) = V0.getBaker acc
 accountBaker (PAV2 acc) = V1.getBaker acc
+accountBaker (PAV3 acc) = V1.getBaker acc
 
 -- | Get a reference to the baker info (if any) attached to an account.
 accountBakerInfoRef :: (MonadBlobStore m) => PersistentAccount av -> m (Maybe (PersistentBakerInfoRef av))
 accountBakerInfoRef (PAV0 acc) = fmap PBIRV0 <$> V0.getBakerInfoRef acc
 accountBakerInfoRef (PAV1 acc) = fmap PBIRV1 <$> V0.getBakerInfoRef acc
 accountBakerInfoRef (PAV2 acc) = fmap PBIRV2 <$> V1.getBakerInfoRef acc
+accountBakerInfoRef (PAV3 acc) = fmap PBIRV3 <$> V1.getBakerInfoRef acc
 
 -- | Get the baker and baker info reference (if any) attached to the account.
 accountBakerAndInfoRef :: (MonadBlobStore m) => PersistentAccount av -> m (Maybe (AccountBaker av, PersistentBakerInfoRef av))
 accountBakerAndInfoRef (PAV0 acc) = fmap (second PBIRV0) <$> V0.getBakerAndInfoRef acc
 accountBakerAndInfoRef (PAV1 acc) = fmap (second PBIRV1) <$> V0.getBakerAndInfoRef acc
 accountBakerAndInfoRef (PAV2 acc) = fmap (second PBIRV2) <$> V1.getBakerAndInfoRef acc
+accountBakerAndInfoRef (PAV3 acc) = fmap (second PBIRV3) <$> V1.getBakerAndInfoRef acc
 
 -- | Get the delegator (if any) attached to the account.
 accountDelegator :: (MonadBlobStore m) => PersistentAccount av -> m (Maybe (AccountDelegation av))
 accountDelegator (PAV0 acc) = V0.getDelegator acc
 accountDelegator (PAV1 acc) = V0.getDelegator acc
 accountDelegator (PAV2 acc) = V1.getDelegator acc
+accountDelegator (PAV3 acc) = V1.getDelegator acc
 
 -- | Get the baker or stake delegation information attached to an account.
 accountStake :: (MonadBlobStore m) => PersistentAccount av -> m (AccountStake av)
 accountStake (PAV0 acc) = V0.getStake acc
 accountStake (PAV1 acc) = V0.getStake acc
 accountStake (PAV2 acc) = V1.getStake acc
+accountStake (PAV3 acc) = V1.getStake acc
 
 -- | Determine if an account has stake as a baker or delegator.
-accountHasStake :: PersistentAccount av -> Bool
-accountHasStake (PAV0 acc) = V0.hasStake acc
-accountHasStake (PAV1 acc) = V0.hasStake acc
-accountHasStake (PAV2 acc) = V1.hasStake acc
+accountHasActiveStake :: PersistentAccount av -> Bool
+accountHasActiveStake (PAV0 acc) = V0.hasActiveStake acc
+accountHasActiveStake (PAV1 acc) = V0.hasActiveStake acc
+accountHasActiveStake (PAV2 acc) = V1.hasActiveStake acc
+accountHasActiveStake (PAV3 acc) = V1.hasActiveStake acc
 
 -- | Get details about an account's stake.
 accountStakeDetails :: (MonadBlobStore m) => PersistentAccount av -> m (StakeDetails av)
 accountStakeDetails (PAV0 acc) = V0.getStakeDetails acc
 accountStakeDetails (PAV1 acc) = V0.getStakeDetails acc
 accountStakeDetails (PAV2 acc) = V1.getStakeDetails acc
+accountStakeDetails (PAV3 acc) = V1.getStakeDetails acc
+
+-- | Get the 'Cooldowns' for an account, if any. This is only available at account versions that
+-- support flexible cooldowns.
+accountCooldowns ::
+    (MonadBlobStore m, AVSupportsFlexibleCooldown av) =>
+    PersistentAccount av ->
+    m (Maybe Cooldowns)
+accountCooldowns (PAV3 acc) = V1.getCooldowns acc
+
+-- | Determine if an account has a pre-pre-cooldown.
+accountHasPrePreCooldown ::
+    (MonadBlobStore m, AVSupportsFlexibleCooldown av) =>
+    PersistentAccount av ->
+    m Bool
+accountHasPrePreCooldown = fmap check . accountCooldowns
+  where
+    check = maybe False (not . null . prePreCooldown)
 
 -- | Get the 'AccountHash' for the account.
 accountHash :: (MonadBlobStore m) => PersistentAccount av -> m (AccountHash av)
 accountHash (PAV0 acc) = getHashM acc
 accountHash (PAV1 acc) = getHashM acc
 accountHash (PAV2 acc) = getHashM acc
+accountHash (PAV3 acc) = getHashM acc
 
 -- ** 'PersistentBakerInfoRef' queries
 
@@ -242,18 +299,21 @@ loadBakerInfo :: (MonadBlobStore m) => PersistentBakerInfoRef av -> m BakerInfo
 loadBakerInfo (PBIRV0 bir) = V0.loadBakerInfo bir
 loadBakerInfo (PBIRV1 bir) = V0.loadBakerInfo bir
 loadBakerInfo (PBIRV2 bir) = V1.loadBakerInfo bir
+loadBakerInfo (PBIRV3 bir) = V1.loadBakerInfo bir
 
 -- | Load 'BakerInfoEx' from a 'PersistentBakerInfoRef'.
 loadPersistentBakerInfoRef :: (MonadBlobStore m) => PersistentBakerInfoRef av -> m (BakerInfoEx av)
 loadPersistentBakerInfoRef (PBIRV0 bir) = V0.loadPersistentBakerInfoEx bir
 loadPersistentBakerInfoRef (PBIRV1 bir) = V0.loadPersistentBakerInfoEx bir
 loadPersistentBakerInfoRef (PBIRV2 bir) = V1.loadPersistentBakerInfoEx bir
+loadPersistentBakerInfoRef (PBIRV3 bir) = V1.loadPersistentBakerInfoEx bir
 
 -- | Load the 'BakerId' from a 'PersistentBakerInfoRef'.
 loadBakerId :: (MonadBlobStore m) => PersistentBakerInfoRef av -> m BakerId
 loadBakerId (PBIRV0 bir) = V0.loadBakerId bir
 loadBakerId (PBIRV1 bir) = V0.loadBakerId bir
 loadBakerId (PBIRV2 bir) = V1.loadBakerId bir
+loadBakerId (PBIRV3 bir) = V1.loadBakerId bir
 
 -- * Updates
 
@@ -262,6 +322,7 @@ updateAccount :: (MonadBlobStore m) => AccountUpdate -> PersistentAccount av -> 
 updateAccount upd (PAV0 acc) = PAV0 <$> V0.updateAccount upd acc
 updateAccount upd (PAV1 acc) = PAV1 <$> V0.updateAccount upd acc
 updateAccount upd (PAV2 acc) = PAV2 <$> V1.updateAccount upd acc
+updateAccount upd (PAV3 acc) = PAV3 <$> V1.updateAccount upd acc
 
 -- | Add or remove credentials on an account.
 --  The caller must ensure the following, which are not checked:
@@ -288,6 +349,8 @@ updateAccountCredentials cuRemove cuAdd cuAccountThreshold (PAV1 acc) =
     PAV1 <$> V0.updateAccountCredentials cuRemove cuAdd cuAccountThreshold acc
 updateAccountCredentials cuRemove cuAdd cuAccountThreshold (PAV2 acc) =
     PAV2 <$> V1.updateAccountCredentials cuRemove cuAdd cuAccountThreshold acc
+updateAccountCredentials cuRemove cuAdd cuAccountThreshold (PAV3 acc) =
+    PAV3 <$> V1.updateAccountCredentials cuRemove cuAdd cuAccountThreshold acc
 
 -- | Optionally update the verification keys and signature threshold for an account.
 --  Precondition: The credential with given credential index exists.
@@ -306,12 +369,15 @@ updateAccountCredentialKeys credIndex credKeys (PAV1 acc) =
     PAV1 <$> V0.updateAccountCredentialKeys credIndex credKeys acc
 updateAccountCredentialKeys credIndex credKeys (PAV2 acc) =
     PAV2 <$> V1.updateAccountCredentialKeys credIndex credKeys acc
+updateAccountCredentialKeys credIndex credKeys (PAV3 acc) =
+    PAV3 <$> V1.updateAccountCredentialKeys credIndex credKeys acc
 
 -- | Add an amount to the account's balance.
 addAccountAmount :: (MonadBlobStore m) => Amount -> PersistentAccount av -> m (PersistentAccount av)
 addAccountAmount amt (PAV0 acc) = PAV0 <$> V0.addAmount amt acc
 addAccountAmount amt (PAV1 acc) = PAV1 <$> V0.addAmount amt acc
 addAccountAmount amt (PAV2 acc) = PAV2 <$> V1.addAmount amt acc
+addAccountAmount amt (PAV3 acc) = PAV3 <$> V1.addAmount amt acc
 
 -- | Applies a pending stake change to an account. The account MUST have a pending stake change.
 --  If the account does not have a pending stake change, or is not staking, then this will raise
@@ -339,6 +405,16 @@ addAccountBakerV1 ::
     m (PersistentAccount av)
 addAccountBakerV1 binfo amt restake (PAV1 acc) = PAV1 <$> V0.addBakerV1 binfo amt restake acc
 addAccountBakerV1 binfo amt restake (PAV2 acc) = PAV2 <$> V1.addBakerV1 binfo amt restake acc
+addAccountBakerV1 binfo amt restake (PAV3 acc) = PAV3 <$> V1.addBakerV1 binfo amt restake acc
+
+-- | Remove a baker/delegator from an account.
+--  This removes any baker or delegator record and sets the active stake to 0.
+--  This does not affect the stake in cooldown, which should be updated separately.
+removeAccountStake ::
+    (MonadBlobStore m, AVSupportsFlexibleCooldown av) =>
+    PersistentAccount av ->
+    m (PersistentAccount av)
+removeAccountStake (PAV3 acc) = PAV3 <$> V1.removeStake acc
 
 -- | Add a delegator to an account.
 --  This will replace any existing staking information on the account.
@@ -349,6 +425,7 @@ addAccountDelegator ::
     m (PersistentAccount av)
 addAccountDelegator del (PAV1 acc) = PAV1 <$> V0.addDelegator del acc
 addAccountDelegator del (PAV2 acc) = PAV2 <$> V1.addDelegator del acc
+addAccountDelegator del (PAV3 acc) = PAV3 <$> V1.addDelegator del acc
 
 -- | Update the pool info on a baker account.
 --  This MUST only be called with an account that is a baker.
@@ -359,6 +436,7 @@ updateAccountBakerPoolInfo ::
     m (PersistentAccount av)
 updateAccountBakerPoolInfo upd (PAV1 acc) = PAV1 <$> V0.updateBakerPoolInfo upd acc
 updateAccountBakerPoolInfo upd (PAV2 acc) = PAV2 <$> V1.updateBakerPoolInfo upd acc
+updateAccountBakerPoolInfo upd (PAV3 acc) = PAV3 <$> V1.updateBakerPoolInfo upd acc
 
 -- | Set the baker keys on a baker account.
 --  This MUST only be called with an account that is a baker.
@@ -370,6 +448,7 @@ setAccountBakerKeys ::
 setAccountBakerKeys keys (PAV0 acc) = PAV0 <$> V0.setBakerKeys keys acc
 setAccountBakerKeys keys (PAV1 acc) = PAV1 <$> V0.setBakerKeys keys acc
 setAccountBakerKeys keys (PAV2 acc) = PAV2 <$> V1.setBakerKeys keys acc
+setAccountBakerKeys keys (PAV3 acc) = PAV3 <$> V1.setBakerKeys keys acc
 
 -- | Set the stake of a baker or delegator account.
 --  This MUST only be called with an account that is either a baker or delegator.
@@ -382,6 +461,24 @@ setAccountStake ::
 setAccountStake newStake (PAV0 acc) = PAV0 <$> V0.setStake newStake acc
 setAccountStake newStake (PAV1 acc) = PAV1 <$> V0.setStake newStake acc
 setAccountStake newStake (PAV2 acc) = PAV2 <$> V1.setStake newStake acc
+setAccountStake newStake (PAV3 acc) = PAV3 <$> V1.setStake newStake acc
+
+-- | Add a specified amount to the pre-pre-cooldown inactive stake.
+addAccountPrePreCooldown ::
+    (MonadBlobStore m, AVSupportsFlexibleCooldown av) =>
+    Amount ->
+    PersistentAccount av ->
+    m (PersistentAccount av)
+addAccountPrePreCooldown amt (PAV3 acc) = PAV3 <$> V1.addPrePreCooldown amt acc
+
+-- | Remove up to the given amount from the cooldowns, starting with pre-pre-cooldown, then
+--  pre-cooldown, and finally from the amounts in cooldown, in decreasing order of timestamp.
+reactivateCooldownAmount ::
+    (MonadBlobStore m, AVSupportsFlexibleCooldown av) =>
+    Amount ->
+    PersistentAccount av ->
+    m (PersistentAccount av)
+reactivateCooldownAmount amt (PAV3 acc) = PAV3 <$> V1.reactivateCooldownAmount amt acc
 
 -- | Set whether a baker or delegator account restakes its earnings.
 --  This MUST only be called with an account that is either a baker or delegator.
@@ -393,6 +490,7 @@ setAccountRestakeEarnings ::
 setAccountRestakeEarnings restake (PAV0 acc) = PAV0 <$> V0.setRestakeEarnings restake acc
 setAccountRestakeEarnings restake (PAV1 acc) = PAV1 <$> V0.setRestakeEarnings restake acc
 setAccountRestakeEarnings restake (PAV2 acc) = PAV2 <$> V1.setRestakeEarnings restake acc
+setAccountRestakeEarnings restake (PAV3 acc) = PAV3 <$> V1.setRestakeEarnings restake acc
 
 -- | Set the pending change on baker or delegator account.
 --  This MUST only be called with an account that is either a baker or delegator.
@@ -404,6 +502,7 @@ setAccountStakePendingChange ::
 setAccountStakePendingChange pc (PAV0 acc) = PAV0 <$> V0.setStakePendingChange pc acc
 setAccountStakePendingChange pc (PAV1 acc) = PAV1 <$> V0.setStakePendingChange pc acc
 setAccountStakePendingChange pc (PAV2 acc) = PAV2 <$> V1.setStakePendingChange pc acc
+setAccountStakePendingChange pc (PAV3 acc) = PAV3 <$> V1.setStakePendingChange pc acc
 
 -- | Set the target of a delegating account.
 --  This MUST only be called with an account that is a delegator.
@@ -415,6 +514,7 @@ setAccountDelegationTarget ::
 setAccountDelegationTarget target (PAV0 acc) = PAV0 <$> V0.setDelegationTarget target acc
 setAccountDelegationTarget target (PAV1 acc) = PAV1 <$> V0.setDelegationTarget target acc
 setAccountDelegationTarget target (PAV2 acc) = PAV2 <$> V1.setDelegationTarget target acc
+setAccountDelegationTarget target (PAV3 acc) = PAV3 <$> V1.setDelegationTarget target acc
 
 -- | Remove any staking on an account.
 removeAccountStaking ::
@@ -424,6 +524,7 @@ removeAccountStaking ::
 removeAccountStaking (PAV0 acc) = PAV0 <$> V0.removeStaking acc
 removeAccountStaking (PAV1 acc) = PAV1 <$> V0.removeStaking acc
 removeAccountStaking (PAV2 acc) = PAV2 <$> V1.removeStaking acc
+removeAccountStaking (PAV3 acc) = PAV3 <$> V1.removeStaking acc
 
 -- | Set the commission rates on a baker account.
 --  This MUST only be called with an account that is a baker.
@@ -434,6 +535,7 @@ setAccountCommissionRates ::
     m (PersistentAccount av)
 setAccountCommissionRates rates (PAV1 acc) = PAV1 <$> V0.setCommissionRates rates acc
 setAccountCommissionRates rates (PAV2 acc) = PAV2 <$> V1.setCommissionRates rates acc
+setAccountCommissionRates rates (PAV3 acc) = PAV3 <$> V1.setCommissionRates rates acc
 
 -- | Unlock scheduled releases on an account up to and including the given timestamp.
 --  This returns the next timestamp at which a release is scheduled for the account, if any,
@@ -446,6 +548,38 @@ unlockAccountReleases ::
 unlockAccountReleases ts (PAV0 acc) = second PAV0 <$> V0.unlockReleases ts acc
 unlockAccountReleases ts (PAV1 acc) = second PAV1 <$> V0.unlockReleases ts acc
 unlockAccountReleases ts (PAV2 acc) = second PAV2 <$> V1.unlockReleases ts acc
+unlockAccountReleases ts (PAV3 acc) = second PAV3 <$> V1.unlockReleases ts acc
+
+-- | Process the cooldowns on an account up to and including the given timestamp.
+--  This returns the next timestamp at which a cooldown expires, if any.
+processAccountCooldownsUntil ::
+    (MonadBlobStore m, AVSupportsFlexibleCooldown av) =>
+    Timestamp ->
+    PersistentAccount av ->
+    m (Maybe Timestamp, PersistentAccount av)
+processAccountCooldownsUntil ts (PAV3 acc) =
+    second PAV3 <$> V1.processCooldownsUntil ts acc
+
+-- | Move the pre-cooldown amount on an account into cooldown with the specified release time.
+--  This returns @Just (Just ts)@ if the previous next cooldown time was @ts@, but the new next
+--  cooldown (i.e. the supplied timestamp) time is earlier. It returns @Just Nothing@ if the account
+--  did not have a cooldown but now does. Otherwise, it returns @Nothing@.
+processAccountPreCooldown ::
+    (MonadBlobStore m, AVSupportsFlexibleCooldown av) =>
+    Timestamp ->
+    PersistentAccount av ->
+    m (Maybe (Maybe Timestamp), PersistentAccount av)
+processAccountPreCooldown ts (PAV3 acc) = second PAV3 <$> V1.processPreCooldown ts acc
+
+-- | Move the pre-pre-cooldown amount on an account into pre-cooldown.
+--  It should be the case that the account has a pre-pre-cooldown amount and no pre-cooldown amount.
+--  However, if there is no pre-pre-cooldown amount, this will do nothing, and if there is already
+--  a pre-cooldown amount, the pre-pre-cooldown amount will be added to it.
+processAccountPrePreCooldown ::
+    (MonadBlobStore m, AVSupportsFlexibleCooldown av) =>
+    PersistentAccount av ->
+    m (PersistentAccount av)
+processAccountPrePreCooldown (PAV3 acc) = PAV3 <$> V1.processPrePreCooldown acc
 
 -- * Creation
 
@@ -459,7 +593,7 @@ makePersistentAccount tacc = case accountVersion @av of
     SAccountV0 -> PAV0 <$> V0.makePersistentAccount tacc
     SAccountV1 -> PAV1 <$> V0.makePersistentAccount tacc
     SAccountV2 -> PAV2 <$> V1.makePersistentAccount tacc
-    SAccountV3 -> undefined -- TODO: Implement account version 3
+    SAccountV3 -> PAV3 <$> V1.makePersistentAccount tacc
 
 -- | Create an empty account with the given public key, address and credential.
 newAccount ::
@@ -473,7 +607,7 @@ newAccount = case accountVersion @av of
     SAccountV0 -> \ctx addr cred -> PAV0 <$> V0.newAccount ctx addr cred
     SAccountV1 -> \ctx addr cred -> PAV1 <$> V0.newAccount ctx addr cred
     SAccountV2 -> \ctx addr cred -> PAV2 <$> V1.newAccount ctx addr cred
-    SAccountV3 -> undefined -- TODO: Implement account version 3
+    SAccountV3 -> \ctx addr cred -> PAV3 <$> V1.newAccount ctx addr cred
 
 -- | Make a persistent account from a genesis account.
 --  The data is immediately flushed to disc and cached.
@@ -493,7 +627,8 @@ makeFromGenesisAccount spv =
             PAV1 <$> V0.makeFromGenesisAccount spv cryptoParams chainParameters genesisAccount
         SAccountV2 -> \cryptoParams chainParameters genesisAccount ->
             PAV2 <$> V1.makeFromGenesisAccount spv cryptoParams chainParameters genesisAccount
-        SAccountV3 -> undefined -- TODO: Implement account version 3
+        SAccountV3 -> \cryptoParams chainParameters genesisAccount ->
+            PAV3 <$> V1.makeFromGenesisAccount spv cryptoParams chainParameters genesisAccount
 
 -- ** 'PersistentBakerInfoRef' creation
 
@@ -507,7 +642,7 @@ makePersistentBakerInfoRef = case accountVersion @av of
     SAccountV0 -> fmap PBIRV0 . V0.makePersistentBakerInfoEx
     SAccountV1 -> fmap PBIRV1 . V0.makePersistentBakerInfoEx
     SAccountV2 -> fmap PBIRV2 . V1.makePersistentBakerInfoEx
-    SAccountV3 -> undefined -- TODO: Implement account version 3
+    SAccountV3 -> fmap PBIRV3 . V1.makePersistentBakerInfoEx
 
 -- * Migration
 
@@ -524,12 +659,13 @@ migratePersistentAccount ::
 migratePersistentAccount m@StateMigrationParametersTrivial (PAV0 acc) = PAV0 <$> V0.migratePersistentAccount m acc
 migratePersistentAccount m@StateMigrationParametersTrivial (PAV1 acc) = PAV1 <$> V0.migratePersistentAccount m acc
 migratePersistentAccount m@StateMigrationParametersTrivial (PAV2 acc) = PAV2 <$> V1.migratePersistentAccount m acc
+migratePersistentAccount StateMigrationParametersTrivial (PAV3 _) = undefined -- TODO: Implement migration
 migratePersistentAccount m@StateMigrationParametersP1P2 (PAV0 acc) = PAV0 <$> V0.migratePersistentAccount m acc
 migratePersistentAccount m@StateMigrationParametersP2P3 (PAV0 acc) = PAV0 <$> V0.migratePersistentAccount m acc
 migratePersistentAccount m@StateMigrationParametersP3ToP4{} (PAV0 acc) = PAV1 <$> V0.migratePersistentAccount m acc
 migratePersistentAccount m@StateMigrationParametersP4ToP5{} (PAV1 acc) = PAV2 <$> V1.migratePersistentAccountFromV0 m acc
 migratePersistentAccount m@StateMigrationParametersP5ToP6{} (PAV2 acc) = PAV2 <$> V1.migratePersistentAccount m acc
-migratePersistentAccount StateMigrationParametersP6ToP7{} _ = undefined -- TODO: Implement migration
+migratePersistentAccount m@StateMigrationParametersP6ToP7{} (PAV2 acc) = PAV3 <$> V1.migratePersistentAccount m acc
 
 -- | Migrate a 'PersistentBakerInfoRef' between protocol versions according to a state migration.
 migratePersistentBakerInfoRef ::
@@ -538,15 +674,16 @@ migratePersistentBakerInfoRef ::
     StateMigrationParameters oldpv pv ->
     PersistentBakerInfoRef (AccountVersionFor oldpv) ->
     t m (PersistentBakerInfoRef (AccountVersionFor pv))
+migratePersistentBakerInfoRef m@StateMigrationParametersTrivial (PBIRV0 bir) = PBIRV0 <$> V0.migratePersistentBakerInfoEx m bir
 migratePersistentBakerInfoRef m@StateMigrationParametersTrivial (PBIRV1 bir) = PBIRV1 <$> V0.migratePersistentBakerInfoEx m bir
 migratePersistentBakerInfoRef m@StateMigrationParametersTrivial (PBIRV2 bir) = PBIRV2 <$> V1.migratePersistentBakerInfoEx m bir
-migratePersistentBakerInfoRef m@StateMigrationParametersTrivial (PBIRV0 bir) = PBIRV0 <$> V0.migratePersistentBakerInfoEx m bir
+migratePersistentBakerInfoRef m@StateMigrationParametersTrivial (PBIRV3 bir) = PBIRV3 <$> V1.migratePersistentBakerInfoEx m bir
 migratePersistentBakerInfoRef m@StateMigrationParametersP1P2 (PBIRV0 bir) = PBIRV0 <$> V0.migratePersistentBakerInfoEx m bir
 migratePersistentBakerInfoRef m@StateMigrationParametersP2P3 (PBIRV0 bir) = PBIRV0 <$> V0.migratePersistentBakerInfoEx m bir
 migratePersistentBakerInfoRef m@StateMigrationParametersP3ToP4{} (PBIRV0 bir) = PBIRV1 <$> V0.migratePersistentBakerInfoEx m bir
 migratePersistentBakerInfoRef m@StateMigrationParametersP4ToP5{} (PBIRV1 bir) = PBIRV2 <$> V1.migratePersistentBakerInfoExFromV0 m bir
 migratePersistentBakerInfoRef m@StateMigrationParametersP5ToP6{} (PBIRV2 bir) = PBIRV2 <$> V1.migratePersistentBakerInfoEx m bir
-migratePersistentBakerInfoRef StateMigrationParametersP6ToP7{} _ = undefined -- TODO: Implement migration
+migratePersistentBakerInfoRef m@StateMigrationParametersP6ToP7{} (PBIRV2 bir) = PBIRV3 <$> V1.migratePersistentBakerInfoEx m bir
 
 -- * Conversion
 
@@ -555,3 +692,4 @@ toTransientAccount :: (MonadBlobStore m) => PersistentAccount av -> m (Transient
 toTransientAccount (PAV0 acc) = V0.toTransientAccount acc
 toTransientAccount (PAV1 acc) = V0.toTransientAccount acc
 toTransientAccount (PAV2 acc) = V1.toTransientAccount acc
+toTransientAccount (PAV3 acc) = V1.toTransientAccount acc

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/CooldownQueue.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/CooldownQueue.hs
@@ -1,0 +1,215 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Concordium.GlobalState.Persistent.Account.CooldownQueue where
+
+import Data.Bool.Singletons
+import Data.Functor
+import qualified Data.Map.Strict as Map
+
+import Concordium.Types
+import Concordium.Types.Conditionally
+import Concordium.Types.HashableTo
+import Concordium.Types.Option
+import Concordium.Utils
+
+import Concordium.GlobalState.Account
+import Concordium.GlobalState.CooldownQueue as Cooldowns
+import Concordium.GlobalState.Persistent.BlobStore
+
+-- | A 'CooldownQueue' records the inactive stake amounts that are due to be released in future.
+--  Note that prior to account version 3 (protocol version 7), the only value is the empty cooldown
+--  queue.
+data CooldownQueue (av :: AccountVersion) where
+    -- | The empty cooldown queue.
+    EmptyCooldownQueue :: CooldownQueue av
+    -- | A non-empty cooldown queue.
+    --  INVARIANT: The 'Cooldowns' must not satisfy 'isEmptyCooldowns'.
+    CooldownQueue ::
+        (AVSupportsFlexibleCooldown av) =>
+        !(EagerBufferedRef Cooldowns) ->
+        CooldownQueue av
+
+deriving instance Show (CooldownQueue av)
+
+instance forall m av. (MonadBlobStore m, IsAccountVersion av) => BlobStorable m (CooldownQueue av) where
+    load = case sSupportsFlexibleCooldown (accountVersion @av) of
+        SFalse -> return $ return EmptyCooldownQueue
+        STrue -> do
+            mRef <- load
+            return $!
+                mRef <&> \case
+                    Null -> EmptyCooldownQueue
+                    Some cooldowns -> CooldownQueue cooldowns
+    storeUpdate = case sSupportsFlexibleCooldown (accountVersion @av) of
+        SFalse -> \queue -> return (return (), queue)
+        STrue -> \queue -> do
+            (putter, nRef) <- storeUpdate (asNullable queue)
+            return $!! (putter, ofNullable nRef)
+      where
+        asNullable :: CooldownQueue av -> Nullable (EagerBufferedRef Cooldowns)
+        asNullable EmptyCooldownQueue = Null
+        asNullable (CooldownQueue queue) = Some queue
+        ofNullable Null = EmptyCooldownQueue
+        ofNullable (Some queue) = CooldownQueue queue
+
+-- | The has of 'EmptyCooldownQueue'.
+emptyCooldownQueueHash :: CooldownQueueHash av
+{-# NOINLINE emptyCooldownQueueHash #-}
+emptyCooldownQueueHash = CooldownQueueHash (getHash emptyCooldowns)
+
+instance (MonadBlobStore m) => MHashableTo m (CooldownQueueHash av) (CooldownQueue av) where
+    getHashM EmptyCooldownQueue = return emptyCooldownQueueHash
+    getHashM (CooldownQueue ref) = CooldownQueueHash . getHash <$> refLoad ref
+
+-- | The empty 'CooldownQueue'.
+emptyCooldownQueue :: CooldownQueue av
+emptyCooldownQueue = EmptyCooldownQueue
+
+-- | Check if a 'CooldownQueue' is empty.
+isCooldownQueueEmpty :: CooldownQueue av -> Bool
+isCooldownQueueEmpty EmptyCooldownQueue = True
+isCooldownQueueEmpty _ = False
+
+-- | Construct a 'CooldownQueue' from a 'Cooldowns', which may be empty.
+makeCooldownQueue ::
+    (MonadBlobStore m, AVSupportsFlexibleCooldown av) =>
+    Cooldowns ->
+    m (CooldownQueue av)
+makeCooldownQueue cooldowns
+    | isEmptyCooldowns cooldowns = return EmptyCooldownQueue
+    | otherwise = CooldownQueue <$> refMake cooldowns
+
+-- | Construct a 'CooldownQueue' from the representation used for transient accounts.
+makePersistentCooldownQueue ::
+    (MonadBlobStore m) =>
+    Conditionally (SupportsFlexibleCooldown av) Cooldowns ->
+    m (CooldownQueue av)
+makePersistentCooldownQueue CFalse = return EmptyCooldownQueue
+makePersistentCooldownQueue (CTrue cooldowns) = makeCooldownQueue cooldowns
+
+-- | Convert a 'CooldownQueue' to representation used for transient accounts.
+toTransientCooldownQueue ::
+    forall av.
+    (IsAccountVersion av) =>
+    CooldownQueue av ->
+    Conditionally (SupportsFlexibleCooldown av) Cooldowns
+toTransientCooldownQueue = case sSupportsFlexibleCooldown (accountVersion @av) of
+    SFalse -> const CFalse
+    STrue ->
+        CTrue . \case
+            EmptyCooldownQueue -> emptyCooldowns
+            CooldownQueue ref -> eagerBufferedDeref ref
+
+-- | Create an initial 'CooldownQueue' with only the given amount set in pre-pre-cooldown.
+initialPrePreCooldownQueue ::
+    (MonadBlobStore m, AVSupportsFlexibleCooldown av) =>
+    -- | Initial amount in pre-pre-cooldown.
+    Amount ->
+    m (CooldownQueue av)
+initialPrePreCooldownQueue target =
+    CooldownQueue
+        <$> refMake
+            Cooldowns
+                { inCooldown = Map.empty,
+                  preCooldown = Absent,
+                  prePreCooldown = Present target
+                }
+
+-- | Migrate a cooldown queue unchanged.
+migrateCooldownQueue :: forall m t av. (SupportMigration m t) => CooldownQueue av -> t m (CooldownQueue av)
+migrateCooldownQueue EmptyCooldownQueue = return EmptyCooldownQueue
+migrateCooldownQueue (CooldownQueue queueRef) =
+    CooldownQueue <$> migrateEagerBufferedRef return queueRef
+
+-- | Get the total stake in cooldown, pre-cooldown and pre-pre-cooldown.
+cooldownStake :: CooldownQueue av -> Amount
+cooldownStake EmptyCooldownQueue = 0
+cooldownStake (CooldownQueue queueRef) = cooldownTotal $ eagerBufferedDeref queueRef
+
+-- | Add the given amount to the pre-pre-cooldown.
+addPrePreCooldown ::
+    (MonadBlobStore m, AVSupportsFlexibleCooldown av) =>
+    -- | The amount to add to the pre-pre-cooldown.
+    Amount ->
+    CooldownQueue av ->
+    m (CooldownQueue av)
+addPrePreCooldown amount EmptyCooldownQueue = initialPrePreCooldownQueue amount
+addPrePreCooldown amount (CooldownQueue queueRef) = do
+    let oldCooldowns = eagerBufferedDeref queueRef
+    let !newCooldowns = Cooldowns.addPrePreCooldown amount oldCooldowns
+    makeCooldownQueue newCooldowns
+
+-- | Remove up to the given amount from the cooldowns, starting with pre-pre-cooldown, then
+--  pre-cooldown, and finally from the amounts in cooldown, in decreasing order of timestamp.
+reactivateCooldownAmount ::
+    (MonadBlobStore m, AVSupportsFlexibleCooldown av) =>
+    -- | The amount to reactivate.
+    Amount ->
+    CooldownQueue av ->
+    m (CooldownQueue av)
+reactivateCooldownAmount _ EmptyCooldownQueue = return EmptyCooldownQueue
+reactivateCooldownAmount amount (CooldownQueue queueRef) = do
+    let oldCooldowns = eagerBufferedDeref queueRef
+    let !newCooldowns = Cooldowns.reactivateCooldownAmount amount oldCooldowns
+    makeCooldownQueue newCooldowns
+
+-- | Process all cooldowns that expire at or before the given timestamp.
+--   This returns the next timestamp at which a cooldown expires, if any.
+processCooldownsUntil ::
+    (MonadBlobStore m) =>
+    -- | Release all cooldowns up to and including this timestamp.
+    Timestamp ->
+    CooldownQueue av ->
+    m (Maybe Timestamp, CooldownQueue av)
+processCooldownsUntil _ EmptyCooldownQueue = return (Nothing, EmptyCooldownQueue)
+processCooldownsUntil ts (CooldownQueue queueRef) = do
+    let !newCooldowns = processCooldowns ts $ eagerBufferedDeref queueRef
+    let !nextTimestamp = firstCooldownTimestamp newCooldowns
+    newQueue <- makeCooldownQueue newCooldowns
+    return (nextTimestamp, newQueue)
+
+-- | Move the pre-cooldown amount on into cooldown with the specified release time.
+--  This returns @Just (Just ts)@ if the previous next cooldown time was @ts@, but the new next
+--  cooldown (i.e. the supplied timestamp) time is earlier. It returns @Just Nothing@ if there was
+--  no cooldown but now there is. Otherwise, it returns @Nothing@.
+processPreCooldown ::
+    (MonadBlobStore m) =>
+    -- | The timestamp at which the pre-cooldown should be released.
+    Timestamp ->
+    CooldownQueue av ->
+    m (Maybe (Maybe Timestamp), CooldownQueue av)
+processPreCooldown _ EmptyCooldownQueue = return (Nothing, EmptyCooldownQueue)
+processPreCooldown ts (CooldownQueue queueRef) = do
+    let oldCooldowns = eagerBufferedDeref queueRef
+    let !newCooldowns = Cooldowns.processPreCooldown ts oldCooldowns
+    let oldNextTimestamp = firstCooldownTimestamp oldCooldowns
+    let nextTimestamp = firstCooldownTimestamp newCooldowns
+    let !res
+            | Just oldTS <- oldNextTimestamp,
+              Just nextTS <- nextTimestamp,
+              nextTS < oldTS =
+                Just (Just oldTS)
+            | Nothing <- oldNextTimestamp,
+              Just _ <- nextTimestamp =
+                Just Nothing
+            | otherwise = Nothing
+    newQueue <- makeCooldownQueue newCooldowns
+    return (res, newQueue)
+
+-- | Move the pre-pre-cooldown amount on into pre-cooldown.
+--  It should be the case that there is a pre-pre-cooldown amount and no pre-cooldown amount.
+--  However, if there is no pre-pre-cooldown amount, this will do nothing, and if there is already
+--  a pre-cooldown amount, the pre-pre-cooldown amount will be added to it.
+processPrePreCooldown :: (MonadBlobStore m) => CooldownQueue av -> m (CooldownQueue av)
+processPrePreCooldown EmptyCooldownQueue = return EmptyCooldownQueue
+processPrePreCooldown (CooldownQueue queueRef) = do
+    let oldCooldowns = eagerBufferedDeref queueRef
+    let !newCooldowns = Cooldowns.processPrePreCooldown oldCooldowns
+    makeCooldownQueue newCooldowns

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV0.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV0.hs
@@ -743,8 +743,8 @@ getStake :: (MonadBlobStore m, IsAccountVersion av, AVStructureV0 av) => Persist
 getStake acc = loadAccountStake (acc ^. accountStake)
 
 -- | Determine if an account has stake as a baker or delegator.
-hasStake :: PersistentAccount av -> Bool
-hasStake acc = case acc ^. accountStake of
+hasActiveStake :: PersistentAccount av -> Bool
+hasActiveStake acc = case acc ^. accountStake of
     PersistentAccountStakeNone -> False
     _ -> True
 
@@ -1205,4 +1205,5 @@ toTransientAccount PersistentAccount{..} = do
         PersistentAccountStakeNone -> return AccountStakeNone
         PersistentAccountStakeBaker bkr -> AccountStakeBaker <$> (loadPersistentAccountBaker =<< refLoad bkr)
         PersistentAccountStakeDelegate dlg -> AccountStakeDelegate <$> refLoad dlg
+    let _accountStakeCooldown = Transient.emptyCooldownQueue (accountVersion @av)
     return $ Transient.Account{..}

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
@@ -261,6 +261,7 @@ instance HashableTo (AccountMerkleHash av) (PersistentAccountEnduringData av) wh
     getHash = paedHash
 
 -- | Construct a 'PersistentAccountEnduringData' from the components by computing the hash.
+--  Used for 'AccountV2'.
 --
 --  Precondition: if the 'PersistentAccountEncryptedAmount' is present then it must not satisfy
 --  'isInitialPersistentAccountEncryptedAmount'.
@@ -290,6 +291,14 @@ makeAccountEnduringDataAV2 paedPersistingData paedEncryptedAmount paedReleaseSch
         paedStakeCooldown = emptyCooldownQueue
     return $! PersistentAccountEnduringData{..}
 
+-- | Construct a 'PersistentAccountEnduringData' from the components by computing the hash.
+--   Used for 'AccountV3'.
+--
+--  Precondition: if the 'PersistentAccountEncryptedAmount' is present then it must not satisfy
+--  'isInitialPersistentAccountEncryptedAmount'.
+--
+--  Precondition: if the 'AccountReleaseSchedule' is present, then it must have some releases
+--  and the total amount of the releases must be the provided amount.
 makeAccountEnduringDataAV3 ::
     ( MonadBlobStore m
     ) =>
@@ -314,8 +323,12 @@ makeAccountEnduringDataAV3 paedPersistingData paedEncryptedAmount paedReleaseSch
         !paedHash = getHash hashInputs
     return $! PersistentAccountEnduringData{..}
 
--- | [For internal use in this module.] Recompute the Merkle hash of the enduring account data.
-rehashAccountEnduringDataAV2 :: (MonadBlobStore m) => PersistentAccountEnduringData 'AccountV2 -> m (PersistentAccountEnduringData 'AccountV2)
+-- | [For internal use in this module.] Recompute the Merkle hash of the enduring account data,
+--  for 'AccountV2'.
+rehashAccountEnduringDataAV2 ::
+    (MonadBlobStore m) =>
+    PersistentAccountEnduringData 'AccountV2 ->
+    m (PersistentAccountEnduringData 'AccountV2)
 rehashAccountEnduringDataAV2 ed = do
     amhi2PersistingAccountDataHash <- getHashM (paedPersistingData ed)
     (amhi2AccountStakeHash :: AccountStakeHash 'AccountV2) <- getHashM (paedStake ed)
@@ -325,11 +338,15 @@ rehashAccountEnduringDataAV2 ed = do
     amhi2AccountReleaseScheduleHash <- case paedReleaseSchedule ed of
         Null -> return TARSV1.emptyAccountReleaseScheduleHashV1
         Some (rs, _) -> getHashM rs
-    let hashInputs :: AccountMerkleHashInputs 'AccountV2
-        hashInputs = AccountMerkleHashInputsV2{..}
+    let hashInputs = AccountMerkleHashInputsV2{..}
     return $! ed{paedHash = getHash hashInputs}
 
-rehashAccountEnduringDataAV3 :: (MonadBlobStore m) => PersistentAccountEnduringData 'AccountV3 -> m (PersistentAccountEnduringData 'AccountV3)
+-- | [For internal use in this module.] Recompute the Merkle hash of the enduring account data,
+--  for 'AccountV3'.
+rehashAccountEnduringDataAV3 ::
+    (MonadBlobStore m) =>
+    PersistentAccountEnduringData 'AccountV3 ->
+    m (PersistentAccountEnduringData 'AccountV3)
 rehashAccountEnduringDataAV3 ed = do
     amhi3PersistingAccountDataHash <- getHashM (paedPersistingData ed)
     (amhi3AccountStakeHash :: AccountStakeHash 'AccountV3) <- getHashM (paedStake ed)
@@ -340,10 +357,10 @@ rehashAccountEnduringDataAV3 ed = do
         Null -> return TARSV1.emptyAccountReleaseScheduleHashV1
         Some (rs, _) -> getHashM rs
     amhi3Cooldown <- getHashM $ paedStakeCooldown ed
-    let hashInputs :: AccountMerkleHashInputs 'AccountV3
-        hashInputs = AccountMerkleHashInputsV3{..}
+    let hashInputs = AccountMerkleHashInputsV3{..}
     return $! ed{paedHash = getHash hashInputs}
 
+-- | [For internal use in this module.] Recompute the Merkle hash of the enduring account data.
 rehashAccountEnduringData ::
     forall m av.
     (MonadBlobStore m, IsAccountVersion av, AccountStructureVersionFor av ~ 'AccountStructureV1) =>
@@ -353,6 +370,8 @@ rehashAccountEnduringData = case accountVersion @av of
     SAccountV2 -> rehashAccountEnduringDataAV2
     SAccountV3 -> rehashAccountEnduringDataAV3
 
+-- | Compute the 'EnduringDataFlags' from a 'PersistentAccountEnduringData' for the purposes of
+--  storing the account.
 enduringDataFlags ::
     forall av.
     (IsAccountVersion av) =>
@@ -513,7 +532,8 @@ stakeFlagsFromBits bs = case bs .&. 0b11_0000 of
 --    a cooldown.
 --
 --  - The remaining bits indicate the staking status of the account, in accordance with
---    'StakeFlags' (where bit 0 is cleared in the case of flexible cooldowns).
+--    'StakeFlags'. (Note that bits 0 and 1 are used for the pending change type if the account
+--    version does not support flexible cooldowns.)
 data EnduringDataFlags (av :: AccountVersion) = EnduringDataFlags
     { -- | Whether the enduring data includes a (non-initial) encrypted amount.
       edHasEncryptedAmount :: !Bool,
@@ -1545,8 +1565,19 @@ newAccount cryptoParams _accountAddress credential = do
     accountEnduringData <-
         refMake
             =<< case accountVersion @av of
-                SAccountV2 -> makeAccountEnduringDataAV2 paedPersistingData Null Null PersistentAccountStakeEnduringNone
-                SAccountV3 -> makeAccountEnduringDataAV3 paedPersistingData Null Null PersistentAccountStakeEnduringNone emptyCooldownQueue
+                SAccountV2 ->
+                    makeAccountEnduringDataAV2
+                        paedPersistingData
+                        Null
+                        Null
+                        PersistentAccountStakeEnduringNone
+                SAccountV3 ->
+                    makeAccountEnduringDataAV3
+                        paedPersistingData
+                        Null
+                        Null
+                        PersistentAccountStakeEnduringNone
+                        emptyCooldownQueue
     return $!
         PersistentAccount
             { accountNonce = minNonce,
@@ -1599,8 +1630,19 @@ makeFromGenesisAccount spv cryptoParams chainParameters GenesisAccount{..} = do
     accountEnduringData <-
         refMakeFlushed
             =<< case accountVersion @av of
-                SAccountV2 -> makeAccountEnduringDataAV2 paedPersistingData Null Null stakeEnduring
-                SAccountV3 -> makeAccountEnduringDataAV3 paedPersistingData Null Null stakeEnduring emptyCooldownQueue
+                SAccountV2 ->
+                    makeAccountEnduringDataAV2
+                        paedPersistingData
+                        Null
+                        Null
+                        stakeEnduring
+                SAccountV3 ->
+                    makeAccountEnduringDataAV3
+                        paedPersistingData
+                        Null
+                        Null
+                        stakeEnduring
+                        emptyCooldownQueue
     return $!
         PersistentAccount
             { accountNonce = minNonce,

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -361,7 +361,7 @@ initialBirkParameters accounts seedState _bakerFinalizationCommitteeParameters =
 
                 nextBakerIds <- Trie.insert bakerId activeDelegators $ aibpBakerIds accum
                 nextBakerKeys <- Trie.insert aggregationKey () $ aibpBakerKeys accum
-                stake <- accountStakedAmount account
+                stake <- accountActiveStakedAmount account
 
                 return
                     updatedAccum
@@ -1407,8 +1407,8 @@ doAddBaker pbs ai ba@BakerAdd{..} = do
         -- Cannot resolve the account
         Nothing -> return (BAInvalidAccount, pbs)
         Just acct
-            -- Account is already a baker
-            | accountHasStake acct -> return (BAAlreadyBaker (BakerId ai), pbs)
+            -- Account is already a baker. (NB: cannot be a delegator at AccountV0.)
+            | accountHasActiveStake acct -> return (BAAlreadyBaker (BakerId ai), pbs)
             -- Account is not a baker
             | otherwise -> do
                 cp <- (^. cpPoolParameters . ppBakerStakeThreshold) <$> lookupCurrentParameters (bspUpdates bsp)
@@ -3503,7 +3503,7 @@ instance (PersistentState av pv r m, IsProtocolVersion pv) => AccountOperations 
 
     getAccountAmount = accountAmount
 
-    getAccountStakedAmount = accountStakedAmount
+    getAccountTotalStakedAmount = accountTotalStakedAmount
 
     getAccountLockedAmount = accountLockedAmount
 
@@ -3534,6 +3534,8 @@ instance (PersistentState av pv r m, IsProtocolVersion pv) => AccountOperations 
     derefBakerInfo = loadBakerInfo
 
     getAccountHash = accountHash
+
+    getAccountCooldowns = accountCooldowns
 
 instance (IsProtocolVersion pv, PersistentState av pv r m) => BlockStateOperations (PersistentBlockStateMonad pv r m) where
     bsoGetModule pbs mref = doGetModule pbs mref

--- a/concordium-consensus/src/Concordium/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler.hs
@@ -1360,7 +1360,7 @@ handleContractUpdateV1 depth originAddr istance checkAndGetSender transferAmount
                                                 balance <- getCurrentAccountTotalAmount indexedAccount
                                                 -- During this transaction the staked and locked amount could not have been affected.
                                                 -- Hence we can simply take the relevant balance from the "state account".
-                                                stake <- getAccountStakedAmount account
+                                                stake <- getAccountTotalStakedAmount account
                                                 lockedAmount <- getAccountLockedAmount account
                                                 -- Construct the return value.
                                                 let returnValue = WasmV1.byteStringToReturnValue $ S.runPut $ do

--- a/concordium-consensus/src/Concordium/Scheduler/Environment.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/Environment.hs
@@ -1218,7 +1218,7 @@ instance (MonadProtocolVersion m, StaticInformation m, AccountOperations m, Cont
     getCurrentAccountAvailableAmount (ai, acc) = do
         oldTotal <- getAccountAmount acc
         oldLockedUp <- getAccountLockedAmount acc
-        staked <- getAccountStakedAmount acc
+        staked <- getAccountTotalStakedAmount acc
         !txCtx <- ask
         -- If the account is the sender, subtract the deposit
         let netDeposit =

--- a/concordium-consensus/tests/consensus/ConcordiumTests/EndToEnd/CredentialDeploymentTests.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/EndToEnd/CredentialDeploymentTests.hs
@@ -101,7 +101,7 @@ testBB1 =
                     }
             SBlockHashVersion1 ->
                 DerivableBlockHashesV1
-                    { dbhv1BlockResultHash = read "26c5ed1dc59b3110601dcf22797d52ca744a332bdd425069acc77326e8adf739"
+                    { dbhv1BlockResultHash = read "dca0b796dbfac96e7043942548c9d7cd470226740e2bdc793107de026d423e8d"
                     }
         }
   where
@@ -130,7 +130,7 @@ testBB2 =
                     }
             SBlockHashVersion1 ->
                 DerivableBlockHashesV1
-                    { dbhv1BlockResultHash = read "b23eb835ac2c975a7e9116590d1a6e5b9b26fe65aeaa7b311760431a189fa20c"
+                    { dbhv1BlockResultHash = read "3812ac3fa24c5676ea40c5879d9e88cd60e8af79d6ad7847c59df0880baacd01"
                     }
         }
   where
@@ -159,7 +159,7 @@ testBB3 =
                     }
             SBlockHashVersion1 ->
                 DerivableBlockHashesV1
-                    { dbhv1BlockResultHash = read "e708da0aeec770abd93544a9717e456712e699e1722fc292c424b8e8fdbbb43d"
+                    { dbhv1BlockResultHash = read "cad9520a6cfac6e3f08a75394d68dcfbb9fa1a857d79e0048be5c7752ca72907"
                     }
         }
   where
@@ -212,7 +212,7 @@ testBB2' =
                     }
             SBlockHashVersion1 ->
                 DerivableBlockHashesV1
-                    { dbhv1BlockResultHash = read "3ee65d909c11c7329694fbbfada2095b7abb8423394122e0d9e97b43cf5d1b4a"
+                    { dbhv1BlockResultHash = read "c97b0cc90e29c62eb0e094696ef38891799360c0a89ad69b418205ab3b15b17a"
                     }
         }
   where
@@ -241,7 +241,7 @@ testBB3' =
                     }
             SBlockHashVersion1 ->
                 DerivableBlockHashesV1
-                    { dbhv1BlockResultHash = read "4ec24c4ad39bce3662a8ce00fc684730df8e96c7c8acda340086826ff08de708"
+                    { dbhv1BlockResultHash = read "f14475f1014ff13d2acf98f56a8f01823c1ae52ae01d53a8004f0e728c538357"
                     }
         }
   where
@@ -268,7 +268,7 @@ testBB4 =
                     }
             SBlockHashVersion1 ->
                 DerivableBlockHashesV1
-                    { dbhv1BlockResultHash = read "cdca4d101170df0990e2624dd2a1bc07b301a9a867f8e0c1d4f8dcc2a60629ee"
+                    { dbhv1BlockResultHash = read "9f757ba3e2fb79512a3c199fbd8b6c0a45eaef0fd3a5cc6a3ca78cf8f7ae18a6"
                     }
         }
   where
@@ -295,7 +295,7 @@ testBB5 =
                     }
             SBlockHashVersion1 ->
                 DerivableBlockHashesV1
-                    { dbhv1BlockResultHash = read "984ba9867ae9574fea5c7f358fb8e365009f298d83e75136231c480b8db45530"
+                    { dbhv1BlockResultHash = read "aca6161199f608947b265a048fd6dc404d31424a2a2a86d42be42310f6fd22a0"
                     }
         }
   where

--- a/concordium-consensus/tests/consensus/ConcordiumTests/EndToEnd/TransactionTableIntegrationTest.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/EndToEnd/TransactionTableIntegrationTest.hs
@@ -70,7 +70,7 @@ testBB1 =
                     }
             SBlockHashVersion1 ->
                 DerivableBlockHashesV1
-                    { dbhv1BlockResultHash = read "c61642de9fe839abbf378f8e9e56bfd5a2ed744dae5ce82df8dcb9a7849f9ce2"
+                    { dbhv1BlockResultHash = read "796f0c4a934152c4f5a233d5120dbf1dd13370f3499af37c88b4ebf0601983b6"
                     }
         }
   where
@@ -99,7 +99,7 @@ testBB2 =
                     }
             SBlockHashVersion1 ->
                 DerivableBlockHashesV1
-                    { dbhv1BlockResultHash = read "569e1cb324b05d744c3d3f29146c87252e0062f5654278b2e935e92e92778f49"
+                    { dbhv1BlockResultHash = read "c3585a5c1f76d7a8fa587b52c077fce936bd2c6f865afadd50068a61ea52d42e"
                     }
         }
   where
@@ -128,7 +128,7 @@ testBB3 =
                     }
             SBlockHashVersion1 ->
                 DerivableBlockHashesV1
-                    { dbhv1BlockResultHash = read "ce6d3023e834d92e0ac4cde15ed1f20aacab400d1083c98adca13c9ee1b9c426"
+                    { dbhv1BlockResultHash = read "a29f1403de7350e5791d985de61183c093c3e138ff81695908529ff876dbe49d"
                     }
         }
   where
@@ -156,7 +156,7 @@ testBB4 =
                     }
             SBlockHashVersion1 ->
                 DerivableBlockHashesV1
-                    { dbhv1BlockResultHash = read "e40b8cfe9cf6f2f26f1e81783c46dbd4f5de533f9f6a9a789d4849b2ece32b90"
+                    { dbhv1BlockResultHash = read "9c2f41bb1e9ef0636bf67fe35755e2cc56be0c8e9a6e8b41defbdc7d1cdb945b"
                     }
         }
   where

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/CatchUp.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/CatchUp.hs
@@ -451,7 +451,7 @@ catchupWithTwoBranchesResponse sProtocolVersion =
                                         }
                                 SBlockHashVersion1 ->
                                     DerivableBlockHashesV1
-                                        { dbhv1BlockResultHash = read "58b9be13250f5b498d7590f8cb856a14f547b7028031fb73f3c2018c826a7398"
+                                        { dbhv1BlockResultHash = read "1a40cf446d0ad26c9cebf35e008c37685a3823e33b930b7d5dbbefffae411232"
                                         }
                             }
         TestBlocks.succeedReceiveBlock b4
@@ -586,7 +586,7 @@ testMakeCatchupStatus sProtocolVersion =
                                         }
                                 SBlockHashVersion1 ->
                                     DerivableBlockHashesV1
-                                        { dbhv1BlockResultHash = read "58b9be13250f5b498d7590f8cb856a14f547b7028031fb73f3c2018c826a7398"
+                                        { dbhv1BlockResultHash = read "1a40cf446d0ad26c9cebf35e008c37685a3823e33b930b7d5dbbefffae411232"
                                         }
                             }
         TestBlocks.succeedReceiveBlock b4

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Common.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Common.hs
@@ -148,8 +148,8 @@ forEveryProtocolVersion check =
           check SP3 "P3",
           check SP4 "P4",
           check SP5 "P5",
-          check SP6 "P6"
-          -- FIXME: check SP7 "P7"
+          check SP6 "P6",
+          check SP7 "P7"
         ]
 
 -- | Run tests for each protocol version using consensus v1 (P6 and onwards).

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Consensus/Blocks.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Consensus/Blocks.hs
@@ -300,7 +300,7 @@ testBB1 =
                     }
             SBlockHashVersion1 ->
                 DerivableBlockHashesV1
-                    { dbhv1BlockResultHash = read "6c4e7d2eb2692eef3991a972fd84b6a6f7fdcad37699438362c570f7f60c0ffd"
+                    { dbhv1BlockResultHash = read "0970b0f7459e5150a56ac283eee6f587fc49cb1c3408146b46ee05457235bec7"
                     }
         }
   where
@@ -328,7 +328,7 @@ testBB2 =
                     }
             SBlockHashVersion1 ->
                 DerivableBlockHashesV1
-                    { dbhv1BlockResultHash = read "0d1ee312e4b05a071cfa45e79a4730a8dfbcd6ac939d262e0ba2256c61e718d5"
+                    { dbhv1BlockResultHash = read "2e6636b8275663e44452650e4b7968ecb26a32d57998fbbccc0292fdecb1522d"
                     }
         }
   where
@@ -356,7 +356,7 @@ testBB3 =
                     }
             SBlockHashVersion1 ->
                 DerivableBlockHashesV1
-                    { dbhv1BlockResultHash = read "fd03b1ae16b3cd1d671e6770b9fbb56727b8ef7957dbaad52efdfd826a07de03"
+                    { dbhv1BlockResultHash = read "5777ce2df452ce52ee6beb43c555051588cdad67ad742e7be438cf9d22e31950"
                     }
         }
   where
@@ -377,7 +377,7 @@ testBB2' =
                     }
             SBlockHashVersion1 ->
                 DerivableBlockHashesV1
-                    { dbhv1BlockResultHash = read "132f09cbb3e1dc7d17a50ecebd47bd7ab041e77a0a74796e2f15e2165662b2e9"
+                    { dbhv1BlockResultHash = read "04185ac844f6aea6e32b667debd1e9a337d67a80350d12f1cb813bf212a4bc23"
                     }
         }
   where
@@ -399,7 +399,7 @@ testBB3' =
                     }
             SBlockHashVersion1 ->
                 DerivableBlockHashesV1
-                    { dbhv1BlockResultHash = read "05dfceadaa719c3204b3ac5e1ad2f6ce5e9bbd54e904696280917e7e495b1bd6"
+                    { dbhv1BlockResultHash = read "11e59c1a721359a64b86a0c6bcee8f6cac7c5bc3a6b98517b0b4f8c5a726f9c5"
                     }
         }
   where
@@ -428,7 +428,7 @@ testBB4' =
                     }
             SBlockHashVersion1 ->
                 DerivableBlockHashesV1
-                    { dbhv1BlockResultHash = read "019ae29c33a1a4cdbb6097b58224c0ac5cb4dc0eaea62cf615e2766474dc7be1"
+                    { dbhv1BlockResultHash = read "ad8a288f88806037899d782b7dd3a37ade59e0d5f3e7a90b1db2b722ae9cbe3d"
                     }
         }
   where
@@ -480,7 +480,7 @@ testBB1E =
                     }
             SBlockHashVersion1 ->
                 DerivableBlockHashesV1
-                    { dbhv1BlockResultHash = read "6a1eedbfcdd077bbcb62c65cb4b627530c95963525639fd107ef54972592ab2f"
+                    { dbhv1BlockResultHash = read "1811353ec3811af6241f3e5dc2e19740acf518f02dccc51f427310b8cfe9ca6c"
                     }
         }
   where
@@ -508,7 +508,7 @@ testBB2E =
                     }
             SBlockHashVersion1 ->
                 DerivableBlockHashesV1
-                    { dbhv1BlockResultHash = read "7f71d798c41a33a276416fa60246f35393cd8a081b436c01a0a013694a7779f3"
+                    { dbhv1BlockResultHash = read "99fc52af1ee2336f0d353a84c4d6c15345882271f648f7b84e69d9c40d5571c2"
                     }
         }
   where
@@ -538,7 +538,7 @@ testBB3EX =
                     }
             SBlockHashVersion1 ->
                 DerivableBlockHashesV1
-                    { dbhv1BlockResultHash = read "4bc4b02fa0512059352d4054c08782f17736fb8287f74e952564e2f2dcb7cac0"
+                    { dbhv1BlockResultHash = read "0236b72bafe1575fdde0b01b35d24ad16613569600b83ed46b7e17c3c3dbaf28"
                     }
         }
   where
@@ -584,7 +584,7 @@ testBB3E =
                     }
             SBlockHashVersion1 ->
                 DerivableBlockHashesV1
-                    { dbhv1BlockResultHash = read "9442d3f6be34f90ec8c7fe4ffb6097759d9e0f462f00e05b50b4d1630d0bbdd1"
+                    { dbhv1BlockResultHash = read "2a12a1b02d8cfb835d6f572ffd3a0156145ec2142b47ef7b9e9495b61ff241b7"
                     }
         }
   where
@@ -623,7 +623,7 @@ testBB4E =
                     }
             SBlockHashVersion1 ->
                 DerivableBlockHashesV1
-                    { dbhv1BlockResultHash = read "64fc28137ab6df9b2b78aef5115613a5e8f6ae542c82f1931b13401cd17a1f96"
+                    { dbhv1BlockResultHash = read "66cf8d97a956e2306e60337848775d606f575bd48f4d1e4420d4cf579d5bfb0e"
                     }
         }
   where
@@ -646,7 +646,7 @@ testBB4E' =
                     }
             SBlockHashVersion1 ->
                 DerivableBlockHashesV1
-                    { dbhv1BlockResultHash = read "e862dea1573ec8c64209a71da05ffc7fd4654786bf933cdf300eb81692f99880"
+                    { dbhv1BlockResultHash = read "e0d460456228a923c4d0116b6add192b491279b24ce160067652e1afa11bac56"
                     }
         }
   where
@@ -676,7 +676,7 @@ testBB5E' =
                     }
             SBlockHashVersion1 ->
                 DerivableBlockHashesV1
-                    { dbhv1BlockResultHash = read "175c2ef08169361026461f69b03bab2b4b0e470ef9ddb8cbb3f2a7cf06cc493a"
+                    { dbhv1BlockResultHash = read "2c8ff8fbc07b5e1486ebad3e241fa0aefdb7637651c6120b0a50a27057f7431a"
                     }
         }
   where
@@ -719,7 +719,7 @@ testBB2Ex =
                     }
             SBlockHashVersion1 ->
                 DerivableBlockHashesV1
-                    { dbhv1BlockResultHash = read "13604fd2ea1b003cc98fb1ada3c62af493a608b09dacb70d53b6ca67d18ccc8f"
+                    { dbhv1BlockResultHash = read "a562963223c07cbcee46e78bba06968d578120b71eaf59d8ce12f3f384b21f47"
                     }
         }
   where
@@ -764,7 +764,7 @@ testBB3Ex =
                     }
             SBlockHashVersion1 ->
                 DerivableBlockHashesV1
-                    { dbhv1BlockResultHash = read "64c40bfa061ec21944f37f6b94a2724083e3c3d87d20066e61cdaa4e340fd31d"
+                    { dbhv1BlockResultHash = read "2ea4f556dc29b5a1774635cb670f7b9aa3182eb2cc685b0e4f59daf9541cb539"
                     }
         }
   where
@@ -797,7 +797,7 @@ testBB3EA =
                     }
             SBlockHashVersion1 ->
                 DerivableBlockHashesV1
-                    { dbhv1BlockResultHash = read "7f71d798c41a33a276416fa60246f35393cd8a081b436c01a0a013694a7779f3"
+                    { dbhv1BlockResultHash = read "99fc52af1ee2336f0d353a84c4d6c15345882271f648f7b84e69d9c40d5571c2"
                     }
         }
   where
@@ -830,7 +830,7 @@ testBB4EA =
                     }
             SBlockHashVersion1 ->
                 DerivableBlockHashesV1
-                    { dbhv1BlockResultHash = read "e862dea1573ec8c64209a71da05ffc7fd4654786bf933cdf300eb81692f99880"
+                    { dbhv1BlockResultHash = read "e0d460456228a923c4d0116b6add192b491279b24ce160067652e1afa11bac56"
                     }
         }
   where

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/EnduringDataFlags.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/EnduringDataFlags.hs
@@ -1,39 +1,62 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
 -- | This module tests the serialization and deserialization of the 'EnduringDataFlags', which
 --  are used in the persistent storage of accounts from 'P5' onwards.
 module GlobalStateTests.EnduringDataFlags where
 
+import Data.Singletons
 import Test.Hspec
 import Test.QuickCheck
+
+import Concordium.Types
+import Concordium.Types.Conditionally
 
 import Concordium.GlobalState.Persistent.Account.StructureV1
 
 genPendingChangeFlags :: Gen PendingChangeFlags
 genPendingChangeFlags = elements [PendingChangeNone, PendingChangeReduce, PendingChangeRemove]
 
-genStakeFlags :: Gen StakeFlags
-genStakeFlags =
+genStakeFlags :: Bool -> Gen StakeFlags
+genStakeFlags flexCooldown =
     oneof
-        [ pure StakeFlagsNone,
-          StakeFlagsBaker <$> arbitrary <*> genPendingChangeFlags,
-          StakeFlagsDelegator <$> arbitrary <*> arbitrary <*> genPendingChangeFlags
+        [ return StakeFlagsNone,
+          StakeFlagsBaker <$> arbitrary <*> genPCF,
+          StakeFlagsDelegator <$> arbitrary <*> arbitrary <*> genPCF
         ]
+  where
+    genPCF = if flexCooldown then return PendingChangeNone else genPendingChangeFlags
 
-genEnduringDataFlags :: Gen EnduringDataFlags
-genEnduringDataFlags = EnduringDataFlags <$> arbitrary <*> arbitrary <*> genStakeFlags
+genEnduringDataFlags ::
+    forall av.
+    (IsAccountVersion av) =>
+    SAccountVersion av ->
+    Gen (EnduringDataFlags av)
+genEnduringDataFlags _ =
+    EnduringDataFlags
+        <$> arbitrary
+        <*> arbitrary
+        <*> genStakeFlags (fromSing $ sSupportsFlexibleCooldown (accountVersion @av))
+        <*> conditionallyA (sSupportsFlexibleCooldown (accountVersion @av)) arbitrary
 
 -- | Test that converting 'EnduringDataFlags' to bits and big is the identity.
-testToFromBits :: Property
-testToFromBits = forAll genEnduringDataFlags $ \edf ->
+testToFromBits :: (IsAccountVersion av) => SAccountVersion av -> Property
+testToFromBits sav = forAll (genEnduringDataFlags sav) $ \edf ->
     Right edf === enduringDataFlagsFromBits (enduringDataFlagsToBits edf)
 
 -- | Test that converting bits to 'EnduringDataFlags' and back is the identity where the first
 --  conversion is well-defined.
-testFromToBits :: Property
-testFromToBits = property $ \bs -> case enduringDataFlagsFromBits bs of
+testFromToBits :: forall av. (IsAccountVersion av) => SAccountVersion av -> Property
+testFromToBits _sav = property $ \bs -> case enduringDataFlagsFromBits @av bs of
     Left _ -> property ()
     Right edf -> bs === enduringDataFlagsToBits edf
 
 tests :: Spec
 tests = parallel $ do
-    it "EnduringDataFlags to then from bits" $ withMaxSuccess 10000 testToFromBits
-    it "EnduringDataFlags from then to bits" $ withMaxSuccess 10000 testFromToBits
+    describe "AccountV2" $ avTests SAccountV2
+    describe "AccountV3" $ avTests SAccountV3
+  where
+    avTests :: (IsAccountVersion av) => SAccountVersion av -> Spec
+    avTests sav = do
+        it "EnduringDataFlags to then from bits" $ withMaxSuccess 10000 (testToFromBits sav)
+        it "EnduringDataFlags from then to bits" $ withMaxSuccess 10000 (testFromToBits sav)

--- a/concordium-consensus/tests/scheduler/SchedulerTests/Delegation.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/Delegation.hs
@@ -538,7 +538,7 @@ tests =
         case delegationSupport @(AccountVersionFor pv) of
             SAVDelegationNotSupported -> return ()
             SAVDelegationSupported ->
-                -- FIXME: re-enable when P7 cases are implemented
+                -- FIXME: re-enable when P7 cases are implemented (#1145)
                 (if demoteProtocolVersion spv == P7 then xdescribe "P7 cases unimplemented" else id) $ do
                     testCase1 spv pvString
                     testCase2 spv pvString

--- a/concordium-consensus/tests/scheduler/SchedulerTests/Delegation.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/Delegation.hs
@@ -537,13 +537,15 @@ tests =
     testCases spv pvString =
         case delegationSupport @(AccountVersionFor pv) of
             SAVDelegationNotSupported -> return ()
-            SAVDelegationSupported -> do
-                testCase1 spv pvString
-                testCase2 spv pvString
-                testCase3 spv pvString
-                testCase4 spv pvString
-                testCase5 spv pvString
-                testCase6 spv pvString
-                testCase7 spv pvString
-                testCase8 spv pvString
-                testCase9 spv pvString
+            SAVDelegationSupported ->
+                -- FIXME: re-enable when P7 cases are implemented
+                (if demoteProtocolVersion spv == P7 then xdescribe "P7 cases unimplemented" else id) $ do
+                    testCase1 spv pvString
+                    testCase2 spv pvString
+                    testCase3 spv pvString
+                    testCase4 spv pvString
+                    testCase5 spv pvString
+                    testCase6 spv pvString
+                    testCase7 spv pvString
+                    testCase8 spv pvString
+                    testCase9 spv pvString

--- a/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
@@ -133,8 +133,8 @@ forEveryProtocolVersion check =
       check Types.SP3 "P3",
       check Types.SP4 "P4",
       check Types.SP5 "P5",
-      check Types.SP6 "P6"
-      -- FIXME: check Types.SP7 "P7"
+      check Types.SP6 "P6",
+      check Types.SP7 "P7"
     ]
 
 -- | Construct a test block state containing the provided accounts.


### PR DESCRIPTION
## Purpose

Add cooldowns to the account structure.

Closes #1146

## Changes

- Redefine account hashing to include cooldowns in `AccountV3`
- Conditionally add cooldowns to the "basic" account implementation
- `AccountOperations`: rename `getAccountStakedAmount` to `getAccountTotalStakedAmount` (this disambiguates total stake vs. active and inactive stake), add `getAccountCooldowns`.
- Persistent account:
  - implement `AccountV3` using `StructureV1`;
  - replace `accountStakedAmount` with `accountActiveStakedAmount` and `accountTotalStakedAmount`;
  - new queries and operations: `accountCooldowns`, `accountHasPrePreCooldown`, `removeAccountStake`, `addAccountPrePreCooldown`, `reactivateCooldownAmount`, `processAccountCooldownsUntil`, `processAccountPreCooldown`, `processAccountPrePreCooldown`
  - `Concordium.GlobalState.Persistent.Account.CooldownQueue`: storage wrapper around `Concordium.GlobalState.CooldownQueue.Cooldowns`.
- Expose account cooldowns in queries.
- Testing: re-enable (most) testing for `P7`; support modified `EnduringDataFlags` for new account version.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.