### PR TITLE
Add global cooldown index. Support P6->P7 migration.

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
@@ -28,6 +28,7 @@ import Concordium.GlobalState.BakerInfo
 import qualified Concordium.GlobalState.Basic.BlockState.Account as Transient
 import Concordium.GlobalState.BlockState (AccountAllowance)
 import Concordium.GlobalState.CooldownQueue
+import Concordium.GlobalState.Persistent.Account.MigrationStateInterface
 import qualified Concordium.GlobalState.Persistent.Account.StructureV0 as V0
 import qualified Concordium.GlobalState.Persistent.Account.StructureV1 as V1
 import Concordium.GlobalState.Persistent.BlobStore
@@ -647,11 +648,26 @@ makePersistentBakerInfoRef = case accountVersion @av of
 -- * Migration
 
 -- | Migrate a 'PersistentAccount' between protocol versions according to a state migration.
+--
+--  When migrating P6->P7 (account version 2 to 3), the 'AccountMigration' interface is used as
+--  follows:
+--
+--   * Accounts that previously had a pending change are updated to have a pre-pre-cooldown, and
+--     'addAccountInPrePreCooldown' is called. If the pending change is a reduction in stake,
+--     the reduction is applied immediately to the active stake. If the pending change is a removal,
+--     the baker or delegator record is removed altogether.
+--
+--   * Accounts that are still delegating but were delegating to a baker for which 'isBakerRemoved'
+--     returns @True@ are updated to delegate to passive delegation.
+--
+--   * For accounts that are still delegating, 'retainDelegator' is called to record the (new)
+--     delegation amount and target.
 migratePersistentAccount ::
     forall oldpv pv t m.
     ( IsProtocolVersion oldpv,
       IsProtocolVersion pv,
-      SupportMigration m t
+      SupportMigration m t,
+      AccountMigration (AccountVersionFor pv) (t m)
     ) =>
     StateMigrationParameters oldpv pv ->
     PersistentAccount (AccountVersionFor oldpv) ->
@@ -659,7 +675,7 @@ migratePersistentAccount ::
 migratePersistentAccount m@StateMigrationParametersTrivial (PAV0 acc) = PAV0 <$> V0.migratePersistentAccount m acc
 migratePersistentAccount m@StateMigrationParametersTrivial (PAV1 acc) = PAV1 <$> V0.migratePersistentAccount m acc
 migratePersistentAccount m@StateMigrationParametersTrivial (PAV2 acc) = PAV2 <$> V1.migratePersistentAccount m acc
