### PR TITLE
Boilerplate code for protocol v8

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Account.hs
@@ -281,6 +281,19 @@ data AccountMerkleHashInputs (av :: AccountVersion) where
           amhi3Cooldown :: !(CooldownQueueHash 'AccountV3)
         } ->
         AccountMerkleHashInputs 'AccountV3
+    AccountMerkleHashInputsV4 ::
+        { -- | Hash of the persisting account data.
+          amhi4PersistingAccountDataHash :: !PersistingAccountDataHash,
+          -- | Hash of the account stake.
+          amhi4AccountStakeHash :: !(AccountStakeHash 'AccountV4),
+          -- | Hash of the account's encrypted amount.
+          amhi4EncryptedAmountHash :: !EncryptedAmountHash,
+          -- | Hash of the account's release schedule.
+          amhi4AccountReleaseScheduleHash :: !ARSV1.AccountReleaseScheduleHashV1,
+          -- | Hash of the account's cooldown queue.
+          amhi4Cooldown :: !(CooldownQueueHash 'AccountV4)
+        } ->
+        AccountMerkleHashInputs 'AccountV4
 
 -- | The Merkle hash derived from the seldom-updated parts of an account, namely the persisting
 --  account data, account stake, encrypted amount, and account release schedule.
@@ -312,6 +325,20 @@ instance HashableTo (AccountMerkleHash av) (AccountMerkleHashInputs av) where
                     ( Hash.hashOfHashes
                         (ARSV1.theAccountReleaseScheduleHashV1 amhi3AccountReleaseScheduleHash)
                         (theCooldownQueueHash amhi3Cooldown)
+                    )
+                )
+    getHash AccountMerkleHashInputsV4{..} =
+        AccountMerkleHash $
+            Hash.hashOfHashes
+                ( Hash.hashOfHashes
+                    (thePersistingAccountDataHash amhi4PersistingAccountDataHash)
+                    (theAccountStakeHash amhi4AccountStakeHash)
+                )
+                ( Hash.hashOfHashes
+                    (theEncryptedAmountHash amhi4EncryptedAmountHash)
+                    ( Hash.hashOfHashes
+                        (ARSV1.theAccountReleaseScheduleHashV1 amhi4AccountReleaseScheduleHash)
+                        (theCooldownQueueHash amhi4Cooldown)
                     )
                 )
 
@@ -349,12 +376,23 @@ makeAccountHashV3 AccountHashInputsV2{..} = Hash.hashLazy $ runPutLazy $ do
     put ahi2StakedBalance
     put ahi2MerkleHash
 
+-- | Generate the hash for an account (for 'AccountV3'), given the
+--  'AccountHashInputsV2'. 'makeAccountHash' should be used in preference to this function.
+makeAccountHashV4 :: AccountHashInputsV2 av -> Hash.Hash
+makeAccountHashV4 AccountHashInputsV2{..} = Hash.hashLazy $ runPutLazy $ do
+    putShortByteString "AC04"
+    put ahi2NextNonce
+    put ahi2AccountBalance
+    put ahi2StakedBalance
+    put ahi2MerkleHash
+
 -- | Inputs for computing the 'AccountHash' for an account.
 data AccountHashInputs (av :: AccountVersion) where
     AHIV0 :: AccountHashInputsV0 'AccountV0 -> AccountHashInputs 'AccountV0
     AHIV1 :: AccountHashInputsV0 'AccountV1 -> AccountHashInputs 'AccountV1
     AHIV2 :: AccountHashInputsV2 'AccountV2 -> AccountHashInputs 'AccountV2
     AHIV3 :: AccountHashInputsV2 'AccountV3 -> AccountHashInputs 'AccountV3
+    AHIV4 :: AccountHashInputsV2 'AccountV4 -> AccountHashInputs 'AccountV4
 
 -- | Generate the hash for an account, given the 'AccountHashInputs'.
 makeAccountHash :: AccountHashInputs av -> AccountHash av
@@ -363,6 +401,7 @@ makeAccountHash (AHIV0 ahi) = AccountHash $ makeAccountHashV0 ahi
 makeAccountHash (AHIV1 ahi) = AccountHash $ makeAccountHashV0 ahi
 makeAccountHash (AHIV2 ahi) = AccountHash $ makeAccountHashV2 ahi
 makeAccountHash (AHIV3 ahi) = AccountHash $ makeAccountHashV3 ahi
+makeAccountHash (AHIV4 ahi) = AccountHash $ makeAccountHashV4 ahi
 
 data EncryptedAmountUpdate
     = -- | Replace encrypted amounts less than the given index,

--- a/concordium-consensus/src/Concordium/GlobalState/BakerInfo.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BakerInfo.hs
@@ -318,6 +318,7 @@ genesisBakerInfoEx spv cp GenesisBaker{..} = case spv of
     SP5 -> binfoV1
     SP6 -> binfoV1
     SP7 -> binfoV1
+    SP8 -> binfoV1
   where
     bkrInfo =
         BakerInfo

--- a/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/AccountReleaseSchedule.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/AccountReleaseSchedule.hs
@@ -26,6 +26,7 @@ type family AccountReleaseSchedule' (av :: AccountVersion) where
     AccountReleaseSchedule' 'AccountV1 = ARSV0.AccountReleaseSchedule
     AccountReleaseSchedule' 'AccountV2 = ARSV1.AccountReleaseSchedule
     AccountReleaseSchedule' 'AccountV3 = ARSV1.AccountReleaseSchedule
+    AccountReleaseSchedule' 'AccountV4 = ARSV1.AccountReleaseSchedule
 
 -- | Release schedule on an account, parametrized by the account version.
 newtype AccountReleaseSchedule (av :: AccountVersion) = AccountReleaseSchedule
@@ -53,6 +54,7 @@ theAccountReleaseScheduleV1 ::
 theAccountReleaseScheduleV1 = case accountVersion @av of
     SAccountV2 -> theAccountReleaseSchedule
     SAccountV3 -> theAccountReleaseSchedule
+    SAccountV4 -> theAccountReleaseSchedule
 
 -- | Converse of 'theAccountReleaseScheduleV0'.
 fromAccountReleaseScheduleV0 ::
@@ -73,6 +75,7 @@ fromAccountReleaseScheduleV1 ::
 fromAccountReleaseScheduleV1 = case accountVersion @av of
     SAccountV2 -> AccountReleaseSchedule
     SAccountV3 -> AccountReleaseSchedule
+    SAccountV4 -> AccountReleaseSchedule
 
 instance (IsAccountVersion av) => Eq (AccountReleaseSchedule av) where
     (==) = case accountVersion @av of
@@ -80,6 +83,7 @@ instance (IsAccountVersion av) => Eq (AccountReleaseSchedule av) where
         SAccountV1 -> (==) `on` theAccountReleaseSchedule
         SAccountV2 -> (==) `on` theAccountReleaseSchedule
         SAccountV3 -> (==) `on` theAccountReleaseSchedule
+        SAccountV4 -> (==) `on` theAccountReleaseSchedule
 
 instance (IsAccountVersion av) => Show (AccountReleaseSchedule av) where
     show = case accountVersion @av of
@@ -87,6 +91,7 @@ instance (IsAccountVersion av) => Show (AccountReleaseSchedule av) where
         SAccountV1 -> show . theAccountReleaseSchedule
         SAccountV2 -> show . theAccountReleaseSchedule
         SAccountV3 -> show . theAccountReleaseSchedule
+        SAccountV4 -> show . theAccountReleaseSchedule
 
 -- | Produce an 'AccountReleaseSummary' from an 'AccountReleaseSchedule'.
 toAccountReleaseSummary :: forall av. (IsAccountVersion av) => AccountReleaseSchedule av -> AccountReleaseSummary
@@ -95,6 +100,7 @@ toAccountReleaseSummary = case accountVersion @av of
     SAccountV1 -> ARSV0.toAccountReleaseSummary . theAccountReleaseSchedule
     SAccountV2 -> ARSV1.toAccountReleaseSummary . theAccountReleaseSchedule
     SAccountV3 -> ARSV1.toAccountReleaseSummary . theAccountReleaseSchedule
+    SAccountV4 -> ARSV1.toAccountReleaseSummary . theAccountReleaseSchedule
 
 instance (IsAccountVersion av, AccountStructureVersionFor av ~ 'AccountStructureV0) => HashableTo ARSV0.AccountReleaseScheduleHashV0 (AccountReleaseSchedule av) where
     getHash = case accountVersion @av of
@@ -106,6 +112,7 @@ instance (IsAccountVersion av, AccountStructureVersionFor av ~ 'AccountStructure
     getHash = case accountVersion @av of
         SAccountV2 -> getHash . theAccountReleaseSchedule
         SAccountV3 -> getHash . theAccountReleaseSchedule
+        SAccountV4 -> getHash . theAccountReleaseSchedule
     {-# INLINE getHash #-}
 
 -- | Create an empty account release schedule
@@ -115,6 +122,7 @@ emptyAccountReleaseSchedule = case accountVersion @av of
     SAccountV1 -> AccountReleaseSchedule ARSV0.emptyAccountReleaseSchedule
     SAccountV2 -> AccountReleaseSchedule ARSV1.emptyAccountReleaseSchedule
     SAccountV3 -> AccountReleaseSchedule ARSV1.emptyAccountReleaseSchedule
+    SAccountV4 -> AccountReleaseSchedule ARSV1.emptyAccountReleaseSchedule
 
 -- | Add a list of amounts to this @AccountReleaseSchedule@.
 --
@@ -130,6 +138,7 @@ addReleases = case accountVersion @av of
     SAccountV1 -> \rels (AccountReleaseSchedule ars) -> AccountReleaseSchedule (ARSV0.addReleases rels ars)
     SAccountV2 -> \rels (AccountReleaseSchedule ars) -> AccountReleaseSchedule (ARSV1.addReleases rels ars)
     SAccountV3 -> \rels (AccountReleaseSchedule ars) -> AccountReleaseSchedule (ARSV1.addReleases rels ars)
+    SAccountV4 -> \rels (AccountReleaseSchedule ars) -> AccountReleaseSchedule (ARSV1.addReleases rels ars)
 
 -- | Remove the amounts up to and including the given timestamp.
 -- It returns the unlocked amount, maybe the next smallest timestamp for this account and the new account release schedule.
@@ -148,6 +157,8 @@ unlockAmountsUntil = case accountVersion @av of
         _3 %~ AccountReleaseSchedule $ ARSV1.unlockAmountsUntil ts ars
     SAccountV3 -> \ts (AccountReleaseSchedule ars) ->
         _3 %~ AccountReleaseSchedule $ ARSV1.unlockAmountsUntil ts ars
+    SAccountV4 -> \ts (AccountReleaseSchedule ars) ->
+        _3 %~ AccountReleaseSchedule $ ARSV1.unlockAmountsUntil ts ars
 
 -- | Get the timestamp at which the next scheduled release will occur (if any).
 nextReleaseTimestamp :: forall av. (IsAccountVersion av) => AccountReleaseSchedule av -> Maybe Timestamp
@@ -156,6 +167,7 @@ nextReleaseTimestamp = case accountVersion @av of
     SAccountV1 -> ARSV0.nextReleaseTimestamp . theAccountReleaseSchedule
     SAccountV2 -> ARSV1.nextReleaseTimestamp . theAccountReleaseSchedule
     SAccountV3 -> ARSV1.nextReleaseTimestamp . theAccountReleaseSchedule
+    SAccountV4 -> ARSV1.nextReleaseTimestamp . theAccountReleaseSchedule
 
 -- | Get the total locked balance.
 totalLockedUpBalance :: forall av. (IsAccountVersion av) => SimpleGetter (AccountReleaseSchedule av) Amount
@@ -164,6 +176,7 @@ totalLockedUpBalance = case accountVersion @av of
     SAccountV1 -> to theAccountReleaseSchedule . ARSV0.totalLockedUpBalance
     SAccountV2 -> to (ARSV1.arsTotalLockedAmount . theAccountReleaseSchedule)
     SAccountV3 -> to (ARSV1.arsTotalLockedAmount . theAccountReleaseSchedule)
+    SAccountV4 -> to (ARSV1.arsTotalLockedAmount . theAccountReleaseSchedule)
 
 -- | Compute the sum of releases in the release schedule.
 --  This should produce the same result as '_totalLockedUpBalance', and is provided for testing
@@ -174,3 +187,4 @@ sumOfReleases = case accountVersion @av of
     SAccountV1 -> ARSV0.sumOfReleases . theAccountReleaseSchedule
     SAccountV2 -> ARSV1.sumOfReleases . theAccountReleaseSchedule
     SAccountV3 -> ARSV1.sumOfReleases . theAccountReleaseSchedule
+    SAccountV4 -> ARSV1.sumOfReleases . theAccountReleaseSchedule

--- a/concordium-consensus/src/Concordium/GlobalState/Block.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Block.hs
@@ -137,6 +137,7 @@ blockVersion SP4 = 2
 blockVersion SP5 = 2
 blockVersion SP6 = 3
 blockVersion SP7 = 3
+blockVersion SP8 = 3
 {-# INLINE blockVersion #-}
 
 -- | Type class that supports serialization of a block.

--- a/concordium-consensus/src/Concordium/GlobalState/DummyData.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/DummyData.hs
@@ -299,12 +299,16 @@ dummyRewardParametersV0 =
                 }
         }
 
-dummyRewardParametersV1 :: RewardParameters 'ChainParametersV1
-dummyRewardParametersV1 =
+-- | Dummy reward parameters for `ChainParameters` V1 to V3.
+dummyRewardParametersVX ::
+    Conditionally (SupportsMintPerSlot (MintDistributionVersionFor cpv)) MintRate ->
+    Conditionally (SupportsGASFinalizationProof (GasRewardsVersionFor cpv)) AmountFraction ->
+    RewardParameters cpv
+dummyRewardParametersVX dummyMdMintPerSlot dummyGasFinalizationProof =
     RewardParameters
         { _rpMintDistribution =
             MintDistribution
-                { _mdMintPerSlot = CFalse,
+                { _mdMintPerSlot = dummyMdMintPerSlot,
                   _mdBakingReward = AmountFraction 60000, -- 60%
                   _mdFinalizationReward = AmountFraction 30000 -- 30%
                 },
@@ -316,57 +320,20 @@ dummyRewardParametersV1 =
           _rpGASRewards =
             GASRewards
                 { _gasBaker = AmountFraction 25000, -- 25%
-                  _gasFinalizationProof = CTrue $ AmountFraction 50, -- 0.05%
+                  _gasFinalizationProof = dummyGasFinalizationProof, -- 0.05%
                   _gasAccountCreation = AmountFraction 200, -- 0.2%
                   _gasChainUpdate = AmountFraction 50 -- 0.05%
                 }
         }
+
+dummyRewardParametersV1 :: RewardParameters 'ChainParametersV1
+dummyRewardParametersV1 = dummyRewardParametersVX CFalse (CTrue $ AmountFraction 50)
 
 dummyRewardParametersV2 :: RewardParameters 'ChainParametersV2
-dummyRewardParametersV2 =
-    RewardParameters
-        { _rpMintDistribution =
-            MintDistribution
-                { _mdMintPerSlot = CFalse,
-                  _mdBakingReward = AmountFraction 60000, -- 60%
-                  _mdFinalizationReward = AmountFraction 30000 -- 30%
-                },
-          _rpTransactionFeeDistribution =
-            TransactionFeeDistribution
-                { _tfdBaker = AmountFraction 45000, -- 45%
-                  _tfdGASAccount = AmountFraction 45000 -- 45%
-                },
-          _rpGASRewards =
-            GASRewards
-                { _gasBaker = AmountFraction 25000, -- 25%
-                  _gasFinalizationProof = CFalse,
-                  _gasAccountCreation = AmountFraction 200, -- 0.2%
-                  _gasChainUpdate = AmountFraction 50 -- 0.05%
-                }
-        }
+dummyRewardParametersV2 = dummyRewardParametersVX CFalse CFalse
 
 dummyRewardParametersV3 :: RewardParameters 'ChainParametersV3
-dummyRewardParametersV3 =
-    RewardParameters
-        { _rpMintDistribution =
-            MintDistribution
-                { _mdMintPerSlot = CFalse,
-                  _mdBakingReward = AmountFraction 60000, -- 60%
-                  _mdFinalizationReward = AmountFraction 30000 -- 30%
-                },
-          _rpTransactionFeeDistribution =
-            TransactionFeeDistribution
-                { _tfdBaker = AmountFraction 45000, -- 45%
-                  _tfdGASAccount = AmountFraction 45000 -- 45%
-                },
-          _rpGASRewards =
-            GASRewards
-                { _gasBaker = AmountFraction 25000, -- 25%
-                  _gasFinalizationProof = CFalse,
-                  _gasAccountCreation = AmountFraction 200, -- 0.2%
-                  _gasChainUpdate = AmountFraction 50 -- 0.05%
-                }
-        }
+dummyRewardParametersV3 = dummyRewardParametersVX CFalse CFalse
 
 -- | Consensus parameters for the second consensus protocol.
 dummyConsensusParametersV1 :: ConsensusParameters' 'ConsensusParametersVersion1

--- a/concordium-consensus/src/Concordium/GlobalState/DummyData.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/DummyData.hs
@@ -345,6 +345,29 @@ dummyRewardParametersV2 =
                 }
         }
 
+dummyRewardParametersV3 :: RewardParameters 'ChainParametersV3
+dummyRewardParametersV3 =
+    RewardParameters
+        { _rpMintDistribution =
+            MintDistribution
+                { _mdMintPerSlot = CFalse,
+                  _mdBakingReward = AmountFraction 60000, -- 60%
+                  _mdFinalizationReward = AmountFraction 30000 -- 30%
+                },
+          _rpTransactionFeeDistribution =
+            TransactionFeeDistribution
+                { _tfdBaker = AmountFraction 45000, -- 45%
+                  _tfdGASAccount = AmountFraction 45000 -- 45%
+                },
+          _rpGASRewards =
+            GASRewards
+                { _gasBaker = AmountFraction 25000, -- 25%
+                  _gasFinalizationProof = CFalse,
+                  _gasAccountCreation = AmountFraction 200, -- 0.2%
+                  _gasChainUpdate = AmountFraction 50 -- 0.05%
+                }
+        }
+
 -- | Consensus parameters for the second consensus protocol.
 dummyConsensusParametersV1 :: ConsensusParameters' 'ConsensusParametersVersion1
 dummyConsensusParametersV1 =
@@ -449,6 +472,44 @@ dummyChainParameters = case chainParametersVersion @cpv of
                         },
               _cpAccountCreationLimit = 10,
               _cpRewardParameters = dummyRewardParametersV2,
+              _cpFoundationAccount = 0,
+              _cpPoolParameters =
+                PoolParametersV1
+                    { _ppMinimumEquityCapital = 300000000000,
+                      _ppCapitalBound = CapitalBound (makeAmountFraction 100000),
+                      _ppLeverageBound = 5,
+                      _ppPassiveCommissions =
+                        CommissionRates
+                            { _finalizationCommission = makeAmountFraction 100000,
+                              _bakingCommission = makeAmountFraction 5000,
+                              _transactionCommission = makeAmountFraction 5000
+                            },
+                      _ppCommissionBounds =
+                        CommissionRanges
+                            { _finalizationCommissionRange = fullRange,
+                              _bakingCommissionRange = fullRange,
+                              _transactionCommissionRange = fullRange
+                            }
+                    },
+              _cpFinalizationCommitteeParameters = SomeParam dummyFinalizationCommitteeParameters
+            }
+    SChainParametersV3 ->
+        ChainParameters
+            { _cpConsensusParameters = dummyConsensusParametersV1,
+              _cpExchangeRates = makeExchangeRates 0.0001 1000000,
+              _cpCooldownParameters =
+                CooldownParametersV1
+                    { _cpPoolOwnerCooldown = cooldown,
+                      _cpDelegatorCooldown = cooldown
+                    },
+              _cpTimeParameters =
+                SomeParam
+                    TimeParametersV1
+                        { _tpRewardPeriodLength = 2,
+                          _tpMintPerPayday = MintRate 1 8
+                        },
+              _cpAccountCreationLimit = 10,
+              _cpRewardParameters = dummyRewardParametersV3,
               _cpFoundationAccount = 0,
               _cpPoolParameters =
                 PoolParametersV1

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
@@ -44,29 +44,34 @@ data PersistentAccount (av :: AccountVersion) where
     PAV1 :: !(V0.PersistentAccount 'AccountV1) -> PersistentAccount 'AccountV1
     PAV2 :: !(V1.PersistentAccount 'AccountV2) -> PersistentAccount 'AccountV2
     PAV3 :: !(V1.PersistentAccount 'AccountV3) -> PersistentAccount 'AccountV3
+    PAV4 :: !(V1.PersistentAccount 'AccountV4) -> PersistentAccount 'AccountV4
 
 instance (MonadBlobStore m) => MHashableTo m (AccountHash av) (PersistentAccount av) where
     getHashM (PAV0 acc) = getHashM acc
     getHashM (PAV1 acc) = getHashM acc
     getHashM (PAV2 acc) = getHashM acc
     getHashM (PAV3 acc) = getHashM acc
+    getHashM (PAV4 acc) = getHashM acc
 
 instance (MonadBlobStore m) => MHashableTo m Hash.Hash (PersistentAccount av) where
     getHashM (PAV0 acc) = getHashM acc
     getHashM (PAV1 acc) = getHashM acc
     getHashM (PAV2 acc) = getHashM acc
     getHashM (PAV3 acc) = getHashM acc
+    getHashM (PAV4 acc) = getHashM acc
 
 instance (IsAccountVersion av, MonadBlobStore m) => BlobStorable m (PersistentAccount av) where
     storeUpdate (PAV0 acct) = second PAV0 <$!> storeUpdate acct
     storeUpdate (PAV1 acct) = second PAV1 <$!> storeUpdate acct
     storeUpdate (PAV2 acct) = second PAV2 <$!> storeUpdate acct
     storeUpdate (PAV3 acct) = second PAV3 <$!> storeUpdate acct
+    storeUpdate (PAV4 acct) = second PAV4 <$!> storeUpdate acct
     load = case accountVersion @av of
         SAccountV0 -> fmap PAV0 <$> load
         SAccountV1 -> fmap PAV1 <$> load
         SAccountV2 -> fmap PAV2 <$> load
         SAccountV3 -> fmap PAV3 <$> load
+        SAccountV4 -> fmap PAV4 <$> load
 
 -- | Type of references to persistent accounts.
 type AccountRef (av :: AccountVersion) = HashedCachedRef (AccountCache av) (PersistentAccount av)
@@ -77,23 +82,27 @@ data PersistentBakerInfoRef (av :: AccountVersion) where
     PBIRV1 :: !(V0.PersistentBakerInfoEx 'AccountV1) -> PersistentBakerInfoRef 'AccountV1
     PBIRV2 :: !(V1.PersistentBakerInfoEx 'AccountV2) -> PersistentBakerInfoRef 'AccountV2
     PBIRV3 :: !(V1.PersistentBakerInfoEx 'AccountV3) -> PersistentBakerInfoRef 'AccountV3
+    PBIRV4 :: !(V1.PersistentBakerInfoEx 'AccountV4) -> PersistentBakerInfoRef 'AccountV4
 
 instance Show (PersistentBakerInfoRef av) where
     show (PBIRV0 pibr) = show pibr
     show (PBIRV1 pibr) = show pibr
     show (PBIRV2 pibr) = show pibr
     show (PBIRV3 pibr) = show pibr
+    show (PBIRV4 pibr) = show pibr
 
 instance (IsAccountVersion av, MonadBlobStore m) => BlobStorable m (PersistentBakerInfoRef av) where
     storeUpdate (PBIRV0 bir) = second PBIRV0 <$!> storeUpdate bir
     storeUpdate (PBIRV1 bir) = second PBIRV1 <$!> storeUpdate bir
     storeUpdate (PBIRV2 bir) = second PBIRV2 <$!> storeUpdate bir
     storeUpdate (PBIRV3 bir) = second PBIRV3 <$!> storeUpdate bir
+    storeUpdate (PBIRV4 bir) = second PBIRV4 <$!> storeUpdate bir
     load = case accountVersion @av of
         SAccountV0 -> fmap PBIRV0 <$!> load
         SAccountV1 -> fmap PBIRV1 <$!> load
         SAccountV2 -> fmap PBIRV2 <$!> load
         SAccountV3 -> fmap PBIRV3 <$!> load
+        SAccountV4 -> fmap PBIRV4 <$!> load
 
 -- * Account cache
 
@@ -112,6 +121,7 @@ accountCanonicalAddress (PAV0 acc) = V0.getCanonicalAddress acc
 accountCanonicalAddress (PAV1 acc) = V0.getCanonicalAddress acc
 accountCanonicalAddress (PAV2 acc) = V1.getCanonicalAddress acc
 accountCanonicalAddress (PAV3 acc) = V1.getCanonicalAddress acc
+accountCanonicalAddress (PAV4 acc) = V1.getCanonicalAddress acc
 
 -- | Get the current public account balance.
 accountAmount :: (MonadBlobStore m) => PersistentAccount av -> m Amount
@@ -119,6 +129,7 @@ accountAmount (PAV0 acc) = V0.getAmount acc
 accountAmount (PAV1 acc) = V0.getAmount acc
 accountAmount (PAV2 acc) = V1.getAmount acc
 accountAmount (PAV3 acc) = V1.getAmount acc
+accountAmount (PAV4 acc) = V1.getAmount acc
 
 -- | Gets the amount of a baker's stake, or 'Nothing' if the account is not a baker.
 --  This consists only of the active stake, and does not include any inactive stake.
@@ -127,6 +138,7 @@ accountBakerStakeAmount (PAV0 acc) = V0.getBakerStakeAmount acc
 accountBakerStakeAmount (PAV1 acc) = V0.getBakerStakeAmount acc
 accountBakerStakeAmount (PAV2 acc) = V1.getBakerStakeAmount acc
 accountBakerStakeAmount (PAV3 acc) = V1.getBakerStakeAmount acc
+accountBakerStakeAmount (PAV4 acc) = V1.getBakerStakeAmount acc
 
 -- | Get the amount that is actively staked on an account as a baker or delegator.
 accountActiveStakedAmount :: (MonadBlobStore m) => PersistentAccount av -> m Amount
@@ -134,6 +146,7 @@ accountActiveStakedAmount (PAV0 acc) = V0.getStakedAmount acc
 accountActiveStakedAmount (PAV1 acc) = V0.getStakedAmount acc
 accountActiveStakedAmount (PAV2 acc) = V1.getActiveStakedAmount acc
 accountActiveStakedAmount (PAV3 acc) = V1.getActiveStakedAmount acc
+accountActiveStakedAmount (PAV4 acc) = V1.getActiveStakedAmount acc
 
 -- | Get the amount that is staked on the account (both active and inactive).
 accountTotalStakedAmount :: (MonadBlobStore m) => PersistentAccount av -> m Amount
@@ -143,6 +156,7 @@ accountTotalStakedAmount (PAV2 acc) =
     -- This is the same as the total staked amount in account version 2.
     V1.getActiveStakedAmount acc
 accountTotalStakedAmount (PAV3 acc) = V1.getTotalStakedAmount acc
+accountTotalStakedAmount (PAV4 acc) = V1.getTotalStakedAmount acc
 
 -- | Get the amount that is locked in scheduled releases on the account.
 accountLockedAmount :: (MonadBlobStore m) => PersistentAccount av -> m Amount
@@ -150,6 +164,7 @@ accountLockedAmount (PAV0 acc) = V0.getLockedAmount acc
 accountLockedAmount (PAV1 acc) = V0.getLockedAmount acc
 accountLockedAmount (PAV2 acc) = V1.getLockedAmount acc
 accountLockedAmount (PAV3 acc) = V1.getLockedAmount acc
+accountLockedAmount (PAV4 acc) = V1.getLockedAmount acc
 
 -- | Get the current public account available balance.
 -- This accounts for lock-up and staked amounts.
@@ -159,6 +174,7 @@ accountAvailableAmount (PAV0 acc) = V0.getAvailableAmount acc
 accountAvailableAmount (PAV1 acc) = V0.getAvailableAmount acc
 accountAvailableAmount (PAV2 acc) = V1.getAvailableAmount acc
 accountAvailableAmount (PAV3 acc) = V1.getAvailableAmount acc
+accountAvailableAmount (PAV4 acc) = V1.getAvailableAmount acc
 
 -- | Get the next account nonce for transactions from this account.
 accountNonce :: (MonadBlobStore m) => PersistentAccount av -> m Nonce
@@ -166,6 +182,7 @@ accountNonce (PAV0 acc) = V0.getNonce acc
 accountNonce (PAV1 acc) = V0.getNonce acc
 accountNonce (PAV2 acc) = V1.getNonce acc
 accountNonce (PAV3 acc) = V1.getNonce acc
+accountNonce (PAV4 acc) = V1.getNonce acc
 
 -- | Determine if a given operation is permitted for the account.
 --
@@ -177,6 +194,7 @@ accountIsAllowed (PAV0 acc) = V0.isAllowed acc
 accountIsAllowed (PAV1 acc) = V0.isAllowed acc
 accountIsAllowed (PAV2 acc) = V1.isAllowed acc
 accountIsAllowed (PAV3 acc) = V1.isAllowed acc
+accountIsAllowed (PAV4 acc) = V1.isAllowed acc
 
 -- | Get the credentials deployed on the account. This map is always non-empty and (presently)
 --  will have a credential at index 'initialCredentialIndex' (0) that cannot be changed.
@@ -185,6 +203,7 @@ accountCredentials (PAV0 acc) = V0.getCredentials acc
 accountCredentials (PAV1 acc) = V0.getCredentials acc
 accountCredentials (PAV2 acc) = V1.getCredentials acc
 accountCredentials (PAV3 acc) = V1.getCredentials acc
+accountCredentials (PAV4 acc) = V1.getCredentials acc
 
 -- | Get the key used to verify transaction signatures, it records the signature scheme used as well.
 accountVerificationKeys :: (MonadBlobStore m) => PersistentAccount av -> m AccountInformation
@@ -192,6 +211,7 @@ accountVerificationKeys (PAV0 acc) = V0.getVerificationKeys acc
 accountVerificationKeys (PAV1 acc) = V0.getVerificationKeys acc
 accountVerificationKeys (PAV2 acc) = V1.getVerificationKeys acc
 accountVerificationKeys (PAV3 acc) = V1.getVerificationKeys acc
+accountVerificationKeys (PAV4 acc) = V1.getVerificationKeys acc
 
 -- | Get the current encrypted amount on the account.
 accountEncryptedAmount :: (MonadBlobStore m) => PersistentAccount av -> m AccountEncryptedAmount
@@ -199,6 +219,7 @@ accountEncryptedAmount (PAV0 acc) = V0.getEncryptedAmount acc
 accountEncryptedAmount (PAV1 acc) = V0.getEncryptedAmount acc
 accountEncryptedAmount (PAV2 acc) = V1.getEncryptedAmount acc
 accountEncryptedAmount (PAV3 acc) = V1.getEncryptedAmount acc
+accountEncryptedAmount (PAV4 acc) = V1.getEncryptedAmount acc
 
 -- | Get the public key used to receive encrypted amounts.
 accountEncryptionKey :: (MonadBlobStore m) => PersistentAccount av -> m AccountEncryptionKey
@@ -206,6 +227,7 @@ accountEncryptionKey (PAV0 acc) = V0.getEncryptionKey acc
 accountEncryptionKey (PAV1 acc) = V0.getEncryptionKey acc
 accountEncryptionKey (PAV2 acc) = V1.getEncryptionKey acc
 accountEncryptionKey (PAV3 acc) = V1.getEncryptionKey acc
+accountEncryptionKey (PAV4 acc) = V1.getEncryptionKey acc
 
 -- | Get the 'AccountReleaseSummary' summarising scheduled releases for an account.
 accountReleaseSummary :: (MonadBlobStore m) => PersistentAccount av -> m AccountReleaseSummary
@@ -213,6 +235,7 @@ accountReleaseSummary (PAV0 acc) = V0.getReleaseSummary acc
 accountReleaseSummary (PAV1 acc) = V0.getReleaseSummary acc
 accountReleaseSummary (PAV2 acc) = V1.getReleaseSummary acc
 accountReleaseSummary (PAV3 acc) = V1.getReleaseSummary acc
+accountReleaseSummary (PAV4 acc) = V1.getReleaseSummary acc
 
 -- | Get the timestamp at which the next scheduled release will occur (if any).
 accountNextReleaseTimestamp :: (MonadBlobStore m) => PersistentAccount av -> m (Maybe Timestamp)
@@ -220,6 +243,7 @@ accountNextReleaseTimestamp (PAV0 acc) = V0.getNextReleaseTimestamp acc
 accountNextReleaseTimestamp (PAV1 acc) = V0.getNextReleaseTimestamp acc
 accountNextReleaseTimestamp (PAV2 acc) = V1.getNextReleaseTimestamp acc
 accountNextReleaseTimestamp (PAV3 acc) = V1.getNextReleaseTimestamp acc
+accountNextReleaseTimestamp (PAV4 acc) = V1.getNextReleaseTimestamp acc
 
 -- | Get the baker (if any) attached to an account.
 accountBaker :: (MonadBlobStore m) => PersistentAccount av -> m (Maybe (AccountBaker av))
@@ -227,6 +251,7 @@ accountBaker (PAV0 acc) = V0.getBaker acc
 accountBaker (PAV1 acc) = V0.getBaker acc
 accountBaker (PAV2 acc) = V1.getBaker acc
 accountBaker (PAV3 acc) = V1.getBaker acc
+accountBaker (PAV4 acc) = V1.getBaker acc
 
 -- | Get a reference to the baker info (if any) attached to an account.
 accountBakerInfoRef :: (MonadBlobStore m) => PersistentAccount av -> m (Maybe (PersistentBakerInfoRef av))
@@ -234,6 +259,7 @@ accountBakerInfoRef (PAV0 acc) = fmap PBIRV0 <$> V0.getBakerInfoRef acc
 accountBakerInfoRef (PAV1 acc) = fmap PBIRV1 <$> V0.getBakerInfoRef acc
 accountBakerInfoRef (PAV2 acc) = fmap PBIRV2 <$> V1.getBakerInfoRef acc
 accountBakerInfoRef (PAV3 acc) = fmap PBIRV3 <$> V1.getBakerInfoRef acc
+accountBakerInfoRef (PAV4 acc) = fmap PBIRV4 <$> V1.getBakerInfoRef acc
 
 -- | Get the baker and baker info reference (if any) attached to the account.
 accountBakerAndInfoRef :: (MonadBlobStore m) => PersistentAccount av -> m (Maybe (AccountBaker av, PersistentBakerInfoRef av))
@@ -241,6 +267,7 @@ accountBakerAndInfoRef (PAV0 acc) = fmap (second PBIRV0) <$> V0.getBakerAndInfoR
 accountBakerAndInfoRef (PAV1 acc) = fmap (second PBIRV1) <$> V0.getBakerAndInfoRef acc
 accountBakerAndInfoRef (PAV2 acc) = fmap (second PBIRV2) <$> V1.getBakerAndInfoRef acc
 accountBakerAndInfoRef (PAV3 acc) = fmap (second PBIRV3) <$> V1.getBakerAndInfoRef acc
+accountBakerAndInfoRef (PAV4 acc) = fmap (second PBIRV4) <$> V1.getBakerAndInfoRef acc
 
 -- | Get the delegator (if any) attached to the account.
 accountDelegator :: (MonadBlobStore m) => PersistentAccount av -> m (Maybe (AccountDelegation av))
@@ -248,6 +275,7 @@ accountDelegator (PAV0 acc) = V0.getDelegator acc
 accountDelegator (PAV1 acc) = V0.getDelegator acc
 accountDelegator (PAV2 acc) = V1.getDelegator acc
 accountDelegator (PAV3 acc) = V1.getDelegator acc
+accountDelegator (PAV4 acc) = V1.getDelegator acc
 
 -- | Get the baker or stake delegation information attached to an account.
 accountStake :: (MonadBlobStore m) => PersistentAccount av -> m (AccountStake av)
@@ -255,6 +283,7 @@ accountStake (PAV0 acc) = V0.getStake acc
 accountStake (PAV1 acc) = V0.getStake acc
 accountStake (PAV2 acc) = V1.getStake acc
 accountStake (PAV3 acc) = V1.getStake acc
+accountStake (PAV4 acc) = V1.getStake acc
 
 -- | Determine if an account has stake as a baker or delegator.
 accountHasActiveStake :: PersistentAccount av -> Bool
@@ -262,6 +291,7 @@ accountHasActiveStake (PAV0 acc) = V0.hasActiveStake acc
 accountHasActiveStake (PAV1 acc) = V0.hasActiveStake acc
 accountHasActiveStake (PAV2 acc) = V1.hasActiveStake acc
 accountHasActiveStake (PAV3 acc) = V1.hasActiveStake acc
+accountHasActiveStake (PAV4 acc) = V1.hasActiveStake acc
 
 -- | Get details about an account's stake.
 accountStakeDetails :: (MonadBlobStore m) => PersistentAccount av -> m (StakeDetails av)
@@ -269,6 +299,7 @@ accountStakeDetails (PAV0 acc) = V0.getStakeDetails acc
 accountStakeDetails (PAV1 acc) = V0.getStakeDetails acc
 accountStakeDetails (PAV2 acc) = V1.getStakeDetails acc
 accountStakeDetails (PAV3 acc) = V1.getStakeDetails acc
+accountStakeDetails (PAV4 acc) = V1.getStakeDetails acc
 
 -- | Get the 'Cooldowns' for an account, if any. This is only available at account versions that
 -- support flexible cooldowns.
@@ -277,6 +308,7 @@ accountCooldowns ::
     PersistentAccount av ->
     m (Maybe Cooldowns)
 accountCooldowns (PAV3 acc) = V1.getCooldowns acc
+accountCooldowns (PAV4 acc) = V1.getCooldowns acc
 
 -- | Determine if an account has a pre-pre-cooldown.
 accountHasPrePreCooldown ::
@@ -293,6 +325,7 @@ accountHash (PAV0 acc) = getHashM acc
 accountHash (PAV1 acc) = getHashM acc
 accountHash (PAV2 acc) = getHashM acc
 accountHash (PAV3 acc) = getHashM acc
+accountHash (PAV4 acc) = getHashM acc
 
 -- ** 'PersistentBakerInfoRef' queries
 
@@ -302,6 +335,7 @@ loadBakerInfo (PBIRV0 bir) = V0.loadBakerInfo bir
 loadBakerInfo (PBIRV1 bir) = V0.loadBakerInfo bir
 loadBakerInfo (PBIRV2 bir) = V1.loadBakerInfo bir
 loadBakerInfo (PBIRV3 bir) = V1.loadBakerInfo bir
+loadBakerInfo (PBIRV4 bir) = V1.loadBakerInfo bir
 
 -- | Load 'BakerInfoEx' from a 'PersistentBakerInfoRef'.
 loadPersistentBakerInfoRef :: (MonadBlobStore m) => PersistentBakerInfoRef av -> m (BakerInfoEx av)
@@ -309,6 +343,7 @@ loadPersistentBakerInfoRef (PBIRV0 bir) = V0.loadPersistentBakerInfoEx bir
 loadPersistentBakerInfoRef (PBIRV1 bir) = V0.loadPersistentBakerInfoEx bir
 loadPersistentBakerInfoRef (PBIRV2 bir) = V1.loadPersistentBakerInfoEx bir
 loadPersistentBakerInfoRef (PBIRV3 bir) = V1.loadPersistentBakerInfoEx bir
+loadPersistentBakerInfoRef (PBIRV4 bir) = V1.loadPersistentBakerInfoEx bir
 
 -- | Load the 'BakerId' from a 'PersistentBakerInfoRef'.
 loadBakerId :: (MonadBlobStore m) => PersistentBakerInfoRef av -> m BakerId
@@ -316,6 +351,7 @@ loadBakerId (PBIRV0 bir) = V0.loadBakerId bir
 loadBakerId (PBIRV1 bir) = V0.loadBakerId bir
 loadBakerId (PBIRV2 bir) = V1.loadBakerId bir
 loadBakerId (PBIRV3 bir) = V1.loadBakerId bir
+loadBakerId (PBIRV4 bir) = V1.loadBakerId bir
 
 -- * Updates
 
@@ -325,6 +361,7 @@ updateAccount upd (PAV0 acc) = PAV0 <$> V0.updateAccount upd acc
 updateAccount upd (PAV1 acc) = PAV1 <$> V0.updateAccount upd acc
 updateAccount upd (PAV2 acc) = PAV2 <$> V1.updateAccount upd acc
 updateAccount upd (PAV3 acc) = PAV3 <$> V1.updateAccount upd acc
+updateAccount upd (PAV4 acc) = PAV4 <$> V1.updateAccount upd acc
 
 -- | Add or remove credentials on an account.
 --  The caller must ensure the following, which are not checked:
@@ -353,6 +390,8 @@ updateAccountCredentials cuRemove cuAdd cuAccountThreshold (PAV2 acc) =
     PAV2 <$> V1.updateAccountCredentials cuRemove cuAdd cuAccountThreshold acc
 updateAccountCredentials cuRemove cuAdd cuAccountThreshold (PAV3 acc) =
     PAV3 <$> V1.updateAccountCredentials cuRemove cuAdd cuAccountThreshold acc
+updateAccountCredentials cuRemove cuAdd cuAccountThreshold (PAV4 acc) =
+    PAV4 <$> V1.updateAccountCredentials cuRemove cuAdd cuAccountThreshold acc
 
 -- | Optionally update the verification keys and signature threshold for an account.
 --  Precondition: The credential with given credential index exists.
@@ -373,6 +412,8 @@ updateAccountCredentialKeys credIndex credKeys (PAV2 acc) =
     PAV2 <$> V1.updateAccountCredentialKeys credIndex credKeys acc
 updateAccountCredentialKeys credIndex credKeys (PAV3 acc) =
     PAV3 <$> V1.updateAccountCredentialKeys credIndex credKeys acc
+updateAccountCredentialKeys credIndex credKeys (PAV4 acc) =
+    PAV4 <$> V1.updateAccountCredentialKeys credIndex credKeys acc
 
 -- | Add an amount to the account's balance.
 addAccountAmount :: (MonadBlobStore m) => Amount -> PersistentAccount av -> m (PersistentAccount av)
@@ -380,6 +421,7 @@ addAccountAmount amt (PAV0 acc) = PAV0 <$> V0.addAmount amt acc
 addAccountAmount amt (PAV1 acc) = PAV1 <$> V0.addAmount amt acc
 addAccountAmount amt (PAV2 acc) = PAV2 <$> V1.addAmount amt acc
 addAccountAmount amt (PAV3 acc) = PAV3 <$> V1.addAmount amt acc
+addAccountAmount amt (PAV4 acc) = PAV4 <$> V1.addAmount amt acc
 
 -- | Applies a pending stake change to an account. The account MUST have a pending stake change.
 --  If the account does not have a pending stake change, or is not staking, then this will raise
@@ -408,6 +450,7 @@ addAccountBakerV1 ::
 addAccountBakerV1 binfo amt restake (PAV1 acc) = PAV1 <$> V0.addBakerV1 binfo amt restake acc
 addAccountBakerV1 binfo amt restake (PAV2 acc) = PAV2 <$> V1.addBakerV1 binfo amt restake acc
 addAccountBakerV1 binfo amt restake (PAV3 acc) = PAV3 <$> V1.addBakerV1 binfo amt restake acc
+addAccountBakerV1 binfo amt restake (PAV4 acc) = PAV4 <$> V1.addBakerV1 binfo amt restake acc
 
 -- | Add a delegator to an account.
 --  This will replace any existing staking information on the account.
@@ -419,6 +462,7 @@ addAccountDelegator ::
 addAccountDelegator del (PAV1 acc) = PAV1 <$> V0.addDelegator del acc
 addAccountDelegator del (PAV2 acc) = PAV2 <$> V1.addDelegator del acc
 addAccountDelegator del (PAV3 acc) = PAV3 <$> V1.addDelegator del acc
+addAccountDelegator del (PAV4 acc) = PAV4 <$> V1.addDelegator del acc
 
 -- | Update the pool info on a baker account.
 --  This MUST only be called with an account that is a baker.
@@ -430,6 +474,7 @@ updateAccountBakerPoolInfo ::
 updateAccountBakerPoolInfo upd (PAV1 acc) = PAV1 <$> V0.updateBakerPoolInfo upd acc
 updateAccountBakerPoolInfo upd (PAV2 acc) = PAV2 <$> V1.updateBakerPoolInfo upd acc
 updateAccountBakerPoolInfo upd (PAV3 acc) = PAV3 <$> V1.updateBakerPoolInfo upd acc
+updateAccountBakerPoolInfo upd (PAV4 acc) = PAV4 <$> V1.updateBakerPoolInfo upd acc
 
 -- | Set the baker keys on a baker account.
 --  This MUST only be called with an account that is a baker.
@@ -442,6 +487,7 @@ setAccountBakerKeys keys (PAV0 acc) = PAV0 <$> V0.setBakerKeys keys acc
 setAccountBakerKeys keys (PAV1 acc) = PAV1 <$> V0.setBakerKeys keys acc
 setAccountBakerKeys keys (PAV2 acc) = PAV2 <$> V1.setBakerKeys keys acc
 setAccountBakerKeys keys (PAV3 acc) = PAV3 <$> V1.setBakerKeys keys acc
+setAccountBakerKeys keys (PAV4 acc) = PAV4 <$> V1.setBakerKeys keys acc
 
 -- | Set the stake of a baker or delegator account.
 --  This MUST only be called with an account that is either a baker or delegator.
@@ -455,6 +501,7 @@ setAccountStake newStake (PAV0 acc) = PAV0 <$> V0.setStake newStake acc
 setAccountStake newStake (PAV1 acc) = PAV1 <$> V0.setStake newStake acc
 setAccountStake newStake (PAV2 acc) = PAV2 <$> V1.setStake newStake acc
 setAccountStake newStake (PAV3 acc) = PAV3 <$> V1.setStake newStake acc
+setAccountStake newStake (PAV4 acc) = PAV4 <$> V1.setStake newStake acc
 
 -- | Add a specified amount to the pre-pre-cooldown inactive stake.
 addAccountPrePreCooldown ::
@@ -463,6 +510,7 @@ addAccountPrePreCooldown ::
     PersistentAccount av ->
     m (PersistentAccount av)
 addAccountPrePreCooldown amt (PAV3 acc) = PAV3 <$> V1.addPrePreCooldown amt acc
+addAccountPrePreCooldown amt (PAV4 acc) = PAV4 <$> V1.addPrePreCooldown amt acc
 
 -- | Remove up to the given amount from the cooldowns, starting with pre-pre-cooldown, then
 --  pre-cooldown, and finally from the amounts in cooldown, in decreasing order of timestamp.
@@ -472,6 +520,7 @@ reactivateCooldownAmount ::
     PersistentAccount av ->
     m (PersistentAccount av)
 reactivateCooldownAmount amt (PAV3 acc) = PAV3 <$> V1.reactivateCooldownAmount amt acc
+reactivateCooldownAmount amt (PAV4 acc) = PAV4 <$> V1.reactivateCooldownAmount amt acc
 
 -- | Set whether a baker or delegator account restakes its earnings.
 --  This MUST only be called with an account that is either a baker or delegator.
@@ -484,6 +533,7 @@ setAccountRestakeEarnings restake (PAV0 acc) = PAV0 <$> V0.setRestakeEarnings re
 setAccountRestakeEarnings restake (PAV1 acc) = PAV1 <$> V0.setRestakeEarnings restake acc
 setAccountRestakeEarnings restake (PAV2 acc) = PAV2 <$> V1.setRestakeEarnings restake acc
 setAccountRestakeEarnings restake (PAV3 acc) = PAV3 <$> V1.setRestakeEarnings restake acc
+setAccountRestakeEarnings restake (PAV4 acc) = PAV4 <$> V1.setRestakeEarnings restake acc
 
 -- | Set the pending change on baker or delegator account.
 --  This MUST only be called with an account that is either a baker or delegator.
@@ -496,6 +546,7 @@ setAccountStakePendingChange pc (PAV0 acc) = PAV0 <$> V0.setStakePendingChange p
 setAccountStakePendingChange pc (PAV1 acc) = PAV1 <$> V0.setStakePendingChange pc acc
 setAccountStakePendingChange pc (PAV2 acc) = PAV2 <$> V1.setStakePendingChange pc acc
 setAccountStakePendingChange pc (PAV3 acc) = PAV3 <$> V1.setStakePendingChange pc acc
+setAccountStakePendingChange pc (PAV4 acc) = PAV4 <$> V1.setStakePendingChange pc acc
 
 -- | Set the target of a delegating account.
 --  This MUST only be called with an account that is a delegator.
@@ -508,6 +559,7 @@ setAccountDelegationTarget target (PAV0 acc) = PAV0 <$> V0.setDelegationTarget t
 setAccountDelegationTarget target (PAV1 acc) = PAV1 <$> V0.setDelegationTarget target acc
 setAccountDelegationTarget target (PAV2 acc) = PAV2 <$> V1.setDelegationTarget target acc
 setAccountDelegationTarget target (PAV3 acc) = PAV3 <$> V1.setDelegationTarget target acc
+setAccountDelegationTarget target (PAV4 acc) = PAV4 <$> V1.setDelegationTarget target acc
 
 -- | Remove any staking on an account.
 removeAccountStaking ::
@@ -518,6 +570,7 @@ removeAccountStaking (PAV0 acc) = PAV0 <$> V0.removeStaking acc
 removeAccountStaking (PAV1 acc) = PAV1 <$> V0.removeStaking acc
 removeAccountStaking (PAV2 acc) = PAV2 <$> V1.removeStaking acc
 removeAccountStaking (PAV3 acc) = PAV3 <$> V1.removeStaking acc
+removeAccountStaking (PAV4 acc) = PAV4 <$> V1.removeStaking acc
 
 -- | Set the commission rates on a baker account.
 --  This MUST only be called with an account that is a baker.
@@ -529,6 +582,7 @@ setAccountCommissionRates ::
 setAccountCommissionRates rates (PAV1 acc) = PAV1 <$> V0.setCommissionRates rates acc
 setAccountCommissionRates rates (PAV2 acc) = PAV2 <$> V1.setCommissionRates rates acc
 setAccountCommissionRates rates (PAV3 acc) = PAV3 <$> V1.setCommissionRates rates acc
+setAccountCommissionRates rates (PAV4 acc) = PAV4 <$> V1.setCommissionRates rates acc
 
 -- | Unlock scheduled releases on an account up to and including the given timestamp.
 --  This returns the next timestamp at which a release is scheduled for the account, if any,
@@ -542,6 +596,7 @@ unlockAccountReleases ts (PAV0 acc) = second PAV0 <$> V0.unlockReleases ts acc
 unlockAccountReleases ts (PAV1 acc) = second PAV1 <$> V0.unlockReleases ts acc
 unlockAccountReleases ts (PAV2 acc) = second PAV2 <$> V1.unlockReleases ts acc
 unlockAccountReleases ts (PAV3 acc) = second PAV3 <$> V1.unlockReleases ts acc
+unlockAccountReleases ts (PAV4 acc) = second PAV4 <$> V1.unlockReleases ts acc
 
 -- | Process the cooldowns on an account up to and including the given timestamp.
 --  This returns the next timestamp at which a cooldown expires, if any.
@@ -552,6 +607,8 @@ processAccountCooldownsUntil ::
     m (Maybe Timestamp, PersistentAccount av)
 processAccountCooldownsUntil ts (PAV3 acc) =
     second PAV3 <$> V1.processCooldownsUntil ts acc
+processAccountCooldownsUntil ts (PAV4 acc) =
+    second PAV4 <$> V1.processCooldownsUntil ts acc
 
 -- | Move the pre-cooldown amount on an account into cooldown with the specified release time.
 --  This returns @Just (Just ts)@ if the previous next cooldown time was @ts@, but the new next
@@ -563,6 +620,7 @@ processAccountPreCooldown ::
     PersistentAccount av ->
     m (NextCooldownChange, PersistentAccount av)
 processAccountPreCooldown ts (PAV3 acc) = second PAV3 <$> V1.processPreCooldown ts acc
+processAccountPreCooldown ts (PAV4 acc) = second PAV4 <$> V1.processPreCooldown ts acc
 
 -- | Move the pre-pre-cooldown amount on an account into pre-cooldown.
 --  It should be the case that the account has a pre-pre-cooldown amount and no pre-cooldown amount.
@@ -573,6 +631,7 @@ processAccountPrePreCooldown ::
     PersistentAccount av ->
     m (PersistentAccount av)
 processAccountPrePreCooldown (PAV3 acc) = PAV3 <$> V1.processPrePreCooldown acc
+processAccountPrePreCooldown (PAV4 acc) = PAV4 <$> V1.processPrePreCooldown acc
 
 -- * Creation
 
@@ -587,6 +646,7 @@ makePersistentAccount tacc = case accountVersion @av of
     SAccountV1 -> PAV1 <$> V0.makePersistentAccount tacc
     SAccountV2 -> PAV2 <$> V1.makePersistentAccount tacc
     SAccountV3 -> PAV3 <$> V1.makePersistentAccount tacc
+    SAccountV4 -> PAV4 <$> V1.makePersistentAccount tacc
 
 -- | Create an empty account with the given public key, address and credential.
 newAccount ::
@@ -601,6 +661,7 @@ newAccount = case accountVersion @av of
     SAccountV1 -> \ctx addr cred -> PAV1 <$> V0.newAccount ctx addr cred
     SAccountV2 -> \ctx addr cred -> PAV2 <$> V1.newAccount ctx addr cred
     SAccountV3 -> \ctx addr cred -> PAV3 <$> V1.newAccount ctx addr cred
+    SAccountV4 -> \ctx addr cred -> PAV4 <$> V1.newAccount ctx addr cred
 
 -- | Make a persistent account from a genesis account.
 --  The data is immediately flushed to disc and cached.
@@ -622,6 +683,8 @@ makeFromGenesisAccount spv =
             PAV2 <$> V1.makeFromGenesisAccount spv cryptoParams chainParameters genesisAccount
         SAccountV3 -> \cryptoParams chainParameters genesisAccount ->
             PAV3 <$> V1.makeFromGenesisAccount spv cryptoParams chainParameters genesisAccount
+        SAccountV4 -> \cryptoParams chainParameters genesisAccount ->
+            PAV4 <$> V1.makeFromGenesisAccount spv cryptoParams chainParameters genesisAccount
 
 -- ** 'PersistentBakerInfoRef' creation
 
@@ -636,6 +699,7 @@ makePersistentBakerInfoRef = case accountVersion @av of
     SAccountV1 -> fmap PBIRV1 . V0.makePersistentBakerInfoEx
     SAccountV2 -> fmap PBIRV2 . V1.makePersistentBakerInfoEx
     SAccountV3 -> fmap PBIRV3 . V1.makePersistentBakerInfoEx
+    SAccountV4 -> fmap PBIRV4 . V1.makePersistentBakerInfoEx
 
 -- * Migration
 
@@ -668,12 +732,14 @@ migratePersistentAccount m@StateMigrationParametersTrivial (PAV0 acc) = PAV0 <$>
 migratePersistentAccount m@StateMigrationParametersTrivial (PAV1 acc) = PAV1 <$> V0.migratePersistentAccount m acc
 migratePersistentAccount m@StateMigrationParametersTrivial (PAV2 acc) = PAV2 <$> V1.migratePersistentAccount m acc
 migratePersistentAccount m@StateMigrationParametersTrivial (PAV3 acc) = PAV3 <$> V1.migratePersistentAccount m acc
+migratePersistentAccount m@StateMigrationParametersTrivial (PAV4 acc) = PAV4 <$> V1.migratePersistentAccount m acc
 migratePersistentAccount m@StateMigrationParametersP1P2 (PAV0 acc) = PAV0 <$> V0.migratePersistentAccount m acc
 migratePersistentAccount m@StateMigrationParametersP2P3 (PAV0 acc) = PAV0 <$> V0.migratePersistentAccount m acc
 migratePersistentAccount m@StateMigrationParametersP3ToP4{} (PAV0 acc) = PAV1 <$> V0.migratePersistentAccount m acc
 migratePersistentAccount m@StateMigrationParametersP4ToP5{} (PAV1 acc) = PAV2 <$> V1.migratePersistentAccountFromV0 m acc
 migratePersistentAccount m@StateMigrationParametersP5ToP6{} (PAV2 acc) = PAV2 <$> V1.migratePersistentAccount m acc
 migratePersistentAccount m@StateMigrationParametersP6ToP7{} (PAV2 acc) = PAV3 <$> V1.migratePersistentAccount m acc
+migratePersistentAccount StateMigrationParametersP7ToP8{} (PAV3 _acc) = error "TODO(drsk) github #1222. Implement migratePersistentAccount for p7 -> p8"
 
 -- | Migrate a 'PersistentBakerInfoRef' between protocol versions according to a state migration.
 migratePersistentBakerInfoRef ::
@@ -686,12 +752,14 @@ migratePersistentBakerInfoRef m@StateMigrationParametersTrivial (PBIRV0 bir) = P
 migratePersistentBakerInfoRef m@StateMigrationParametersTrivial (PBIRV1 bir) = PBIRV1 <$> V0.migratePersistentBakerInfoEx m bir
 migratePersistentBakerInfoRef m@StateMigrationParametersTrivial (PBIRV2 bir) = PBIRV2 <$> V1.migratePersistentBakerInfoEx m bir
 migratePersistentBakerInfoRef m@StateMigrationParametersTrivial (PBIRV3 bir) = PBIRV3 <$> V1.migratePersistentBakerInfoEx m bir
+migratePersistentBakerInfoRef m@StateMigrationParametersTrivial (PBIRV4 bir) = PBIRV4 <$> V1.migratePersistentBakerInfoEx m bir
 migratePersistentBakerInfoRef m@StateMigrationParametersP1P2 (PBIRV0 bir) = PBIRV0 <$> V0.migratePersistentBakerInfoEx m bir
 migratePersistentBakerInfoRef m@StateMigrationParametersP2P3 (PBIRV0 bir) = PBIRV0 <$> V0.migratePersistentBakerInfoEx m bir
 migratePersistentBakerInfoRef m@StateMigrationParametersP3ToP4{} (PBIRV0 bir) = PBIRV1 <$> V0.migratePersistentBakerInfoEx m bir
 migratePersistentBakerInfoRef m@StateMigrationParametersP4ToP5{} (PBIRV1 bir) = PBIRV2 <$> V1.migratePersistentBakerInfoExFromV0 m bir
 migratePersistentBakerInfoRef m@StateMigrationParametersP5ToP6{} (PBIRV2 bir) = PBIRV2 <$> V1.migratePersistentBakerInfoEx m bir
 migratePersistentBakerInfoRef m@StateMigrationParametersP6ToP7{} (PBIRV2 bir) = PBIRV3 <$> V1.migratePersistentBakerInfoEx m bir
+migratePersistentBakerInfoRef m@StateMigrationParametersP7ToP8{} (PBIRV3 bir) = PBIRV4 <$> V1.migratePersistentBakerInfoEx m bir
 
 -- * Conversion
 
@@ -701,3 +769,4 @@ toTransientAccount (PAV0 acc) = V0.toTransientAccount acc
 toTransientAccount (PAV1 acc) = V0.toTransientAccount acc
 toTransientAccount (PAV2 acc) = V1.toTransientAccount acc
 toTransientAccount (PAV3 acc) = V1.toTransientAccount acc
+toTransientAccount (PAV4 acc) = V1.toTransientAccount acc

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
@@ -117,6 +117,7 @@ migratePersistentBakerInfoEx StateMigrationParametersP6ToP7{} = migrateReference
         BakerInfoEx av1 ->
         m' (BakerInfoEx av2)
     migrateBakerInfoExV1 BakerInfoExV1{..} = return BakerInfoExV1{..}
+migratePersistentBakerInfoEx StateMigrationParametersP7ToP8{} = error "TODO(drsk) github #1220. Implement migratePersistenBakerInfoEx p7 -> p8"
 
 -- | Migrate a 'V0.PersistentBakerInfoEx' to a 'PersistentBakerInfoEx'.
 --  See documentation of @migratePersistentBlockState@.
@@ -311,6 +312,9 @@ instance (MonadBlobStore m) => MHashableTo m (AccountStakeHash 'AccountV2) (Pers
 instance (MonadBlobStore m) => MHashableTo m (AccountStakeHash 'AccountV3) (PersistentAccountStakeEnduring 'AccountV3) where
     getHashM stake = getHash <$> persistentToAccountStake stake 0
 
+instance (MonadBlobStore m) => MHashableTo m (AccountStakeHash 'AccountV4) (PersistentAccountStakeEnduring 'AccountV4) where
+    getHashM stake = getHash <$> persistentToAccountStake stake 0
+
 -- * Enduring account data
 
 -- | Enduring data associated with an account. This is data that does not change very often.
@@ -422,6 +426,38 @@ makeAccountEnduringDataAV3 paedPersistingData paedEncryptedAmount paedReleaseSch
         !paedHash = getHash hashInputs
     return $! PersistentAccountEnduringData{..}
 
+-- | Construct a 'PersistentAccountEnduringData' from the components by computing the hash.
+--   Used for 'AccountV4'.
+--
+--  Precondition: if the 'PersistentAccountEncryptedAmount' is present then it must not satisfy
+--  'isInitialPersistentAccountEncryptedAmount'.
+--
+--  Precondition: if the 'AccountReleaseSchedule' is present, then it must have some releases
+--  and the total amount of the releases must be the provided amount.
+makeAccountEnduringDataAV4 ::
+    ( MonadBlobStore m
+    ) =>
+    EagerBufferedRef PersistingAccountData ->
+    Nullable (LazyBufferedRef PersistentAccountEncryptedAmount) ->
+    Nullable (LazyBufferedRef AccountReleaseSchedule, Amount) ->
+    PersistentAccountStakeEnduring 'AccountV4 ->
+    CooldownQueue 'AccountV4 ->
+    m (PersistentAccountEnduringData 'AccountV4)
+makeAccountEnduringDataAV4 paedPersistingData paedEncryptedAmount paedReleaseSchedule paedStake paedStakeCooldown = do
+    amhi4PersistingAccountDataHash <- getHashM paedPersistingData
+    (amhi4AccountStakeHash :: AccountStakeHash 'AccountV4) <- getHashM paedStake
+    amhi4EncryptedAmountHash <- case paedEncryptedAmount of
+        Null -> return initialAccountEncryptedAmountHash
+        Some e -> getHash <$> (loadPersistentAccountEncryptedAmount =<< refLoad e)
+    amhi4AccountReleaseScheduleHash <- case paedReleaseSchedule of
+        Null -> return TARSV1.emptyAccountReleaseScheduleHashV1
+        Some (rs, _) -> getHashM rs
+    amhi4Cooldown <- getHashM paedStakeCooldown
+    let hashInputs :: AccountMerkleHashInputs 'AccountV4
+        hashInputs = AccountMerkleHashInputsV4{..}
+        !paedHash = getHash hashInputs
+    return $! PersistentAccountEnduringData{..}
+
 -- | [For internal use in this module.] Recompute the Merkle hash of the enduring account data,
 --  for 'AccountV2'.
 rehashAccountEnduringDataAV2 ::
@@ -459,6 +495,23 @@ rehashAccountEnduringDataAV3 ed = do
     let hashInputs = AccountMerkleHashInputsV3{..}
     return $! ed{paedHash = getHash hashInputs}
 
+rehashAccountEnduringDataAV4 ::
+    (MonadBlobStore m) =>
+    PersistentAccountEnduringData 'AccountV4 ->
+    m (PersistentAccountEnduringData 'AccountV4)
+rehashAccountEnduringDataAV4 ed = do
+    amhi4PersistingAccountDataHash <- getHashM (paedPersistingData ed)
+    (amhi4AccountStakeHash :: AccountStakeHash 'AccountV4) <- getHashM (paedStake ed)
+    amhi4EncryptedAmountHash <- case paedEncryptedAmount ed of
+        Null -> return initialAccountEncryptedAmountHash
+        Some e -> getHash <$> (loadPersistentAccountEncryptedAmount =<< refLoad e)
+    amhi4AccountReleaseScheduleHash <- case paedReleaseSchedule ed of
+        Null -> return TARSV1.emptyAccountReleaseScheduleHashV1
+        Some (rs, _) -> getHashM rs
+    amhi4Cooldown <- getHashM $ paedStakeCooldown ed
+    let hashInputs = AccountMerkleHashInputsV4{..}
+    return $! ed{paedHash = getHash hashInputs}
+
 -- | [For internal use in this module.] Recompute the Merkle hash of the enduring account data.
 rehashAccountEnduringData ::
     forall m av.
@@ -468,6 +521,7 @@ rehashAccountEnduringData ::
 rehashAccountEnduringData = case accountVersion @av of
     SAccountV2 -> rehashAccountEnduringDataAV2
     SAccountV3 -> rehashAccountEnduringDataAV3
+    SAccountV4 -> rehashAccountEnduringDataAV4
 
 -- | Compute the 'EnduringDataFlags' from a 'PersistentAccountEnduringData' for the purposes of
 --  storing the account.
@@ -836,7 +890,19 @@ instance HashableTo (AccountHash 'AccountV3) (PersistentAccount 'AccountV3) wher
                       ahi2MerkleHash = getHash accountEnduringData
                     }
 
+instance HashableTo (AccountHash 'AccountV4) (PersistentAccount 'AccountV4) where
+    getHash PersistentAccount{..} =
+        makeAccountHash $
+            AHIV4 $
+                AccountHashInputsV2
+                    { ahi2NextNonce = accountNonce,
+                      ahi2AccountBalance = accountAmount,
+                      ahi2StakedBalance = accountStakedAmount,
+                      ahi2MerkleHash = getHash accountEnduringData
+                    }
+
 instance (Monad m) => MHashableTo m (AccountHash 'AccountV3) (PersistentAccount 'AccountV3)
+instance (Monad m) => MHashableTo m (AccountHash 'AccountV4) (PersistentAccount 'AccountV4)
 
 instance HashableTo Hash.Hash (PersistentAccount 'AccountV2) where
     getHash = theAccountHash @'AccountV2 . getHash
@@ -846,7 +912,11 @@ instance (Monad m) => MHashableTo m Hash.Hash (PersistentAccount 'AccountV2)
 instance HashableTo Hash.Hash (PersistentAccount 'AccountV3) where
     getHash = theAccountHash @'AccountV3 . getHash
 
+instance HashableTo Hash.Hash (PersistentAccount 'AccountV4) where
+    getHash = theAccountHash @'AccountV4 . getHash
+
 instance (Monad m) => MHashableTo m Hash.Hash (PersistentAccount 'AccountV3)
+instance (Monad m) => MHashableTo m Hash.Hash (PersistentAccount 'AccountV4)
 
 instance (MonadBlobStore m, IsAccountVersion av) => BlobStorable m (PersistentAccount av) where
     storeUpdate acc@PersistentAccount{..} = do
@@ -1632,6 +1702,13 @@ makePersistentAccount Transient.Account{..} = do
                         paedReleaseSchedule
                         paedStake
                         paedStakeCooldown
+                SAccountV4 ->
+                    makeAccountEnduringDataAV4
+                        paedPersistingData
+                        paedEncryptedAmount
+                        paedReleaseSchedule
+                        paedStake
+                        paedStakeCooldown
     return $!
         PersistentAccount
             { accountNonce = _accountNonce,
@@ -1672,6 +1749,13 @@ newAccount cryptoParams _accountAddress credential = do
                         PersistentAccountStakeEnduringNone
                 SAccountV3 ->
                     makeAccountEnduringDataAV3
+                        paedPersistingData
+                        Null
+                        Null
+                        PersistentAccountStakeEnduringNone
+                        emptyCooldownQueue
+                SAccountV4 ->
+                    makeAccountEnduringDataAV4
                         paedPersistingData
                         Null
                         Null
@@ -1737,6 +1821,13 @@ makeFromGenesisAccount spv cryptoParams chainParameters GenesisAccount{..} = do
                         stakeEnduring
                 SAccountV3 ->
                     makeAccountEnduringDataAV3
+                        paedPersistingData
+                        Null
+                        Null
+                        stakeEnduring
+                        emptyCooldownQueue
+                SAccountV4 ->
+                    makeAccountEnduringDataAV4
                         paedPersistingData
                         Null
                         Null
@@ -1818,6 +1909,22 @@ migrateEnduringDataV3toV3 ed = do
     paedStakeCooldown <- migrateCooldownQueue (paedStakeCooldown ed)
     makeAccountEnduringDataAV3 paedPersistingData paedEncryptedAmount paedReleaseSchedule paedStake paedStakeCooldown
 
+-- | Migration for 'PersistentAccountEnduringData'. Only supports 'AccountV4'.
+--  The data is unchanged in the migration.
+migrateEnduringDataV4toV4 ::
+    (SupportMigration m t) =>
+    PersistentAccountEnduringData 'AccountV4 ->
+    t m (PersistentAccountEnduringData 'AccountV4)
+migrateEnduringDataV4toV4 ed = do
+    paedPersistingData <- migrateEagerBufferedRef return (paedPersistingData ed)
+    paedEncryptedAmount <- forM (paedEncryptedAmount ed) $ migrateReference migratePersistentEncryptedAmount
+    paedReleaseSchedule <- forM (paedReleaseSchedule ed) $ \(oldRSRef, lockedAmt) -> do
+        newRSRef <- migrateReference migrateAccountReleaseSchedule oldRSRef
+        return (newRSRef, lockedAmt)
+    paedStake <- migratePersistentAccountStakeEnduring (paedStake ed)
+    paedStakeCooldown <- migrateCooldownQueue (paedStakeCooldown ed)
+    makeAccountEnduringDataAV4 paedPersistingData paedEncryptedAmount paedReleaseSchedule paedStake paedStakeCooldown
+
 -- | A trivial migration from account version 2 to account version 2.
 --  In particular the data is retained as-is.
 migrateV2ToV2 ::
@@ -1893,6 +2000,34 @@ migrateV3ToV3 acc = do
               ..
             }
 
+migrateV3ToV4 ::
+    ( MonadBlobStore m,
+      MonadBlobStore (t m),
+      MonadTrans t
+    ) =>
+    PersistentAccount 'AccountV3 ->
+    t m (PersistentAccount 'AccountV4)
+migrateV3ToV4 _acc = error "TODO(drsk) github #1221. implement migrateV3ToV4"
+
+-- | A trivial migration from account version 4 to account version 4.
+--  In particular the data is retained as-is.
+migrateV4ToV4 ::
+    ( MonadBlobStore m,
+      MonadBlobStore (t m),
+      MonadTrans t
+    ) =>
+    PersistentAccount 'AccountV4 ->
+    t m (PersistentAccount 'AccountV4)
+migrateV4ToV4 acc = do
+    accountEnduringData <- migrateEagerBufferedRef migrateEnduringDataV4toV4 (accountEnduringData acc)
+    return $!
+        PersistentAccount
+            { accountNonce = accountNonce acc,
+              accountAmount = accountAmount acc,
+              accountStakedAmount = accountStakedAmount acc,
+              ..
+            }
+
 -- | Migration for 'PersistentAccount'. Supports 'AccountV2' and 'AccountV3'.
 --
 --  When migrating P6->P7 (account version 2 to 3), the 'AccountMigration' interface is used as
@@ -1921,8 +2056,10 @@ migratePersistentAccount ::
 migratePersistentAccount StateMigrationParametersTrivial acc = case accountVersion @(AccountVersionFor oldpv) of
     SAccountV2 -> migrateV2ToV2 acc
     SAccountV3 -> migrateV3ToV3 acc
+    SAccountV4 -> migrateV4ToV4 acc
 migratePersistentAccount StateMigrationParametersP5ToP6{} acc = migrateV2ToV2 acc
 migratePersistentAccount StateMigrationParametersP6ToP7{} acc = migrateV2ToV3 acc
+migratePersistentAccount StateMigrationParametersP7ToP8{} acc = migrateV3ToV4 acc
 
 -- | Migration for 'PersistentAccount' from 'V0.PersistentAccount'. This supports migration from
 --  'P4' to 'P5'.

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Bakers.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Bakers.hs
@@ -154,6 +154,7 @@ migratePersistentEpochBakers migration PersistentEpochBakers{..} = do
             StateMigrationParametersP4ToP5 -> NoParam
             (StateMigrationParametersP5ToP6 P6.StateMigrationData{..}) -> SomeParam $ P6.updateFinalizationCommitteeParameters migrationProtocolUpdateData
             StateMigrationParametersP6ToP7{} -> _bakerFinalizationCommitteeParameters
+            StateMigrationParametersP7ToP8{} -> error "TODO(drsk). github #1223. Implement migratePersistentEpochBakers p7 -> p8"
     return
         PersistentEpochBakers
             { _bakerInfos = newBakerInfos,
@@ -314,6 +315,10 @@ migratePersistentActiveDelegators StateMigrationParametersP6ToP7{} = \case
     PersistentActiveDelegatorsV1{..} -> do
         newDelegators <- Trie.migrateTrieN True return adDelegators
         return PersistentActiveDelegatorsV1{adDelegators = newDelegators, ..}
+migratePersistentActiveDelegators StateMigrationParametersP7ToP8{} = \case
+    PersistentActiveDelegatorsV1{..} -> do
+        newDelegators <- Trie.migrateTrieN True return adDelegators
+        return PersistentActiveDelegatorsV1{adDelegators = newDelegators, ..}
 
 emptyPersistentActiveDelegators :: forall av. (IsAccountVersion av) => PersistentActiveDelegators av
 emptyPersistentActiveDelegators =
@@ -363,6 +368,7 @@ migrateTotalActiveCapital (StateMigrationParametersP3ToP4 _) bts TotalActiveCapi
 migrateTotalActiveCapital StateMigrationParametersP4ToP5 _ (TotalActiveCapitalV1 bts) = TotalActiveCapitalV1 bts
 migrateTotalActiveCapital StateMigrationParametersP5ToP6{} _ (TotalActiveCapitalV1 bts) = TotalActiveCapitalV1 bts
 migrateTotalActiveCapital StateMigrationParametersP6ToP7{} _ (TotalActiveCapitalV1 bts) = TotalActiveCapitalV1 bts
+migrateTotalActiveCapital StateMigrationParametersP7ToP8{} _ (TotalActiveCapitalV1 bts) = TotalActiveCapitalV1 bts
 
 instance (IsAccountVersion av) => Serialize (TotalActiveCapital av) where
     put TotalActiveCapitalV0 = return ()

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/Modules.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/Modules.hs
@@ -460,6 +460,7 @@ migrateModules migration mods = do
                     StateMigrationParametersP4ToP5{} -> return $! moduleVInterface{GSWasm.miModule = PIMVMem artifact}
                     StateMigrationParametersP5ToP6{} -> return $! moduleVInterface{GSWasm.miModule = PIMVMem artifact}
                     StateMigrationParametersP6ToP7{} -> migrateToP7 @v wasmMod -- always recompile to lower transaction costs.
+                    StateMigrationParametersP7ToP8{} -> error "TODO(drsk). github #1224. Implement state migration p7 -> p8"
 
         -- store the module into the new state, and remove it from memory
         makeFlushedHashedCachedRef $!

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/Updates.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/Updates.hs
@@ -305,6 +305,8 @@ migratePendingUpdates migration PendingUpdates{..} = withCPVConstraints (chainPa
             SomeParam _ -> return NoParam
         StateMigrationParametersP6ToP7{} -> case pElectionDifficultyQueue of
             NoParam -> return NoParam
+        StateMigrationParametersP7ToP8{} -> case pElectionDifficultyQueue of
+            NoParam -> return NoParam
     newTimeParameters <- case migration of
         StateMigrationParametersTrivial -> case pTimeParametersQueue of
             NoParam -> return NoParam
@@ -321,6 +323,8 @@ migratePendingUpdates migration PendingUpdates{..} = withCPVConstraints (chainPa
         StateMigrationParametersP5ToP6{} -> case pTimeParametersQueue of
             SomeParam hbr -> SomeParam <$> migrateHashedBufferedRef (migrateUpdateQueue id) hbr
         StateMigrationParametersP6ToP7{} -> case pTimeParametersQueue of
+            SomeParam hbr -> SomeParam <$> migrateHashedBufferedRef (migrateUpdateQueue id) hbr
+        StateMigrationParametersP7ToP8{} -> case pTimeParametersQueue of
             SomeParam hbr -> SomeParam <$> migrateHashedBufferedRef (migrateUpdateQueue id) hbr
     newCooldownParameters <- case migration of
         StateMigrationParametersTrivial -> case pCooldownParametersQueue of
@@ -340,6 +344,8 @@ migratePendingUpdates migration PendingUpdates{..} = withCPVConstraints (chainPa
             SomeParam hbr -> SomeParam <$> migrateHashedBufferedRef (migrateUpdateQueue id) hbr
         StateMigrationParametersP6ToP7{} -> case pCooldownParametersQueue of
             SomeParam hbr -> SomeParam <$> migrateHashedBufferedRef (migrateUpdateQueue id) hbr
+        StateMigrationParametersP7ToP8{} -> case pCooldownParametersQueue of
+            SomeParam hbr -> SomeParam <$> migrateHashedBufferedRef (migrateUpdateQueue id) hbr
     newTimeoutParameters <- case migration of
         StateMigrationParametersTrivial -> case pTimeoutParametersQueue of
             NoParam -> return NoParam
@@ -356,6 +362,8 @@ migratePendingUpdates migration PendingUpdates{..} = withCPVConstraints (chainPa
             (!hbr, _) <- refFlush =<< refMake emptyUpdateQueue
             return (SomeParam hbr)
         StateMigrationParametersP6ToP7{} -> case pTimeoutParametersQueue of
+            SomeParam hbr -> SomeParam <$> migrateHashedBufferedRef (migrateUpdateQueue id) hbr
+        StateMigrationParametersP7ToP8{} -> case pTimeoutParametersQueue of
             SomeParam hbr -> SomeParam <$> migrateHashedBufferedRef (migrateUpdateQueue id) hbr
     newMinBlockTimeQueue <- case migration of
         StateMigrationParametersTrivial -> case pMinBlockTimeQueue of
@@ -374,6 +382,8 @@ migratePendingUpdates migration PendingUpdates{..} = withCPVConstraints (chainPa
             return (SomeParam hbr)
         StateMigrationParametersP6ToP7{} -> case pMinBlockTimeQueue of
             SomeParam hbr -> SomeParam <$> migrateHashedBufferedRef (migrateUpdateQueue id) hbr
+        StateMigrationParametersP7ToP8{} -> case pMinBlockTimeQueue of
+            SomeParam hbr -> SomeParam <$> migrateHashedBufferedRef (migrateUpdateQueue id) hbr
     newBlockEnergyLimitQueue <- case migration of
         StateMigrationParametersTrivial -> case pBlockEnergyLimitQueue of
             NoParam -> return NoParam
@@ -391,6 +401,8 @@ migratePendingUpdates migration PendingUpdates{..} = withCPVConstraints (chainPa
             return (SomeParam hbr)
         StateMigrationParametersP6ToP7{} -> case pBlockEnergyLimitQueue of
             SomeParam hbr -> SomeParam <$> migrateHashedBufferedRef (migrateUpdateQueue id) hbr
+        StateMigrationParametersP7ToP8{} -> case pBlockEnergyLimitQueue of
+            SomeParam hbr -> SomeParam <$> migrateHashedBufferedRef (migrateUpdateQueue id) hbr
     newFinalizationCommitteeParametersQueue <- case migration of
         StateMigrationParametersTrivial -> case pFinalizationCommitteeParametersQueue of
             NoParam -> return NoParam
@@ -407,6 +419,8 @@ migratePendingUpdates migration PendingUpdates{..} = withCPVConstraints (chainPa
             (!hbr, _) <- refFlush =<< refMake emptyUpdateQueue
             return (SomeParam hbr)
         StateMigrationParametersP6ToP7{} -> case pFinalizationCommitteeParametersQueue of
+            SomeParam hbr -> SomeParam <$> migrateHashedBufferedRef (migrateUpdateQueue id) hbr
+        StateMigrationParametersP7ToP8{} -> case pFinalizationCommitteeParametersQueue of
             SomeParam hbr -> SomeParam <$> migrateHashedBufferedRef (migrateUpdateQueue id) hbr
     return $!
         PendingUpdates

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Genesis.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Genesis.hs
@@ -18,6 +18,7 @@ import qualified Concordium.Genesis.Data.P4 as P4
 import qualified Concordium.Genesis.Data.P5 as P5
 import qualified Concordium.Genesis.Data.P6 as P6
 import qualified Concordium.Genesis.Data.P7 as P7
+import qualified Concordium.Genesis.Data.P8 as P8
 import qualified Concordium.GlobalState.CapitalDistribution as CapDist
 import qualified Concordium.GlobalState.Persistent.Account as Account
 import qualified Concordium.GlobalState.Persistent.Accounts as Accounts
@@ -80,6 +81,9 @@ genesisState gd = MTL.runExceptT $ case Types.protocolVersion @pv of
             buildGenesisBlockState (CGPV1 genesisCore) genesisInitialState
     Types.SP7 -> case gd of
         GenesisData.GDP7 P7.GDP7Initial{..} ->
+            buildGenesisBlockState (CGPV1 genesisCore) genesisInitialState
+    Types.SP8 -> case gd of
+        GenesisData.GDP8 P8.GDP8Initial{..} ->
             buildGenesisBlockState (CGPV1 genesisCore) genesisInitialState
 
 -------- Types -----------

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/ReleaseSchedule.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/ReleaseSchedule.hs
@@ -308,6 +308,7 @@ instance (MonadBlobStore m, IsProtocolVersion pv) => BlobStorable m (ReleaseSche
         SP5 -> fmap ReleaseScheduleP5 <$> load
         SP6 -> fmap ReleaseScheduleP5 <$> load
         SP7 -> fmap ReleaseScheduleP5 <$> load
+        SP8 -> fmap ReleaseScheduleP5 <$> load
 
 instance (MonadBlobStore m) => Cacheable m (ReleaseSchedule pv) where
     cache (ReleaseScheduleP0 rs) = ReleaseScheduleP0 <$> cache rs
@@ -338,6 +339,7 @@ emptyReleaseSchedule = case protocolVersion @pv of
     SP5 -> rsP1
     SP6 -> rsP1
     SP7 -> rsP1
+    SP8 -> rsP1
   where
     rsP0 :: (RSAccountRef pv ~ AccountAddress) => m (ReleaseSchedule pv)
     rsP0 = do
@@ -385,6 +387,7 @@ trivialReleaseScheduleMigration = case protocolVersion @pv of
     SP5 -> RSMNewToNew
     SP6 -> RSMNewToNew
     SP7 -> RSMNewToNew
+    SP8 -> RSMNewToNew
 
 -- | Migrate a release schedule from one protocol version to another, given by a
 --  'ReleaseScheduleMigration'.

--- a/concordium-consensus/src/Concordium/KonsensusV1/TestMonad.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TestMonad.hs
@@ -27,10 +27,11 @@ import Concordium.Types
 import qualified Concordium.Genesis.Data.BaseV1 as BaseV1
 import qualified Concordium.Genesis.Data.P6 as P6
 import qualified Concordium.Genesis.Data.P7 as P7
+import qualified Concordium.Genesis.Data.P8 as P8
 import qualified Concordium.GlobalState.AccountMap.LMDB as LMDBAccountMap
 import Concordium.GlobalState.BlockState
 import Concordium.GlobalState.Parameters (
-    GenesisData (GDP6, GDP7),
+    GenesisData (GDP6, GDP7, GDP8),
     defaultRuntimeParameters,
     genesisBlockHash,
  )
@@ -148,6 +149,7 @@ genesisCore :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => GenesisDat
 genesisCore = case protocolVersion @pv of
     SP6 -> \(GDP6 P6.GDP6Initial{genesisCore = core}) -> core
     SP7 -> \(GDP7 P7.GDP7Initial{genesisCore = core}) -> core
+    SP8 -> \(GDP8 P8.GDP8Initial{genesisCore = core}) -> core
 
 -- | Run an operation in the 'TestMonad' with the given baker, time and genesis data.
 --  This sets up a temporary blob store for the block state that is deleted after use.

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -1090,6 +1090,8 @@ getAccountInfoHelper getASI getCooldowns acct bs = do
         aiAccountAddress <- BS.getAccountCanonicalAddress acc
         aiAccountCooldowns <- getCooldowns acc
         aiAccountAvailableAmount <- BS.getAccountAvailableAmount acc
+        -- TODO(drsk). github #1225. Implement getAccountIsSuspended
+        let aiAccountIsSuspended = False
         return AccountInfo{..}
 
 -- | Get the details of a smart contract instance in the block state.

--- a/concordium-consensus/src/Concordium/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler.hs
@@ -1256,6 +1256,7 @@ handleContractUpdateV1 depth originAddr istance checkAndGetSender transferAmount
                                                             P5 -> resumeEvent False : interruptEvent : events
                                                             P6 -> resumeEvent False : interruptEvent : events
                                                             P7 -> resumeEvent False : interruptEvent : events
+                                                            P8 -> resumeEvent False : interruptEvent : events
                                                 go newEvents =<< runInterpreter (return . WasmV1.resumeReceiveFun rrdInterruptedConfig rrdCurrentState False entryBalance (WasmV1.Error (WasmV1.EnvFailure (WasmV1.MissingContract imcTo))) Nothing)
                                             Just (InstanceInfoV0 targetInstance) -> do
                                                 -- we are invoking a V0 instance.

--- a/concordium-consensus/src/Concordium/Scheduler/TreeStateEnvironment.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/TreeStateEnvironment.hs
@@ -1181,6 +1181,7 @@ putBakerCommissionsInRange ranges bs (BakerId ai) = case protocolVersion @(MPV m
     SP5 -> bsoConstrainBakerCommission bs ai ranges
     SP6 -> bsoConstrainBakerCommission bs ai ranges
     SP7 -> bsoConstrainBakerCommission bs ai ranges
+    SP8 -> bsoConstrainBakerCommission bs ai ranges
 
 -- | The result of executing the block prologue.
 data PrologueResult m = PrologueResult

--- a/concordium-consensus/src/Concordium/Startup.hs
+++ b/concordium-consensus/src/Concordium/Startup.hs
@@ -38,6 +38,7 @@ import qualified Concordium.Genesis.Data.P4 as P4
 import qualified Concordium.Genesis.Data.P5 as P5
 import qualified Concordium.Genesis.Data.P6 as P6
 import qualified Concordium.Genesis.Data.P7 as P7
+import qualified Concordium.Genesis.Data.P8 as P8
 import Concordium.GlobalState.BakerInfo
 import Concordium.GlobalState.DummyData
 import Concordium.GlobalState.Parameters
@@ -261,6 +262,12 @@ makeGenesisDataV1
             SP7 ->
                 GDP7
                     P7.GDP7Initial
+                        { genesisCore = GDBaseV1.CoreGenesisParametersV1{..},
+                          genesisInitialState = GenesisData.GenesisState{genesisAccounts = Vec.fromList genesisAccounts, ..}
+                        }
+            SP8 ->
+                GDP8
+                    P8.GDP8Initial
                         { genesisCore = GDBaseV1.CoreGenesisParametersV1{..},
                           genesisInitialState = GenesisData.GenesisState{genesisAccounts = Vec.fromList genesisAccounts, ..}
                         }

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Consensus/Blocks.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Consensus/Blocks.hs
@@ -40,6 +40,7 @@ import qualified Concordium.Types.Transactions as Transactions
 
 import qualified Concordium.Genesis.Data.P6 as P6
 import qualified Concordium.Genesis.Data.P7 as P7
+import qualified Concordium.Genesis.Data.P8 as P8
 import Concordium.GlobalState.BakerInfo
 import Concordium.GlobalState.Basic.BlockState.LFMBTree (hashAsLFMBTV0)
 import Concordium.GlobalState.BlockState (TransactionSummaryV1)
@@ -124,6 +125,7 @@ genesisLEN :: (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv ->
 genesisLEN sProtocolVersion = case sProtocolVersion of
     SP6 -> genesisLeadershipElectionNonce $ P6.genesisInitialState $ unGDP6 $ genesisData sProtocolVersion
     SP7 -> genesisLeadershipElectionNonce $ P7.genesisInitialState $ unGDP7 $ genesisData sProtocolVersion
+    SP8 -> genesisLeadershipElectionNonce $ P8.genesisInitialState $ unGDP8 $ genesisData sProtocolVersion
 
 -- | Full bakers at genesis
 genesisFullBakers :: forall pv. (IsConsensusV1 pv, IsProtocolVersion pv) => SProtocolVersion pv -> FullBakers

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/TransactionProcessingTest.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/TransactionProcessingTest.hs
@@ -48,6 +48,7 @@ import qualified Concordium.Genesis.Data.Base as Base
 import Concordium.Genesis.Data.BaseV1
 import Concordium.Genesis.Data.P6
 import Concordium.Genesis.Data.P7
+import Concordium.Genesis.Data.P8
 import Concordium.GlobalState.BakerInfo
 import Concordium.GlobalState.DummyData
 import Concordium.GlobalState.Parameters (defaultRuntimeParameters)
@@ -259,6 +260,12 @@ makeTestingGenesisData idps =
             SP7 ->
                 GDP7
                     GDP7Initial
+                        { genesisCore = coreGenesisParams,
+                          genesisInitialState = Base.GenesisState{..}
+                        }
+            SP8 ->
+                GDP8
+                    GDP8Initial
                         { genesisCore = coreGenesisParams,
                           genesisInitialState = Base.GenesisState{..}
                         }


### PR DESCRIPTION
## Purpose

This adds boilerplate code necessary for account version 4, which is part of protocol version 8. This is mainly guided by the compiler and is at the moment exactly the same as account v3, except that the type has been changed. Non-trivial migration functions are implemented as errors and tracked in Github issues. It would be great to further compress all the boilerplate, especially for the trivial things, but this won't be part of this PR.

## Changes

All the boilerplate required for account version 4 and protocol version 8.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
