### PR TITLE
Consensus exception handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Improve consensus behaviour in the event of an unrecoverable exception.
+
 ## 7.0.1
 
 - Fix a bug in migration from protocol version 6 to 7.

--- a/concordium-consensus/src-lib/Concordium/External.hs
+++ b/concordium-consensus/src-lib/Concordium/External.hs
@@ -726,7 +726,7 @@ stopBaker cptr = mask_ $ do
 -- |    16 | ResultNonexistingSenderAccount              | The transaction's sender account does not exist according to the focus block                  | No       |
 -- +-------+---------------------------------------------+-----------------------------------------------------------------------------------------------+----------+
 -- |    17 | ResultDuplicateNonce                        | The sequence number for this account or update type was already used                          | No       |
--- i+-------+---------------------------------------------+-----------------------------------------------------------------------------------------------+----------+
+-- +-------+---------------------------------------------+-----------------------------------------------------------------------------------------------+----------+
 -- |    18 | ResultNonceTooLarge                         | The transaction seq. number is larger than the next one for this account/update type          | No       |
 -- +-------+---------------------------------------------+-----------------------------------------------------------------------------------------------+----------+
 -- |    19 | ResultTooLowEnergy                          | The stated transaction energy is lower than the minimum amount necessary to execute it        | No       |
@@ -754,6 +754,8 @@ stopBaker cptr = mask_ $ do
 -- |    30 | ResultInsufficientFunds                     | The sender did not have enough funds to cover the costs.                                      | No       |
 -- +-------+---------------------------------------------+-----------------------------------------------------------------------------------------------+----------+
 -- |    31 | ResultDoubleSign                            | The consensus message is a result of malignant double signing.                                | No       |
+-- +-------+---------------------------------------------+-----------------------------------------------------------------------------------------------+----------+
+-- |    32 | ResultConsensusFailure                      | The consensus has thrown an exception and entered an unrecoverable state.                     | No       |
 -- +-------+---------------------------------------------+-----------------------------------------------------------------------------------------------+----------+
 type ReceiveResult = Int64
 
@@ -791,12 +793,13 @@ toReceiveResult ResultChainUpdateInvalidSignatures = 28
 toReceiveResult ResultEnergyExceeded = 29
 toReceiveResult ResultInsufficientFunds = 30
 toReceiveResult ResultDoubleSign = 31
+toReceiveResult ResultConsensusFailure = 32
 
 -- | Handle receipt of a block.
 --  The possible return codes are @ResultSuccess@, @ResultSerializationFail@,
 --  @ResultInvalid@, @ResultPendingBlock@, @ResultDuplicate@, @ResultStale@,
 --  @ResultConsensusShutDown@, @ResultEarlyBlock@, @ResultInvalidGenesisIndex@, and
---  @ResultDoubleSign@.
+--  @ResultDoubleSign@. Additionally @ResultConsensusFailure@ is returned if an exception occurs.
 --  'receiveBlock' may invoke the callbacks for new finalization messages.
 --  If the block was successfully verified i.e. baker signature, finalization proofs etc. then
 --  the continuation for executing the block will be written to the 'Ptr' provided.
@@ -827,25 +830,27 @@ receiveBlock bptr genIndex msg msgLen ptrPtrExecuteBlock = do
             poke ptrPtrExecuteBlock =<< newStablePtr eb
             return $ toReceiveResult receiveResult
 
--- | Execute a block that has been received and succesfully verified.
+-- | Execute a block that has been received and successfully verified.
 --  The 'MV.ExecuteBlock' continuation is obtained via first calling 'receiveBlock' which in return
 --  will construct a pointer to the continuation.
 --  The 'StablePtr' is freed here and so this function should only be called once for each 'MV.ExecuteBlock'.
 --  The possible return codes are @ResultSuccess@, @ResultSerializationFail@, @ResultInvalid@
 --  and @ResultConsensusShutDown@.