-migratePersistentAccount StateMigrationParametersTrivial (PAV3 _) = undefined -- TODO: Implement migration
+migratePersistentAccount m@StateMigrationParametersTrivial (PAV3 acc) = PAV3 <$> V1.migratePersistentAccount m acc
 migratePersistentAccount m@StateMigrationParametersP1P2 (PAV0 acc) = PAV0 <$> V0.migratePersistentAccount m acc
 migratePersistentAccount m@StateMigrationParametersP2P3 (PAV0 acc) = PAV0 <$> V0.migratePersistentAccount m acc
 migratePersistentAccount m@StateMigrationParametersP3ToP4{} (PAV0 acc) = PAV1 <$> V0.migratePersistentAccount m acc

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/MigrationState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/MigrationState.hs
@@ -1,0 +1,262 @@
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Concordium.GlobalState.Persistent.Account.MigrationState where
+
+import Control.Monad
+import Control.Monad.IO.Class
+import Control.Monad.State.Class
+import Control.Monad.Trans
+import Control.Monad.Trans.State.Strict
+import Data.Bool.Singletons
+import Data.Kind
+import Data.Maybe
+import Lens.Micro.Platform
+
+import Concordium.Types
+import Concordium.Types.Accounts
+import Concordium.Types.Conditionally
+import Concordium.Utils
+
+import qualified Concordium.GlobalState.AccountMap.LMDB as LMDBAccountMap
+import Concordium.GlobalState.Persistent.Account
+import Concordium.GlobalState.Persistent.Account.MigrationStateInterface
+import Concordium.GlobalState.Persistent.Accounts
+import Concordium.GlobalState.Persistent.Bakers as Bakers
+import Concordium.GlobalState.Persistent.BlobStore
+import Concordium.GlobalState.Persistent.Cache
+import Concordium.GlobalState.Persistent.Cooldown
+import qualified Concordium.GlobalState.Persistent.Trie as Trie
+
+-- | Whether the migration from one protocol version to another introduces flexible cooldown
+--  support.
+type IntroducesFlexibleCooldown (oldpv :: ProtocolVersion) (pv :: ProtocolVersion) =
+    Not (SupportsFlexibleCooldown (AccountVersionFor oldpv))
+        && SupportsFlexibleCooldown (AccountVersionFor pv)
+
+data AccountMigrationState (oldpv :: ProtocolVersion) (pv :: ProtocolVersion) = AccountMigrationState
+    { -- | In the P6 -> P7 protocol update, this records the accounts that previously were in
+      --  cooldown, and now will be in pre-pre-cooldown.
+      _migrationPrePreCooldown ::
+        !( Conditionally
+            (IntroducesFlexibleCooldown oldpv pv)
+            AccountList
+         ),
+      -- | When migrating P6->P7, we build up the 'PersistentActiveBakers' while
+      --  traversing the account table. This should be initialised with the active bakers (that
+      --  survive migration) but no delegators.
+      _persistentActiveBakers ::
+        !( Conditionally
+            (IntroducesFlexibleCooldown oldpv pv)
+            (PersistentActiveBakers (AccountVersionFor pv))
+         ),
+      -- | A counter to track the index of the current account as we traverse the account table.
+      _currentAccountIndex :: !AccountIndex
+    }
+makeLenses ''AccountMigrationState
+
+-- | Construct an initial 'PersistentActiveBakers' that records all of the bakers that are still
+-- active after migration, but does not include any delegators. This only applies when migrating
+-- to a protocol version that supports flexible cooldowns for the first time. The total active
+-- capital constitutes the stake of all bakers that remain active, with their capital reduced
+-- corresponding to any pending reduction in their stakes.
+--
+-- The idea is that with the P6->P7 migration, bakers that are in cooldown to be removed will
+-- actually be removed as bakers. During the processing of the account table, the delegators
+-- will be added back to the 'PersistentActiveBakers' as they are encountered.
+initialPersistentActiveBakersForMigration ::
+    forall oldpv av t m.
+    ( IsAccountVersion av,
+      SupportMigration m t,
+      SupportsPersistentAccount oldpv m
+    ) =>
+    Accounts oldpv ->
+    PersistentActiveBakers (AccountVersionFor oldpv) ->
+    t
+        m
+        ( Conditionally
+            (Not (SupportsFlexibleCooldown (AccountVersionFor oldpv)) && SupportsFlexibleCooldown av)
+            (PersistentActiveBakers av)
+        )
+initialPersistentActiveBakersForMigration oldAccounts oldActiveBakers = case (oldSFC, newSFC) of
+    (SFalse, SFalse) -> return CFalse
+    (STrue, _) -> return CFalse
+    (SFalse, STrue) -> do
+        bakers <- lift $ Trie.keysAsc (oldActiveBakers ^. activeBakers)
+        CTrue <$> foldM accumBakers emptyPersistentActiveBakers bakers
+      where
+        accumBakers :: PersistentActiveBakers av -> BakerId -> t m (PersistentActiveBakers av)
+        accumBakers pab bakerId =
+            lift (indexedAccount (bakerAccountIndex bakerId) oldAccounts) >>= \case
+                Nothing -> error "Baker account does not exist"
+                Just account -> do
+                    lift (accountBaker account) >>= \case
+                        Nothing -> error "Baker account is not a baker."
+                        Just bkr -> case _bakerPendingChange bkr of
+                            RemoveStake{} -> do
+                                -- The baker is pending removal, so it will be removed from
+                                -- the account in this update.
+                                return pab
+                            ReduceStake newStake _ -> do
+                                -- The baker's stake is reduced, so retain it with the new stake.
+                                retainBaker newStake
+                            NoChange -> do
+                                -- Retain the baker with the existing stake.
+                                retainBaker (bkr ^. stakedAmount)
+                          where
+                            retainBaker newStake = do
+                                -- The baker is still active, so add it to the persistent active
+                                -- bakers.
+                                newActiveBakers <- Trie.insert bakerId emptyPersistentActiveDelegators (pab ^. activeBakers)
+                                newAggregationKeys <- Trie.insert (bkr ^. bakerAggregationVerifyKey) () (pab ^. aggregationKeys)
+                                let newTotalActiveCapital = addActiveCapital newStake (pab ^. totalActiveCapital)
+                                return
+                                    pab
+                                        { _activeBakers = newActiveBakers,
+                                          _aggregationKeys = newAggregationKeys,
+                                          _totalActiveCapital = newTotalActiveCapital
+                                        }
+  where
+    oldSFC = sSupportsFlexibleCooldown (accountVersion @(AccountVersionFor oldpv))
+    newSFC = sSupportsFlexibleCooldown (accountVersion @av)
+
+-- | An 'AccountMigrationState' in an initial state.
+initialAccountMigrationState ::
+    forall oldpv pv.
+    (IsProtocolVersion oldpv, IsProtocolVersion pv) =>
+    -- | The active bakers without the delegators.
+    Conditionally
+        (IntroducesFlexibleCooldown oldpv pv)
+        (PersistentActiveBakers (AccountVersionFor pv)) ->
+    AccountMigrationState oldpv pv
+initialAccountMigrationState _persistentActiveBakers = AccountMigrationState{..}
+  where
+    _migrationPrePreCooldown = case sSupportsFlexibleCooldown (accountVersion @(AccountVersionFor oldpv)) of
+        SFalse -> case sSupportsFlexibleCooldown (accountVersion @(AccountVersionFor pv)) of
+            SFalse -> CFalse
+            STrue -> CTrue Null
+        STrue -> CFalse
+    _currentAccountIndex = 0
+
+-- | Construct an initial account migration state that records all of the active bakers that
+--  remain active after the migration. This is then used
+makeInitialAccountMigrationState ::
+    ( IsProtocolVersion pv,
+      SupportMigration m t,
+      SupportsPersistentAccount oldpv m
+    ) =>
+    Accounts oldpv ->
+    PersistentActiveBakers (AccountVersionFor oldpv) ->
+    t m (AccountMigrationState oldpv pv)
+makeInitialAccountMigrationState accounts pab =
+    initialAccountMigrationState <$> initialPersistentActiveBakersForMigration accounts pab
+
+-- | A monad transformer transformer that left-composes @StateT (AccountMigrationState old pv)@
+--  with a given monad transformer @t@.
+newtype
+    AccountMigrationStateTT
+        (oldpv :: ProtocolVersion)
+        (pv :: ProtocolVersion)
+        (t :: (Type -> Type) -> (Type -> Type))
+        (m :: (Type -> Type))
+        (a :: Type) = AccountMigrationStateTT
+    { runAccountMigrationStateTT' ::
+        StateT (AccountMigrationState oldpv pv) (t m) a
+    }
+    deriving newtype
+        ( Functor,
+          Applicative,
+          Monad,
+          MonadState (AccountMigrationState oldpv pv),
+          MonadIO,
+          LMDBAccountMap.MonadAccountMapStore
+        )
+
+-- | Run an 'AccountMigrationStateTT' computation with the given initial state.
+--  This is used to add 'AccountMigration' and 'AccountsMigration' interfaces to the monad stack.
+runAccountMigrationStateTT ::
+    AccountMigrationStateTT oldpv pv t m a ->
+    AccountMigrationState oldpv pv ->
+    t m (a, AccountMigrationState oldpv pv)
+runAccountMigrationStateTT = runStateT . runAccountMigrationStateTT'
+
+deriving via
+    forall
+        (oldpv :: ProtocolVersion)
+        (pv :: ProtocolVersion)
+        (t :: (Type -> Type) -> (Type -> Type))
+        (m :: (Type -> Type)).
+    ( StateT (AccountMigrationState oldpv pv) (t m)
+    )
+    instance
+        (MonadBlobStore (t m)) =>
+        (MonadBlobStore (AccountMigrationStateTT oldpv pv t m))
+
+deriving via
+    forall
+        (oldpv :: ProtocolVersion)
+        (pv :: ProtocolVersion)
+        (t :: (Type -> Type) -> (Type -> Type))
+        (m :: (Type -> Type)).
+    ( StateT (AccountMigrationState oldpv pv) (t m)
+    )
+    instance
+        (MonadCache c (t m)) =>
+        (MonadCache c (AccountMigrationStateTT oldpv pv t m))
+
+instance (MonadTrans t) => MonadTrans (AccountMigrationStateTT oldpv pv t) where
+    lift = AccountMigrationStateTT . lift . lift
+
+instance
+    (MonadBlobStore (t m), IsProtocolVersion pv, av ~ AccountVersionFor pv) =>
+    AccountMigration av (AccountMigrationStateTT oldpv pv t m)
+    where
+    addAccountInPrePreCooldown = do
+        ai <- use currentAccountIndex
+        mmpc <- use migrationPrePreCooldown
+        case mmpc of
+            CTrue mpc -> do
+                newHead <-
+                    makeUnbufferedRef
+                        AccountListItem
+                            { accountListEntry = ai,
+                              accountListTail = mpc
+                            }
+                migrationPrePreCooldown .= CTrue (Some newHead)
+            CFalse -> return ()
+
+    isBakerRemoved bakerId =
+        use persistentActiveBakers >>= \case
+            CFalse -> return False
+            CTrue pab ->
+                isNothing <$> Trie.lookup bakerId (pab ^. activeBakers)
+
+    retainDelegator delId delAmt delTarget =
+        use persistentActiveBakers >>= \case
+            CTrue pab ->
+                Bakers.addDelegator delTarget delId delAmt pab >>= \case
+                    Left bid ->
+                        error $
+                            "Baker "
+                                ++ show bid
+                                ++ " (delegated to by "
+                                ++ show delId
+                                ++ ") is not a baker."
+                    Right newPAB -> do
+                        -- Note that addDelegator does not change the total active capital, so
+                        -- we do it here.
+                        persistentActiveBakers
+                            .= CTrue (newPAB & totalActiveCapital %~ addActiveCapital delAmt)
+            CFalse -> return ()
+
+instance
+    (MonadBlobStore (t m), IsProtocolVersion pv, av ~ AccountVersionFor pv) =>
+    AccountsMigration av (AccountMigrationStateTT oldpv pv t m)
+    where
+    nextAccount = currentAccountIndex %=! (+ 1)

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/MigrationStateInterface.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/MigrationStateInterface.hs
@@ -1,0 +1,30 @@
+module Concordium.GlobalState.Persistent.Account.MigrationStateInterface where
+
+import Concordium.Types
+import Concordium.Types.Execution
+
+-- | This class provides functionality used during account migration. Much of this functionality
+--  is dependent on the protocol versions involved in the migration. This interface is used when
+--  migrating one particular account.
+class AccountMigration (av :: AccountVersion) m | m -> av where
+    -- | Add the current account to the set of accounts that should be considered in
+    --  pre-pre-cooldown as part of migration. This only has an effect when transitioning from a
+    --  protocol version that does not support flexible cooldown to one that does.
+    addAccountInPrePreCooldown :: m ()
+
+    -- | Query if the given 'BakerId' is set to be removed in this migration.
+    --  (The result is unspecified if the 'BakerId' was not a baker prior to migration.)
+    isBakerRemoved :: BakerId -> m Bool
+
+    -- | Record that a delegator is retained, delegating a specified amount to a delegation target.
+    --  The delegator must not already have been retained. This MUST be called for every delegator
+    --  that remains a delegator after migration when transitioning from a protocol version that
+    --  does not support flexible delegation to one that does. Outside of such a transition, this
+    --  has no effect.
+    retainDelegator :: (AVSupportsDelegation av) => DelegatorId -> Amount -> DelegationTarget -> m ()
+
+-- | This class provides functionality used during account migration. This interface is used when
+--  migrating the entire account table.
+class (AccountMigration av m) => AccountsMigration (av :: AccountVersion) m | m -> av where
+    -- | Progress to the next sequential account index.
+    nextAccount :: m ()

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/MigrationStateInterface.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/MigrationStateInterface.hs
@@ -20,7 +20,8 @@ class AccountMigration (av :: AccountVersion) m | m -> av where
     --  The delegator must not already have been retained. This MUST be called for every delegator
     --  that remains a delegator after migration when transitioning from a protocol version that
     --  does not support flexible delegation to one that does. Outside of such a transition, this
