### PR TITLE
Fix the payday timing at the P6->P7 protocol update.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased changes
 
+- Fix the timing of paydays after protocol update from version 6 to 7.
 - Improve consensus behaviour in the event of an unrecoverable exception.
 
 ## 7.0.1


### PR DESCRIPTION
## Purpose

Closes #1232

Fix the payday timing after P6->P7 protocol update so that it occurs when it would if the protocol update had not happened.

## Changes

- Adjust the new payday epoch calculation as required, factoring it out.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