+--  Additionally @ResultConsensusFailure@ is returned if an exception occurs.
 executeBlock :: StablePtr ConsensusRunner -> StablePtr MV.ExecuteBlock -> IO ReceiveResult
 executeBlock ptrConsensus ptrCont = do
     (ConsensusRunner mvr) <- deRefStablePtr ptrConsensus
     executableBlock <- deRefStablePtr ptrCont
     freeStablePtr ptrCont
     mvLog mvr External LLTrace "Executing block."
-    res <- MV.runBlock executableBlock
+    res <- runMVR (MV.executeBlock executableBlock) mvr
     return $ toReceiveResult res
 
 -- | Handle receipt of a finalization message.
 --  The possible return codes are @ResultSuccess@, @ResultSerializationFail@, @ResultInvalid@,
 --  @ResultPendingFinalization@, @ResultDuplicate@, @ResultStale@, @ResultIncorrectFinalizationSession@,
 --  @ResultUnverifiable@, @ResultConsensusShutDown@, @ResultInvalidGenesisIndex@, and @ResultDoubleSign@.
+--  Additionally @ResultConsensusFailure@ is returned if an exception occurs.
 --  'receiveFinalization' may invoke the callbacks for new finalization messages.
 receiveFinalizationMessage ::
     StablePtr ConsensusRunner ->
@@ -863,6 +868,7 @@ receiveFinalizationMessage bptr genIndex msg msgLen = do
 --  The possible return codes are @ResultSuccess@, @ResultSerializationFail@, @ResultInvalid@,
 --  @ResultPendingBlock@, @ResultPendingFinalization@, @ResultDuplicate@, @ResultStale@,
 --  @ResultConsensusShutDown@ and @ResultInvalidGenesisIndex@.
+--  Additionally @ResultConsensusFailure@ is returned if an exception occurs.
 --  'receiveFinalizationRecord' may invoke the callbacks for new finalization messages.
 receiveFinalizationRecord ::
     StablePtr ConsensusRunner ->
@@ -885,7 +891,8 @@ receiveFinalizationRecord bptr genIndex msg msgLen = do
 --  @ResultCredentialDeploymentInvalidIP@, @ResultCredentialDeploymentInvalidAR@,
 --  @ResultCredentialDeploymentExpired@, @ResultChainUpdateInvalidSequenceNumber@,
 --  @ResultChainUpdateInvalidEffectiveTime@, @ResultChainUpdateInvalidSignatures@,
---  @ResultEnergyExceeded@
+--  @ResultEnergyExceeded@.
+--  Additionally @ResultConsensusFailure@ is returned if an exception occurs.
 receiveTransaction :: StablePtr ConsensusRunner -> CString -> Int64 -> Ptr Word8 -> IO ReceiveResult
 receiveTransaction bptr transactionData transactionLen outPtr = do
     (ConsensusRunner mvr) <- deRefStablePtr bptr
@@ -907,6 +914,7 @@ receiveTransaction bptr transactionData transactionLen outPtr = do
 --  * @ResultPendingBlock@ -- the sender has some data I am missing, and should be marked pending
 --  * @ResultSuccess@ -- I do not require additional data from the sender, so mark it as up-to-date
 --  * @ResultContinueCatchUp@ -- The sender should be marked pending if it is currently up-to-date (no change otherwise)
+--  * @ResultConsensusFailure@ -- an internal exception occurred
 receiveCatchUpStatus ::
     -- | Consensus pointer
     StablePtr ConsensusRunner ->
@@ -957,6 +965,7 @@ getCatchUpStatus cptr genIndexPtr resPtr = do
 
 -- | Import a file consisting of a set of blocks and finalization records for the purposes of
 --  out-of-band catch-up.
+--  @ResultConsensusFailure@ is returned if an exception occurs.
 importBlocks ::
     -- | Consensus runner
     StablePtr ConsensusRunner ->

--- a/concordium-consensus/src/Concordium/MultiVersion.hs
+++ b/concordium-consensus/src/Concordium/MultiVersion.hs
@@ -518,7 +518,8 @@ data GlobalLockPoisonError = GlobalLockPoisonError
     deriving (Eq, Show, Typeable)
 
 instance Exception GlobalLockPoisonError where