-    --  has no effect.
+    --  has no effect. If the target is a baker, then the baker must be one that is retained
+    --  (i.e. it was previously a baker and has not been removed in the migration).
     retainDelegator :: (AVSupportsDelegation av) => DelegatorId -> Amount -> DelegationTarget -> m ()
 
 -- | This class provides functionality used during account migration. This interface is used when

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
@@ -1775,7 +1775,7 @@ migrateEnduringDataV2 ed = do
 --   * If the account previously had a pending change, it will now have a pre-pre-cooldown, and
 --     'addAccountInPrePreCooldown' is called (to register this globally). If the pending change
 --     was a reduction in stake, the reduction is applied immediately to the active stake. If the
---     pending change wass a removal, the baker or delegator record is removed altogether.
+--     pending change was a removal, the baker or delegator record is removed altogether.
 --
 --   * If the account is still delegating but was delegating to a baker for which 'isBakerRemoved'
 --     returns @True@, the delegation target is updated to passive delegation.
@@ -1842,7 +1842,7 @@ migrateV2ToV2 acc = do
 --   * If the account previously had a pending change, it will now have a pre-pre-cooldown, and
 --     'addAccountInPrePreCooldown' is called (to register this globally). If the pending change
 --     was a reduction in stake, the reduction is applied immediately to the active stake. If the
---     pending change wass a removal, the baker or delegator record is removed altogether.
+--     pending change was a removal, the baker or delegator record is removed altogether.
 --
 --   * If the account is still delegating but was delegating to a baker for which 'isBakerRemoved'
 --     returns @True@, the delegation target is updated to passive delegation.

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Bakers.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Bakers.hs
@@ -437,6 +437,24 @@ migratePersistentActiveBakers migration accounts PersistentActiveBakers{..} = do
               _totalActiveCapital = newTotalActiveCapital
             }
 
