### PR TITLE
Processing cooldowns at epoch transitions

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Account.hs
@@ -570,3 +570,24 @@ data StakeDetails (av :: AccountVersion) where
           sdDelegationTarget :: !DelegationTarget
         } ->
         StakeDetails av
+
+instance Show (StakeDetails av) where
+    show StakeDetailsNone = "StakeDetailsNone"
+    show StakeDetailsBaker{..} =
+        "StakeDetailsBaker {sdStakedCapital = "
+            <> show sdStakedCapital
+            <> ", sdRestakeEarnings = "
+            <> show sdRestakeEarnings
+            <> ", sdPendingChange = "
+            <> show sdPendingChange
+            <> "}"
+    show StakeDetailsDelegator{..} =
+        "StakeDetailsDelegator {sdStakedCapital = "
+            <> show sdStakedCapital
+            <> ", sdRestakeEarnings = "
+            <> show sdRestakeEarnings
+            <> ", sdPendingChange = "
+            <> show sdPendingChange
+            <> ", sdDelegationTarget = "
+            <> show sdDelegationTarget
+            <> "}"

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -52,6 +52,7 @@ import Concordium.GlobalState.CapitalDistribution
 import qualified Concordium.GlobalState.ContractStateV1 as StateV1
 import Concordium.GlobalState.Parameters
 import Concordium.GlobalState.Persistent.Account
+import Concordium.GlobalState.Persistent.Account.CooldownQueue (NextCooldownChange (..))
 import qualified Concordium.GlobalState.Persistent.Account.MigrationState as MigrationState
 import Concordium.GlobalState.Persistent.Accounts (SupportsPersistentAccount)
 import qualified Concordium.GlobalState.Persistent.Accounts as Accounts
@@ -3433,11 +3434,11 @@ doProcessCooldowns pbs now newExpiry = do
         case res of
             -- In this case, the account already had cooldowns, but the new cooldown expires
             -- earlier, so the release schedule needs to be updated.
-            Just (Just oldTS) -> withCooldown $ updateAccountRelease oldTS newExpiry acc
+            EarlierNextCooldown oldTS -> withCooldown $ updateAccountRelease oldTS newExpiry acc
             -- In this case, the account did not have cooldowns, so the new cooldown is added.
-            Just Nothing -> withCooldown $ addAccountRelease newExpiry acc
+            NewNextCooldown -> withCooldown $ addAccountRelease newExpiry acc
             -- In this case, the earliest cooldown on the account has not changed.
-            Nothing -> return ()
+            NextCooldownUnchanged -> return ()
         return newPA
 
 -- | Move all pre-pre-cooldowns into pre-cooldown.

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -3401,30 +3401,48 @@ doProcessCooldowns pbs now newExpiry = do
               bspAccounts = newAccts
             }
   where
+    -- Perform a monadic update on the global cooldown release schedule.
     withCooldown a = (_1 . cooldown .=) =<< a =<< use (_1 . cooldown)
+    -- Perform a monadic update an the accounts table.
     withAccounts a = (_2 .=) =<< a =<< use _2
     process = do
+        -- Determine which accounts have cooldowns that have expired and remove them from the
+        -- cooldown schedule.
         cooldown0 <- use (_1 . cooldown)
         (cooldownList, cooldown1) <- processReleasesUntil now cooldown0
         _1 . cooldown .= cooldown1
