### PR TITLE
Suspend resume configure baker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Add support for suspend/resume to validator configuration updates.
+
 ## 7.0.3
 
 - Fix a bug in the computation of the genesis height after the second protocol update. (#1237)

--- a/concordium-consensus/src/Concordium/GlobalState/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Account.hs
@@ -376,7 +376,7 @@ makeAccountHashV3 AccountHashInputsV2{..} = Hash.hashLazy $ runPutLazy $ do
     put ahi2StakedBalance
     put ahi2MerkleHash
 
--- | Generate the hash for an account (for 'AccountV3'), given the
+-- | Generate the hash for an account (for 'AccountV4'), given the
 --  'AccountHashInputsV2'. 'makeAccountHash' should be used in preference to this function.
 makeAccountHashV4 :: AccountHashInputsV2 av -> Hash.Hash
 makeAccountHashV4 AccountHashInputsV2{..} = Hash.hashLazy $ runPutLazy $ do

--- a/concordium-consensus/src/Concordium/GlobalState/BakerInfo.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BakerInfo.hs
@@ -228,7 +228,9 @@ data ValidatorUpdate = ValidatorUpdate
       -- | The new baking reward commission for the validator.
       vuBakingRewardCommission :: !(Maybe AmountFraction),
       -- | The new finalization reward commission for the validator.
-      vuFinalizationRewardCommission :: !(Maybe AmountFraction)
+      vuFinalizationRewardCommission :: !(Maybe AmountFraction),
+      -- | Whether the validator's account should be suspended/resumed.
+      vuSuspend :: !(Maybe Bool)
     }
     deriving (Eq, Show)
 

--- a/concordium-consensus/src/Concordium/GlobalState/BakerInfo.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BakerInfo.hs
@@ -207,8 +207,7 @@ data ValidatorAdd = ValidatorAdd
       vaMetadataURL :: !UrlText,
       -- | The commission rates for the validator.
       vaCommissionRates :: !CommissionRates
-      -- | TODO (drsk) Github issue #1246. Support suspend/resume for ValidatorAdd.
-      -- vaSuspend :: !Bool
+      -- TODO (drsk) Github issue #1246. Support suspend/resume for ValidatorAdd.
     }
     deriving (Eq, Show)
 

--- a/concordium-consensus/src/Concordium/GlobalState/BakerInfo.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BakerInfo.hs
@@ -207,6 +207,8 @@ data ValidatorAdd = ValidatorAdd
       vaMetadataURL :: !UrlText,
       -- | The commission rates for the validator.
       vaCommissionRates :: !CommissionRates
+      -- | TODO (drsk) Github issue #1246. Support suspend/resume for ValidatorAdd.
+      -- vaSuspend :: !Bool
     }
     deriving (Eq, Show)
 

--- a/concordium-consensus/src/Concordium/GlobalState/BakerInfo.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BakerInfo.hs
@@ -245,7 +245,8 @@ validatorRemove =
           vuMetadataURL = Nothing,
           vuTransactionFeeCommission = Nothing,
           vuBakingRewardCommission = Nothing,
-          vuFinalizationRewardCommission = Nothing
+          vuFinalizationRewardCommission = Nothing,
+          vuSuspend = Nothing
         }
 
 -- | Failure modes when configuring a validator.
@@ -276,6 +277,8 @@ data BakerConfigureUpdateChange
     | BakerConfigureTransactionFeeCommission !AmountFraction
     | BakerConfigureBakingRewardCommission !AmountFraction
     | BakerConfigureFinalizationRewardCommission !AmountFraction
+    | BakerConfigureSuspended
+    | BakerConfigureResumed
     deriving (Eq, Show)
 
 -- | Parameters for adding a delegator.

--- a/concordium-consensus/src/Concordium/GlobalState/BakerInfo.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BakerInfo.hs
@@ -367,9 +367,12 @@ genesisBakerInfoEx spv cp GenesisBaker{..} = case spv of
     binfoV1 :: (PVSupportsDelegation pv, PoolParametersVersionFor (ChainParametersVersionFor pv) ~ 'PoolParametersVersion1) => BakerInfoEx (AccountVersionFor pv)
     binfoV1 =
         BakerInfoExV1
-            bkrInfo
-            BakerPoolInfo
-                { _poolOpenStatus = OpenForAll,
-                  _poolMetadataUrl = emptyUrlText,
-                  _poolCommissionRates = cp ^. cpPoolParameters . ppCommissionBounds . to maximumCommissionRates
-                }
+            { _bieBakerInfo = bkrInfo,
+              _bieBakerPoolInfo =
+                BakerPoolInfo
+                    { _poolOpenStatus = OpenForAll,
+                      _poolMetadataUrl = emptyUrlText,
+                      _poolCommissionRates = cp ^. cpPoolParameters . ppCommissionBounds . to maximumCommissionRates
+                    },
+              _bieAccountIsSuspended = conditionally (sSupportsValidatorSuspension (sAccountVersionFor spv)) False
+            }

--- a/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/Account.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -61,9 +60,7 @@ data Account (av :: AccountVersion) = Account
       -- | The cooldown on the account.
       _accountStakeCooldown :: !(Conditionally (SupportsFlexibleCooldown av) Cooldowns)
     }
-
-deriving instance forall av. (IsAccountVersion av) => Eq (Account av)
-deriving instance forall av. (IsAccountVersion av) => Show (Account av)
+    deriving (Eq, Show)
 
 makeLenses ''Account
 

--- a/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/Account.hs
@@ -5,9 +5,11 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Concordium.GlobalState.Basic.BlockState.Account (
     module Concordium.GlobalState.Account,
@@ -60,7 +62,9 @@ data Account (av :: AccountVersion) = Account
       -- | The cooldown on the account.
       _accountStakeCooldown :: !(Conditionally (SupportsFlexibleCooldown av) Cooldowns)
     }
-    deriving (Eq, Show)
+
+deriving instance forall av. (IsAccountVersion av) => Eq (Account av)
+deriving instance forall av. (IsAccountVersion av) => Show (Account av)
 
 makeLenses ''Account
 