+-- | Construct a 'PersistentActiveBakers' with no bakers or delegators.
+emptyPersistentActiveBakers :: forall av. (IsAccountVersion av) => PersistentActiveBakers av
+emptyPersistentActiveBakers = case delegationSupport @av of
+    SAVDelegationSupported ->
+        PersistentActiveBakers
+            { _activeBakers = Trie.empty,
+              _aggregationKeys = Trie.empty,
+              _passiveDelegators = PersistentActiveDelegatorsV1 Trie.empty 0,
+              _totalActiveCapital = TotalActiveCapitalV1 0
+            }
+    SAVDelegationNotSupported ->
+        PersistentActiveBakers
+            { _activeBakers = Trie.empty,
+              _aggregationKeys = Trie.empty,
+              _passiveDelegators = PersistentActiveDelegatorsV0,
+              _totalActiveCapital = TotalActiveCapitalV0
+            }
+
 totalActiveCapitalV1 :: (AVSupportsDelegation av) => Lens' (PersistentActiveBakers av) Amount
 totalActiveCapitalV1 = totalActiveCapital . tac
   where

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Cooldown.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Cooldown.hs
@@ -1,0 +1,251 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Concordium.GlobalState.Persistent.Cooldown where
+
+import Control.Monad
+import Data.Bool.Singletons
+import qualified Data.Map.Strict as Map
+import Data.Serialize
+import Lens.Micro.Platform
+
+import qualified Concordium.GlobalState.CooldownQueue as CooldownQueue
+import Concordium.GlobalState.Persistent.Account
+import Concordium.GlobalState.Persistent.BlobStore
+import Concordium.GlobalState.Persistent.ReleaseSchedule
+import Concordium.Types
+import Concordium.Types.Conditionally
+import Concordium.Types.Option
+
+-- | An 'AccountIndex' and the (possibly empty) tail of the list.
+data AccountListItem = AccountListItem
+    { accountListEntry :: !AccountIndex,
+      accountListTail :: !AccountList
+    }
+
+instance (MonadBlobStore m) => BlobStorable m AccountListItem where
+    load = do
+        mAccountListEntry <- load
+        mAccountListTail <- load
+        return (AccountListItem <$> mAccountListEntry <*> mAccountListTail)
+    storeUpdate ali = do
+        (pAccountListTail, newAccountListTail) <- storeUpdate (accountListTail ali)
+        return
+            ( put (accountListEntry ali) >> pAccountListTail,
+              ali{accountListTail = newAccountListTail}
+            )
+
+-- | A possibly empty list of 'AccountIndex'es, stored under 'UnbufferedRef's.
+type AccountList = Nullable (UnbufferedRef AccountListItem)
+
+-- | Prepend an 'AccountIndex' to an 'AccountList'.
+consAccountList :: (MonadBlobStore m) => AccountIndex -> AccountList -> m AccountList
+consAccountList accountIndex accountList = do
+    ref <- refMake (AccountListItem accountIndex accountList)
+    return (Some ref)
+
+-- | Load an entire account list. This is intended for testing purposes.
+loadAccountList :: (MonadBlobStore m) => AccountList -> m [AccountIndex]
+loadAccountList Null = return []
+loadAccountList (Some ref) = do
+    AccountListItem{..} <- refLoad ref
+    (accountListEntry :) <$> loadAccountList accountListTail
+
+-- | Migrate an 'AccountList' from one context to another.
+migrateAccountList :: (SupportMigration m t) => AccountList -> t m AccountList
+migrateAccountList Null = return Null
+migrateAccountList (Some ubRef) = do
+    Some <$> migrateReference migrateAccountListItem ubRef
+  where
+    migrateAccountListItem ali = do
+        newTail <- migrateAccountList (accountListTail ali)
+        return $! ali{accountListTail = newTail}
+
+removeAccountFromAccountListItem :: (MonadBlobStore m) => AccountIndex -> AccountListItem -> m AccountList
+removeAccountFromAccountListItem ai alist =
+    if accountListEntry alist == ai
+        then return $ accountListTail alist
+        else case accountListTail alist of
+            Null -> Some <$> refMake alist
+            Some ref -> do
+                alistItem <- refLoad ref
+                newList <- removeAccountFromAccountListItem ai alistItem
+                newRef <- refMake $ AccountListItem (accountListEntry alist) newList
+                return $ Some newRef
+
+removeAccountFromAccountList :: (MonadBlobStore m) => AccountIndex -> AccountList -> m AccountList
+removeAccountFromAccountList ai alist = case alist of
+    Null -> return Null
+    Some ref -> do
+        item <- refLoad ref
+        removeAccountFromAccountListItem ai item
+
+-- | This is an indexing structure and therefore does not need to be hashed. FIXME: add more docs
+data AccountsInCooldown = AccountsInCooldown
+    { -- | The accounts that are in cooldown with their earliest release times.
+      _cooldown :: !NewReleaseSchedule,
+      -- | The accounts that are in pre-cooldown.
+      _preCooldown :: !AccountList,
+      -- | The accounts that are in pre-pre-cooldown.
+      _prePreCooldown :: !AccountList
+    }
+
+makeLenses ''AccountsInCooldown
+
+-- | The cacheable instance only caches the 'cooldown' field, since the
+--  'preCooldown' and 'prePreCooldown' are implemented using 'UnbufferedRef's (and so
+--  would have no benefit from caching).
+instance (MonadBlobStore m) => Cacheable m AccountsInCooldown where
+    cache = cooldown cache
+
+instance (MonadBlobStore m) => BlobStorable m AccountsInCooldown where
+    load = do
+        mCooldown <- load
+        mPreCooldown <- load
+        mPrePreCooldown <- load
+        return (AccountsInCooldown <$> mCooldown <*> mPreCooldown <*> mPrePreCooldown)
+    storeUpdate aic = do
+        (pCooldown, newCooldown) <- storeUpdate (_cooldown aic)
+        (pPreCooldown, newPreCooldown) <- storeUpdate (_preCooldown aic)
+        (pPrePreCooldown, newPrePreCooldown) <- storeUpdate (_prePreCooldown aic)
+        let putAIC = pCooldown >> pPreCooldown >> pPrePreCooldown
+        return
+            ( putAIC,
+              AccountsInCooldown
+                { _cooldown = newCooldown,
+                  _preCooldown = newPreCooldown,
+                  _prePreCooldown = newPrePreCooldown
+                }
+            )
+
+-- | An 'AccountsInCooldown' with no accounts in (pre)*cooldown.
+emptyAccountsInCooldown :: AccountsInCooldown
+emptyAccountsInCooldown =
+    AccountsInCooldown
+        { _cooldown = emptyNewReleaseSchedule,
+          _preCooldown = Null,
+          _prePreCooldown = Null
+        }
+
+-- | Migrate 'AccountsInCooldown' from one 'BlobStore' to another.
+migrateAccountsInCooldown ::
+    (SupportMigration m t) =>
+    AccountsInCooldown ->
+    t m AccountsInCooldown
+migrateAccountsInCooldown aic = do
+    newCooldown <- migrateNewReleaseSchedule (_cooldown aic)
+    newPreCooldown <- migrateAccountList (_preCooldown aic)
+    newPrePreCooldown <- migrateAccountList (_prePreCooldown aic)
+    return $!
+        AccountsInCooldown
+            { _cooldown = newCooldown,
+              _preCooldown = newPreCooldown,
+              _prePreCooldown = newPrePreCooldown
+            }
+
+newtype AccountsInCooldownForPV pv = AccountsInCooldownForPV
+    { theAccountsInCooldownForPV ::
+        Conditionally (SupportsFlexibleCooldown (AccountVersionFor pv)) AccountsInCooldown
+    }
+
+instance (MonadBlobStore m, IsProtocolVersion pv) => BlobStorable m (AccountsInCooldownForPV pv) where
+    load = case sSupportsFlexibleCooldown (accountVersion @(AccountVersionFor pv)) of
+        SFalse -> return (return (AccountsInCooldownForPV CFalse))
+        STrue -> fmap (AccountsInCooldownForPV . CTrue) <$> load
+    storeUpdate aicPV@(AccountsInCooldownForPV CFalse) = do
+        return (return (), aicPV)
+    storeUpdate (AccountsInCooldownForPV (CTrue aic)) = do
+        (paic, aic') <- storeUpdate aic
+        return (paic, AccountsInCooldownForPV (CTrue aic'))
+
+-- | A lens for accessing the 'AccountsInCooldown' in an 'AccountsInCooldownForPV' when the
+--  protocol version supports flexible cooldown.
+accountsInCooldown ::
+    (PVSupportsFlexibleCooldown pv) =>
+    Lens' (AccountsInCooldownForPV pv) AccountsInCooldown
+accountsInCooldown =
+    lens
+        (uncond . theAccountsInCooldownForPV)
+        (\_ aic -> AccountsInCooldownForPV (CTrue aic))
+
+-- | An 'AccountsInCooldownForPV' with no accounts in (pre)*cooldown.
+emptyAccountsInCooldownForPV ::
+    forall pv.
+    (IsProtocolVersion pv) =>
+    AccountsInCooldownForPV pv
+emptyAccountsInCooldownForPV =
+    AccountsInCooldownForPV (conditionally cond emptyAccountsInCooldown)
+  where
+    cond = sSupportsFlexibleCooldown (accountVersion @(AccountVersionFor pv))
+
+instance (MonadBlobStore m) => Cacheable m (AccountsInCooldownForPV pv) where
+    cache = fmap AccountsInCooldownForPV . mapM cache . theAccountsInCooldownForPV
+
+-- | Generate the initial 'AccountsInCooldownForPV' structure from the initial accounts.
+initialAccountsInCooldown ::
+    forall pv m.
+    (MonadBlobStore m, IsProtocolVersion pv) =>
+    [PersistentAccount (AccountVersionFor pv)] ->
+    m (AccountsInCooldownForPV pv)
+initialAccountsInCooldown accounts = case sSupportsFlexibleCooldown sAV of
+    SFalse -> return emptyAccountsInCooldownForPV
+    STrue -> do
+        AccountsInCooldownForPV . CTrue
+            <$> foldM checkAccount emptyAccountsInCooldown (zip [0 ..] accounts)
+  where
+    sAV = accountVersion @(AccountVersionFor pv)
+    checkAccount aic (aid, acct) = do
+        accountCooldowns acct >>= \case
+            Nothing -> return aic
+            Just accCooldowns -> do
+                newCooldown <- case Map.lookupMin (CooldownQueue.inCooldown accCooldowns) of
+                    Nothing -> return $ aic ^. cooldown
+                    Just (ts, _) -> addAccountRelease ts aid (aic ^. cooldown)
+                newPreCooldown <- case CooldownQueue.preCooldown accCooldowns of
+                    Absent -> return $ aic ^. preCooldown
+                    Present _ -> consAccountList aid (aic ^. preCooldown)
+                newPrePreCooldown <- case CooldownQueue.prePreCooldown accCooldowns of
+                    Absent -> return $ aic ^. prePreCooldown
+                    Present _ -> consAccountList aid (aic ^. prePreCooldown)
+                return $
+                    aic
+                        & cooldown .~ newCooldown
+                        & preCooldown .~ newPreCooldown
+                        & prePreCooldown .~ newPrePreCooldown
+
+-- | Migrate an 'AccountsInCooldownForPV'.
+--
+--   * If the new protocol version (@pv@) does not support flexible cooldown, then this just
+--     produces the 'emptyAccountsInCooldownForPV'.
+--
+--   * Otherwise, if the old protocol version (@oldpv@) does not support flexible cooldown, then
+--     this produces an 'emptyAccountsInCooldownForPV' but with the 'prePreCooldown' accounts set
+--     to the provided list.
+--
+--   * If both protocol versions support flexible cooldown, the 'AccountsInCooldown' structure is
+--     simply migrated across unchanged.
+migrateAccountsInCooldownForPV ::
+    forall oldpv pv t m.
+    (SupportMigration m t, IsProtocolVersion pv, IsProtocolVersion oldpv) =>
+    Conditionally
+        ( Not (SupportsFlexibleCooldown (AccountVersionFor oldpv))
+            && SupportsFlexibleCooldown (AccountVersionFor pv)
+        )
+        AccountList ->
+    AccountsInCooldownForPV oldpv ->
+    t m (AccountsInCooldownForPV pv)
+migrateAccountsInCooldownForPV =
+    case sSupportsFlexibleCooldown (accountVersion @(AccountVersionFor pv)) of
+        SFalse -> \_ _ -> return emptyAccountsInCooldownForPV
+        STrue -> case sSupportsFlexibleCooldown (accountVersion @(AccountVersionFor oldpv)) of
+            SFalse -> \(CTrue prePreCooldownAccts) _ ->
+                return
+                    ( AccountsInCooldownForPV
+                        (CTrue (emptyAccountsInCooldown{_prePreCooldown = prePreCooldownAccts}))
+                    )
+            STrue -> \_ (AccountsInCooldownForPV (CTrue oldAIC)) ->
+                AccountsInCooldownForPV . CTrue <$> migrateAccountsInCooldown oldAIC

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Genesis.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Genesis.hs
@@ -26,6 +26,7 @@ import qualified Concordium.GlobalState.Persistent.BlobStore as Blob
 import qualified Concordium.GlobalState.Persistent.BlockState as BS
 import qualified Concordium.GlobalState.Persistent.BlockState.Modules as Modules
 import qualified Concordium.GlobalState.Persistent.BlockState.Updates as Updates
+import qualified Concordium.GlobalState.Persistent.Cooldown as Cooldown
 import qualified Concordium.GlobalState.Persistent.Instances as Instances
 import qualified Concordium.GlobalState.Persistent.LFMBTree as LFMBT
 import qualified Concordium.GlobalState.Persistent.PoolRewards as Rewards
@@ -243,6 +244,7 @@ buildGenesisBlockState vcgp GenesisData.GenesisState{..} = do
                   bspTransactionOutcomes = BS.emptyPersistentTransactionOutcomes,
                   bspUpdates = updates,
                   bspReleaseSchedule = releaseSchedule,
+                  bspAccountsInCooldown = Cooldown.emptyAccountsInCooldownForPV,
                   bspRewardDetails = rewardDetails
                 }
     bps <- MTL.liftIO $ newIORef $! bsp

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/LFMBTree.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/LFMBTree.hs
@@ -487,7 +487,8 @@ mmap_ f (NonEmpty _ t) = mmap_T t
         mmap_T =<< refLoad r
 
 -- | Migrate a LFMBTree from one context to the other. The new tree is cached in
--- memory and written to disk.
+-- memory and written to disk. Accounts are migrated in order of increasing account
+-- index.
 migrateLFMBTree ::
     forall m t ref1 ref2 v1 v2 k.
     (CanStoreLFMBTree m ref1 v1, Reference (t m) ref2 (T ref2 v2), MonadTrans t) =>

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/ReleaseSchedule.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/ReleaseSchedule.hs
@@ -224,6 +224,41 @@ instance (MonadBlobStore m) => ReleaseScheduleOperations m NewReleaseSchedule wh
                         newMap <- Trie.delete minTS m
                         go (accum ++ Set.toList (theAccountSet accs)) newMap
 
+-- | A release schedule with no entries.
+emptyNewReleaseSchedule :: NewReleaseSchedule
+emptyNewReleaseSchedule =
+    NewReleaseSchedule
+        { nrsFirstTimestamp = Timestamp maxBound,
+          nrsMap = Trie.empty
+        }
+
+-- | Migrate a 'NewReleaseSchedule' from one 'BlobStore' to another.
+migrateNewReleaseSchedule :: (SupportMigration m t) => NewReleaseSchedule -> t m NewReleaseSchedule
+migrateNewReleaseSchedule rs = do
+    newMap <- Trie.migrateTrieN True return (nrsMap rs)
+    return $!
+        NewReleaseSchedule
+            { nrsFirstTimestamp = nrsFirstTimestamp rs,
+              nrsMap = newMap
+            }
+
+removeAccountFromReleaseSchedule :: (MonadBlobStore m) => Timestamp -> AccountIndex -> NewReleaseSchedule -> m NewReleaseSchedule
+removeAccountFromReleaseSchedule ts ai rs = do
+    (_, nrsMap) <- Trie.adjust remAcc ts (nrsMap rs)
+    newMin <- Trie.findMin nrsMap
+    case newMin of
+        Nothing -> return $! emptyNewReleaseSchedule
+        Just (nrsFirstTimestamp, _) -> return $! NewReleaseSchedule{..}
+  where
+    remAcc Nothing = error "removeAccountFromReleaseSchedule: no entry at expected release time"
+    remAcc (Just (AccountSet accs)) =
+        return $!
+            let accs' = Set.delete ai accs
+            in  if Set.null accs' then ((), Trie.Remove) else ((), Trie.Insert (AccountSet accs'))
+
+updateAccountFromReleaseSchedule :: (MonadBlobStore m) => Timestamp -> Timestamp -> AccountIndex -> NewReleaseSchedule -> m NewReleaseSchedule
+updateAccountFromReleaseSchedule = updateAccountRelease
+
 -- | A reference to an account used in the top-level release schedule.
 --  For protocol version prior to 'P5', this is 'AccountAddress', and for 'P5' onward this is
 --  'AccountIndex'. This type determines the implementation of the release schedule use for the