-    displayException _ = "The global state lock was poisoned by an error in another thread."
+    displayException _ =
+        "The global state lock was poisoned by an unrecoverable error in another thread."
 
 -- | The context for managing multi-version consensus.
 data MultiVersionRunner finconf = MultiVersionRunner

--- a/concordium-consensus/src/Concordium/MultiVersion.hs
+++ b/concordium-consensus/src/Concordium/MultiVersion.hs
@@ -23,9 +23,9 @@
 module Concordium.MultiVersion where
 
 import Control.Concurrent
-import Control.Exception
+import Control.Exception hiding (handle)
 import Control.Monad
-import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow (throwM))
+import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow (throwM), handle)
 import Control.Monad.Reader
 import qualified Control.Monad.State.Strict as State
 import Data.ByteString (ByteString)
@@ -34,6 +34,7 @@ import Data.IORef
 import Data.Serialize
 import qualified Data.Text as Text
 import Data.Time
+import Data.Typeable
 import qualified Data.Vector as Vec
 import System.FilePath
 
@@ -500,6 +501,25 @@ data CatchUpStatusBufferState
     | -- | We should not send any more catch-up status messages.
       BufferShutdown
 
+-- | A representation of whether the global write lock has been poisoned due to an exception in
+--  a thread that held the lock.
+data GlobalStateStatus
+    = -- | The global state is in a consistent state.
+      GSOk
+    | -- | A thread has thrown an exception while processing the global state, indicating an
+      --  unrecoverable error.
+      GSError
+    deriving (Eq)
+
+-- | An exception indicating that the global state lock was poisoned by an error in another thread.
+--  This indicates that some invariants of the global state may have been violated, and is not
+--  recoverable.
+data GlobalLockPoisonError = GlobalLockPoisonError
+    deriving (Eq, Show, Typeable)
+
+instance Exception GlobalLockPoisonError where
+    displayException _ = "The global state lock was poisoned by an error in another thread."
+
 -- | The context for managing multi-version consensus.
 data MultiVersionRunner finconf = MultiVersionRunner
     { -- | Base configuration.
@@ -515,7 +535,7 @@ data MultiVersionRunner finconf = MultiVersionRunner
       --  the write lock is held.
       mvVersions :: !(IORef (Vec.Vector (EVersionedConfiguration finconf))),
       -- | Global write lock.
-      mvWriteLock :: !(MVar ()),
+      mvWriteLock :: !(MVar GlobalStateStatus),
       -- | Flag to stop importing blocks. When importing blocks from a file is in progress,
       --  setting this flag to True will cause the import to stop.
       mvShouldStopImportingBlocks :: !(IORef Bool),
@@ -546,6 +566,25 @@ instance MonadLogger (MVR finconf) where
     logEvent src lvl msg = MVR $ \mvr -> mvLog mvr src lvl msg
     {-# INLINE logEvent #-}
 
+-- | Catch and log exceptions in the 'MVR' monad.
+--  Returns a specified value in the event of an exception.
+handleMVRExceptionsWith ::
+    -- | Value to return in the event of an exception.
+    a ->
+    -- | Action to run
+    MVR finconf a ->
+    MVR finconf a
+handleMVRExceptionsWith failRes = handle handler
+  where
+    handler (e :: SomeException) = do
+        logEvent Runner LLError $ "Unrecoverable exception: " <> displayException e
+        return failRes
+
+-- | Catch and log exceptions in the 'MVR' monad.
+--  Returns 'Skov.ResultConsensusFailure' in the event of an exception.
+handleMVRExceptions :: MVR finconf Skov.UpdateResult -> MVR finconf Skov.UpdateResult
+handleMVRExceptions = handleMVRExceptionsWith Skov.ResultConsensusFailure
+
 -- | Perform an action while holding the global state write lock.
 --  If the action throws an exception, this ensures that the lock is
 --  released.
@@ -561,14 +600,23 @@ withWriteLockIO :: MultiVersionRunner finconf -> IO a -> IO a
 withWriteLockIO MultiVersionRunner{..} a =
     bracketOnError
         (takeMVar mvWriteLock)
-        ( \() ->
-            tryPutMVar mvWriteLock ()
-                >> mvLog Runner LLWarning "Released global state lock following error."
+        ( \_ -> do
+            poisoned <- tryPutMVar mvWriteLock GSError
+            when poisoned $
+                mvLog
+                    Runner
+                    LLWarning
+                    "An error occurred while holding the global state lock.\
+                    \ This will be propagated to other threads."
         )
-        $ \_ -> do
-            res <- a
-            putMVar mvWriteLock ()
-            return res
+        $ \case
+            GSOk -> do
+                res <- a
+                putMVar mvWriteLock GSOk
+                return res
+            GSError -> do
+                putMVar mvWriteLock GSError
+                throwIO GlobalLockPoisonError
 
 -- | Perform an action while holding the global state write lock. Optionally, when the action
 --  completes, a thread is forked to perform a follow-up action before releasing the lock.
@@ -585,17 +633,26 @@ withWriteLockMaybeFork action followup = MVR $ \mvr ->
 withWriteLockMaybeForkIO :: MultiVersionRunner finconf -> IO (a, Maybe b) -> (b -> IO ()) -> IO a
 {-# INLINE withWriteLockMaybeForkIO #-}
 withWriteLockMaybeForkIO MultiVersionRunner{..} action followup = mask $ \unmask -> do
-    () <- takeMVar mvWriteLock
-    (res, mContinue) <- unmask action `onException` tryPutMVar mvWriteLock ()
+    gsStatus <- takeMVar mvWriteLock
+    when (gsStatus == GSError) $ do
+        putMVar mvWriteLock GSError
+        throwIO GlobalLockPoisonError
+    (res, mContinue) <- unmask action `onException` tryPutMVar mvWriteLock GSError
     case mContinue of
         Just continueArg -> do
-            let release = putMVar mvWriteLock ()
+            let release (Left exception) = do
+                    mvLog Runner LLError $
+                        "An unrecovarable error occurred in a worker thread\
+                        \ while holding the global state lock: "
+                            ++ show exception
+                    putMVar mvWriteLock GSError
+                release (Right _) = putMVar mvWriteLock GSOk
             -- forkIO is guaranteed to be uninterruptible, so we can be sure that an async exception
             -- won't prevent the lock being released. Also note that the masking state of the thread
             -- is inherited, so we unmask when running the follow-up.
-            void $ forkIO (unmask (try @SomeException (followup continueArg)) >> release)
+            void $ forkIO (unmask (try @SomeException (followup continueArg)) >>= release)
         Nothing -> do
-            putMVar mvWriteLock ()
+            putMVar mvWriteLock GSOk
     return res
 
 -- | Lift a 'LogIO' action into the 'MVR' monad.
@@ -1137,7 +1194,7 @@ makeMultiVersionRunner
         mvTransactionPurgingThread <- newEmptyMVar
         let mvr = MultiVersionRunner{..}
         runMVR (startupSkov genesis) mvr
-        putMVar mvWriteLock ()
+        putMVar mvWriteLock GSOk
         startTransactionPurgingThread mvr
         return mvr
 
@@ -1467,12 +1524,14 @@ shutdownMultiVersionRunner MultiVersionRunner{..} = mask_ $ do
     -- Kill the transaction purging thread, if any.
     tryTakeMVar mvTransactionPurgingThread >>= mapM_ killThread
     -- Acquire the write lock. This prevents further updates, as they will block.
-    takeMVar mvWriteLock
-    versions <- readIORef mvVersions
-    -- Shut down the consensus databases.
-    runLoggerT (forM_ versions evcShutdown) mvLog
-    -- Shut down the global account map.
-    LMDBAccountMap.closeDatabase (globalAccountMap (mvcStateConfig mvConfiguration))
+    takeMVar mvWriteLock >>= \case
+        GSOk -> do
+            versions <- readIORef mvVersions
+            -- Shut down the consensus databases.
+            runLoggerT (forM_ versions evcShutdown) mvLog
+            -- Shut down the global account map.
+            LMDBAccountMap.closeDatabase (globalAccountMap (mvcStateConfig mvConfiguration))
+        GSError -> throwIO GlobalLockPoisonError
 
 -- | Lift a version-0 consensus skov action to the 'MVR' monad, running it on a
 --  particular 'VersionedConfigurationV0'. Note that this does not
@@ -1678,58 +1737,67 @@ receiveBlock ::
     GenesisIndex ->
     ByteString ->
     MVR finconf (Skov.UpdateResult, Maybe ExecuteBlock)
-receiveBlock gi blockBS = withLatestExpectedVersion gi $ \case
-    (EVersionedConfigurationV0 (vc :: VersionedConfigurationV0 finconf pv)) -> do
-        MVR $ \mvr -> do
-            now <- currentTime
-            case deserializeExactVersionedPendingBlock (protocolVersion @pv) blockBS now of
-                Left err -> do
-                    mvLog mvr Runner LLDebug err
-                    return (Skov.ResultSerializationFail, Nothing)
-                Right block -> do
-                    (updateResult, mVerifiedPendingBlock) <- runMVR (runSkovV0Transaction vc (Skov.receiveBlock block)) mvr
-                    case mVerifiedPendingBlock of
-                        Nothing -> return (updateResult, Nothing)
-                        Just verifiedPendingBlock -> do
-                            let exec = do
-                                    runSkovV0Transaction vc (Skov.executeBlock verifiedPendingBlock)
-                            let cont = ExecuteBlock $ runMVR exec mvr
-                            return (updateResult, Just cont)
-    (EVersionedConfigurationV1 (vc :: VersionedConfigurationV1 finconf pv)) -> do
-        MVR $ \mvr -> do
-            now <- currentTime
-            case SkovV1.deserializeExactVersionedPendingBlock @pv blockBS now of
-                Left err -> do
-                    mvLog mvr Runner LLDebug err
-                    return (Skov.ResultSerializationFail, Nothing)
-                Right block -> do
-                    blockResult <- runMVR (runSkovV1Transaction vc (SkovV1.uponReceivingBlock block)) mvr
-                    case blockResult of
-                        SkovV1.BlockResultSuccess vb -> do
-                            let exec = do
-                                    runSkovV1Transaction vc (SkovV1.executeBlock vb)
-                                    return Skov.ResultSuccess
-                            let cont = ExecuteBlock $ runMVR exec mvr
-                            return (Skov.ResultSuccess, Just cont)
-                        SkovV1.BlockResultDoubleSign vb -> do
-                            runMVR (runSkovV1Transaction vc (SkovV1.executeBlock vb)) mvr
-                            return (Skov.ResultDoubleSign, Nothing)
-                        SkovV1.BlockResultInvalid -> return (Skov.ResultInvalid, Nothing)
-                        SkovV1.BlockResultStale -> return (Skov.ResultStale, Nothing)
-                        SkovV1.BlockResultPending -> return (Skov.ResultPendingBlock, Nothing)
-                        SkovV1.BlockResultEarly -> return (Skov.ResultEarlyBlock, Nothing)
-                        SkovV1.BlockResultDuplicate -> return (Skov.ResultDuplicate, Nothing)
-                        SkovV1.BlockResultConsensusShutdown -> return (Skov.ResultConsensusShutDown, Nothing)
+receiveBlock gi blockBS = handleMVRExceptionsWith (Skov.ResultConsensusFailure, Nothing) $
+    withLatestExpectedVersion gi $ \case
+        (EVersionedConfigurationV0 (vc :: VersionedConfigurationV0 finconf pv)) -> do
+            MVR $ \mvr -> do
+                now <- currentTime
+                case deserializeExactVersionedPendingBlock (protocolVersion @pv) blockBS now of
+                    Left err -> do
+                        mvLog mvr Runner LLDebug err
+                        return (Skov.ResultSerializationFail, Nothing)
+                    Right block -> do
+                        (updateResult, mVerifiedPendingBlock) <-
+                            runMVR
+                                (runSkovV0Transaction vc (Skov.receiveBlock block))
+                                mvr
+                        case mVerifiedPendingBlock of
+                            Nothing -> return (updateResult, Nothing)
+                            Just verifiedPendingBlock -> do
+                                let exec = do
+                                        runSkovV0Transaction vc $
+                                            Skov.executeBlock verifiedPendingBlock
+                                let cont = ExecuteBlock $ runMVR exec mvr
+                                return (updateResult, Just cont)
+        (EVersionedConfigurationV1 (vc :: VersionedConfigurationV1 finconf pv)) -> do
+            MVR $ \mvr -> do
+                now <- currentTime
+                case SkovV1.deserializeExactVersionedPendingBlock @pv blockBS now of
+                    Left err -> do
+                        mvLog mvr Runner LLDebug err
+                        return (Skov.ResultSerializationFail, Nothing)
+                    Right block -> do
+                        blockResult <-
+                            runMVR
+                                (runSkovV1Transaction vc (SkovV1.uponReceivingBlock block))
+                                mvr
+                        case blockResult of
+                            SkovV1.BlockResultSuccess vb -> do
+                                let exec = do
+                                        runSkovV1Transaction vc (SkovV1.executeBlock vb)
+                                        return Skov.ResultSuccess
+                                let cont = ExecuteBlock $ runMVR exec mvr
+                                return (Skov.ResultSuccess, Just cont)
+                            SkovV1.BlockResultDoubleSign vb -> do
+                                runMVR (runSkovV1Transaction vc (SkovV1.executeBlock vb)) mvr
+                                return (Skov.ResultDoubleSign, Nothing)
+                            SkovV1.BlockResultInvalid -> return (Skov.ResultInvalid, Nothing)
+                            SkovV1.BlockResultStale -> return (Skov.ResultStale, Nothing)
+                            SkovV1.BlockResultPending -> return (Skov.ResultPendingBlock, Nothing)
+                            SkovV1.BlockResultEarly -> return (Skov.ResultEarlyBlock, Nothing)
+                            SkovV1.BlockResultDuplicate -> return (Skov.ResultDuplicate, Nothing)
+                            SkovV1.BlockResultConsensusShutdown ->
+                                return (Skov.ResultConsensusShutDown, Nothing)
 
 -- | Invoke the continuation yielded by 'receiveBlock'.
 --  The continuation performs a transaction which will acquire the write lock
 --  before trying to add the block to the tree and release the lock again afterwards.
 executeBlock :: ExecuteBlock -> MVR finconf Skov.UpdateResult
-executeBlock = liftIO . runBlock
+executeBlock = handleMVRExceptions . liftIO . runBlock
 
 -- | Deserialize and receive a finalization message at a given genesis index.
 receiveFinalizationMessage :: GenesisIndex -> ByteString -> MVR finconf Skov.UpdateResult
-receiveFinalizationMessage gi finMsgBS = withLatestExpectedVersion_ gi $ \case
+receiveFinalizationMessage gi finMsgBS = handleMVRExceptions $ withLatestExpectedVersion_ gi $ \case
     (EVersionedConfigurationV0 (vc :: VersionedConfigurationV0 finconf pv)) ->
         case runGet getExactVersionedFPM finMsgBS of
             Left err -> do
@@ -1748,16 +1816,16 @@ receiveFinalizationMessage gi finMsgBS = withLatestExpectedVersion_ gi $ \case
                             Left leftRes -> (leftRes, Nothing)
                             Right cont -> (Skov.ResultSuccess, Just cont)
                     followup = liftSkovV1Update vc
-                -- We spawn a thread to perform the follow-up so that the P2P layer can immediately
-                -- relay the message, since the follow-up action can be time consuming (including
-                -- finalizing blocks and baking a new block).
+                -- We spawn a thread to perform the follow-up so that the P2P layer can
+                -- immediately relay the message, since the follow-up action can be time
+                -- consuming (including finalizing blocks and baking a new block).
                 withWriteLockMaybeFork receive followup
 
 -- | Deserialize and receive a finalization entity.
 --  For consensus version 0 this should be a 'FinalizationRecord'.
 --  For consensus version 1 this should be a 'FinalizationEntry'.
 receiveFinalization :: GenesisIndex -> ByteString -> MVR finconf Skov.UpdateResult
-receiveFinalization gi finBS = withLatestExpectedVersion_ gi $ \case
+receiveFinalization gi finBS = handleMVRExceptions $ withLatestExpectedVersion_ gi $ \case
     (EVersionedConfigurationV0 (vc :: VersionedConfigurationV0 finconf pv)) ->
         case runGet getExactVersionedFinalizationRecord finBS of
             Left err -> do
@@ -1794,7 +1862,7 @@ receiveCatchUpStatus ::
     CatchUpConfiguration ->
     MVR finconf Skov.UpdateResult
 receiveCatchUpStatus gi catchUpBS cuConfig@CatchUpConfiguration{..} =
-    case runGet getVersionedCatchUpStatus catchUpBS of
+    handleMVRExceptions $ case runGet getVersionedCatchUpStatus catchUpBS of
         Left err -> do
             logEvent Runner LLDebug $ "Could not deserialize catch-up status message: " ++ err
             return Skov.ResultSerializationFail
@@ -1988,7 +2056,7 @@ getCatchUpRequest = do
 --  the result of the update. The hash is present unless the transaction could
 --  not be deserialized.
 receiveTransaction :: forall finconf. ByteString -> MVR finconf (Maybe TransactionHash, Skov.UpdateResult)
-receiveTransaction transactionBS = do
+receiveTransaction transactionBS = handleMVRExceptionsWith (Nothing, Skov.ResultConsensusFailure) $ do
     now <- utcTimeToTransactionTime <$> currentTime
     mvr <- ask
     vvec <- liftIO $ readIORef $ mvVersions mvr
@@ -2094,7 +2162,7 @@ receiveExecuteBlock gi blockBS = withLatestExpectedVersion_ gi $ \case
 
 -- | Import a block file for out-of-band catch-up.
 importBlocks :: FilePath -> MVR finconf Skov.UpdateResult
-importBlocks importFile = do
+importBlocks importFile = handleMVRExceptions $ do
     vvec <- liftIO . readIORef =<< asks mvVersions
     -- Import starting from the genesis index of the latest consensus
     let genIndex = evcIndex (Vec.last vvec)

--- a/concordium-consensus/src/Concordium/Skov/Monad.hs
+++ b/concordium-consensus/src/Concordium/Skov/Monad.hs
@@ -111,6 +111,8 @@ data UpdateResult
       ResultInsufficientFunds
     | -- | The consensus message is a result of double signing, indicating malicious behaviour.
       ResultDoubleSign
+    | -- | The consensus has thrown an exception and entered an unrecoverable state.
+      ResultConsensusFailure
     deriving (Eq, Show)
 
 -- | Maps a 'TV.VerificationResult' to the corresponding 'UpdateResult' type.

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_node"
-version = "7.0.0"
+version = "7.0.1"
 dependencies = [
  "anyhow",
  "app_dirs2",


### PR DESCRIPTION
## Purpose

Closes #1233

This improves the handling of exceptions in consensus so that, if an unrecoverable exception occurs (e.g. an invariant violation), then consensus cannot continue actively.

## Changes

- When an (unrecoverable) exception occurs in a thread holding the global write lock, the lock is put into a poisoned state. When another thread attempts to acquire the lock, it will also raise an exception.
- Ensure that such exceptions are handled appropriately.
- Add a `ResultConsensusFailure` return code to the FFI `receive` functions indicating that an exception has occurred and consensus has been stopped.
- On the Rust side, observing `ConsensusFailure` results in a panic.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