--- a/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/Account.hs
@@ -9,7 +9,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UndecidableInstances #-}
 
 module Concordium.GlobalState.Basic.BlockState.Account (
     module Concordium.GlobalState.Account,

--- a/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/AccountReleaseSchedule.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/AccountReleaseSchedule.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UndecidableInstances #-}
 -- We suppress redundant constraint warnings since GHC does not detect when a constraint is used
 -- for pattern matching. (See: https://gitlab.haskell.org/ghc/ghc/-/issues/20896)
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}

--- a/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/AccountReleaseSchedule.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/AccountReleaseSchedule.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 -- We suppress redundant constraint warnings since GHC does not detect when a constraint is used
 -- for pattern matching. (See: https://gitlab.haskell.org/ghc/ghc/-/issues/20896)
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}

--- a/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
@@ -253,6 +253,9 @@ class (BlockStateTypes m, Monad m) => AccountOperations m where
         Account m ->
         m (Maybe Cooldowns)
 
+    -- | Get the suspended flag for an account, if any.
+    getAccountIsSuspended :: Account m -> m Bool
+
 -- * Active, current and next bakers/delegators
 
 --
@@ -1709,6 +1712,7 @@ instance (Monad (t m), MonadTrans t, AccountOperations m) => AccountOperations (
     derefBakerInfo = lift . derefBakerInfo
     getAccountHash = lift . getAccountHash
     getAccountCooldowns = lift . getAccountCooldowns
+    getAccountIsSuspended = lift . getAccountIsSuspended
     {-# INLINE getAccountCanonicalAddress #-}
     {-# INLINE getAccountAmount #-}
     {-# INLINE getAccountAvailableAmount #-}
@@ -1724,6 +1728,7 @@ instance (Monad (t m), MonadTrans t, AccountOperations m) => AccountOperations (
     {-# INLINE derefBakerInfo #-}
     {-# INLINE getAccountHash #-}
     {-# INLINE getAccountCooldowns #-}
+    {-# INLINE getAccountIsSuspended #-}
 
 instance (Monad (t m), MonadTrans t, ContractStateOperations m) => ContractStateOperations (MGSTrans t m) where
     thawContractState = lift . thawContractState

--- a/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
@@ -253,9 +253,6 @@ class (BlockStateTypes m, Monad m) => AccountOperations m where
         Account m ->
         m (Maybe Cooldowns)
 
-    -- | Get the suspended flag for an account, if any.
-    getAccountIsSuspended :: Account m -> m Bool
-
 -- * Active, current and next bakers/delegators
 
 --
@@ -1712,7 +1709,6 @@ instance (Monad (t m), MonadTrans t, AccountOperations m) => AccountOperations (
     derefBakerInfo = lift . derefBakerInfo
     getAccountHash = lift . getAccountHash
     getAccountCooldowns = lift . getAccountCooldowns
-    getAccountIsSuspended = lift . getAccountIsSuspended
     {-# INLINE getAccountCanonicalAddress #-}
     {-# INLINE getAccountAmount #-}
     {-# INLINE getAccountAvailableAmount #-}
@@ -1728,7 +1724,6 @@ instance (Monad (t m), MonadTrans t, AccountOperations m) => AccountOperations (
     {-# INLINE derefBakerInfo #-}
     {-# INLINE getAccountHash #-}
     {-# INLINE getAccountCooldowns #-}
-    {-# INLINE getAccountIsSuspended #-}
 
 instance (Monad (t m), MonadTrans t, ContractStateOperations m) => ContractStateOperations (MGSTrans t m) where
     thawContractState = lift . thawContractState

--- a/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
@@ -1109,7 +1109,7 @@ class (BlockStateQuery m) => BlockStateOperations m where
 
     --        (1) Suspend/resume the validator according to the flag.
 
-    --        (2) Append @BakerConfigureSuspended, @BakerConfigureResumed respectively to @events@.
+    --        (2) Append @BakerConfigureSuspended@ or @BakerConfigureResumed@ accordingly to @events@.
     --
     --  9. Return @events@ with the updated block state.
     bsoUpdateValidator ::

--- a/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
@@ -1105,7 +1105,13 @@ class (BlockStateQuery m) => BlockStateOperations m where
     --         is (preferentially) reactivated from the inactive stake, updating the global indices
     --         accordingly.
     --
-    --  8. Return @events@ with the updated block state.
+    --  8. If the suspended/resumed flag is set and (>= P8):
+
+    --        (1) Suspend/resume the validator according to the flag.
+
+    --        (2) Append @BakerConfigureSuspended, @BakerConfigureResumed respectively to @events@.
+    --
+    --  9. Return @events@ with the updated block state.
     bsoUpdateValidator ::
         (PVSupportsDelegation (MPV m)) =>
         UpdatableBlockState m ->

--- a/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
@@ -1105,7 +1105,7 @@ class (BlockStateQuery m) => BlockStateOperations m where
     --         is (preferentially) reactivated from the inactive stake, updating the global indices
     --         accordingly.
     --
-    --  8. If the suspended/resumed flag is set and (>= P8):
+    --  8. (>= P8) If the suspended/resumed flag is set:
 
     --        (1) Suspend/resume the validator according to the flag.
 

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
@@ -519,7 +519,7 @@ setAccountValidatorSuspended ::
     Bool ->
     PersistentAccount av ->
     m (PersistentAccount av)
-setAccountSuspended isSuspended (PAV4 acc) = PAV4 <$> V1.setSuspended isSuspended acc
+setAccountValidatorSuspended isSuspended (PAV4 acc) = PAV4 <$> V1.setValidatorSuspended isSuspended acc
 
 -- | Add a specified amount to the pre-pre-cooldown inactive stake.
 addAccountPrePreCooldown ::

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
@@ -320,16 +320,6 @@ accountHasPrePreCooldown = fmap check . accountCooldowns
   where
     check = maybe False (not . null . prePreCooldown)
 
-accountIsSuspended ::
-    (MonadBlobStore m) =>
-    PersistentAccount av ->
-    m Bool
-accountIsSuspended (PAV0 _acc) = return False
-accountIsSuspended (PAV1 _acc) = return False
-accountIsSuspended (PAV2 _acc) = return False
-accountIsSuspended (PAV3 _acc) = return False
-accountIsSuspended (PAV4 acc) = V1.getIsSuspended acc
-
 -- | Get the 'AccountHash' for the account.
 accountHash :: (MonadBlobStore m) => PersistentAccount av -> m (AccountHash av)
 accountHash (PAV0 acc) = getHashM acc

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
@@ -514,7 +514,7 @@ setAccountStake newStake (PAV2 acc) = PAV2 <$> V1.setStake newStake acc
 setAccountStake newStake (PAV3 acc) = PAV3 <$> V1.setStake newStake acc
 setAccountStake newStake (PAV4 acc) = PAV4 <$> V1.setStake newStake acc
 
-setAccountSuspended ::
+setAccountValidatorSuspended ::
     (MonadBlobStore m, AVSupportsValidatorSuspension av) =>
     Bool ->
     PersistentAccount av ->

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
@@ -514,9 +514,11 @@ setAccountStake newStake (PAV2 acc) = PAV2 <$> V1.setStake newStake acc
 setAccountStake newStake (PAV3 acc) = PAV3 <$> V1.setStake newStake acc
 setAccountStake newStake (PAV4 acc) = PAV4 <$> V1.setStake newStake acc
 
-setAccountSuspended :: 
+setAccountSuspended ::
     (MonadBlobStore m, AVSupportsValidatorSuspension av) =>
-    Bool -> PersistentAccount av -> m (PersistentAccount av)
+    Bool ->
+    PersistentAccount av ->
+    m (PersistentAccount av)
 setAccountSuspended isSuspended (PAV4 acc) = PAV4 <$> V1.setSuspended isSuspended acc
 
 -- | Add a specified amount to the pre-pre-cooldown inactive stake.

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
@@ -504,7 +504,7 @@ setAccountStake newStake (PAV2 acc) = PAV2 <$> V1.setStake newStake acc
 setAccountStake newStake (PAV3 acc) = PAV3 <$> V1.setStake newStake acc
 setAccountStake newStake (PAV4 acc) = PAV4 <$> V1.setStake newStake acc
 
--- | Suspend or resume the account of a validator. 
+-- | Suspend or resume the account of a validator.
 --  This MUST only be called with an account that is a validator.
 setAccountValidatorSuspended ::
     (MonadBlobStore m, AVSupportsValidatorSuspension av) =>

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
@@ -320,6 +320,16 @@ accountHasPrePreCooldown = fmap check . accountCooldowns
   where
     check = maybe False (not . null . prePreCooldown)
 
+accountIsSuspended ::
+    (MonadBlobStore m) =>
+    PersistentAccount av ->
+    m Bool
+accountIsSuspended (PAV0 _acc) = return False
+accountIsSuspended (PAV1 _acc) = return False
+accountIsSuspended (PAV2 _acc) = return False
+accountIsSuspended (PAV3 _acc) = return False
+accountIsSuspended (PAV4 acc) = V1.getIsSuspended acc
+
 -- | Get the 'AccountHash' for the account.
 accountHash :: (MonadBlobStore m) => PersistentAccount av -> m (AccountHash av)
 accountHash (PAV0 acc) = getHashM acc
@@ -503,6 +513,11 @@ setAccountStake newStake (PAV1 acc) = PAV1 <$> V0.setStake newStake acc
 setAccountStake newStake (PAV2 acc) = PAV2 <$> V1.setStake newStake acc
 setAccountStake newStake (PAV3 acc) = PAV3 <$> V1.setStake newStake acc
 setAccountStake newStake (PAV4 acc) = PAV4 <$> V1.setStake newStake acc
+
+setAccountSuspended :: 
+    (MonadBlobStore m, AVSupportsValidatorSuspension av) =>
+    Bool -> PersistentAccount av -> m (PersistentAccount av)
+setAccountSuspended isSuspended (PAV4 acc) = PAV4 <$> V1.setSuspended isSuspended acc
 
 -- | Add a specified amount to the pre-pre-cooldown inactive stake.
 addAccountPrePreCooldown ::

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
@@ -504,6 +504,8 @@ setAccountStake newStake (PAV2 acc) = PAV2 <$> V1.setStake newStake acc
 setAccountStake newStake (PAV3 acc) = PAV3 <$> V1.setStake newStake acc
 setAccountStake newStake (PAV4 acc) = PAV4 <$> V1.setStake newStake acc
 
+-- | Suspend or resume the account of a validator. 
+--  This MUST only be called with an account that is a validator.
 setAccountValidatorSuspended ::
     (MonadBlobStore m, AVSupportsValidatorSuspension av) =>
     Bool ->

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/CooldownQueue.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/CooldownQueue.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Concordium.GlobalState.Persistent.Account.CooldownQueue where
 

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/CooldownQueue.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/CooldownQueue.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE UndecidableInstances #-}
 
 module Concordium.GlobalState.Persistent.Account.CooldownQueue where
 

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV0.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV0.hs
@@ -691,7 +691,11 @@ getNextReleaseTimestamp :: (MonadBlobStore m) => PersistentAccount av -> m (Mayb
 getNextReleaseTimestamp acc = nextReleaseTimestamp <$!> refLoad (acc ^. accountReleaseSchedule)
 
 -- | Get the baker and baker info reference (if any) attached to the account.
-getBakerAndInfoRef :: forall m av. (MonadBlobStore m, IsAccountVersion av, AVStructureV0 av, SupportsValidatorSuspension av ~ 'False) => PersistentAccount av -> m (Maybe (AccountBaker av, PersistentBakerInfoEx av))
+getBakerAndInfoRef ::
+    forall m av.
+    (MonadBlobStore m, IsAccountVersion av, AVStructureV0 av, SupportsValidatorSuspension av ~ 'False) =>
+    PersistentAccount av ->
+    m (Maybe (AccountBaker av, PersistentBakerInfoEx av))
 getBakerAndInfoRef acc = case acc ^. accountBaker of
     Null -> return Nothing
     Some bref -> do
@@ -719,7 +723,11 @@ getBakerAndInfoRef acc = case acc ^. accountBaker of
                         )
 
 -- | Get the baker (if any) attached to an account.
-getBaker :: forall m av. (MonadBlobStore m, IsAccountVersion av, AVStructureV0 av, SupportsValidatorSuspension av ~ 'False) => PersistentAccount av -> m (Maybe (AccountBaker av))
+getBaker ::
+    forall m av.
+    (MonadBlobStore m, IsAccountVersion av, AVStructureV0 av, SupportsValidatorSuspension av ~ 'False) =>
+    PersistentAccount av ->
+    m (Maybe (AccountBaker av))
 getBaker acc = fmap fst <$> getBakerAndInfoRef acc
 
 -- | Get the baker and baker info reference (if any) attached to the account.

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV0.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV0.hs
@@ -212,7 +212,7 @@ loadPersistentBakerInfoEx PersistentBakerInfoEx{..} = do
         SAccountV0 -> return $ BakerInfoExV0 bkrInfo
         SAccountV1 -> do
             bkrInfoEx <- refLoad (bakerInfoExtra ^. theExtraBakerInfo)
-            return $ BakerInfoExV1 bkrInfo bkrInfoEx
+            return $ BakerInfoExV1 bkrInfo bkrInfoEx CFalse
 
 -- | Load the baker id from the 'PersistentBakerInfoEx' structure.
 loadBakerId :: (MonadBlobStore m) => PersistentBakerInfoEx av -> m BakerId
@@ -227,7 +227,7 @@ makePersistentBakerInfoEx :: (IsAccountVersion av, AVStructureV0 av, MonadBlobSt
 makePersistentBakerInfoEx (BakerInfoExV0 bi) = do
     bakerInfoRef <- refMake bi
     return PersistentBakerInfoEx{bakerInfoExtra = PersistentExtraBakerInfo (), ..}
-makePersistentBakerInfoEx (BakerInfoExV1 bi ebi) = do
+makePersistentBakerInfoEx (BakerInfoExV1 bi ebi _isSuspended) = do
     bakerInfoRef <- refMake bi
     bakerInfoExtra <- makePersistentExtraBakerInfoV1 <$> refMake ebi
     return PersistentBakerInfoEx{..}
@@ -691,7 +691,7 @@ getNextReleaseTimestamp :: (MonadBlobStore m) => PersistentAccount av -> m (Mayb
 getNextReleaseTimestamp acc = nextReleaseTimestamp <$!> refLoad (acc ^. accountReleaseSchedule)
 
 -- | Get the baker and baker info reference (if any) attached to the account.
-getBakerAndInfoRef :: forall m av. (MonadBlobStore m, IsAccountVersion av, AVStructureV0 av) => PersistentAccount av -> m (Maybe (AccountBaker av, PersistentBakerInfoEx av))
+getBakerAndInfoRef :: forall m av. (MonadBlobStore m, IsAccountVersion av, AVStructureV0 av, SupportsValidatorSuspension av ~ 'False) => PersistentAccount av -> m (Maybe (AccountBaker av, PersistentBakerInfoEx av))
 getBakerAndInfoRef acc = case acc ^. accountBaker of
     Null -> return Nothing
     Some bref -> do
@@ -712,14 +712,14 @@ getBakerAndInfoRef acc = case acc ^. accountBaker of
                 return $
                     Just
                         ( AccountBaker
-                            { _accountBakerInfo = BakerInfoExV1 abi ebi,
+                            { _accountBakerInfo = BakerInfoExV1 abi ebi CFalse,
                               ..
                             },
                           pab ^. accountBakerInfoEx
                         )
 
 -- | Get the baker (if any) attached to an account.
-getBaker :: forall m av. (MonadBlobStore m, IsAccountVersion av, AVStructureV0 av) => PersistentAccount av -> m (Maybe (AccountBaker av))
+getBaker :: forall m av. (MonadBlobStore m, IsAccountVersion av, AVStructureV0 av, SupportsValidatorSuspension av ~ 'False) => PersistentAccount av -> m (Maybe (AccountBaker av))
 getBaker acc = fmap fst <$> getBakerAndInfoRef acc
 
 -- | Get the baker and baker info reference (if any) attached to the account.

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UndecidableInstances #-}
 -- We suppress redundant constraint warnings since GHC does not detect when a constraint is used
 -- for pattern matching. (See: https://gitlab.haskell.org/ghc/ghc/-/issues/20896)
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
@@ -1493,6 +1493,8 @@ setStake ::
     m (PersistentAccount av)
 setStake newStake acc = return $! acc{accountStakedAmount = newStake}
 
+-- | Set the suspended flag of a validator account.
+--  This MUST only be called with an account that is a validator.
 setSuspended ::
     forall av m.
     ( MonadBlobStore m,

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
@@ -1505,7 +1505,7 @@ setValidatorSuspended ::
     Bool ->
     PersistentAccount av ->
     m (PersistentAccount av)
-setSuspended isSusp = updateStake $ \case
+setValidatorSuspended isSusp = updateStake $ \case
     baker@PersistentAccountStakeEnduringBaker{} -> do
         oldInfo <- refLoad (paseBakerInfo baker)
         let newInfo = oldInfo & bieAccountIsSuspended .~ isSusp

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
@@ -1222,23 +1222,6 @@ getCooldowns =
         EmptyCooldownQueue -> return Nothing
         CooldownQueue ref -> Just <$> refLoad ref
 
-getIsSuspended ::
-    ( MonadBlobStore m,
-      IsAccountVersion av,
-      AVSupportsValidatorSuspension av
-    ) =>
-    PersistentAccount av ->
-    m Bool
-getIsSuspended acc = do
-    let stake = paedStake $ enduringData acc
-    case stake of
-        PersistentAccountStakeEnduringNone -> return False
-        PersistentAccountStakeEnduringDelegator{} -> return False
-        PersistentAccountStakeEnduringBaker{..} -> do
-            bie <- refLoad paseBakerInfo
-            case _bieAccountIsSuspended bie of
-                CTrue b -> return b
-
 -- ** Updates
 
 -- | Apply account updates to an account. It is assumed that the address in

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
@@ -1493,9 +1493,9 @@ setValidatorSuspended isSusp = updateStake $ \case
         newInfoRef <- refMake $! newInfo
         return $! baker{paseBakerInfo = newInfoRef}
     PersistentAccountStakeEnduringDelegator{} ->
-        error "setSuspend invariant violation: account is not a baker"
+        error "setValidatorSuspended invariant violation: account is not a baker"
     PersistentAccountStakeEnduringNone ->
-        error "setSuspend invariant violation: account is not a baker"
+        error "setValidatorSuspended invariant violation: account is not a baker"
 
 -- | Add a specified amount to the pre-pre-cooldown inactive stake.
 addPrePreCooldown ::

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
@@ -1467,9 +1467,7 @@ setBakerKeys upd = updateStake $ \case
 --  This MUST only be called with an account that is either a baker or delegator.
 --  This does no check that the staked amount is sensible, and has no effect on pending changes.
 setStake ::
-    ( Monad m,
-      AccountStructureVersionFor av ~ 'AccountStructureV1
-    ) =>
+    (Monad m) =>
     Amount ->
     PersistentAccount av ->
     m (PersistentAccount av)

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
@@ -1473,7 +1473,7 @@ setStake ::
     m (PersistentAccount av)
 setStake newStake acc = return $! acc{accountStakedAmount = newStake}
 
--- | Set the suspended flag of a validator account.
+-- | Set the suspended state of a validator account.
 --  This MUST only be called with an account that is a validator.
 setValidatorSuspended ::
     forall av m.

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
@@ -1495,7 +1495,12 @@ setStake newStake acc = return $! acc{accountStakedAmount = newStake}
 
 setSuspended ::
     forall av m.
-    (MonadBlobStore m, IsAccountVersion av, AccountStructureVersionFor av ~ 'AccountStructureV1, AVSupportsDelegation av, AVSupportsValidatorSuspension av) =>
+    ( MonadBlobStore m,
+      IsAccountVersion av,
+      AccountStructureVersionFor av ~ 'AccountStructureV1,
+      AVSupportsDelegation av,
+      AVSupportsValidatorSuspension av
+    ) =>
     Bool ->
     PersistentAccount av ->
     m (PersistentAccount av)

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
@@ -1494,7 +1494,7 @@ setStake newStake acc = return $! acc{accountStakedAmount = newStake}
 
 -- | Set the suspended flag of a validator account.
 --  This MUST only be called with an account that is a validator.
-setSuspended ::
+setValidatorSuspended ::
     forall av m.
     ( MonadBlobStore m,
       IsAccountVersion av,

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Bakers.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Bakers.hs
@@ -10,7 +10,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UndecidableInstances #-}
 -- We suppress redundant constraint warnings since GHC does not detect when a constraint is used
 -- for pattern matching. (See: https://gitlab.haskell.org/ghc/ghc/-/issues/20896)
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Bakers.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Bakers.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 -- We suppress redundant constraint warnings since GHC does not detect when a constraint is used
 -- for pattern matching. (See: https://gitlab.haskell.org/ghc/ghc/-/issues/20896)
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
@@ -261,7 +262,7 @@ epochToFullBakersEx PersistentEpochBakers{..} = do
             }
   where
     mkFullBakerInfoEx :: BaseAccounts.BakerInfoEx (AccountVersionFor pv) -> Amount -> FullBakerInfoEx
-    mkFullBakerInfoEx (BaseAccounts.BakerInfoExV1 info extra) stake =
+    mkFullBakerInfoEx (BaseAccounts.BakerInfoExV1 info extra _isSuspended) stake =
         FullBakerInfoEx (FullBakerInfo info stake) (extra ^. BaseAccounts.poolCommissionRates)
 
 type DelegatorIdTrieSet = Trie.TrieN BufferedFix DelegatorId ()

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -1644,7 +1644,7 @@ newAddValidator pbs ai va@ValidatorAdd{..} = do
   where
     bid = BakerId ai
     flexibleCooldowns = sSupportsFlexibleCooldown (accountVersion @(AccountVersionFor pv))
-    hasValidatorSuspension = (sSupportsValidatorSuspension (accountVersion @(AccountVersionFor pv)))
+    hasValidatorSuspension = sSupportsValidatorSuspension (accountVersion @(AccountVersionFor pv))
 
 -- | Check the conditions required for successfully updating a validator. This does not modify
 --  the block state.

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -1848,7 +1848,7 @@ newUpdateValidator pbs curTimestamp ai vu@ValidatorUpdate{..} = do
         ifPresent vuSuspend $ \suspend (bsp, acc) -> do
             case sSupportsValidatorSuspension (accountVersion @(AccountVersionFor pv)) of
                 STrue -> do
-                    acc1 <- setAccountSuspended suspend acc
+                    acc1 <- setAccountValidatorSuspended suspend acc
                     MTL.tell [if suspend then BakerConfigureSuspended else BakerConfigureResumed]
                     return (bsp, acc1)
                 SFalse -> return (bsp, acc)

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -1681,8 +1681,7 @@ updateValidatorChecks ::
     MTL.ExceptT ValidatorConfigureFailure m ()
 updateValidatorChecks bsp baker ValidatorUpdate{..} = do
     chainParams <- lookupCurrentParameters (bspUpdates bsp)
-    let
-        poolParams = chainParams ^. cpPoolParameters
+    let poolParams = chainParams ^. cpPoolParameters
         capitalMin = poolParams ^. ppMinimumEquityCapital
         ranges = poolParams ^. ppCommissionBounds
     -- Check if the aggregation key is fresh (or the same as the baker's existing one).
@@ -1807,7 +1806,7 @@ updateValidatorChecks bsp baker ValidatorUpdate{..} = do
 --         index by adding the difference between the new and old capital) and append
 --         @BakerConfigureStakeIncreased capital@ to @events@.
 
---  9. If the suspended/resumed flag is set and (>= P8):
+--  9. (>= P8) If the suspended/resumed flag is set:
 
 --        (1) Suspend/resume the validator according to the flag.
 

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -1614,12 +1614,12 @@ newAddValidator pbs ai va@ValidatorAdd{..} = do
                   _poolCommissionRates = vaCommissionRates
                 }
     let bakerInfo = bakerKeyUpdateToInfo bid vaKeys
-    let bakerInfoEx = BaseAccounts.BakerInfoExV1
-                         { _bieBakerPoolInfo = poolInfo,
-                           _bieBakerInfo = bakerInfo
-                           _bieBakerInfo = bakerInfo,
-                           _bieAccountIsSuspended = conditionally hasValidatorSuspension False
-                         }
+    let bakerInfoEx =
+            BaseAccounts.BakerInfoExV1
+                { _bieBakerPoolInfo = poolInfo,
+                  _bieBakerInfo = bakerInfo,
+                  _bieAccountIsSuspended = conditionally hasValidatorSuspension False
+                }
     -- The precondition guaranties that the account exists
     acc <- fromJust <$> Accounts.indexedAccount ai (bspAccounts bsp)
     -- Add the baker to the account.
@@ -1844,12 +1844,12 @@ newUpdateValidator pbs curTimestamp ai vu@ValidatorUpdate{..} = do
     -- Only do the given update if specified.
     ifPresent Nothing _ = return
     ifPresent (Just v) k = k v
-    updateSuspend STrue  =
-            case bcuSuspend of
-                Nothing -> return return
-                Just b ->  do
-                    MTL.tell [if b then BakerConfigureSuspended else BakerConfigureResumed]
-                    return $ setAccountSuspended b
+    updateSuspend STrue =
+        case bcuSuspend of
+            Nothing -> return return
+            Just b -> do
+                MTL.tell [if b then BakerConfigureSuspended else BakerConfigureResumed]
+                return $ setAccountSuspended b
     updateSuspend SFalse = return return
     updateKeys oldBaker = ifPresent vuKeys $ \keys (bsp, acc) -> do
         let oldAggrKey = oldBaker ^. BaseAccounts.bakerAggregationVerifyKey
@@ -2818,8 +2818,8 @@ doMint pbs mint = do
             bspBank bsp
                 & unhashed
                     %~ (Rewards.totalGTU +~ mintTotal mint)
-                    . (Rewards.bakingRewardAccount +~ mintBakingReward mint)
-                    . (Rewards.finalizationRewardAccount +~ mintFinalizationReward mint)
+                        . (Rewards.bakingRewardAccount +~ mintBakingReward mint)
+                        . (Rewards.finalizationRewardAccount +~ mintFinalizationReward mint)
     let updAcc = addAccountAmount $ mintDevelopmentCharge mint
     foundationAccount <- (^. cpFoundationAccount) <$> lookupCurrentParameters (bspUpdates bsp)
     newAccounts <- Accounts.updateAccountsAtIndex' updAcc foundationAccount (bspAccounts bsp)

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -1806,8 +1806,14 @@ updateValidatorChecks bsp baker ValidatorUpdate{..} = do
 --         equity capital to the new capital (updating the total active capital in the active baker
 --         index by adding the difference between the new and old capital) and append
 --         @BakerConfigureStakeIncreased capital@ to @events@.
+
+--  9. If the suspended/resumed flag is set and (>= P8):
+
+--        (1) Suspend/resume the validator according to the flag.
+
+--        (2) Append @BakerConfigureSuspended, @BakerConfigureResumed respectively to @events@.
 --
---  9. Return @events@ with the updated block state.
+--  10. Return @events@ with the updated block state.
 newUpdateValidator ::
     forall pv m.
     ( SupportsPersistentState pv m,

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -1810,7 +1810,7 @@ updateValidatorChecks bsp baker ValidatorUpdate{..} = do
 
 --        (1) Suspend/resume the validator according to the flag.
 
---        (2) Append @BakerConfigureSuspended, @BakerConfigureResumed respectively to @events@.
+--        (2) Append @BakerConfigureSuspended@ or @BakerConfigureResumed@ accordingly to @events@.
 --
 --  10. Return @events@ with the updated block state.
 newUpdateValidator ::

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -4255,8 +4255,6 @@ instance (PersistentState av pv r m, IsProtocolVersion pv) => AccountOperations 
 
     getAccountCooldowns = accountCooldowns
 
-    getAccountIsSuspended = accountIsSuspended
-
 instance (IsProtocolVersion pv, PersistentState av pv r m) => BlockStateOperations (PersistentBlockStateMonad pv r m) where
     bsoGetModule pbs mref = doGetModule pbs mref
     bsoGetAccount bs = doGetAccount bs

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -4240,6 +4240,8 @@ instance (PersistentState av pv r m, IsProtocolVersion pv) => AccountOperations 
 
     getAccountCooldowns = accountCooldowns
 
+    getAccountIsSuspended = error "TODO(drsk) implement accountIsSuspended"
+
 instance (IsProtocolVersion pv, PersistentState av pv r m) => BlockStateOperations (PersistentBlockStateMonad pv r m) where
     bsoGetModule pbs mref = doGetModule pbs mref
     bsoGetAccount bs = doGetAccount bs

--- a/concordium-consensus/src/Concordium/ProtocolUpdate/P8.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/P8.hs
@@ -24,7 +24,7 @@ import Concordium.KonsensusV1.TreeState.Implementation
 import Concordium.KonsensusV1.TreeState.Types
 import qualified Concordium.ProtocolUpdate.P8.Reboot as Reboot
 
--- | Updates that are supported from protocol version P7.
+-- | Updates that are supported from protocol version P8.
 data Update = Reboot
     deriving (Show)
 
@@ -40,7 +40,7 @@ checkUpdate ProtocolUpdate{..} = case HM.lookup puSpecificationHash updates of
         Left err -> Left $! "Could not deserialize auxiliary data: " ++ err
         Right update -> return update
 
--- | Construct the genesis data for a P7 update.
+-- | Construct the genesis data for a P8 update.
 updateRegenesis ::
     ( MPV m ~ 'P8,
       BlockStateStorage m,

--- a/concordium-consensus/src/Concordium/ProtocolUpdate/P8.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/P8.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Concordium.ProtocolUpdate.P8 (
+    Update (..),
+    checkUpdate,
+    updateRegenesis,
+    updateNextProtocolVersion,
+) where
+
+import Control.Monad.State
+import qualified Data.HashMap.Strict as HM
+import Data.Serialize
+
+import qualified Concordium.Crypto.SHA256 as SHA256
+import Concordium.Types
+import Concordium.Types.Updates
+
+import Concordium.GlobalState.BlockState
+import qualified Concordium.GlobalState.Persistent.BlockState as PBS
+import Concordium.GlobalState.Types
+import qualified Concordium.GlobalState.Types as GSTypes
+import Concordium.KonsensusV1.TreeState.Implementation
+import Concordium.KonsensusV1.TreeState.Types
+import qualified Concordium.ProtocolUpdate.P8.Reboot as Reboot
+
+-- | Updates that are supported from protocol version P7.
+data Update = Reboot
+    deriving (Show)
+
+-- | Hash map for resolving updates from their specification hash.
+updates :: HM.HashMap SHA256.Hash (Get Update)
+updates = HM.fromList [(Reboot.updateHash, return Reboot)]
+
+-- | Determine if a 'ProtocolUpdate' corresponds to a supported update type.
+checkUpdate :: ProtocolUpdate -> Either String Update
+checkUpdate ProtocolUpdate{..} = case HM.lookup puSpecificationHash updates of
+    Nothing -> Left "Specification hash does not correspond to a known protocol update."
+    Just updateGet -> case runGet updateGet puSpecificationAuxiliaryData of
+        Left err -> Left $! "Could not deserialize auxiliary data: " ++ err
+        Right update -> return update
+
+-- | Construct the genesis data for a P7 update.
+updateRegenesis ::
+    ( MPV m ~ 'P8,
+      BlockStateStorage m,
+      MonadState (SkovData (MPV m)) m,
+      GSTypes.BlockState m ~ PBS.HashedPersistentBlockState (MPV m)
+    ) =>
+    -- | The update taking effect.
+    Update ->
+    -- | The terminal block of the old chain.
+    BlockPointer (MPV m) ->
+    m (PVInit m)
+updateRegenesis Reboot = Reboot.updateRegenesis
+
+-- | Determine the protocol version the update will update to.
+updateNextProtocolVersion ::
+    Update ->
+    SomeProtocolVersion
+updateNextProtocolVersion Reboot{} = SomeProtocolVersion SP8

--- a/concordium-consensus/src/Concordium/ProtocolUpdate/P8/Reboot.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/P8/Reboot.hs
@@ -18,7 +18,7 @@
 --
 --      * the hash of the genesis block of the previous chain, if it is a 'GDP8Initial'; or
 --      * the 'genesisFirstGenesis' value of the genesis block of the previous chain, if it
---        is a 'GDP6Regenesis'.
+--        is a 'GDP8Regenesis'.
 --
 --  * 'genesisPreviousGenesis' is the hash of the previous genesis block.
 --

--- a/concordium-consensus/src/Concordium/ProtocolUpdate/P8/Reboot.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/P8/Reboot.hs
@@ -1,0 +1,110 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | This module implements the P8.Reboot protocol update.
+--  This protocol update is valid at protocol version P8, and updates
+--  to protocol version P8.
+--  This produces a new 'RegenesisDataP8 using the 'GDP8Regenesis' constructor,
+--  as follows:
+--
+--  * 'genesisCore':
+--
+--      * 'genesisTime' is the timestamp of the last finalized block of the previous chain.
+--      * 'genesisEpochDuration' is taken from the previous genesis.
+--      * 'genesisSignatureThreshold' is taken from the previous genesis.
+--
+--  * 'genesisFirstGenesis' is either:
+--
+--      * the hash of the genesis block of the previous chain, if it is a 'GDP8Initial'; or
+--      * the 'genesisFirstGenesis' value of the genesis block of the previous chain, if it
+--        is a 'GDP6Regenesis'.
+--
+--  * 'genesisPreviousGenesis' is the hash of the previous genesis block.
+--
+--  * 'genesisTerminalBlock' is the hash of the last finalized block of the previous chain.
+--
+--  * 'genesisStateHash' is the state hash of the last finalized block of the previous chain.
+--
+--  The block state is taken from the last finalized block of the previous chain. It is updated
+--  as part of the state migration, which makes the following changes:
+--
+--  * The seed state is migrated as follows:
+--
+--      * The current epoch is reset to zero.
+--      * The current and updated leadership election nonce are set to the hash of
+--        @"Regenesis" <> encode oldUpdatedNonce@.
+--      * The trigger block time is kept the same, meaning that the epoch will transition as soon
+--        as possible.
+--      * The epoch transition triggered flag is set.
+--      * The shutdown triggered flag is cleared.
+--
+--  * The old current epoch is subtracted from the next payday epoch.
+--
+--  * The protocol update queue is emptied during the migration.
+--
+--  Note that, the initial epoch of the new chain is not considered
+--  a new epoch for the purposes of block rewards and baker/finalization committee determination.
+--  In particular, the timing of the next payday will be the same as if the protocol update
+--  had not happened. (For instance, if it would have happened at the start of the next epoch
+--  prior to the protocol update, after the update it will happen at the start of epoch 1.
+--  The trigger block time in epoch 0 of the new consensus is the same as the trigger block
+--  time in the final epoch of the old consensus.)
+--  Furthermore, the bakers from the final epoch of the previous chain are also the bakers for the
+--  initial epoch of the new chain.
+module Concordium.ProtocolUpdate.P8.Reboot where
+
+import Control.Monad.State
+import Lens.Micro.Platform
+
+import qualified Concordium.Crypto.SHA256 as SHA256
+import qualified Concordium.Genesis.Data as GenesisData
+import qualified Concordium.Genesis.Data.BaseV1 as BaseV1
+import qualified Concordium.Genesis.Data.P8 as P8
+import Concordium.GlobalState.BlockState
+import qualified Concordium.GlobalState.Persistent.BlockState as PBS
+import Concordium.GlobalState.Types
+import qualified Concordium.GlobalState.Types as GSTypes
+import Concordium.KonsensusV1.TreeState.Implementation
+import Concordium.KonsensusV1.TreeState.Types
+import Concordium.KonsensusV1.Types
+import Concordium.Types.HashableTo (getHash)
+import Concordium.Types.ProtocolVersion
+
+-- | The hash that identifies the P8.Reboot update.
+updateHash :: SHA256.Hash
+updateHash = SHA256.hash "P8.Reboot"
+
+-- | Construct the genesis data for a P8.Reboot update.
+--  This takes the terminal block of the old chain which is used as the basis for constructing
+--  the new genesis block.
+updateRegenesis ::
+    ( MPV m ~ 'P8,
+      BlockStateStorage m,
+      MonadState (SkovData (MPV m)) m,
+      GSTypes.BlockState m ~ PBS.HashedPersistentBlockState (MPV m)
+    ) =>
+    -- | The terminal block of the old chain.
+    BlockPointer 'P8 ->
+    m (PVInit m)
+updateRegenesis terminal = do
+    -- Genesis time is the timestamp of the terminal block
+    let regenesisTime = blockTimestamp terminal
+    -- Core parameters are derived from the old genesis, apart from genesis time which is set for
+    -- the time of the terminal block.
+    gMetadata <- use genesisMetadata
+    BaseV1.CoreGenesisParametersV1{..} <- gmParameters <$> use genesisMetadata
+    let core =
+            BaseV1.CoreGenesisParametersV1
+                { BaseV1.genesisTime = regenesisTime,
+                  ..
+                }
+    -- genesisFirstGenesis is the block hash of the previous genesis, if it is initial,
+    -- or the genesisFirstGenesis of the previous genesis otherwise.
+    let genesisFirstGenesis = gmFirstGenesisHash gMetadata
+        genesisPreviousGenesis = gmCurrentGenesisHash gMetadata
+        genesisTerminalBlock = getHash terminal
+    let regenesisBlockState = bpState terminal
+    genesisStateHash <- getStateHash regenesisBlockState
+    let newGenesis = GenesisData.RGDP8 $ P8.GDP8Regenesis{genesisRegenesis = BaseV1.RegenesisDataV1{genesisCore = core, ..}}
+    return (PVInit newGenesis GenesisData.StateMigrationParametersTrivial (bmHeight $ bpInfo terminal))

--- a/concordium-consensus/src/Concordium/ProtocolUpdate/P8/Reboot.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/P8/Reboot.hs
@@ -71,7 +71,8 @@ import Concordium.KonsensusV1.Types
 import Concordium.Types.HashableTo (getHash)
 import Concordium.Types.ProtocolVersion
 
--- | The hash that identifies the P8.Reboot update.
+-- | The hash that identifies the P8.Reboot update:
+--  ff44f55c68323758f046d18935e74d1fb4387617009b5fb66f5706f7de25a919
 updateHash :: SHA256.Hash
 updateHash = SHA256.hash "P8.Reboot"
 

--- a/concordium-consensus/src/Concordium/ProtocolUpdate/V1.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/V1.hs
@@ -19,15 +19,18 @@ import Concordium.KonsensusV1.TreeState.Implementation
 import Concordium.KonsensusV1.TreeState.Types
 import qualified Concordium.ProtocolUpdate.P6 as P6
 import qualified Concordium.ProtocolUpdate.P7 as P7
+import qualified Concordium.ProtocolUpdate.P8 as P8
 
 -- | Type representing currently supported protocol update types.
 data Update (pv :: ProtocolVersion) where
     UpdateP6 :: P6.Update -> Update 'P6
     UpdateP7 :: P7.Update -> Update 'P7
+    UpdateP8 :: P8.Update -> Update 'P8
 
 instance Show (Update pv) where
     show (UpdateP6 u) = "P6." ++ show u
     show (UpdateP7 u) = "P7." ++ show u
+    show (UpdateP8 u) = "P8." ++ show u
 
 -- | Determine if a 'ProtocolUpdate' corresponds to a supported update type.
 checkUpdate :: forall pv. (IsProtocolVersion pv) => ProtocolUpdate -> Either String (Update pv)
@@ -41,6 +44,7 @@ checkUpdate = case protocolVersion @pv of
     -- These ones are supported in V1.
     SP6 -> fmap UpdateP6 . P6.checkUpdate
     SP7 -> fmap UpdateP7 . P7.checkUpdate
+    SP8 -> fmap UpdateP8 . P8.checkUpdate
 
 -- | Construct the genesis data for a P1 update.
 updateRegenesis ::
@@ -55,6 +59,7 @@ updateRegenesis ::
     m (PVInit m)
 updateRegenesis (UpdateP6 u) = P6.updateRegenesis u
 updateRegenesis (UpdateP7 u) = P7.updateRegenesis u
+updateRegenesis (UpdateP8 u) = P8.updateRegenesis u
 
 -- | Determine the next protocol version for the given update. Although the same
 --  information can be retrieved from 'updateRegenesis', this is more efficient
@@ -64,3 +69,4 @@ updateNextProtocolVersion ::
     SomeProtocolVersion
 updateNextProtocolVersion (UpdateP6 u) = P6.updateNextProtocolVersion u
 updateNextProtocolVersion (UpdateP7 u) = P7.updateNextProtocolVersion u
+updateNextProtocolVersion (UpdateP8 u) = P8.updateNextProtocolVersion u

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -32,6 +32,7 @@ import Concordium.Types
 import Concordium.Types.Accounts
 import Concordium.Types.AnonymityRevokers
 import Concordium.Types.Block (absoluteToLocalBlockHeight, localToAbsoluteBlockHeight)
+import Concordium.Types.Conditionally
 import Concordium.Types.Execution (TransactionSummary)
 import Concordium.Types.HashableTo
 import Concordium.Types.IdentityProviders
@@ -1090,8 +1091,14 @@ getAccountInfoHelper getASI getCooldowns acct bs = do
         aiAccountAddress <- BS.getAccountCanonicalAddress acc
         aiAccountCooldowns <- getCooldowns acc
         aiAccountAvailableAmount <- BS.getAccountAvailableAmount acc
-        -- TODO(drsk). github #1225. Implement getAccountIsSuspended
-        let aiAccountIsSuspended = False
+        aiAccountIsSuspended <- do
+            mAccBaker <- BS.getAccountBaker acc
+            case mAccBaker of
+                -- If the account doesn't have an associated validator, then it can't be suspended.
+                Nothing -> return False
+                Just accBaker ->
+                    return $
+                        fromCondDef (_bieAccountIsSuspended $ _accountBakerInfo accBaker) False
         return AccountInfo{..}
 
 -- | Get the details of a smart contract instance in the block state.

--- a/concordium-consensus/src/Concordium/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler.hs
@@ -2080,7 +2080,7 @@ handleConfigureBaker
     cbMetadataURL
     cbTransactionFeeCommission
     cbBakingRewardCommission
-    cbFinalizationRewardCommission 
+    cbFinalizationRewardCommission
     cbSuspend =
         withDeposit wtc tickGetArgAndBalance chargeAndExecute
       where

--- a/concordium-consensus/src/Concordium/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler.hs
@@ -364,7 +364,17 @@ dispatchTransactionBody msg senderAccount checkHeaderCost = do
                             handleTransferWithSchedule (mkWTC TTTransferWithScheduleAndMemo) twswmTo twswmSchedule $ Just twswmMemo
                         ConfigureBaker{..} ->
                             onlyWithDelegation $
-                                handleConfigureBaker (mkWTC TTConfigureBaker) cbCapital cbRestakeEarnings cbOpenForDelegation cbKeysWithProofs cbMetadataURL cbTransactionFeeCommission cbBakingRewardCommission cbFinalizationRewardCommission cbSuspend
+                                handleConfigureBaker
+                                    (mkWTC TTConfigureBaker)
+                                    cbCapital
+                                    cbRestakeEarnings
+                                    cbOpenForDelegation
+                                    cbKeysWithProofs
+                                    cbMetadataURL
+                                    cbTransactionFeeCommission
+                                    cbBakingRewardCommission
+                                    cbFinalizationRewardCommission
+                                    cbSuspend
                         ConfigureDelegation{..} ->
                             onlyWithDelegation $
                                 handleConfigureDelegation (mkWTC TTConfigureDelegation) cdCapital cdRestakeEarnings cdDelegationTarget

--- a/concordium-consensus/src/Concordium/Scheduler/Runner.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/Runner.hs
@@ -124,6 +124,10 @@ transactionHelper t =
             return $ signTx keys meta (Types.encodePayload Types.ConfigureBaker{..})
         (TJSON meta ConfigureDelegation{..} keys) ->
             return $ signTx keys meta (Types.encodePayload Types.ConfigureDelegation{..})
+        (TJSON meta Suspend keys) ->
+            return $ signTx keys meta (Types.encodePayload Types.Suspend)
+        (TJSON meta Resume keys) ->
+            return $ signTx keys meta (Types.encodePayload Types.Resume)
 
 processTransactions :: (MonadFail m, MonadIO m) => [TransactionJSON] -> m [Types.AccountTransaction]
 processTransactions = mapM transactionHelper
@@ -199,6 +203,10 @@ data PayloadJSON
         { -- | New set of credential keys to be replaced with the existing ones, including updating the threshold.
           uckCredId :: CredentialRegistrationID,
           uckKeys :: !CredentialPublicKeys
+        }
+    | UpdateSuspendResume
+        { -- | Update the suspended flag of the validator account. True: suspend, False: resume.
+          usrSuspendResume :: !Bool
         }
     | TransferToEncrypted
         { tteAmount :: !Amount

--- a/concordium-consensus/src/Concordium/Scheduler/Runner.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/Runner.hs
@@ -124,10 +124,7 @@ transactionHelper t =
             return $ signTx keys meta (Types.encodePayload Types.ConfigureBaker{..})
         (TJSON meta ConfigureDelegation{..} keys) ->
             return $ signTx keys meta (Types.encodePayload Types.ConfigureDelegation{..})
-        (TJSON meta Suspend keys) ->
-            return $ signTx keys meta (Types.encodePayload Types.Suspend)
-        (TJSON meta Resume keys) ->
-            return $ signTx keys meta (Types.encodePayload Types.Resume)
+        (TJSON _meta UpdateSuspendResume{..} _keys) -> error "TODO (drsk) implemnt transactionHelper for suspend/resume"
 
 processTransactions :: (MonadFail m, MonadIO m) => [TransactionJSON] -> m [Types.AccountTransaction]
 processTransactions = mapM transactionHelper

--- a/concordium-consensus/src/Concordium/Scheduler/Runner.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/Runner.hs
@@ -124,7 +124,6 @@ transactionHelper t =
             return $ signTx keys meta (Types.encodePayload Types.ConfigureBaker{..})
         (TJSON meta ConfigureDelegation{..} keys) ->
             return $ signTx keys meta (Types.encodePayload Types.ConfigureDelegation{..})
-        (TJSON _meta UpdateSuspendResume{..} _keys) -> error "TODO (drsk) implemnt transactionHelper for suspend/resume"
 
 processTransactions :: (MonadFail m, MonadIO m) => [TransactionJSON] -> m [Types.AccountTransaction]
 processTransactions = mapM transactionHelper
@@ -200,10 +199,6 @@ data PayloadJSON
         { -- | New set of credential keys to be replaced with the existing ones, including updating the threshold.
           uckCredId :: CredentialRegistrationID,
           uckKeys :: !CredentialPublicKeys
-        }
-    | UpdateSuspendResume
-        { -- | Update the suspended flag of the validator account. True: suspend, False: resume.
-          usrSuspendResume :: !Bool
         }
     | TransferToEncrypted
         { tteAmount :: !Amount

--- a/concordium-consensus/src/Concordium/Scheduler/Runner.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/Runner.hs
@@ -250,7 +250,9 @@ data PayloadJSON
           -- | The commission the pool owner takes on baking rewards.
           cbBakingRewardCommission :: !(Maybe AmountFraction),
           -- | The commission the pool owner takes on finalization rewards.
-          cbFinalizationRewardCommission :: !(Maybe AmountFraction)
+          cbFinalizationRewardCommission :: !(Maybe AmountFraction),
+          -- | Whether to suspend/resume the validator.
+          cbSuspend :: !(Maybe Bool)
         }
     | ConfigureDelegation
         { -- | The capital delegated to the pool.

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/AccountsMigrationP6ToP7.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/AccountsMigrationP6ToP7.hs
@@ -115,7 +115,7 @@ reducedStake accIndex = 10_000_000_000 + 2 ^ accIndex
 -- CCD plus @2^accountIndex@ uCCD. This is to ensure that any given combination of accounts have a
 -- unique total stake.
 dummyBakerStake ::
-    (AVSupportsDelegation av) =>
+    (AVSupportsDelegation av, SupportsValidatorSuspension av ~ 'False) =>
     (AccountIndex -> Amount) ->
     AccountIndex ->
     StakePendingChange av ->
@@ -146,7 +146,8 @@ dummyBakerStake compStake accIndex pc =
                               _bakerElectionVerifyKey = VRF.publicKey (bakerElectionKey seed),
                               _bakerAggregationVerifyKey =
                                 Bls.derivePublicKey (bakerAggregationKey seed)
-                            }
+                            },
+                      _bieAccountIsSuspended = CFalse
                     }
             }
   where

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/BlockStateHelpers.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/BlockStateHelpers.hs
@@ -156,14 +156,13 @@ makeDummyAccount AccountConfig{..} = do
             PAV4 acc -> do
                 let ed = SV1.enduringData acc
                 cq <- CooldownQueue.makeCooldownQueue acCooldowns
-                (staking, stakeAmount) <- makePersistentAccountStakeEnduring acStaking acAccountIndex
                 newEnduring <-
                     refMake
                         =<< SV1.rehashAccountEnduringData
-                            ed{SV1.paedStakeCooldown = cq, SV1.paedStake = staking}
+                            ed{SV1.paedStakeCooldown = cq}
                 return $
                     PAV4
-                        acc{SV1.accountEnduringData = newEnduring, SV1.accountStakedAmount = stakeAmount}
+                        acc{SV1.accountEnduringData = newEnduring}
         SFalse -> return acc1
 
 -- | Run a block state computation using a temporary directory for the blob store and account map.

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/ConfigureValidator.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/ConfigureValidator.hs
@@ -555,8 +555,7 @@ runUpdateValidatorTest spv commissionRanges ValidatorUpdateConfig{vucValidatorUp
     chainParams =
         DummyData.dummyChainParameters @(ChainParametersVersionFor pv)
             & cpPoolParameters . ppMinimumEquityCapital .~ minEquity
-            & cpPoolParameters
-                . ppCommissionBounds
+            & cpPoolParameters . ppCommissionBounds
                 .~ commissionRanges
     mkInitialState accounts =
         hpbsPointers

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/ConfigureValidator.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/ConfigureValidator.hs
@@ -113,8 +113,7 @@ testAddValidatorAllCases spv = describe "bsoAddValidator" $ do
     chainParams =
         DummyData.dummyChainParameters @(ChainParametersVersionFor pv)
             & cpPoolParameters . ppMinimumEquityCapital .~ minEquity
-            & cpPoolParameters
-                . ppCommissionBounds
+            & cpPoolParameters . ppCommissionBounds
                 .~ CommissionRanges
                     { _transactionCommissionRange = InclusiveRange (makeAmountFraction 100) (makeAmountFraction 200),
                       _finalizationCommissionRange = InclusiveRange (makeAmountFraction 300) (makeAmountFraction 400),

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/ConfigureValidator.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/ConfigureValidator.hs
@@ -113,7 +113,8 @@ testAddValidatorAllCases spv = describe "bsoAddValidator" $ do
     chainParams =
         DummyData.dummyChainParameters @(ChainParametersVersionFor pv)
             & cpPoolParameters . ppMinimumEquityCapital .~ minEquity
-            & cpPoolParameters . ppCommissionBounds
+            & cpPoolParameters
+                . ppCommissionBounds
                 .~ CommissionRanges
                     { _transactionCommissionRange = InclusiveRange (makeAmountFraction 100) (makeAmountFraction 200),
                       _finalizationCommissionRange = InclusiveRange (makeAmountFraction 300) (makeAmountFraction 400),
@@ -545,7 +546,8 @@ runUpdateValidatorTest spv commissionRanges ValidatorUpdateConfig{vucValidatorUp
     chainParams =
         DummyData.dummyChainParameters @(ChainParametersVersionFor pv)
             & cpPoolParameters . ppMinimumEquityCapital .~ minEquity
-            & cpPoolParameters . ppCommissionBounds
+            & cpPoolParameters
+                . ppCommissionBounds
                 .~ commissionRanges
     mkInitialState accounts =
         hpbsPointers

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/ConfigureValidator.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/ConfigureValidator.hs
@@ -189,7 +189,8 @@ testAddValidatorAllCases spv = describe "bsoAddValidator" $ do
                                         { _poolOpenStatus = vaOpenForDelegation va,
                                           _poolMetadataUrl = vaMetadataURL va,
                                           _poolCommissionRates = vaCommissionRates va
-                                        }
+                                        },
+                                  _bieAccountIsSuspended = conditionally (sSupportsValidatorSuspension (accountVersion @(AccountVersionFor pv))) False
                                 }
                         }
             bkr <- getAccountBaker (fromJust acc)
@@ -331,6 +332,11 @@ validatorUpdateCases = do
           (Just (makeAmountFraction 350), "same", False),
           (Nothing, "no change", False)
             ]
+    (vuSuspend, vuSuspendDesc) <-
+        [ (Just True, "suspend"),
+          (Just False, "resume"),
+          (Nothing, "no change")
+            ]
     let vucValidatorUpdate = ValidatorUpdate{..}
     let vucValidatorConditions = ValidatorConditions{..}
     vucPendingChangeOrCooldown <- [True, False]
@@ -355,6 +361,8 @@ validatorUpdateCases = do
                         then ", pending change/cooldown"
                         else ", no pending change/cooldown"
                    )
+                <> ", validator suspend/resume: "
+                <> vuSuspendDesc
     return $ ValidatorUpdateConfig{..}
 
 -- | Commission ranges that narrowly include the commission rates used in the test cases.
@@ -422,6 +430,7 @@ testUpdateValidatorOverlappingCommissions spv =
                       vuRestakeEarnings = Nothing,
                       vuOpenForDelegation = Nothing,
                       vuMetadataURL = Nothing,
+                      vuSuspend = Nothing,
                       ..
                     }
         let vucPendingChangeOrCooldown = False

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/Updates.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/Updates.hs
@@ -163,7 +163,8 @@ modifyStakeTo a (bs, ai) = do
                   vuMetadataURL = Nothing,
                   vuTransactionFeeCommission = Nothing,
                   vuBakingRewardCommission = Nothing,
-                  vuFinalizationRewardCommission = Nothing
+                  vuFinalizationRewardCommission = Nothing,
+                  vuSuspend = Nothing
                 }
     res <- bsoUpdateValidator bs 0 ai conf
     return (fmap (,ai) <$> res)

--- a/concordium-consensus/tests/scheduler/SchedulerTests/ConfigureBaker.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/ConfigureBaker.hs
@@ -883,8 +883,7 @@ testUpdateBakerOk _spv pvString =
             . accountBaker
             %~ (stakedAmount .~ stakeAmount)
                 . (stakeEarnings .~ True)
-                . ( accountBakerInfo
-                        . bieBakerPoolInfo
+                . ( accountBakerInfo . bieBakerPoolInfo
                         %~ (poolCommissionRates . transactionCommission .~ makeAmountFraction 1_000)
                             . (poolMetadataUrl .~ emptyUrlText)
                   )
@@ -1127,9 +1126,7 @@ testUpdateBakerRemoveOk spv pvString =
                 updatedAccount1
     updateStaking = case sSupportsFlexibleCooldown (sAccountVersionFor spv) of
         SFalse ->
-            Transient.accountStaking
-                . accountBaker
-                . bakerPendingChange
+            Transient.accountStaking . accountBaker . bakerPendingChange
                 .~ RemoveStake (PendingChangeEffectiveV1 86400000)
         STrue ->
             (Transient.accountStaking .~ AccountStakeNone)
@@ -1230,9 +1227,7 @@ testUpdateBakerReduceStakeOk spv pvString =
                 (Transient.accountStakeCooldown . unconditionally .~ emptyCooldowns{prePreCooldown = Present 200_000_000_000})
                     . (Transient.accountStaking . accountBaker . stakedAmount .~ stakeAmount)
         )
-            . ( Transient.accountStaking
-                    . accountBaker
-                    . accountBakerInfo
+            . ( Transient.accountStaking . accountBaker . accountBakerInfo
                     %~ (poolCommissionRates . bakingCommission .~ makeAmountFraction 1_000)
                         . (poolCommissionRates . finalizationCommission .~ makeAmountFraction 1_000)
                         . (bakerElectionVerifyKey .~ bkwpElectionVerifyKey keysWithProofs)
@@ -1315,9 +1310,10 @@ testUpdateBakerSuspendResumeOk spv pvString suspendOrResume accM =
     accountBaker f (AccountStakeBaker b) = AccountStakeBaker <$> f b
     accountBaker _ x = pure x
     events =
-        [ BakerResumed{ebrBakerId = 4} | suspendOrResume == Resume
+        [ if suspendOrResume == Suspend
+            then BakerSuspended{ebsBakerId = 4}
+            else BakerResumed{ebrBakerId = 4}
         ]
-            ++ [BakerSuspended{ebsBakerId = 4} | suspendOrResume == Suspend]
 
 tests :: Spec
 tests =

--- a/concordium-consensus/tests/scheduler/SchedulerTests/ConfigureBaker.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/ConfigureBaker.hs
@@ -1219,8 +1219,7 @@ testUpdateBakerReduceStakeOk spv pvString =
     updateStaking keysWithProofs =
         ( case sSupportsFlexibleCooldown (sAccountVersionFor spv) of
             SFalse ->
-                Transient.accountStaking
-                    . accountBaker
+                Transient.accountStaking . accountBaker
                     %~ ( bakerPendingChange .~ ReduceStake stakeAmount (PendingChangeEffectiveV1 86400000)
                        )
             STrue ->

--- a/concordium-consensus/tests/scheduler/SchedulerTests/ConfigureBaker.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/ConfigureBaker.hs
@@ -856,13 +856,15 @@ testUpdateBakerOk _spv pvString =
                 )
                 updatedAccount1
     updateStaking =
-        ( Transient.accountStaking . accountBaker
+        ( Transient.accountStaking
+            . accountBaker
             %~ (stakedAmount .~ stakeAmount)
-                . (stakeEarnings .~ True)
-                . ( accountBakerInfo . bieBakerPoolInfo
-                        %~ (poolCommissionRates . transactionCommission .~ makeAmountFraction 1_000)
-                            . (poolMetadataUrl .~ emptyUrlText)
-                  )
+            . (stakeEarnings .~ True)
+            . ( accountBakerInfo
+                    . bieBakerPoolInfo
+                    %~ (poolCommissionRates . transactionCommission .~ makeAmountFraction 1_000)
+                    . (poolMetadataUrl .~ emptyUrlText)
+              )
         )
     accountBaker f (AccountStakeBaker b) = AccountStakeBaker <$> f b
     accountBaker _ x = pure x
@@ -1098,7 +1100,9 @@ testUpdateBakerRemoveOk spv pvString =
                 updatedAccount1
     updateStaking = case sSupportsFlexibleCooldown (sAccountVersionFor spv) of
         SFalse ->
-            Transient.accountStaking . accountBaker . bakerPendingChange
+            Transient.accountStaking
+                . accountBaker
+                . bakerPendingChange
                 .~ RemoveStake (PendingChangeEffectiveV1 86400000)
         STrue ->
             (Transient.accountStaking .~ AccountStakeNone)
@@ -1190,19 +1194,22 @@ testUpdateBakerReduceStakeOk spv pvString =
     updateStaking keysWithProofs =
         ( case sSupportsFlexibleCooldown (sAccountVersionFor spv) of
             SFalse ->
-                Transient.accountStaking . accountBaker
+                Transient.accountStaking
+                    . accountBaker
                     %~ ( bakerPendingChange .~ ReduceStake stakeAmount (PendingChangeEffectiveV1 86400000)
                        )
             STrue ->
                 (Transient.accountStakeCooldown . unconditionally .~ emptyCooldowns{prePreCooldown = Present 200_000_000_000})
                     . (Transient.accountStaking . accountBaker . stakedAmount .~ stakeAmount)
         )
-            . ( Transient.accountStaking . accountBaker . accountBakerInfo
+            . ( Transient.accountStaking
+                    . accountBaker
+                    . accountBakerInfo
                     %~ (poolCommissionRates . bakingCommission .~ makeAmountFraction 1_000)
-                        . (poolCommissionRates . finalizationCommission .~ makeAmountFraction 1_000)
-                        . (bakerElectionVerifyKey .~ bkwpElectionVerifyKey keysWithProofs)
-                        . (bakerSignatureVerifyKey .~ bkwpSignatureVerifyKey keysWithProofs)
-                        . (bakerAggregationVerifyKey .~ bkwpAggregationVerifyKey keysWithProofs)
+                    . (poolCommissionRates . finalizationCommission .~ makeAmountFraction 1_000)
+                    . (bakerElectionVerifyKey .~ bkwpElectionVerifyKey keysWithProofs)
+                    . (bakerSignatureVerifyKey .~ bkwpSignatureVerifyKey keysWithProofs)
+                    . (bakerAggregationVerifyKey .~ bkwpAggregationVerifyKey keysWithProofs)
               )
     accountBaker f (AccountStakeBaker b) = AccountStakeBaker <$> f b
     accountBaker _ x = pure x

--- a/concordium-consensus/tests/scheduler/SchedulerTests/ConfigureBaker.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/ConfigureBaker.hs
@@ -859,12 +859,12 @@ testUpdateBakerOk _spv pvString =
         ( Transient.accountStaking
             . accountBaker
             %~ (stakedAmount .~ stakeAmount)
-            . (stakeEarnings .~ True)
-            . ( accountBakerInfo
-                    . bieBakerPoolInfo
-                    %~ (poolCommissionRates . transactionCommission .~ makeAmountFraction 1_000)
-                    . (poolMetadataUrl .~ emptyUrlText)
-              )
+                . (stakeEarnings .~ True)
+                . ( accountBakerInfo
+                        . bieBakerPoolInfo
+                        %~ (poolCommissionRates . transactionCommission .~ makeAmountFraction 1_000)
+                            . (poolMetadataUrl .~ emptyUrlText)
+                  )
         )
     accountBaker f (AccountStakeBaker b) = AccountStakeBaker <$> f b
     accountBaker _ x = pure x
@@ -1206,10 +1206,10 @@ testUpdateBakerReduceStakeOk spv pvString =
                     . accountBaker
                     . accountBakerInfo
                     %~ (poolCommissionRates . bakingCommission .~ makeAmountFraction 1_000)
-                    . (poolCommissionRates . finalizationCommission .~ makeAmountFraction 1_000)
-                    . (bakerElectionVerifyKey .~ bkwpElectionVerifyKey keysWithProofs)
-                    . (bakerSignatureVerifyKey .~ bkwpSignatureVerifyKey keysWithProofs)
-                    . (bakerAggregationVerifyKey .~ bkwpAggregationVerifyKey keysWithProofs)
+                        . (poolCommissionRates . finalizationCommission .~ makeAmountFraction 1_000)
+                        . (bakerElectionVerifyKey .~ bkwpElectionVerifyKey keysWithProofs)
+                        . (bakerSignatureVerifyKey .~ bkwpSignatureVerifyKey keysWithProofs)
+                        . (bakerAggregationVerifyKey .~ bkwpAggregationVerifyKey keysWithProofs)
               )
     accountBaker f (AccountStakeBaker b) = AccountStakeBaker <$> f b
     accountBaker _ x = pure x

--- a/concordium-consensus/tests/scheduler/SchedulerTests/Delegation.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/Delegation.hs
@@ -34,6 +34,7 @@ import Concordium.GlobalState.DummyData
 import Concordium.Scheduler.DummyData
 import Concordium.Types.Option
 import Control.Monad
+import Data.Bool.Singletons
 import Data.Maybe
 import qualified SchedulerTests.Helpers as Helpers
 import Test.HUnit

--- a/concordium-consensus/tests/scheduler/SchedulerTests/Delegation.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/Delegation.hs
@@ -61,7 +61,8 @@ makeTestBakerV1FromSeed amount stake bakerId seed = do
             BakerInfoExV1
                 { _bieBakerInfo = fulBaker ^. theBakerInfo,
                   _bieBakerPoolInfo = poolInfo,
-                  _bieAccountIsSuspended = conditionally (sSupportsValidatorSuspension (accountVersion @av)) False
+                  _bieAccountIsSuspended =
+                    conditionally (sSupportsValidatorSuspension (accountVersion @av)) False
                 }
     BS.addAccountBakerV1 bakerInfoEx stake True account
   where
@@ -219,7 +220,7 @@ initialBlockState2 =
 -- | Test removing a delegator even if the stake is over the threshold.
 testRemoveDelegatorWithStakeOverThreshold ::
     forall pv.
-    (IsProtocolVersion pv, PVSupportsDelegation pv, PVSupportsDelegation pv) =>
+    (IsProtocolVersion pv, PVSupportsDelegation pv) =>
     SProtocolVersion pv ->
     String ->
     Spec
@@ -265,7 +266,7 @@ testRemoveDelegatorWithStakeOverThreshold _ pvString =
 -- | Test reducing delegator stake in such a way that it stays above the cap threshold.
 testReduceDelegatorStakeStillAboveCapThreshold ::
     forall pv.
-    (IsProtocolVersion pv, PVSupportsDelegation pv, PVSupportsDelegation pv) =>
+    (IsProtocolVersion pv, PVSupportsDelegation pv) =>
     SProtocolVersion pv ->
     String ->
     Spec
@@ -302,7 +303,7 @@ testReduceDelegatorStakeStillAboveCapThreshold _ pvString =
 -- | Test transaction rejects if increasing stake above the threshold of the pool
 testTransactionRejectsIfStakeIncreasedOverThreshold ::
     forall pv.
-    (IsProtocolVersion pv, PVSupportsDelegation pv, PVSupportsDelegation pv) =>
+    (IsProtocolVersion pv, PVSupportsDelegation pv) =>
     SProtocolVersion pv ->
     String ->
     Spec

--- a/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
@@ -134,7 +134,8 @@ forEveryProtocolVersion check =
       check Types.SP4 "P4",
       check Types.SP5 "P5",
       check Types.SP6 "P6",
-      check Types.SP7 "P7"
+      check Types.SP7 "P7",
+      check Types.SP8 "P8"
     ]
 
 -- | Convert an energy value to an amount, based on the exchange rates used in

--- a/concordium-node/src/consensus_ffi/ffi.rs
+++ b/concordium-node/src/consensus_ffi/ffi.rs
@@ -1977,12 +1977,11 @@ impl ConsensusContainer {
 
     pub fn send_finalization(&self, genesis_index: u32, msg: &[u8]) -> ConsensusFfiResponse {
         wrap_send_data_to_c!(self, genesis_index, msg, receiveFinalizationMessage)
-        .check_consistent()
+            .check_consistent()
     }
 
     pub fn send_finalization_record(&self, genesis_index: u32, rec: &[u8]) -> ConsensusFfiResponse {
-        wrap_send_data_to_c!(self, genesis_index, rec, receiveFinalizationRecord)
-        .check_consistent()
+        wrap_send_data_to_c!(self, genesis_index, rec, receiveFinalizationRecord).check_consistent()
     }
 
     /// Send a transaction to consensus. Return whether the operation succeeded


### PR DESCRIPTION
This adds the `suspend` field to the `BakerConfigureUpdate` in the consensus and adds the necessary logic to set/unset the corresponding field. This comes (unfortunately) with more necessary boilerplate code. I haven't found already present tests that could be extended for this.

Fixes #1225.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance



By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