@@ -310,10 +345,7 @@ emptyReleaseSchedule = case protocolVersion @pv of
     rsP1 = do
         return $!
             ReleaseScheduleP5
-                NewReleaseSchedule
-                    { nrsFirstTimestamp = Timestamp maxBound,
-                      nrsMap = Trie.empty
-                    }
+                emptyNewReleaseSchedule
 
 -- | Migration information for a release schedule.
 data ReleaseScheduleMigration m oldpv pv where
@@ -372,13 +404,7 @@ migrateReleaseSchedule (RSMLegacyToNew resolveAcc) (ReleaseScheduleP0 rsRef) = d
                   nrsMap = newMap'
                 }
 migrateReleaseSchedule RSMNewToNew (ReleaseScheduleP5 rs) = do
-    newMap <- Trie.migrateTrieN True return (nrsMap rs)
-    return $!
-        ReleaseScheduleP5
-            NewReleaseSchedule
-                { nrsFirstTimestamp = nrsFirstTimestamp rs,
-                  nrsMap = newMap
-                }
+    ReleaseScheduleP5 <$> migrateNewReleaseSchedule rs
 
 -- | (For testing purposes) get the map of the earliest scheduled releases of each account.
 releasesMap ::

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/ReleaseSchedule.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/ReleaseSchedule.hs
@@ -242,7 +242,18 @@ migrateNewReleaseSchedule rs = do
               nrsMap = newMap
             }
 
-removeAccountFromReleaseSchedule :: (MonadBlobStore m) => Timestamp -> AccountIndex -> NewReleaseSchedule -> m NewReleaseSchedule
+-- | Remove an account from the release schedule, given the timestamp and the account index.
+--
+--  PRECONDITION: The account must have a scheduled release at the given timestamp.
+removeAccountFromReleaseSchedule ::
+    (MonadBlobStore m) =>
+    -- | The timestamp at which the account has a scheduled release.
+    Timestamp ->
+    -- | The account index to remove.
+    AccountIndex ->
+    -- | The release schedule to remove the account from.
+    NewReleaseSchedule ->
+    m NewReleaseSchedule
 removeAccountFromReleaseSchedule ts ai rs = do
     (_, nrsMap) <- Trie.adjust remAcc ts (nrsMap rs)
     newMin <- Trie.findMin nrsMap
@@ -255,9 +266,6 @@ removeAccountFromReleaseSchedule ts ai rs = do
         return $!
             let accs' = Set.delete ai accs
             in  if Set.null accs' then ((), Trie.Remove) else ((), Trie.Insert (AccountSet accs'))