+        -- Process the cooldowns for the accounts that have expired cooldowns, adding them back
+        -- to the cooldown schedule if they have remaining cooldowns.
         forM_ cooldownList $ \acc -> do
             withAccounts (Accounts.updateAccountsAtIndex' (processCooldownForAccount acc) acc)
+        -- Fetch and clear the list of accounts in pre-cooldown.
         preCooldownAL <- _1 . preCooldown <<.= Null
         preCooldowns <- loadAccountList preCooldownAL
+        -- Process the pre-cooldowns, moving them into cooldown.
         forM_ preCooldowns $ \acc -> do
             withAccounts (Accounts.updateAccountsAtIndex' (processPreCooldownForAccount acc) acc)
     processCooldownForAccount acc pa = do
+        -- Release the elapsed cooldowns on the account.
         (mNextCooldown, newPA) <- processAccountCooldownsUntil now pa
+        -- If there are remaining cooldowns, add the account back to the cooldown schedule.
         forM_ mNextCooldown $ \nextCooldown -> withCooldown $ addAccountRelease nextCooldown acc
         return newPA
     processPreCooldownForAccount acc pa = do
+        -- Process the pre-cooldowns on the account.
         (res, newPA) <- processAccountPreCooldown newExpiry pa
         case res of
+            -- In this case, the account already had cooldowns, but the new cooldown expires
+            -- earlier, so the release schedule needs to be updated.
             Just (Just oldTS) -> withCooldown $ updateAccountRelease oldTS newExpiry acc
+            -- In this case, the account did not have cooldowns, so the new cooldown is added.
             Just Nothing -> withCooldown $ addAccountRelease newExpiry acc
+            -- In this case, the earliest cooldown on the account has not changed.
             Nothing -> return ()
         return newPA
 
+-- | Move all pre-pre-cooldowns into pre-cooldown.
+--
+-- PRECONDITION: there are no pre-cooldowns.
 doProcessPrePreCooldowns ::
     forall pv m.
     (SupportsPersistentState pv m, PVSupportsFlexibleCooldown pv) =>
@@ -3433,12 +3451,14 @@ doProcessPrePreCooldowns ::
 doProcessPrePreCooldowns pbs = do
     bsp <- loadPBS pbs
     let oldAIC = bspAccountsInCooldown bsp ^. accountsInCooldown
+    -- The new pre-cooldown list is the old pre-pre-cooldown list.
     let !newPreCooldown = assert (isNull (oldAIC ^. preCooldown)) $ oldAIC ^. prePreCooldown
     let newAIC =
             oldAIC
                 & preCooldown .~ newPreCooldown
                 & prePreCooldown .~ Null
     accounts <- loadAccountList newPreCooldown
+    -- Process the pre-pre-cooldown on each account, moving it to pre-cooldown.
     let processAccount = flip $ Accounts.updateAccountsAtIndex' processAccountPrePreCooldown
     newAccts <- foldM processAccount (bspAccounts bsp) accounts
     storePBS pbs $

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -23,6 +23,7 @@ module Concordium.GlobalState.Persistent.BlockState (
     HashedPersistentBlockState (..),
     hashBlockState,
     PersistentBirkParameters (..),
+    initialBirkParameters,
     initialPersistentState,
     emptyBlockState,
     emptyHashedEpochBlocks,
@@ -37,6 +38,8 @@ module Concordium.GlobalState.Persistent.BlockState (
     cacheStateAndGetTransactionTable,
     migratePersistentBlockState,
     SupportsPersistentState,
+    loadPBS,
+    storePBS,
 ) where
 
 import qualified Concordium.Crypto.SHA256 as H
@@ -995,10 +998,12 @@ emptyBlockState bspBirkParameters cryptParams keysCollection chainParams = do
                 }
     liftIO $ newIORef $! bsp
 
+-- | Load 'BlockStatePointers' from a 'PersistentBlockState'.
 loadPBS :: (SupportsPersistentState pv m) => PersistentBlockState pv -> m (BlockStatePointers pv)
 loadPBS = loadBufferedRef <=< liftIO . readIORef
 {-# INLINE loadPBS #-}
 
+-- | Update the 'BlockStatePointers' stored in a 'PersistentBlockState'.
 storePBS :: (SupportsPersistentAccount pv m) => PersistentBlockState pv -> BlockStatePointers pv -> m (PersistentBlockState pv)
 storePBS pbs bsp = liftIO $ do
     pbsp <- makeBufferedRef bsp
@@ -3374,6 +3379,74 @@ doProcessPendingChanges persistentBS isEffective = do
         newAccounts <- lift $ Accounts.updateAccountsAtIndex' updAcc accId accounts
         _1 .=! newAccounts
 
+-- | Process cooldowns on accounts that have expired, and move pre-cooldowns into cooldown.
+doProcessCooldowns ::
+    forall pv m.
+    (SupportsPersistentState pv m, PVSupportsFlexibleCooldown pv) =>
+    PersistentBlockState pv ->
+    -- | Timestamp for expiring cooldowns.
+    Timestamp ->
+    -- | Timestamp for pre-cooldowns entering cooldown.
+    Timestamp ->
+    m (PersistentBlockState pv)
+doProcessCooldowns pbs now newExpiry = do
+    bsp <- loadPBS pbs
+    (newAIC, newAccts) <-
+        MTL.execStateT
+            process
+            (bspAccountsInCooldown bsp ^. accountsInCooldown, bspAccounts bsp)
+    storePBS pbs $
+        bsp
+            { bspAccountsInCooldown = AccountsInCooldownForPV (CTrue newAIC),
+              bspAccounts = newAccts
+            }
+  where
+    withCooldown a = (_1 . cooldown .=) =<< a =<< use (_1 . cooldown)
+    withAccounts a = (_2 .=) =<< a =<< use _2
+    process = do
+        cooldown0 <- use (_1 . cooldown)
+        (cooldownList, cooldown1) <- processReleasesUntil now cooldown0
+        _1 . cooldown .= cooldown1
+        forM_ cooldownList $ \acc -> do
+            withAccounts (Accounts.updateAccountsAtIndex' (processCooldownForAccount acc) acc)
+        preCooldownAL <- _1 . preCooldown <<.= Null
+        preCooldowns <- loadAccountList preCooldownAL
+        forM_ preCooldowns $ \acc -> do
+            withAccounts (Accounts.updateAccountsAtIndex' (processPreCooldownForAccount acc) acc)
+    processCooldownForAccount acc pa = do
+        (mNextCooldown, newPA) <- processAccountCooldownsUntil now pa
+        forM_ mNextCooldown $ \nextCooldown -> withCooldown $ addAccountRelease nextCooldown acc
+        return newPA
+    processPreCooldownForAccount acc pa = do
+        (res, newPA) <- processAccountPreCooldown newExpiry pa
+        case res of
+            Just (Just oldTS) -> withCooldown $ updateAccountRelease oldTS newExpiry acc
+            Just Nothing -> withCooldown $ addAccountRelease newExpiry acc
+            Nothing -> return ()
+        return newPA
+
+doProcessPrePreCooldowns ::
+    forall pv m.
+    (SupportsPersistentState pv m, PVSupportsFlexibleCooldown pv) =>
+    PersistentBlockState pv ->
+    m (PersistentBlockState pv)
+doProcessPrePreCooldowns pbs = do
+    bsp <- loadPBS pbs
+    let oldAIC = bspAccountsInCooldown bsp ^. accountsInCooldown
+    let !newPreCooldown = assert (isNull (oldAIC ^. preCooldown)) $ oldAIC ^. prePreCooldown
+    let newAIC =
+            oldAIC
+                & preCooldown .~ newPreCooldown
+                & prePreCooldown .~ Null
+    accounts <- loadAccountList newPreCooldown
+    let processAccount = flip $ Accounts.updateAccountsAtIndex' processAccountPrePreCooldown
+    newAccts <- foldM processAccount (bspAccounts bsp) accounts
+    storePBS pbs $
+        bsp
+            { bspAccountsInCooldown = AccountsInCooldownForPV (CTrue newAIC),
+              bspAccounts = newAccts
+            }
+
 doGetBankStatus :: (SupportsPersistentState pv m) => PersistentBlockState pv -> m Rewards.BankStatus
 doGetBankStatus pbs = _unhashed . bspBank <$> loadPBS pbs
 
@@ -3645,6 +3718,8 @@ instance (IsProtocolVersion pv, PersistentState av pv r m) => BlockStateOperatio
     bsoRotateCurrentEpochBakers = doRotateCurrentEpochBakers
     bsoSetNextEpochBakers = doSetNextEpochBakers
     bsoProcessPendingChanges = doProcessPendingChanges
+    bsoProcessCooldowns = doProcessCooldowns
+    bsoProcessPrePreCooldowns = doProcessPrePreCooldowns
     bsoGetBankStatus = doGetBankStatus
     bsoSetRewardAccounts = doSetRewardAccounts
     bsoIsProtocolUpdateEffective = doIsProtocolUpdateEffective

--- a/concordium-consensus/src/Concordium/Kontrol/Bakers.hs
+++ b/concordium-consensus/src/Concordium/Kontrol/Bakers.hs
@@ -81,11 +81,13 @@ delegatedCapitalCap poolParams totalCap bakerCap delCap = min leverageCap boundC
     PoolCaps{..} = delegatedCapitalCaps poolParams totalCap bakerCap delCap
 
 -- | Process a set of bakers and delegators to apply pending changes that are effective.
-applyPendingChanges ::
+-- This is only relevent for protocol versions which support delegation but not flexible cooldowns
+-- (i.e. P4-P6).
+applyPendingChangesP4 ::
     (Timestamp -> Bool) ->
     ([ActiveBakerInfo' bakerInfoRef], [ActiveDelegatorInfo]) ->
     ([ActiveBakerInfo' bakerInfoRef], [ActiveDelegatorInfo])
-applyPendingChanges isEffective (bakers0, passive0) =
+applyPendingChangesP4 isEffective (bakers0, passive0) =
     foldr
         processBaker
         ([], processDelegators passive0)
@@ -123,6 +125,17 @@ applyPendingChanges isEffective (bakers0, passive0) =
         _ -> (baker{activeBakerDelegators = pDelegators} : bakers, passive)
       where
         pDelegators = processDelegators activeBakerDelegators
+
+-- | Process a set of bakers and delegators to apply pending changes that are effective.
+applyPendingChanges ::
+    AccountVersion ->
+    (Timestamp -> Bool) ->
+    ([ActiveBakerInfo' bakerInfoRef], [ActiveDelegatorInfo]) ->
+    ([ActiveBakerInfo' bakerInfoRef], [ActiveDelegatorInfo])
+applyPendingChanges av
+    -- If the account version supports flexible cooldowns, there are no pending changes to apply.
+    | supportsFlexibleCooldown av = \_ infos -> infos
+    | otherwise = applyPendingChangesP4
 
 -- | Compute the timestamp of the start of an epoch based on the genesis data.
 epochTimestamp :: GenesisConfiguration -> Epoch -> Timestamp
@@ -200,9 +213,11 @@ computeBakerStakesAndCapital poolParams activeBakers passiveDelegators = BakerSt
 
 -- | Generate and set the next epoch bakers and next capital based on the current active bakers.
 generateNextBakers ::
+    forall m.
     ( TreeStateMonad m,
       PVSupportsDelegation (MPV m),
-      ChainParametersVersionFor (MPV m) ~ 'ChainParametersV1
+      ChainParametersVersionFor (MPV m) ~ 'ChainParametersV1,
+      SupportsFlexibleCooldown (AccountVersionFor (MPV m)) ~ 'False
     ) =>
     -- | The payday epoch
     Epoch ->
@@ -214,7 +229,7 @@ generateNextBakers paydayEpoch bs0 = do
     -- stake reductions that are currently pending on active bakers with effective time at
     -- or before the next payday.
     (activeBakers, passiveDelegators) <-
-        applyPendingChanges isEffective
+        applyPendingChangesP4 isEffective
             <$> bsoGetActiveBakersAndDelegators bs0
     -- Note that we use the current value of the pool parameters as of this block.
     -- This should account for any updates that are effective at or before this block.
@@ -311,9 +326,11 @@ timeParametersAtSlot targetSlot tp0 upds =
 getSlotBakersP4 ::
     forall m.
     ( BlockStateQuery m,
+      MonadProtocolVersion m,
       PVSupportsDelegation (MPV m),
       ChainParametersVersionFor (MPV m) ~ 'ChainParametersV1,
-      SeedStateVersionFor (MPV m) ~ 'SeedStateVersion0
+      SeedStateVersionFor (MPV m) ~ 'SeedStateVersion0,
+      SupportsFlexibleCooldown (AccountVersionFor (MPV m)) ~ 'False
     ) =>
     GenesisConfiguration ->
     BlockState m ->
@@ -364,7 +381,7 @@ getSlotBakersP4 genData bs slot =
                             -- stake reductions that are currently pending on active bakers with effective time at
                             -- or before the next payday.
                             (activeBakers, passiveDelegators) <-
-                                applyPendingChanges isEffective
+                                applyPendingChangesP4 isEffective
                                     <$> getActiveBakersAndDelegators bs
                             -- Determine the pool parameters that would be effective the epoch before the payday
                             pendingPoolParams <- getPendingPoolParameters bs
@@ -391,7 +408,7 @@ getSlotBakersP4 genData bs slot =
 --  The given slot should never be earlier than the slot of the given block.
 getSlotBakers ::
     forall m.
-    ( IsProtocolVersion (MPV m),
+    ( MonadProtocolVersion m,
       BlockStateQuery m,
       ConsensusParametersVersionFor (ChainParametersVersionFor (MPV m)) ~ 'ConsensusParametersVersion0
     ) =>

--- a/concordium-consensus/src/Concordium/Scheduler/TreeStateEnvironment.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/TreeStateEnvironment.hs
@@ -1087,7 +1087,8 @@ updateBirkParameters newSeedState bs0 oldChainParameters updates = case protocol
     updateCPV1AccountV1 ::
         ( PVSupportsDelegation (MPV m),
           ChainParametersVersionFor (MPV m) ~ 'ChainParametersV1,
-          SeedStateVersionFor (MPV m) ~ 'SeedStateVersion0
+          SeedStateVersionFor (MPV m) ~ 'SeedStateVersion0,
+          SupportsFlexibleCooldown (AccountVersionFor (MPV m)) ~ 'False
         ) =>
         m (MintRewardParams 'ChainParametersV1, UpdatableBlockState m)
     updateCPV1AccountV1 = do

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/BlockStateHelpers.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/BlockStateHelpers.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
+-- | Common functions for testing operations on the block state.
 module GlobalStateTests.BlockStateHelpers where
 
 import Control.Exception
@@ -57,6 +58,8 @@ dummyCooldownAccount ai amt cooldowns = do
             newEnduring <- refMake =<< SV1.rehashAccountEnduringData ed{SV1.paedStakeCooldown = cq}
             return $ PAV3 acc{SV1.accountEnduringData = newEnduring}
 
+-- | A configuration for an account, specifying the account index, amount, staking details and
+--  cooldowns. This is used to create accounts for testing.
 data AccountConfig (av :: AccountVersion) = AccountConfig
     { acAccountIndex :: AccountIndex,
       acAmount :: Amount,
@@ -65,10 +68,14 @@ data AccountConfig (av :: AccountVersion) = AccountConfig
     }
     deriving (Show)
 
+-- | Helper function for creating the initial stake for an account.
 makePersistentAccountStakeEnduring ::
     (MonadBlobStore m, AVSupportsFlexibleCooldown av, AVSupportsDelegation av, IsAccountVersion av) =>
+    -- | The 'StakeDetails' for the account.
     StakeDetails av ->
+    -- | The account index.
     AccountIndex ->
+    -- | The 'SV1.PersistentAccountStakeEnduring' and the amount staked.
     m (SV1.PersistentAccountStakeEnduring av, Amount)
 makePersistentAccountStakeEnduring StakeDetailsNone _ = return (SV1.PersistentAccountStakeEnduringNone, 0)
 makePersistentAccountStakeEnduring StakeDetailsBaker{..} ai = do

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/BlockStateHelpers.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/BlockStateHelpers.hs
@@ -1,0 +1,197 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module GlobalStateTests.BlockStateHelpers where
+
+import Control.Exception
+import Control.Monad.IO.Class
+import qualified Data.Map.Strict as Map
+import Data.Maybe
+import qualified Data.Set as Set
+import Lens.Micro
+import System.FilePath
+import System.IO.Temp
+import Test.HUnit
+
+import Concordium.Types
+import Concordium.Types.Accounts
+import Concordium.Types.Execution
+import Concordium.Types.Option
+
+import Concordium.GlobalState.Account
+import qualified Concordium.GlobalState.AccountMap.LMDB as LMDBAccountMap
+import Concordium.GlobalState.CooldownQueue
+import qualified Concordium.GlobalState.DummyData as DummyData
+import Concordium.GlobalState.Persistent.Account
+import qualified Concordium.GlobalState.Persistent.Account.CooldownQueue as CooldownQueue
+import qualified Concordium.GlobalState.Persistent.Account.StructureV1 as SV1
+import Concordium.GlobalState.Persistent.Accounts
+import Concordium.GlobalState.Persistent.BlobStore
+import Concordium.GlobalState.Persistent.BlockState
+import qualified Concordium.GlobalState.Persistent.BlockState.Modules as Modules
+import qualified Concordium.GlobalState.Persistent.Cooldown as Cooldown
+import qualified Concordium.GlobalState.Persistent.ReleaseSchedule as ReleaseSchedule
+import qualified Concordium.GlobalState.Persistent.Trie as Trie
+import Concordium.Scheduler.DummyData
+
+import GlobalStateTests.Accounts (NoLoggerT (..), runNoLoggerT)
+
+-- | Construct a dummy account with the specified cooldowns.
+dummyCooldownAccount ::
+    forall av m.
+    (IsAccountVersion av, MonadBlobStore m, AVSupportsFlexibleCooldown av) =>
+    AccountIndex ->
+    Amount ->
+    Cooldowns ->
+    m (PersistentAccount av)
+dummyCooldownAccount ai amt cooldowns = do
+    makeTestAccountFromSeed @av amt (fromIntegral ai) >>= \case
+        PAV3 acc -> do
+            let ed = SV1.enduringData acc
+            cq <- CooldownQueue.makeCooldownQueue cooldowns
+            newEnduring <- refMake =<< SV1.rehashAccountEnduringData ed{SV1.paedStakeCooldown = cq}
+            return $ PAV3 acc{SV1.accountEnduringData = newEnduring}
+
+data AccountConfig (av :: AccountVersion) = AccountConfig
+    { acAccountIndex :: AccountIndex,
+      acAmount :: Amount,
+      acStaking :: StakeDetails av,
+      acCooldowns :: Cooldowns
+    }
+    deriving (Show)
+
+makePersistentAccountStakeEnduring ::
+    (MonadBlobStore m, AVSupportsFlexibleCooldown av, AVSupportsDelegation av, IsAccountVersion av) =>
+    StakeDetails av ->
+    AccountIndex ->
+    m (SV1.PersistentAccountStakeEnduring av, Amount)
+makePersistentAccountStakeEnduring StakeDetailsNone _ = return (SV1.PersistentAccountStakeEnduringNone, 0)
+makePersistentAccountStakeEnduring StakeDetailsBaker{..} ai = do
+    let fulBaker = DummyData.mkFullBaker (fromIntegral ai) (BakerId ai) ^. _1
+    paseBakerInfo <-
+        refMake
+            BakerInfoExV1
+                { _bieBakerInfo = fulBaker ^. bakerInfo,
+                  _bieBakerPoolInfo = poolInfo
+                }
+    return
+        ( SV1.PersistentAccountStakeEnduringBaker
+            { paseBakerRestakeEarnings = sdRestakeEarnings,
+              paseBakerPendingChange = NoChange,
+              ..
+            },
+          sdStakedCapital
+        )
+  where
+    poolInfo =
+        BakerPoolInfo
+            { _poolOpenStatus = OpenForAll,
+              _poolMetadataUrl = UrlText "Some URL",
+              _poolCommissionRates =
+                CommissionRates
+                    { _finalizationCommission = makeAmountFraction 50_000,
+                      _bakingCommission = makeAmountFraction 50_000,
+                      _transactionCommission = makeAmountFraction 50_000
+                    }
+            }
+makePersistentAccountStakeEnduring StakeDetailsDelegator{..} ai = do
+    return
+        ( SV1.PersistentAccountStakeEnduringDelegator
+            { paseDelegatorId = DelegatorId ai,
+              paseDelegatorRestakeEarnings = sdRestakeEarnings,
+              paseDelegatorTarget = sdDelegationTarget,
+              paseDelegatorPendingChange = NoChange
+            },
+          sdStakedCapital
+        )
+
+-- | Create a dummy 'PersistentAccount' from an 'AccountConfig'.
+makeDummyAccount ::
+    forall av m.
+    ( IsAccountVersion av,
+      MonadBlobStore m,
+      SupportsFlexibleCooldown av ~ 'True
+    ) =>
+    AccountConfig av ->
+    m (PersistentAccount av)
+makeDummyAccount AccountConfig{..} = do
+    makeTestAccountFromSeed @av acAmount (fromIntegral acAccountIndex) >>= \case
+        PAV3 acc -> do
+            let ed = SV1.enduringData acc
+            cq <- CooldownQueue.makeCooldownQueue acCooldowns
+            (staking, stakeAmount) <- makePersistentAccountStakeEnduring acStaking acAccountIndex
+            newEnduring <-
+                refMake
+                    =<< SV1.rehashAccountEnduringData
+                        ed{SV1.paedStakeCooldown = cq, SV1.paedStake = staking}
+            return $
+                PAV3
+                    acc{SV1.accountEnduringData = newEnduring, SV1.accountStakedAmount = stakeAmount}
+
+-- | Run a block state computation using a temporary directory for the blob store and account map.
+runTestBlockState ::
+    forall pv a.
+    PersistentBlockStateMonad
+        pv
+        (PersistentBlockStateContext pv)
+        (BlobStoreT (PersistentBlockStateContext pv) (NoLoggerT IO))
+        a ->
+    IO a
+runTestBlockState kont = withTempDirectory "." "blockstate" $ \dir -> do
+    bracket
+        ( do
+            pbscBlobStore <- createBlobStore (dir </> "blockstate.dat")
+            pbscAccountCache <- newAccountCache 100
+            pbscModuleCache <- Modules.newModuleCache 100
+            pbscAccountMap <- LMDBAccountMap.openDatabase (dir </> "accountmap")
+            return PersistentBlockStateContext{..}
+        )
+        ( \PersistentBlockStateContext{..} -> do
+            closeBlobStore pbscBlobStore
+            LMDBAccountMap.closeDatabase pbscAccountMap
+        )
+        (runNoLoggerT . runBlobStoreT (runPersistentBlockStateMonad kont))
+
+-- | Get the 'Cooldowns' for each account, and check that the indexes for cooldowns, pre-cooldowns
+--  and pre-pre-cooldowns are correct.
+checkCooldowns :: (PVSupportsFlexibleCooldown pv, SupportsPersistentState pv m) => PersistentBlockState pv -> m [Cooldowns]
+checkCooldowns pbs = do
+    bsp <- loadPBS pbs
+    (_, theCooldowns, cooldownMap, preCooldowns, prePreCooldowns) <-
+        foldAccounts
+            ( \(!ai, accum, cooldownMap, preCooldowns, prePreCooldowns) pa -> do
+                cd <- fromMaybe emptyCooldowns <$> accountCooldowns pa
+                let newCooldowns = cd : accum
+                let newCooldownMap = case Map.lookupMin (inCooldown cd) of
+                        Nothing -> cooldownMap
+                        Just (ts, _) ->
+                            Map.alter
+                                ( \case
+                                    Nothing -> Just (Set.singleton ai)
+                                    Just s -> Just (Set.insert ai s)
+                                )
+                                ts
+                                cooldownMap
+                let newPreCooldowns = case preCooldown cd of
+                        Absent -> preCooldowns
+                        Present _ -> Set.insert ai preCooldowns
+                let newPrePreCooldowns = case prePreCooldown cd of
+                        Absent -> prePreCooldowns
+                        Present _ -> Set.insert ai prePreCooldowns
+                return (ai + 1, newCooldowns, newCooldownMap, newPreCooldowns, newPrePreCooldowns)
+            )
+            (AccountIndex 0, [], Map.empty, Set.empty, Set.empty)
+            (bspAccounts bsp)
+    let aic = bspAccountsInCooldown bsp ^. Cooldown.accountsInCooldown
+    actualCooldownMap <- Trie.toMap (ReleaseSchedule.nrsMap $ aic ^. Cooldown.cooldown)
+    liftIO $ assertEqual "Cooldown map" cooldownMap (ReleaseSchedule.theAccountSet <$> actualCooldownMap)
+    actualPreCooldowns <- Set.fromList <$> Cooldown.loadAccountList (aic ^. Cooldown.preCooldown)
+    liftIO $ assertEqual "Pre-cooldown set" preCooldowns actualPreCooldowns
+    actualPrePreCooldowns <- Set.fromList <$> Cooldown.loadAccountList (aic ^. Cooldown.prePreCooldown)
+    liftIO $ assertEqual "Pre-pre-cooldown set" prePreCooldowns actualPrePreCooldowns
+    return (reverse theCooldowns)

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/CooldownProcessing.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/CooldownProcessing.hs
@@ -1,0 +1,93 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | This module tests the processing of cooldowns in the global state.
+--  Specifically, it tests the 'bsoProcessPrePreCooldowns' and 'bsoProcessCooldowns' functions.
+module GlobalStateTests.CooldownProcessing where
+
+import Control.Monad.IO.Class
+import Test.HUnit
+import Test.Hspec
+import Test.QuickCheck
+
+import qualified Concordium.Crypto.SHA256 as Hash
+import Concordium.Types
+import Concordium.Types.Option
+import Concordium.Types.SeedState
+
+import Concordium.GlobalState.BlockState
+import Concordium.GlobalState.CooldownQueue
+import qualified Concordium.GlobalState.DummyData as DummyData
+import Concordium.GlobalState.Persistent.BlockState
+
+import GlobalStateTests.Accounts ()
+import GlobalStateTests.BlockStateHelpers
+import GlobalStateTests.CooldownQueue (genCooldowns)
+
+-- | Test 'bsoProcessCooldowns' with a state where the account cooldowns are as given.
+propProcessPrePreCooldowns :: [Cooldowns] -> Assertion
+propProcessPrePreCooldowns cds = runTestBlockState @P7 $ do
+    let mkAcct (i, cd) = dummyCooldownAccount i (cooldownTotal cd + 1000) cd
+    initialAccts <- mapM mkAcct (zip [0 ..] cds)
+    initialBS <-
+        initialPersistentState
+            (initialSeedStateV1 (Hash.hash "NONCE") 1000)
+            DummyData.dummyCryptographicParameters
+            initialAccts
+            DummyData.dummyIdentityProviders
+            DummyData.dummyArs
+            DummyData.dummyKeyCollection
+            DummyData.dummyChainParameters
+    bs' <- bsoProcessPrePreCooldowns (hpbsPointers initialBS)
+    newCooldowns <- checkCooldowns bs'
+    liftIO $ assertEqual "Cooldowns" (processPrePreCooldown <$> cds) newCooldowns
+
+propProcessCooldowns :: [Cooldowns] -> Timestamp -> Timestamp -> Assertion
+propProcessCooldowns cds expire new = runTestBlockState @P7 $ do
+    let mkAcct (i, cd) = dummyCooldownAccount i (cooldownTotal cd + 1000) cd
+    initialAccts <- mapM mkAcct (zip [0 ..] cds)
+    initialBS <-
+        initialPersistentState
+            (initialSeedStateV1 (Hash.hash "NONCE") 1000)
+            DummyData.dummyCryptographicParameters
+            initialAccts
+            DummyData.dummyIdentityProviders
+            DummyData.dummyArs
+            DummyData.dummyKeyCollection
+            DummyData.dummyChainParameters
+    bs' <- bsoProcessCooldowns (hpbsPointers initialBS) expire new
+    newCooldowns <- checkCooldowns bs'
+    liftIO $ assertEqual "Cooldowns" (processPreCooldown new . processCooldowns expire <$> cds) newCooldowns
+
+-- | Generate a 'Cooldowns' with no pre-cooldown.
+genCooldownsNoPre :: Gen Cooldowns
+genCooldownsNoPre = do
+    cooldown <- genCooldowns
+    return cooldown{preCooldown = Absent}
+
+-- | Test 'bsoProcessPrePreCooldowns'.
+testProcessPrePreCooldowns :: Spec
+testProcessPrePreCooldowns = do
+    it "10 accounts, no cooldowns" $ propProcessPrePreCooldowns (replicate 10 emptyCooldowns)
+    it "5 accounts no cooldowns, 5 accounts with pre-pre-cooldown" $
+        propProcessPrePreCooldowns $
+            replicate 5 emptyCooldowns ++ replicate 5 (emptyCooldowns{prePreCooldown = Present 1000})
+    it "accounts with arbitray cooldowns (but no pre-cooldown)" $
+        forAll (listOf genCooldownsNoPre) propProcessPrePreCooldowns
+
+-- | Test 'bsoProcessCooldowns'.
+testProcessCooldowns :: Spec
+testProcessCooldowns = do
+    it "accounts with arbitrary cooldowns" $
+        forAll (listOf genCooldowns) $ \cds -> do
+            forAll arbitrary $ \expire ->
+                forAll arbitrary $ \new ->
+                    propProcessCooldowns cds (Timestamp expire) (Timestamp new)
+
+tests :: Spec
+tests = describe "CooldownProcessing" $ do
+    describe "bsoProcessPrePreCooldowns" testProcessPrePreCooldowns
+    describe "bsoProcessCooldowns" testProcessCooldowns

--- a/concordium-consensus/tests/globalstate/Spec.hs
+++ b/concordium-consensus/tests/globalstate/Spec.hs
@@ -11,6 +11,7 @@ import qualified GlobalStateTests.AccountsMigrationP6ToP7 (tests)
 import qualified GlobalStateTests.BlobStore (tests)
 import qualified GlobalStateTests.BlockHash (tests)
 import qualified GlobalStateTests.Cache (tests)
+import qualified GlobalStateTests.CooldownProcessing (tests)
 import qualified GlobalStateTests.CooldownQueue (tests)
 import qualified GlobalStateTests.DifferenceMap (tests)
 import qualified GlobalStateTests.EnduringDataFlags (tests)
@@ -57,3 +58,4 @@ main = atLevel $ \lvl -> hspec $ do
     GlobalStateTests.AccountsMigrationP6ToP7.tests
     GlobalStateTests.AccountList.tests
     GlobalStateTests.CooldownQueue.tests
+    GlobalStateTests.CooldownProcessing.tests

--- a/concordium-consensus/tests/scheduler/SchedulerTests/KonsensusV1/EpochTransition.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/KonsensusV1/EpochTransition.hs
@@ -1,0 +1,688 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module SchedulerTests.KonsensusV1.EpochTransition where
+
+import Control.Exception
+import Control.Monad.IO.Class
+import qualified Data.Map.Strict as Map
+import Data.Maybe
+import qualified Data.Set as Set
+import Lens.Micro
+import System.FilePath
+import System.IO.Temp
+import Test.HUnit
+import Test.Hspec
+import Test.QuickCheck
+
+import qualified Concordium.Crypto.SHA256 as Hash
+import Concordium.Logger
+import Concordium.Types
+import Concordium.Types.Option
+import Concordium.Types.SeedState
+
+import Concordium.GlobalState.Account
+import qualified Concordium.GlobalState.AccountMap.LMDB as LMDBAccountMap
+import Concordium.GlobalState.BakerInfo
+import Concordium.GlobalState.BlockState
+import Concordium.GlobalState.CooldownQueue
+import qualified Concordium.GlobalState.DummyData as DummyData
+import Concordium.GlobalState.Persistent.Account
+import qualified Concordium.GlobalState.Persistent.Account.CooldownQueue as CooldownQueue
+import qualified Concordium.GlobalState.Persistent.Account.StructureV1 as SV1
+import Concordium.GlobalState.Persistent.Accounts
+import Concordium.GlobalState.Persistent.BlobStore
+import Concordium.GlobalState.Persistent.BlockState
+import qualified Concordium.GlobalState.Persistent.BlockState.Modules as Modules
+import qualified Concordium.GlobalState.Persistent.Cooldown as Cooldown
+import qualified Concordium.GlobalState.Persistent.ReleaseSchedule as ReleaseSchedule
+import qualified Concordium.GlobalState.Persistent.Trie as Trie
+import Concordium.GlobalState.Types
+import Concordium.KonsensusV1.Scheduler
+import Concordium.Kontrol.Bakers
+import Concordium.Scheduler.DummyData
+import Concordium.Types.Accounts
+import Concordium.Types.Execution
+import Concordium.Types.Parameters
+import Control.Monad
+import qualified Data.Vector as Vec
+
+dummyCooldownAccount ::
+    forall av m.
+    (IsAccountVersion av, MonadBlobStore m, AVSupportsFlexibleCooldown av) =>
+    AccountIndex ->
+    Amount ->
+    Cooldowns ->
+    m (PersistentAccount av)
+dummyCooldownAccount ai amt cooldowns = do
+    makeTestAccountFromSeed @av amt (fromIntegral ai) >>= \case
+        PAV3 acc -> do
+            let ed = SV1.enduringData acc
+            cq <- CooldownQueue.makeCooldownQueue cooldowns
+            newEnduring <- refMake =<< SV1.rehashAccountEnduringData ed{SV1.paedStakeCooldown = cq}
+            return $ PAV3 acc{SV1.accountEnduringData = newEnduring}
+
+runTestBlockState ::
+    forall pv a.
+    PersistentBlockStateMonad
+        pv
+        (PersistentBlockStateContext pv)
+        (BlobStoreT (PersistentBlockStateContext pv) (LoggerT IO))
+        a ->
+    IO a
+runTestBlockState kont = withTempDirectory "." "blockstate" $ \dir -> do
+    bracket
+        ( do
+            pbscBlobStore <- createBlobStore (dir </> "blockstate.dat")
+            pbscAccountCache <- newAccountCache 100
+            pbscModuleCache <- Modules.newModuleCache 100
+            pbscAccountMap <- LMDBAccountMap.openDatabase (dir </> "accountmap")
+            return PersistentBlockStateContext{..}
+        )
+        ( \PersistentBlockStateContext{..} -> do
+            closeBlobStore pbscBlobStore
+            LMDBAccountMap.closeDatabase pbscAccountMap
+        )
+        (runSilentLogger . runBlobStoreT (runPersistentBlockStateMonad kont))
+
+-- | Get the 'Cooldowns' for each account, and check that the indexes for cooldowns, pre-cooldowns
+--  and pre-pre-cooldowns are correct.
+checkCooldowns :: (PVSupportsFlexibleCooldown pv, SupportsPersistentState pv m) => PersistentBlockState pv -> m [Cooldowns]
+checkCooldowns pbs = do
+    bsp <- loadPBS pbs
+    (_, theCooldowns, cooldownMap, preCooldowns, prePreCooldowns) <-
+        foldAccounts
+            ( \(!ai, accum, cooldownMap, preCooldowns, prePreCooldowns) pa -> do
+                cd <- fromMaybe emptyCooldowns <$> accountCooldowns pa
+                let newCooldowns = cd : accum
+                let newCooldownMap = case Map.lookupMin (inCooldown cd) of
+                        Nothing -> cooldownMap
+                        Just (ts, _) ->
+                            Map.alter
+                                ( \case
+                                    Nothing -> Just (Set.singleton ai)
+                                    Just s -> Just (Set.insert ai s)
+                                )
+                                ts
+                                cooldownMap
+                let newPreCooldowns = case preCooldown cd of
+                        Absent -> preCooldowns
+                        Present _ -> Set.insert ai preCooldowns
+                let newPrePreCooldowns = case prePreCooldown cd of
+                        Absent -> prePreCooldowns
+                        Present _ -> Set.insert ai prePreCooldowns
+                return (ai + 1, newCooldowns, newCooldownMap, newPreCooldowns, newPrePreCooldowns)
+            )
+            (AccountIndex 0, [], Map.empty, Set.empty, Set.empty)
+            (bspAccounts bsp)
+    let aic = bspAccountsInCooldown bsp ^. Cooldown.accountsInCooldown
+    actualCooldownMap <- Trie.toMap (ReleaseSchedule.nrsMap $ aic ^. Cooldown.cooldown)
+    liftIO $ assertEqual "Cooldown map" cooldownMap (ReleaseSchedule.theAccountSet <$> actualCooldownMap)
+    actualPreCooldowns <- Set.fromList <$> Cooldown.loadAccountList (aic ^. Cooldown.preCooldown)
+    liftIO $ assertEqual "Pre-cooldown set" preCooldowns actualPreCooldowns
+    actualPrePreCooldowns <- Set.fromList <$> Cooldown.loadAccountList (aic ^. Cooldown.prePreCooldown)
+    liftIO $ assertEqual "Pre-pre-cooldown set" prePreCooldowns actualPrePreCooldowns
+    return (reverse theCooldowns)
+
+data AccountConfig (av :: AccountVersion) = AccountConfig
+    { acAccountIndex :: AccountIndex,
+      acAmount :: Amount,
+      acInitialStaking :: StakeDetails av,
+      acUpdatedStaking :: StakeDetails av,
+      acCooldowns :: Cooldowns
+    }
+    deriving (Show)
+
+-- | Generate a list of 'AccountConfig's such that:
+--
+--    * The initial staking includes at least one baker, and there are no delegators to invalid bakers.
+--    * The updated staking includes at least one baker, and there are no delegators to invalid bakers.
+--    * The amounts on the account are consistent with the active and inactive stake.
+--    * The cooldowns only include pre-cooldowns if the 'allowPreCooldown' flag is set.
+genAccountConfigs :: (AVSupportsDelegation av) => Bool -> Gen [AccountConfig av]
+genAccountConfigs allowPreCooldown = sized $ \n -> do
+    let accs = [AccountIndex 0 .. fromIntegral (max 0 n)]
+    let chooseBakers = do
+            bkrs <- sublistOf accs
+            if null bkrs
+                then (: []) <$> elements accs
+                else return bkrs
+    initBakers <- chooseBakers
+    updBakers <- chooseBakers
+    let genBakerStakeDetails sdStakedCapital = do
+            sdRestakeEarnings <- arbitrary
+            let sdPendingChange = NoChange
+            return StakeDetailsBaker{..}
+        genDelegatorStakeDetails sdStakedCapital bakers = do
+            sdRestakeEarnings <- arbitrary
+            sdDelegationTarget <-
+                oneof
+                    [ pure DelegatePassive,
+                      DelegateToBaker . BakerId <$> elements bakers
+                    ]
+            let sdPendingChange = NoChange
+            return StakeDetailsDelegator{..}
+        genCooldowns = do
+            inCooldown <- Map.fromList <$> listOf (((,) . Timestamp <$> arbitrary) <*> arbitrary)
+            preCooldown <-
+                if allowPreCooldown
+                    then oneof [return Absent, Present <$> arbitrary]
+                    else return Absent
+            prePreCooldown <- oneof [return Absent, Present <$> arbitrary]
+            return Cooldowns{..}
+        genAcc acAccountIndex = do
+            initStakeAmount <- Amount <$> choose (1_000_000, 1_000_000_000)
+            acInitialStaking <-
+                if acAccountIndex `elem` initBakers
+                    then genBakerStakeDetails initStakeAmount
+                    else
+                        oneof
+                            [ genDelegatorStakeDetails initStakeAmount initBakers,
+                              pure StakeDetailsNone
+                            ]
+            updatedStakeAmount <- Amount <$> choose (1_000_000, 1_000_000_000)
+            acUpdatedStaking <-
+                if acAccountIndex `elem` updBakers
+                    then genBakerStakeDetails updatedStakeAmount
+                    else
+                        oneof
+                            [ genDelegatorStakeDetails updatedStakeAmount updBakers,
+                              pure StakeDetailsNone
+                            ]
+            acCooldowns <- genCooldowns
+            bonusAmount <- Amount <$> choose (0, 1_000_000_000)
+            let acAmount = cooldownTotal acCooldowns + updatedStakeAmount + bonusAmount
+            return AccountConfig{..}
+    mapM genAcc accs
+
+makePersistentAccountStakeEnduring ::
+    (MonadBlobStore m, AVSupportsFlexibleCooldown av, AVSupportsDelegation av, IsAccountVersion av) =>
+    StakeDetails av ->
+    AccountIndex ->
+    m (SV1.PersistentAccountStakeEnduring av, Amount)
+makePersistentAccountStakeEnduring StakeDetailsNone _ = return (SV1.PersistentAccountStakeEnduringNone, 0)
+makePersistentAccountStakeEnduring StakeDetailsBaker{..} ai = do
+    let (fulBaker, _, _, _) = DummyData.mkFullBaker (fromIntegral ai) (BakerId ai)
+    paseBakerInfo <-
+        refMake
+            BakerInfoExV1
+                { _bieBakerInfo = fulBaker ^. bakerInfo,
+                  _bieBakerPoolInfo = poolInfo
+                }
+    return
+        ( SV1.PersistentAccountStakeEnduringBaker
+            { paseBakerRestakeEarnings = sdRestakeEarnings,
+              paseBakerPendingChange = NoChange,
+              ..
+            },
+          sdStakedCapital
+        )
+  where
+    poolInfo =
+        BakerPoolInfo
+            { _poolOpenStatus = OpenForAll,
+              _poolMetadataUrl = UrlText "Some URL",
+              _poolCommissionRates =
+                CommissionRates
+                    { _finalizationCommission = makeAmountFraction 50_000,
+                      _bakingCommission = makeAmountFraction 50_000,
+                      _transactionCommission = makeAmountFraction 50_000
+                    }
+            }
+makePersistentAccountStakeEnduring StakeDetailsDelegator{..} ai = do
+    return
+        ( SV1.PersistentAccountStakeEnduringDelegator
+            { paseDelegatorId = DelegatorId ai,
+              paseDelegatorRestakeEarnings = sdRestakeEarnings,
+              paseDelegatorTarget = sdDelegationTarget,
+              paseDelegatorPendingChange = NoChange
+            },
+          sdStakedCapital
+        )
+
+-- | Create a dummy 'PersistentAccount' from an 'AccountConfig'.
+makeDummyAccount ::
+    forall av m.
+    ( IsAccountVersion av,
+      MonadBlobStore m,
+      AVSupportsFlexibleCooldown av,
+      AVSupportsDelegation av
+    ) =>
+    AccountConfig av ->
+    m (PersistentAccount av)
+makeDummyAccount AccountConfig{..} = do
+    makeTestAccountFromSeed @av acAmount (fromIntegral acAccountIndex) >>= \case
+        PAV3 acc -> do
+            let ed = SV1.enduringData acc
+            cq <- CooldownQueue.makeCooldownQueue acCooldowns
+            (staking, stakeAmount) <- makePersistentAccountStakeEnduring acInitialStaking acAccountIndex
+            newEnduring <-
+                refMake
+                    =<< SV1.rehashAccountEnduringData
+                        ed{SV1.paedStakeCooldown = cq, SV1.paedStake = staking}
+            return $
+                PAV3
+                    acc{SV1.accountEnduringData = newEnduring, SV1.accountStakedAmount = stakeAmount}
+
+-- | Construct an initial state for testing based on the account configuration provided.
+makeInitialState ::
+    forall pv m.
+    ( SupportsPersistentState pv m,
+      PVSupportsFlexibleCooldown pv,
+      IsConsensusV1 pv,
+      BlockStateOperations m,
+      UpdatableBlockState m ~ PersistentBlockState pv,
+      IsSupported 'PTTimeParameters (ChainParametersVersionFor pv) ~ 'True
+    ) =>
+    -- | Initial configuration of accounts.
+    [AccountConfig (AccountVersionFor pv)] ->
+    -- | Initial seed state.
+    SeedState (SeedStateVersionFor pv) ->
+    -- | Length of the reward period.
+    RewardPeriodLength ->
+    m (PersistentBlockState pv)
+makeInitialState accs seedState rpLen = withIsAuthorizationsVersionForPV (protocolVersion @pv) $ do
+    initialAccounts <- mapM makeDummyAccount accs
+    let chainParams :: ChainParameters pv
+        chainParams = DummyData.dummyChainParameters & cpTimeParameters . tpRewardPeriodLength .~ rpLen
+    initialBS <-
+        initialPersistentState
+            seedState
+            DummyData.dummyCryptographicParameters
+            initialAccounts
+            DummyData.dummyIdentityProviders
+            DummyData.dummyArs
+            DummyData.dummyKeyCollection
+            chainParams
+    let pbs0 = hpbsPointers initialBS
+    (activeBakers, passiveDelegators) <- bsoGetActiveBakersAndDelegators pbs0
+    let BakerStakesAndCapital{..} = computeBakerStakesAndCapital (chainParams ^. cpPoolParameters) activeBakers passiveDelegators
+    pbs1 <- bsoSetNextEpochBakers pbs0 bakerStakes (chainParams ^. cpFinalizationCommitteeParameters)
+    capDist <- capitalDistributionM
+    pbs2 <- bsoSetNextCapitalDistribution pbs1 capDist
+    pbs <- bsoRotateCurrentCapitalDistribution =<< bsoRotateCurrentEpochBakers pbs2
+
+    bsp <- loadPBS pbs
+    -- Now we update the accounts with the updated staking information.
+    let
+        updateAccountStake ::
+            AccountConfig (AccountVersionFor pv) ->
+            PersistentAccount (AccountVersionFor pv) ->
+            m (PersistentAccount (AccountVersionFor pv))
+        updateAccountStake AccountConfig{..} (PAV3 pa) = do
+            (staking, newStakeAmount) <- makePersistentAccountStakeEnduring acUpdatedStaking acAccountIndex
+            let ed = SV1.enduringData pa
+            newEnduring <- refMake =<< SV1.rehashAccountEnduringData ed{SV1.paedStake = staking}
+            return $ PAV3 pa{SV1.accountEnduringData = newEnduring, SV1.accountStakedAmount = newStakeAmount}
+    newAccounts <-
+        foldM
+            (\a ac -> updateAccountsAtIndex' (updateAccountStake ac) (acAccountIndex ac) a)
+            (bspAccounts bsp)
+            accs
+    accts <- foldAccountsDesc (\l acc -> return (acc : l)) [] newAccounts
+    newBirkParameters <- initialBirkParameters accts seedState (chainParams ^. cpFinalizationCommitteeParameters)
+    storePBS pbs bsp{bspAccounts = newAccounts, bspBirkParameters = newBirkParameters}
+
+transitionalSeedState :: Epoch -> Timestamp -> SeedState SeedStateVersion1
+transitionalSeedState curEpoch triggerTime =
+    (initialSeedStateV1 (Hash.hash "NONCE") triggerTime)
+        { ss1Epoch = curEpoch,
+          ss1EpochTransitionTriggered = True
+        }
+
+-- | Test an epoch transition with no payday or snapshot.
+testEpochTransitionNoPaydayNoSnapshot :: [AccountConfig 'AccountV3] -> Assertion
+testEpochTransitionNoPaydayNoSnapshot accountConfigs = runTestBlockState @P7 $ do
+    bs0 <- makeInitialState accountConfigs (transitionalSeedState startEpoch startTriggerTime) 2
+    initCapDist <- bsoGetCurrentCapitalDistribution bs0
+    initBakers <- bsoGetCurrentEpochFullBakersEx bs0
+    bs1 <- bsoSetPaydayEpoch bs0 (startEpoch + 10)
+    (mPaydayParams, resState) <- doEpochTransition True hour bs1
+    liftIO $ assertEqual "Payday parameters" Nothing mPaydayParams
+    newCooldowns <- checkCooldowns resState
+    liftIO $ assertEqual "Cooldowns should be unchanged" (map acCooldowns accountConfigs) newCooldowns
+    ss <- bsoGetSeedState resState
+    case ss of
+        SeedStateV1{..} -> liftIO $ do
+            assertEqual "Epoch should be updated" (startEpoch + 1) ss1Epoch
+            assertEqual
+                "Trigger time should be updated"
+                (addDuration startTriggerTime hour)
+                ss1TriggerBlockTime
+            assertEqual
+                "Epoch transition should no longer be triggered"
+                False
+                ss1EpochTransitionTriggered
+    finalCapDist <- bsoGetCurrentCapitalDistribution resState
+    liftIO $ assertEqual "Capital distribution should be unchanged" initCapDist finalCapDist
+    finalBakers <- bsoGetCurrentEpochFullBakersEx resState
+    liftIO $ assertEqual "Bakers should be unchanged" initBakers finalBakers
+    updBakers <- bsoRotateCurrentCapitalDistribution =<< bsoRotateCurrentEpochBakers resState
+    finalNECapDist <- bsoGetCurrentCapitalDistribution updBakers
+    liftIO $ assertEqual "Next-epoch capital distribution should be unchanged" initCapDist finalNECapDist
+    finalNEBakers <- bsoGetCurrentEpochFullBakersEx updBakers
+    liftIO $ assertEqual "Next-epoch bakers should be unchanged" initBakers finalNEBakers
+  where
+    hour = Duration 3_600_000
+    startEpoch = 10
+    startTriggerTime = 1000
+
+-- | Test a payday epoch transition.
+testEpochTransitionPaydayOnly :: [AccountConfig 'AccountV3] -> Assertion
+testEpochTransitionPaydayOnly accountConfigs = runTestBlockState @P7 $ do
+    bs0 <- makeInitialState accountConfigs (transitionalSeedState startEpoch startTriggerTime) 2
+    initCapDist <- bsoGetCurrentCapitalDistribution bs0
+    initBakers <- bsoGetCurrentEpochFullBakersEx bs0
+    bs1 <- bsoSetPaydayEpoch bs0 (startEpoch + 1)
+    (mPaydayParams, resState) <- doEpochTransition True hour bs1
+    liftIO $ case mPaydayParams of
+        Just PaydayParameters{..} -> do
+            assertEqual "Payday capital distribution" initCapDist paydayCapitalDistribution
+            assertEqual "Payday bakers" initBakers paydayBakers
+        Nothing -> do
+            assertFailure "Expected payday parameters"
+    newCooldowns <- checkCooldowns resState
+    let processCooldownAtPayday =
+            processPreCooldown (startTriggerTime `addDurationSeconds` cooldownDuration)
+                . processCooldowns startTriggerTime
+    liftIO $
+        assertEqual
+            "Expired cooldowns should be processed and pre-cooldowns should be moved to cooldowns"
+            (map (processCooldownAtPayday . acCooldowns) accountConfigs)
+            newCooldowns
+    ss <- bsoGetSeedState resState
+    case ss of
+        SeedStateV1{..} -> liftIO $ do
+            assertEqual "Epoch should be updated" (startEpoch + 1) ss1Epoch
+            assertEqual
+                "Trigger time should be updated"
+                (addDuration startTriggerTime hour)
+                ss1TriggerBlockTime
+            assertEqual
+                "Epoch transition should no longer be triggered"
+                False
+                ss1EpochTransitionTriggered
+    finalCapDist <- bsoGetCurrentCapitalDistribution resState
+    liftIO $ assertEqual "Capital distribution should be unchanged" initCapDist finalCapDist
+    finalBakers <- bsoGetCurrentEpochFullBakersEx resState
+    liftIO $ assertEqual "Bakers should be unchanged" initBakers finalBakers
+    updBakers <- bsoRotateCurrentCapitalDistribution =<< bsoRotateCurrentEpochBakers resState
+    finalNECapDist <- bsoGetCurrentCapitalDistribution updBakers
+    liftIO $ assertEqual "Next-epoch capital distribution should be unchanged" initCapDist finalNECapDist
+    finalNEBakers <- bsoGetCurrentEpochFullBakersEx updBakers
+    liftIO $ assertEqual "Next-epoch bakers should be unchanged" initBakers finalNEBakers
+  where
+    hour = Duration 3_600_000
+    startEpoch = 10
+    startTriggerTime = 1000
+    cooldownDuration =
+        DummyData.dummyChainParameters @ChainParametersV2
+            ^. cpCooldownParameters . cpUnifiedCooldown
+
+-- | Test an snapshot epoch transition.
+testEpochTransitionSnapshotOnly :: [AccountConfig 'AccountV3] -> Assertion
+testEpochTransitionSnapshotOnly accountConfigs = runTestBlockState @P7 $ do
+    bs0 <- makeInitialState accountConfigs (transitionalSeedState startEpoch startTriggerTime) 2
+    initCapDist <- bsoGetCurrentCapitalDistribution bs0
+    initBakers <- bsoGetCurrentEpochFullBakersEx bs0
+    bs1 <- bsoSetPaydayEpoch bs0 (startEpoch + 2)
+    (activeBakers, activeDelegators) <- bsoGetActiveBakersAndDelegators bs1
+    let BakerStakesAndCapital{..} =
+            computeBakerStakesAndCapital
+                (chainParams ^. cpPoolParameters)
+                activeBakers
+                activeDelegators
+    updatedCapitalDistr <- capitalDistributionM
+    let mkFullBaker (ref, stake) = do
+            loadPersistentBakerInfoRef @_ @'AccountV3 ref <&> \case
+                (BakerInfoExV1 info extra) ->
+                    FullBakerInfoEx
+                        { _exFullBakerInfo = FullBakerInfo info stake,
+                          _bakerPoolCommissionRates = extra ^. poolCommissionRates
+                        }
+    bkrs <- mapM mkFullBaker bakerStakes
+    let updatedBakerStakes = FullBakersEx (Vec.fromList bkrs) (sum $ snd <$> bakerStakes)
+
+    (mPaydayParams, resState) <- doEpochTransition True hour bs1
+    liftIO $ assertEqual "Payday parameters" Nothing mPaydayParams
+    newCooldowns <- checkCooldowns resState
+    liftIO $
+        assertEqual
+            "Expired cooldowns should be processed and pre-cooldowns should be moved to cooldowns"
+            (map (processPrePreCooldown . acCooldowns) accountConfigs)
+            newCooldowns
+    ss <- bsoGetSeedState resState
+    case ss of
+        SeedStateV1{..} -> liftIO $ do
+            assertEqual "Epoch should be updated" (startEpoch + 1) ss1Epoch
+            assertEqual
+                "Trigger time should be updated"
+                (addDuration startTriggerTime hour)
+                ss1TriggerBlockTime
+            assertEqual
+                "Epoch transition should no longer be triggered"
+                False
+                ss1EpochTransitionTriggered
+    finalCapDist <- bsoGetCurrentCapitalDistribution resState
+    liftIO $ assertEqual "Capital distribution should be unchanged" initCapDist finalCapDist
+    finalBakers <- bsoGetCurrentEpochFullBakersEx resState
+    liftIO $ assertEqual "Bakers should be unchanged" initBakers finalBakers
+    updBakers <- bsoRotateCurrentCapitalDistribution =<< bsoRotateCurrentEpochBakers resState
+    finalNECapDist <- bsoGetCurrentCapitalDistribution updBakers
+    liftIO $ assertEqual "Next-epoch capital distribution should be updated" updatedCapitalDistr finalNECapDist
+    finalNEBakers <- bsoGetCurrentEpochFullBakersEx updBakers
+    liftIO $ assertEqual "Next-epoch bakers should be updated" updatedBakerStakes finalNEBakers
+  where
+    hour = Duration 3_600_000
+    startEpoch = 10
+    startTriggerTime = 1000
+    chainParams = DummyData.dummyChainParameters @ChainParametersV2
+
+-- | Test two successive epoch transitions where the first is a snapshot and the second is a payday.
+testEpochTransitionSnapshotPayday :: [AccountConfig 'AccountV3] -> Assertion
+testEpochTransitionSnapshotPayday accountConfigs = runTestBlockState @P7 $ do
+    bs0 <- makeInitialState accountConfigs (transitionalSeedState startEpoch startTriggerTime) 2
+    initCapDist <- bsoGetCurrentCapitalDistribution bs0
+    initBakers <- bsoGetCurrentEpochFullBakersEx bs0
+    bs1 <- bsoSetPaydayEpoch bs0 (startEpoch + 2)
+    (activeBakers, activeDelegators) <- bsoGetActiveBakersAndDelegators bs1
+    let BakerStakesAndCapital{..} =
+            computeBakerStakesAndCapital
+                (chainParams ^. cpPoolParameters)
+                activeBakers
+                activeDelegators
+    updatedCapitalDistr <- capitalDistributionM
+    let mkFullBaker (ref, stake) = do
+            loadPersistentBakerInfoRef @_ @'AccountV3 ref <&> \case
+                (BakerInfoExV1 info extra) ->
+                    FullBakerInfoEx
+                        { _exFullBakerInfo = FullBakerInfo info stake,
+                          _bakerPoolCommissionRates = extra ^. poolCommissionRates
+                        }
+    bkrs <- mapM mkFullBaker bakerStakes
+    let updatedBakerStakes = FullBakersEx (Vec.fromList bkrs) (sum $ snd <$> bakerStakes)
+
+    (mPaydayParams, snapshotState) <- doEpochTransition True hour bs1
+    liftIO $ assertEqual "Payday parameters" Nothing mPaydayParams
+    newCooldowns <- checkCooldowns snapshotState
+    let expectCooldowns1 = processPrePreCooldown . acCooldowns <$> accountConfigs
+    liftIO $
+        assertEqual
+            "Pre-pre-cooldowns should be moved to pre-cooldown"
+            expectCooldowns1
+            newCooldowns
+    ss <- bsoGetSeedState snapshotState
+    case ss of
+        SeedStateV1{..} -> liftIO $ do
+            assertEqual "Epoch should be updated" (startEpoch + 1) ss1Epoch
+            assertEqual
+                "Trigger time should be updated"
+                (addDuration startTriggerTime hour)
+                ss1TriggerBlockTime
+            assertEqual
+                "Epoch transition should no longer be triggered"
+                False
+                ss1EpochTransitionTriggered
+    snapshotCapDist <- bsoGetCurrentCapitalDistribution snapshotState
+    liftIO $ assertEqual "Capital distribution should be unchanged" initCapDist snapshotCapDist
+    snapshotBakers <- bsoGetCurrentEpochFullBakersEx snapshotState
+    liftIO $ assertEqual "Bakers should be unchanged" initBakers snapshotBakers
+
+    (mPaydayParams', resState) <- doEpochTransition True hour snapshotState
+    liftIO $ case mPaydayParams' of
+        Just PaydayParameters{..} -> do
+            assertEqual "Payday capital distribution" initCapDist paydayCapitalDistribution
+            assertEqual "Payday bakers" initBakers paydayBakers
+        Nothing -> do
+            assertFailure "Expected payday parameters"
+    newCooldowns' <- checkCooldowns resState
+    let paydayTime = startTriggerTime `addDuration` hour
+    let processCooldownAtPayday =
+            processPreCooldown (paydayTime `addDurationSeconds` cooldownDuration)
+                . processCooldowns paydayTime
+    let expectCooldowns2 = processCooldownAtPayday <$> expectCooldowns1
+    liftIO $
+        assertEqual
+            "Expired cooldowns should be processed and pre-cooldowns should be moved to cooldowns"
+            expectCooldowns2
+            newCooldowns'
+    finalCapDist <- bsoGetCurrentCapitalDistribution resState
+    liftIO $ assertEqual "Capital distribution should be updated" updatedCapitalDistr finalCapDist
+    finalBakers <- bsoGetCurrentEpochFullBakersEx resState
+    liftIO $ assertEqual "Bakers should be updated" updatedBakerStakes finalBakers
+
+    updBakers <- bsoRotateCurrentCapitalDistribution =<< bsoRotateCurrentEpochBakers resState
+    finalNECapDist <- bsoGetCurrentCapitalDistribution updBakers
+    liftIO $ assertEqual "Next-epoch capital distribution should be updated" updatedCapitalDistr finalNECapDist
+    finalNEBakers <- bsoGetCurrentEpochFullBakersEx updBakers
+    liftIO $ assertEqual "Next-epoch bakers should be updated" updatedBakerStakes finalNEBakers
+  where
+    hour = Duration 3_600_000
+    startEpoch = 10
+    startTriggerTime = 1000
+    chainParams = DummyData.dummyChainParameters @ChainParametersV2
+    cooldownDuration = chainParams ^. cpCooldownParameters . cpUnifiedCooldown
+
+-- | Test epoch transitions for two successive transitions where the payday length is one epoch.
+-- In this case, both the snapshot and payday processing occur on each transition, so this tests
+-- that they are correctly ordered.
+testEpochTransitionSnapshotPaydayCombo :: [AccountConfig 'AccountV3] -> Assertion
+testEpochTransitionSnapshotPaydayCombo accountConfigs = runTestBlockState @P7 $ do
+    -- Setup the initial state.
+    bs0 <- makeInitialState accountConfigs (transitionalSeedState startEpoch startTriggerTime) 1
+    initCapDist <- bsoGetCurrentCapitalDistribution bs0
+    initBakers <- bsoGetCurrentEpochFullBakersEx bs0
+    bs1 <- bsoSetPaydayEpoch bs0 (startEpoch + 1)
+    (activeBakers, activeDelegators) <- bsoGetActiveBakersAndDelegators bs1
+    let BakerStakesAndCapital{..} =
+            computeBakerStakesAndCapital
+                (chainParams ^. cpPoolParameters)
+                activeBakers
+                activeDelegators
+    updatedCapitalDistr <- capitalDistributionM
+    let mkFullBaker (ref, stake) = do
+            loadPersistentBakerInfoRef @_ @'AccountV3 ref <&> \case
+                (BakerInfoExV1 info extra) ->
+                    FullBakerInfoEx
+                        { _exFullBakerInfo = FullBakerInfo info stake,
+                          _bakerPoolCommissionRates = extra ^. poolCommissionRates
+                        }
+    bkrs <- mapM mkFullBaker bakerStakes
+    let updatedBakerStakes = FullBakersEx (Vec.fromList bkrs) (sum $ snd <$> bakerStakes)
+
+    -- First epoch transition.
+    (mPaydayParams, snapshotState) <- doEpochTransition True hour bs1
+    liftIO $ case mPaydayParams of
+        Just PaydayParameters{..} -> do
+            assertEqual "Payday capital distribution (1)" initCapDist paydayCapitalDistribution
+            assertEqual "Payday bakers (1)" initBakers paydayBakers
+        Nothing -> do
+            assertFailure "Expected payday parameters (1)"
+    newCooldowns1 <- checkCooldowns snapshotState
+    let processPaydayCooldowns paydayTime =
+            processPrePreCooldown
+                . processPreCooldown (paydayTime `addDurationSeconds` cooldownDuration)
+                . processCooldowns paydayTime
+    let expectedCooldowns1 = processPaydayCooldowns startTriggerTime . acCooldowns <$> accountConfigs
+    liftIO $
+        assertEqual
+            "Cooldowns should be processed at payday (1)"
+            expectedCooldowns1
+            newCooldowns1
+    ss <- bsoGetSeedState snapshotState
+    case ss of
+        SeedStateV1{..} -> liftIO $ do
+            assertEqual "Epoch should be updated (1)" (startEpoch + 1) ss1Epoch
+            assertEqual
+                "Trigger time should be updated (1)"
+                (addDuration startTriggerTime hour)
+                ss1TriggerBlockTime
+            assertEqual
+                "Epoch transition should no longer be triggered (1)"
+                False
+                ss1EpochTransitionTriggered
+    snapshotCapDist <- bsoGetCurrentCapitalDistribution snapshotState
+    liftIO $ assertEqual "Capital distribution should be unchanged (1)" initCapDist snapshotCapDist
+    snapshotBakers <- bsoGetCurrentEpochFullBakersEx snapshotState
+    liftIO $ assertEqual "Bakers should be unchanged (1)" initBakers snapshotBakers
+
+    -- Second epoch transition.
+    let payday2Time = startTriggerTime `addDuration` hour
+    (mPaydayParams', resState) <- doEpochTransition True hour snapshotState
+    liftIO $ case mPaydayParams' of
+        Just PaydayParameters{..} -> do
+            assertEqual "Payday capital distribution" initCapDist paydayCapitalDistribution
+            assertEqual "Payday bakers" initBakers paydayBakers
+        Nothing -> do
+            assertFailure "Expected payday parameters"
+    newCooldowns2 <- checkCooldowns snapshotState
+    let expectedCooldowns2 = processPaydayCooldowns payday2Time <$> expectedCooldowns1
+    liftIO $
+        assertEqual
+            "Cooldowns should be processed at payday (2)"
+            expectedCooldowns2
+            newCooldowns2
+    bsoGetSeedState snapshotState >>= \case
+        SeedStateV1{..} -> liftIO $ do
+            assertEqual "Epoch should be updated (2)" (startEpoch + 2) ss1Epoch
+            assertEqual
+                "Trigger time should be updated (2)"
+                (addDuration payday2Time hour)
+                ss1TriggerBlockTime
+            assertEqual
+                "Epoch transition should no longer be triggered (2)"
+                False
+                ss1EpochTransitionTriggered
+    finalCapDist <- bsoGetCurrentCapitalDistribution resState
+    liftIO $ assertEqual "Capital distribution should be updated (2)" updatedCapitalDistr finalCapDist
+    finalBakers <- bsoGetCurrentEpochFullBakersEx resState
+    liftIO $ assertEqual "Bakers should be updated (2)" updatedBakerStakes finalBakers
+    updBakers <- bsoRotateCurrentCapitalDistribution =<< bsoRotateCurrentEpochBakers resState
+    finalNECapDist <- bsoGetCurrentCapitalDistribution updBakers
+    liftIO $ assertEqual "Next-epoch capital distribution should be updated (2)" updatedCapitalDistr finalNECapDist
+    finalNEBakers <- bsoGetCurrentEpochFullBakersEx updBakers
+    liftIO $ assertEqual "Next-epoch bakers should be updated (2)" updatedBakerStakes finalNEBakers
+  where
+    hour = Duration 3_600_000
+    startEpoch = 10
+    startTriggerTime = 1000
+    chainParams = DummyData.dummyChainParameters @ChainParametersV2
+    cooldownDuration = chainParams ^. cpCooldownParameters . cpUnifiedCooldown
+
+tests :: Spec
+tests = parallel $ describe "EpochTransition" $ do
+    it "testEpochTransitionNoPaydayNoSnapshot" $
+        forAll (genAccountConfigs True) testEpochTransitionNoPaydayNoSnapshot
+    it "testEpochTransitionPaydayOnly" $
+        forAll (genAccountConfigs True) testEpochTransitionPaydayOnly
+    it "testEpochTransitionSnapshotOnly" $
+        forAll (genAccountConfigs False) testEpochTransitionSnapshotOnly
+    it "testEpochTransitionSnapshotPayday" $
+        forAll (genAccountConfigs False) testEpochTransitionSnapshotPayday
+    it "testEpochTransitionSnapshotPaydayCombo" $
+        forAll (genAccountConfigs False) testEpochTransitionSnapshotPaydayCombo

--- a/concordium-consensus/tests/scheduler/Spec.hs
+++ b/concordium-consensus/tests/scheduler/Spec.hs
@@ -52,6 +52,8 @@ import qualified SchedulerTests.SmartContracts.V1.Upgrading (tests)
 import qualified SchedulerTests.SmartContracts.V1.UpgradingPersistent (tests)
 import qualified SchedulerTests.SmartContracts.V1.ValidInvalidModules (tests)
 
+import qualified SchedulerTests.KonsensusV1.EpochTransition (tests)
+
 import Test.Hspec
 
 main :: IO ()
@@ -105,3 +107,4 @@ main = hspec $ do
     SchedulerTests.SmartContracts.V1.CustomSectionSize.tests
     SchedulerTests.SmartContracts.V1.AccountSignatureChecks.tests
     SchedulerTests.SmartContracts.V1.InspectModuleReferenceAndContractName.tests
+    SchedulerTests.KonsensusV1.EpochTransition.tests


### PR DESCRIPTION
## Purpose

Closes #1148 

This implements the processing of cooldowns at epoch transitions:
- At a payday epoch:
  - elapsed cooldowns are released
  - pre-cooldowns are moved to cooldown with the appropriate cooldown duration.
- At a snapshot epoch (epoch before a payday), pre-pre-cooldowns are moved to pre-cooldown.

## Changes

- `bsoProcessPendingChanges` - limit to protocol versions that don't support flexible cooldowns.
- Add `bsoProcessCooldowns` for handling the cooldown changes at payday.
- Add `bsoProcessPrePreCooldowns` for handling the cooldown changes at snapshot.
- `doEpochTransition`: perform cooldown handling at the payday and snapshot epoch transitions.
- `applyPendingChanges` (used for computing effective stakes for next payday): account for the fact that there are no pending changes when we support flexible cooldowns (from P7).
- Tests:
  - Unit testing for `bsoProcessCooldowns` and `bsoProcessPrePreCooldowns`.
  - Unit testing for `doEpochTransition`.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
