### PR TITLE
Fix the calculation of the next payday time in `GetTokenomicsInfo`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased changes
 
+## 7.0.4
+
+- Fix a bug where the next payday time reported by the `GetTokenomicsInfo` query was
+  incorrect (#1240).
+
 ## 7.0.3
 
 - Fix a bug in the computation of the genesis height after the second protocol update. (#1237)

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -2798,8 +2798,8 @@ doMint pbs mint = do
             bspBank bsp
                 & unhashed
                     %~ (Rewards.totalGTU +~ mintTotal mint)
-                    . (Rewards.bakingRewardAccount +~ mintBakingReward mint)
-                    . (Rewards.finalizationRewardAccount +~ mintFinalizationReward mint)
+                        . (Rewards.bakingRewardAccount +~ mintBakingReward mint)
+                        . (Rewards.finalizationRewardAccount +~ mintFinalizationReward mint)
     let updAcc = addAccountAmount $ mintDevelopmentCharge mint
     foundationAccount <- (^. cpFoundationAccount) <$> lookupCurrentParameters (bspUpdates bsp)
     newAccounts <- Accounts.updateAccountsAtIndex' updAcc foundationAccount (bspAccounts bsp)

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_node"
-version = "7.0.3"
+version = "7.0.4"
 dependencies = [
  "anyhow",
  "app_dirs2",

--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium_node"
-version = "7.0.3" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
+version = "7.0.4" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
 description = "Concordium Node"
 authors = ["Concordium <developers@concordium.com>"]
 exclude = [".gitignore", ".gitlab-ci.yml", "test/**/*","**/**/.gitignore","**/**/.gitlab-ci.yml"]

--- a/concordium-node/src/consensus_ffi/ffi.rs
+++ b/concordium-node/src/consensus_ffi/ffi.rs
@@ -1977,12 +1977,11 @@ impl ConsensusContainer {
 
     pub fn send_finalization(&self, genesis_index: u32, msg: &[u8]) -> ConsensusFfiResponse {
         wrap_send_data_to_c!(self, genesis_index, msg, receiveFinalizationMessage)
-        .check_consistent()
+            .check_consistent()
     }
 
     pub fn send_finalization_record(&self, genesis_index: u32, rec: &[u8]) -> ConsensusFfiResponse {
-        wrap_send_data_to_c!(self, genesis_index, rec, receiveFinalizationRecord)
-        .check_consistent()
+        wrap_send_data_to_c!(self, genesis_index, rec, receiveFinalizationRecord).check_consistent()
     }
 
     /// Send a transaction to consensus. Return whether the operation succeeded


### PR DESCRIPTION
## Purpose

Closes #1240

This fixes the timing information for the next payday returned by the `GetTokenomicsInfo` query. Instead of basing it on the genesis block time, the time is computed based on the next epoch transition time. This is more accurate, since after the P6->P7 update, the first epoch (epoch 0) is already considered complete.

## Changes

- Revise the computation of the next payday time, as described above.
- Bump node version for new release.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