-
-updateAccountFromReleaseSchedule :: (MonadBlobStore m) => Timestamp -> Timestamp -> AccountIndex -> NewReleaseSchedule -> m NewReleaseSchedule
-updateAccountFromReleaseSchedule = updateAccountRelease
 
 -- | A reference to an account used in the top-level release schedule.
 --  For protocol version prior to 'P5', this is 'AccountAddress', and for 'P5' onward this is

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/AccountList.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/AccountList.hs
@@ -1,0 +1,64 @@
+module GlobalStateTests.AccountList where
+
+import Control.Monad
+import Data.Foldable
+import Test.Hspec
+import Test.QuickCheck
+
+import Concordium.Types
+
+import Concordium.GlobalState.Persistent.BlobStore
+import Concordium.GlobalState.Persistent.Cooldown
+
+-- | Run an an action in the 'MemBlobStoreT' monad transformer from an empty store.
+runBlobStore :: MemBlobStoreT IO a -> IO a
+runBlobStore a = do
+    mbs <- newMemBlobStore
+    runMemBlobStoreT a mbs
+
+data ListAction
+    = -- | Add an account to the list.
+      Cons AccountIndex
+    | -- | Remove the first instance an account from the list.
+      Remove AccountIndex
+    | -- | Flush the list to the blob store.
+      StoreUpdate
+    | -- | Store and reload the list from the blob store
+      StoreLoad
+    deriving (Show)
+
+instance Arbitrary ListAction where
+    arbitrary =
+        frequency
+            [ (5, Cons . AccountIndex <$> arbitrary),
+              (1, Remove . AccountIndex <$> arbitrary),
+              (1, pure StoreUpdate),
+              (1, pure StoreLoad)
+            ]
+
+-- | Determine the list that should result from a sequence of list actions.
+ofListActions :: [ListAction] -> [AccountIndex]
+ofListActions = foldl' go []
+  where
+    go acc (Cons x) = x : acc
+    go acc (Remove x) = removeFirst x acc
+    go acc _ = acc
+    removeFirst _ [] = []
+    removeFirst x (y : ys)
+        | x == y = ys
+        | otherwise = y : removeFirst x ys
+
+-- | Test that a sequence of list actions results in the expected list.
+testActions :: [ListAction] -> Property
+testActions actions = ioProperty $ do
+    list <- runBlobStore $ loadAccountList =<< foldM act Null actions
+    return $ ofListActions actions === list
+  where
+    act al (Cons x) = consAccountList x al
+    act al (Remove x) = removeAccountFromAccountList x al
+    act al StoreUpdate = snd <$> storeUpdate al
+    act al StoreLoad = loadRef =<< storeRef al
+
+tests :: Spec
+tests = describe "AccountList" $ do
+    it "arbitrary list actions" $ withMaxSuccess 10000 $ property testActions

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/AccountsMigrationP6ToP7.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/AccountsMigrationP6ToP7.hs
@@ -1,0 +1,368 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | This module tests the migration of accounts from protocol version 6 to protocol version 7.
+-- In particular, it tests that bakers and delegators are migrated correctly, with any bakers
+-- or delegators that are in cooldown (for removal or stake reduction) are moved to cooldown after
+-- migration. Specifically:
+--
+--  * Bakers/delegators that are in cooldown for removal are removed and have their stake put in
+--    pre-pre-cooldown.
+--  * Bakers/delegators that are in cooldown for reduction have their stake reduced and the
+--    reduction put in pre-pre-cooldown.
+--  * Any account that is put in pre-pre-cooldown is recorded in 'migrationPrePreCooldown'.
+--  * Delegators to bakers that are removed (as a result of migration) are moved to passive
+--    delegation.
+--  * All bakers and delegators that are not removed are correctly recorded in the persistent
+--    active bakers.
+module GlobalStateTests.AccountsMigrationP6ToP7 where
+
+import Test.HUnit
+import Test.Hspec
+
+import Concordium.Types
+import Concordium.Types.Accounts
+
+import qualified Concordium.Crypto.BlockSignature as Sig
+import qualified Concordium.Crypto.BlsSignature as Bls
+import qualified Concordium.Crypto.VRF as VRF
+import Concordium.Genesis.Data
+import Concordium.GlobalState.Account
+import qualified Concordium.GlobalState.AccountMap.LMDB as LMDBAccountMap
+import qualified Concordium.GlobalState.Basic.BlockState.Account as Transient
+import qualified Concordium.GlobalState.Basic.BlockState.AccountReleaseSchedule as Transient
+import Concordium.GlobalState.CooldownQueue
+import Concordium.GlobalState.DummyData
+import Concordium.GlobalState.Persistent.Account
+import qualified Concordium.GlobalState.Persistent.Account.MigrationState as MigrationState
+import Concordium.GlobalState.Persistent.Accounts
+import Concordium.GlobalState.Persistent.Bakers
+import Concordium.GlobalState.Persistent.BlobStore
+import Concordium.GlobalState.Persistent.BlockState
+import qualified Concordium.GlobalState.Persistent.BlockState.Modules as M
+import Concordium.GlobalState.Persistent.Cooldown
+import qualified Concordium.GlobalState.Persistent.Trie as Trie
+import Concordium.ID.Types
+import Concordium.Scheduler.DummyData
+import Concordium.Types.Conditionally
+import Concordium.Types.DummyData
+import Concordium.Types.Execution
+import Concordium.Types.Option
+import Control.Exception
+import Control.Monad
+import Control.Monad.IO.Class
+import qualified Data.Map.Strict as Map
+import GlobalStateTests.Accounts (NoLoggerT (..))
+import Lens.Micro.Platform
+import System.FilePath
+import System.IO.Temp
+
+dummyPersisingAccountData :: Int -> PersistingAccountData
+dummyPersisingAccountData seed =
+    PersistingAccountData
+        { _accountAddress = addr,
+          _accountEncryptionKey = encryptionKey,
+          _accountVerificationKeys = getAccountInformation 1 creds,
+          _accountCredentials = creds,
+          _accountRemovedCredentials = makeHashed EmptyRemovedCredentials
+        }
+  where
+    cred = makeTestCredentialFromSeed seed
+    creds = Map.singleton 0 (toRawAccountCredential cred)
+    addr = accountAddressFromSeed seed
+    encryptionKey = toRawEncryptionKey (makeEncryptionKey dummyCryptographicParameters (credId cred))
+
+-- | Create a test account with the given persisting data and stake.
+--  The balance of the account is set to 1 billion CCD (10^15 uCCD).
+testAccount ::
+    forall av.
+    (IsAccountVersion av) =>
+    PersistingAccountData ->
+    AccountStake av ->
+    Transient.Account av
+testAccount persisting stake =
+    Transient.Account
+        { _accountPersisting = Transient.makeAccountPersisting persisting,
+          _accountNonce = minNonce,
+          _accountAmount = 1_000_000_000_000_000,
+          _accountEncryptedAmount = initialAccountEncryptedAmount,
+          _accountReleaseSchedule = Transient.emptyAccountReleaseSchedule,
+          _accountStaking = stake,
+          _accountStakeCooldown = Transient.emptyCooldownQueue (accountVersion @av)
+        }
+
+-- | Initial stake for a test account, set to 500 million CCD plus @2^accountIndex@ uCCD.
+initialStake :: AccountIndex -> Amount
+initialStake accIndex = 500_000_000_000_000 + 2 ^ accIndex
+
+-- | Target reduced stake for a test account, set to 10_000 CCD plus @2^accountIndex@ uCCD.
+reducedStake :: AccountIndex -> Amount
+reducedStake accIndex = 10_000_000_000 + 2 ^ accIndex
+
+-- | Create a baker stake for a given (small (<38)) account index. The stake is set at 500 million
+-- CCD plus @2^accountIndex@ uCCD. This is to ensure that any given combination of accounts have a
+-- unique total stake.
+dummyBakerStake ::
+    (AVSupportsDelegation av) =>
+    (AccountIndex -> Amount) ->
+    AccountIndex ->
+    StakePendingChange av ->
+    AccountStake av
+dummyBakerStake compStake accIndex pc =
+    AccountStakeBaker $
+        AccountBaker
+            { _stakedAmount = compStake accIndex,
+              _stakeEarnings = True,
+              _bakerPendingChange = pc,
+              _accountBakerInfo =
+                BakerInfoExV1
+                    { _bieBakerPoolInfo =
+                        BakerPoolInfo
+                            { _poolOpenStatus = OpenForAll,
+                              _poolMetadataUrl = emptyUrlText,
+                              _poolCommissionRates =
+                                CommissionRates
+                                    { _finalizationCommission = makeAmountFraction 50_000,
+                                      _bakingCommission = makeAmountFraction 50_000,
+                                      _transactionCommission = makeAmountFraction 50_000
+                                    }
+                            },
+                      _bieBakerInfo =
+                        BakerInfo
+                            { _bakerSignatureVerifyKey = Sig.verifyKey (bakerSignKey seed),
+                              _bakerIdentity = BakerId accIndex,
+                              _bakerElectionVerifyKey = VRF.publicKey (bakerElectionKey seed),
+                              _bakerAggregationVerifyKey =
+                                Bls.derivePublicKey (bakerAggregationKey seed)
+                            }
+                    }
+            }
+  where
+    seed = fromIntegral accIndex
+
+dummyDelegatorStake ::
+    (AVSupportsDelegation av) =>
+    (AccountIndex -> Amount) ->
+    AccountIndex ->
+    DelegationTarget ->
+    StakePendingChange av ->
+    AccountStake av
+dummyDelegatorStake compStake accIndex target pc =
+    AccountStakeDelegate $
+        AccountDelegationV1
+            { _delegationTarget = target,
+              _delegationStakedAmount = compStake accIndex,
+              _delegationStakeEarnings = True,
+              _delegationPendingChange = pc,
+              _delegationIdentity = DelegatorId accIndex
+            }
+
+-- | Create a set of test accounts for migration testing.
+--  The accounts consist of 3 bakers, one with no pending changes, one with a reduction and one
+--  with a removal. Each baker has 3 delegators, one with no pending changes, one with a reduction
+--  and one with a removal. There are also 3 passive delegators, similarly configured.
+setupTestAccounts :: (SupportsPersistentAccount 'P6 m, MonadFail m) => m (Accounts 'P6)
+setupTestAccounts = do
+    a0 <- mkBakerAccount 0 NoChange
+    a1 <- mkBakerAccount 1 (ReduceStake (reducedStake 1) (PendingChangeEffectiveV1 1000))
+    a2 <- mkBakerAccount 2 (RemoveStake (PendingChangeEffectiveV1 2000))
+    a3 <- mkDelegatorAccount 3 (DelegateToBaker 0) NoChange
+    a4 <-
+        mkDelegatorAccount
+            4
+            (DelegateToBaker 0)
+            (ReduceStake (reducedStake 4) (PendingChangeEffectiveV1 3000))
+    a5 <- mkDelegatorAccount 5 (DelegateToBaker 0) (RemoveStake (PendingChangeEffectiveV1 4000))
+    a6 <- mkDelegatorAccount 6 (DelegateToBaker 1) NoChange
+    a7 <-
+        mkDelegatorAccount
+            7
+            (DelegateToBaker 1)
+            (ReduceStake (reducedStake 7) (PendingChangeEffectiveV1 5000))
+    a8 <- mkDelegatorAccount 8 (DelegateToBaker 1) (RemoveStake (PendingChangeEffectiveV1 6000))
+    a9 <- mkDelegatorAccount 9 (DelegateToBaker 2) NoChange
+    a10 <-
+        mkDelegatorAccount
+            10
+            (DelegateToBaker 2)
+            (ReduceStake (reducedStake 10) (PendingChangeEffectiveV1 7000))
+    a11 <- mkDelegatorAccount 11 (DelegateToBaker 2) (RemoveStake (PendingChangeEffectiveV1 8000))
+    a12 <- mkDelegatorAccount 12 DelegatePassive NoChange
+    a13 <-
+        mkDelegatorAccount
+            13
+            DelegatePassive
+            (ReduceStake (reducedStake 13) (PendingChangeEffectiveV1 9000))
+    a14 <- mkDelegatorAccount 14 DelegatePassive (RemoveStake (PendingChangeEffectiveV1 10_000))
+    accounts0 <- emptyAccounts
+    foldM
+        (\accts a -> snd <$> putNewAccount a accts)
+        accounts0
+        [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14]
+  where
+    mkBakerAccount accIdx pc =
+        makePersistentAccount $
+            testAccount
+                (dummyPersisingAccountData (fromIntegral accIdx))
+                (dummyBakerStake initialStake accIdx pc)
+    mkDelegatorAccount accIndex target pc =
+        makePersistentAccount $
+            testAccount
+                (dummyPersisingAccountData (fromIntegral accIndex))
+                (dummyDelegatorStake initialStake accIndex target pc)
+
+initPersistentActiveBakers ::
+    forall pv m.
+    (SupportsPersistentAccount pv m, PVSupportsDelegation pv) =>
+    Accounts pv ->
+    m (PersistentActiveBakers (AccountVersionFor pv))
+initPersistentActiveBakers = foldAccounts addAcct emptyPersistentActiveBakers
+  where
+    addAcct pab acct =
+        accountStake acct >>= \case
+            AccountStakeNone -> return pab
+            AccountStakeBaker b -> do
+                let upd Nothing = return ((), Trie.Insert emptyPersistentActiveDelegators)
+                    upd _ = return ((), Trie.NoChange)
+                (_, newActiveBakers) <- Trie.adjust upd (b ^. bakerIdentity) (pab ^. activeBakers)
+                newAggregationKeys <-
+                    Trie.insert (b ^. bakerAggregationVerifyKey) () (pab ^. aggregationKeys)
+                return $!
+                    pab
+                        & activeBakers .~ newActiveBakers
+                        & totalActiveCapital . tacAmount +~ (b ^. stakedAmount)
+                        & aggregationKeys .~ newAggregationKeys
+            AccountStakeDelegate d -> do
+                (totalActiveCapital . tacAmount +~ delAmt)
+                    <$> case d ^. delegationTarget of
+                        DelegatePassive -> do
+                            passiveDelegators (addDelegatorHelper delId delAmt) pab
+                        DelegateToBaker bid -> do
+                            activeBakers (fmap snd . Trie.adjust upd bid) pab
+              where
+                delId = d ^. delegationIdentity
+                delAmt = d ^. delegationStakedAmount
+                upd Nothing = do
+                    singletonPAD <-
+                        addDelegatorHelper delId delAmt emptyPersistentActiveDelegators
+                    return ((), Trie.Insert singletonPAD)
+                upd (Just pad) = do
+                    newPAD <- addDelegatorHelper delId delAmt pad
+                    return ((), Trie.Insert newPAD)
+
+migrationTest :: PersistentBlockStateContext 'P6 -> PersistentBlockStateContext 'P7 -> Expectation
+migrationTest c0 c1 = runNoLoggerT $ flip runBlobStoreT c0 $ do
+    accounts <- setupTestAccounts
+    pab <- initPersistentActiveBakers accounts
+    flip runBlobStoreT c1 $ do
+        initMigrationState :: MigrationState.AccountMigrationState 'P6 'P7 <-
+            MigrationState.makeInitialAccountMigrationState accounts pab
+
+        (newAccounts :: Accounts 'P7, newMigrationState) <-
+            MigrationState.runAccountMigrationStateTT
+                (migrateAccounts @'P6 @'P7 StateMigrationParametersP6ToP7 accounts)
+                initMigrationState
+        assertMigrationStateCorrect newMigrationState
+        assertAccountsCorrect newAccounts
+        unless (accountDiffMapRef accounts == accountDiffMapRef newAccounts) $
+            liftIO $
+                assertFailure "Expected the same account difference map"
+
+-- | Assert that the accounts marked as in pre-pre-cooldown and the persistent active bakers are as
+--  expected after migration from the test accounts.
+assertMigrationStateCorrect :: forall m. (MonadBlobStore m) => MigrationState.AccountMigrationState 'P6 'P7 -> m ()
+assertMigrationStateCorrect migrationState = do
+    prePreCooldownList <- loadAccountList (migrationState ^. MigrationState.migrationPrePreCooldown . unconditionally)
+    -- All accounts that were in cooldown before migration should be in pre-pre-cooldown after migration.
+    let expectPrePreCooldownList = [14, 13, 11, 10, 8, 7, 5, 4, 2, 1]
+    liftIO $ assertEqual "Expected pre-pre-cooldown list" expectPrePreCooldownList prePreCooldownList
+    let pab = migrationState ^. MigrationState.persistentActiveBakers . unconditionally
+    let unDel :: PersistentActiveDelegators 'AccountV3 -> m ([DelegatorId], Amount)
+        unDel PersistentActiveDelegatorsV1{..} = (,adDelegatorTotalCapital) <$> Trie.keysAsc adDelegators
+    actBkrs <- mapM unDel =<< Trie.toMap (pab ^. activeBakers)
+    let expectActiveBakers =
+            Map.fromList
+                [ (0, ([3, 4], initialStake 3 + reducedStake 4)),
+                  (1, ([6, 7], initialStake 6 + reducedStake 7))
+                ]
+    liftIO $ assertEqual "Active bakers" expectActiveBakers actBkrs
+    aggKeys <- Trie.keys (pab ^. aggregationKeys)
+    -- Note: the aggregation keys happen to be in this order. Technically the order doesn't matter.
+    let expectAggreationKeys = Bls.derivePublicKey . bakerAggregationKey <$> [0, 1]
+    liftIO $ assertEqual "Aggregation keys" expectAggreationKeys aggKeys
+    pasvDlg <- unDel (pab ^. passiveDelegators)
+    let expectPassiveDelegators = ([9, 10, 12, 13], initialStake 9 + reducedStake 10 + initialStake 12 + reducedStake 13)
+    liftIO $ assertEqual "Passive delegators" expectPassiveDelegators pasvDlg
+    let actCapital = pab ^. totalActiveCapital . tacAmount
+    let expectTotalActiveCapital = sum (initialStake <$> [0, 3, 6, 9, 12]) + sum (reducedStake <$> [1, 4, 7, 10, 13])
+    liftIO $ assertEqual "Total active capital" expectTotalActiveCapital actCapital
+
+assertAccountsCorrect :: forall m. (SupportsPersistentAccount 'P7 m, MonadFail m) => Accounts 'P7 -> m ()
+assertAccountsCorrect accounts = do
+    accountExpect 0 (dummyBakerStake initialStake 0 NoChange) Nothing
+    accountExpect 1 (dummyBakerStake reducedStake 1 NoChange) (prePreExpect (cooldownReduce 1))
+    accountExpect 2 AccountStakeNone (prePreExpect (initialStake 2))
+    accountExpect 3 (dummyDelegatorStake initialStake 3 (DelegateToBaker 0) NoChange) Nothing
+    accountExpect 4 (dummyDelegatorStake reducedStake 4 (DelegateToBaker 0) NoChange) (prePreExpect (cooldownReduce 4))
+    accountExpect 5 AccountStakeNone (prePreExpect (initialStake 5))
+    accountExpect 6 (dummyDelegatorStake initialStake 6 (DelegateToBaker 1) NoChange) Nothing
+    accountExpect 7 (dummyDelegatorStake reducedStake 7 (DelegateToBaker 1) NoChange) (prePreExpect (cooldownReduce 7))
+    accountExpect 8 AccountStakeNone (prePreExpect (initialStake 8))
+    accountExpect 9 (dummyDelegatorStake initialStake 9 DelegatePassive NoChange) Nothing
+    accountExpect 10 (dummyDelegatorStake reducedStake 10 DelegatePassive NoChange) (prePreExpect (cooldownReduce 10))
+    accountExpect 11 AccountStakeNone (prePreExpect (initialStake 11))
+    accountExpect 12 (dummyDelegatorStake initialStake 12 DelegatePassive NoChange) Nothing
+    accountExpect 13 (dummyDelegatorStake reducedStake 13 DelegatePassive NoChange) (prePreExpect (cooldownReduce 13))
+    accountExpect 14 AccountStakeNone (prePreExpect (initialStake 14))
+  where
+    availableExpect accIndex = 1_000_000_000_000_000 - initialStake accIndex
+    cooldownReduce accIndex = initialStake accIndex - reducedStake accIndex
+    prePreExpect amt =
+        Just
+            ( Cooldowns
+                { inCooldown = Map.empty,
+                  preCooldown = Absent,
+                  prePreCooldown = Present amt
+                }
+            )
+    accountExpect accIndex expectStake expectCooldowns = do
+        (Just a) <- indexedAccount accIndex accounts
+        liftIO . assertEqual ("Account " ++ show accIndex ++ " stake") expectStake
+            =<< accountStake a
+        liftIO . assertEqual ("Account " ++ show accIndex ++ " cooldowns") expectCooldowns
+            =<< accountCooldowns a
+        liftIO . assertEqual ("Account " ++ show accIndex ++ " available amount") (availableExpect accIndex)
+            =<< accountAvailableAmount a
+
+tests :: Spec
+tests = describe "GlobalStateTests.AccountsMigrationP6ToP7"
+    $ around
+        ( \kont ->
+            withTempDirectory "." "blockstate" $ \dir ->
+                bracket
+                    ( do
+                        c0 <- createPBSC dir "0"
+                        c1 <- createPBSC dir "1"
+                        return (c0, c1)
+                    )
+                    ( \(c0, c1) -> do
+                        destroyPBSC c0
+                        destroyPBSC c1
+                    )
+                    kont
+        )
+    $ do
+        it "migration" (uncurry migrationTest)
+  where
+    createPBSC dir i = do
+        pbscBlobStore <- createBlobStore (dir </> ("blockstate" ++ i ++ ".dat"))
+        pbscAccountCache <- newAccountCache 100
+        pbscModuleCache <- M.newModuleCache 100
+        pbscAccountMap <- LMDBAccountMap.openDatabase (dir </> ("accountmap" ++ i))
+        return PersistentBlockStateContext{..}
+    destroyPBSC PersistentBlockStateContext{..} = do
+        closeBlobStore pbscBlobStore
+        LMDBAccountMap.closeDatabase pbscAccountMap

--- a/concordium-consensus/tests/globalstate/Spec.hs
+++ b/concordium-consensus/tests/globalstate/Spec.hs
@@ -6,6 +6,7 @@ import qualified GlobalStateTests.AccountMap (tests)
 import qualified GlobalStateTests.AccountReleaseScheduleMigration (tests)
 import qualified GlobalStateTests.AccountReleaseScheduleTest (tests)
 import qualified GlobalStateTests.Accounts (tests)
+import qualified GlobalStateTests.AccountsMigrationP6ToP7 (tests)
 import qualified GlobalStateTests.BlobStore (tests)
 import qualified GlobalStateTests.BlockHash (tests)
 import qualified GlobalStateTests.Cache (tests)
@@ -52,4 +53,5 @@ main = atLevel $ \lvl -> hspec $ do
     GlobalStateTests.UpdateQueues.tests
     GlobalStateTests.LMDBAccountMap.tests
     GlobalStateTests.DifferenceMap.tests
+    GlobalStateTests.AccountsMigrationP6ToP7.tests
     GlobalStateTests.CooldownQueue.tests

--- a/concordium-consensus/tests/globalstate/Spec.hs
+++ b/concordium-consensus/tests/globalstate/Spec.hs
@@ -2,6 +2,7 @@ module Main where
 
 import Data.List (stripPrefix)
 import Data.Semigroup
+import qualified GlobalStateTests.AccountList (tests)
 import qualified GlobalStateTests.AccountMap (tests)
 import qualified GlobalStateTests.AccountReleaseScheduleMigration (tests)
 import qualified GlobalStateTests.AccountReleaseScheduleTest (tests)
@@ -54,4 +55,5 @@ main = atLevel $ \lvl -> hspec $ do
     GlobalStateTests.LMDBAccountMap.tests
     GlobalStateTests.DifferenceMap.tests
     GlobalStateTests.AccountsMigrationP6ToP7.tests
+    GlobalStateTests.AccountList.tests
     GlobalStateTests.CooldownQueue.tests


### PR DESCRIPTION
## Purpose

Closes #1144 

Add a global index of cooldowns to the block state, which records:
- which accounts are in pre-pre-cooldown
- which accounts are in pre-cooldown
- which accounts are in cooldown, and their soonest expiry time.

Add support for state migration from P6->P7. This applies any pending stake changes to accounts, moving the change in stake into pre-pre-cooldown.

## Changes

- When migrating P6->P7, we rebuild the `PersistentActiveBakers` structure to account for changes to the active bakers. This is supported by the `AccountMigration` interface and implemented by `AccountMigrationStateTT` (a monad transformer transformer that adds the migration state to an existing monad transformer).
- `StructureV1`: implement migration from `AccountV2` to `AccountV3`, applying pending stake changes and moving the delta to pre-pre-cooldown. This uses the `AccountMigration` interface to account for changes to the bakers and delegators in the migration process.
- `Concordium.GlobalState.Persistent.Cooldown`: representation of global index of cooldowns. This re-uses the (new) release schedule implementation for tracking the accounts that are in cooldown. As such, some new functionality as added on the release schedule implementation to facilitate removing accounts from cooldown prematurely (by putting them back to active staking).
- Testing for account migration.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
