### PR TITLE
New GRPC endpoint - GetConsensusDetailedStatus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased changes
 
+- Add `GetConsensusDetailedStatus` gRPC endpoint for getting detailed information on the status
+  of the consensus, at consensus version 1.
+
 ## 7.0.5
 
 - Fix inconsistent handling of valid contract names.

--- a/concordium-consensus/lib.def
+++ b/concordium-consensus/lib.def
@@ -34,6 +34,7 @@ EXPORTS
  getInstanceStateV2
  getNextAccountSequenceNumberV2
  getConsensusInfoV2
+ getConsensusDetailedStatusV2
  getBlockItemStatusV2
  getCryptographicParametersV2
  getBlockInfoV2

--- a/concordium-consensus/src-lib/Concordium/External/GRPC2.hs
+++ b/concordium-consensus/src-lib/Concordium/External/GRPC2.hs
@@ -322,7 +322,7 @@ getConsensusDetailedStatusV2 ::
     -- | Genesis index
     Word32 ->
     Ptr ReceiverVec ->
-    FunPtr (Ptr ReceiverVec -> Ptr Word8 -> Int64 -> IO ()) ->
+    FunPtr CopyToVecCallback ->
     IO Int64
 getConsensusDetailedStatusV2 cptr explicitGenesisIndex genesisIndex outVec copierCbk = do
     Ext.ConsensusRunner mvr <- deRefStablePtr cptr

--- a/concordium-consensus/src/Concordium/GlobalState/BakerInfo.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BakerInfo.hs
@@ -9,13 +9,17 @@
 module Concordium.GlobalState.BakerInfo where
 
 import qualified Concordium.Crypto.SHA256 as H
+import Concordium.GRPC2
 import Concordium.Genesis.Data
 import Concordium.Scheduler.Types
 import Concordium.Types.Accounts
 import Concordium.Types.HashableTo
 import Concordium.Utils.BinarySearch
 import Concordium.Utils.Serialization
+import qualified Proto.V2.Concordium.Types as Proto
+import qualified Proto.V2.Concordium.Types_Fields as ProtoFields
 
+import qualified Data.ProtoLens.Combinators as Proto
 import Data.Ratio
 import Data.Serialize
 import qualified Data.Vector as Vec
@@ -42,6 +46,15 @@ instance HasBakerInfo FullBakerInfo where
     bakerInfo = theBakerInfo
 instance HashableTo H.Hash FullBakerInfo where
     getHash = H.hash . encode
+
+instance ToProto FullBakerInfo where
+    type Output FullBakerInfo = Proto.FullBakerInfo
+    toProto fbi = Proto.make $ do
+        ProtoFields.bakerIdentity .= toProto (fbi ^. bakerIdentity)
+        ProtoFields.electionVerifyKey .= toProto (fbi ^. bakerElectionVerifyKey)
+        ProtoFields.signatureVerifyKey .= toProto (fbi ^. bakerSignatureVerifyKey)
+        ProtoFields.aggregationVerifyKey .= toProto (fbi ^. bakerAggregationVerifyKey)
+        ProtoFields.stake .= toProto (fbi ^. bakerStake)
 
 data FullBakers = FullBakers
     { -- | All bakers in ascending order of BakerId.

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
@@ -162,7 +162,7 @@ insertDeadCache !bh dc@DeadCache{..}
     | HS.member bh _dcHashes = dc
     | otherwise =
         let newHashes = HS.insert bh _dcHashes
-        in  if HS.size newHashes > deadCacheSize
+        in  if deadCacheCurrentSize dc >= deadCacheSize
                 then
                     let (newHashes', newQueue) = case _dcQueue of
                             h Seq.:<| q -> (HS.delete h newHashes, q)
@@ -180,6 +180,10 @@ insertDeadCache !bh dc@DeadCache{..}
 -- | Return whether the given block hash is in the cache.
 memberDeadCache :: BlockHash -> DeadCache -> Bool
 memberDeadCache bh DeadCache{..} = HS.member bh _dcHashes
+
+-- | Return the current size of the dead block cache.
+deadCacheCurrentSize :: DeadCache -> Int
+deadCacheCurrentSize = Seq.length . _dcQueue
 
 -- | A table of live and non-finalized blocks together with a small cache of dead
 --  ones.

--- a/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Types.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TreeState/Types.hs
@@ -10,19 +10,25 @@
 
 module Concordium.KonsensusV1.TreeState.Types where
 
+import Control.Monad
 import qualified Data.ByteString as BS
+import Data.Foldable
 import Data.Function
 import qualified Data.Map.Strict as Map
+import qualified Data.ProtoLens.Combinators as Proto
 import Data.Serialize
 import Data.Time
 import Data.Time.Clock.POSIX
 import Data.Word
 import Lens.Micro.Platform
 
+import Concordium.GRPC2 (ToProto (..))
 import Concordium.Types
 import qualified Concordium.Types.Conditionally as Cond
 import Concordium.Types.Execution
 import Concordium.Types.HashableTo
+import qualified Proto.V2.Concordium.Types as Proto
+import qualified Proto.V2.Concordium.Types_Fields as ProtoFields
 
 import Concordium.GlobalState.BakerInfo
 import qualified Concordium.GlobalState.Persistent.BlockState as PBS
@@ -299,6 +305,14 @@ instance Serialize PersistentRoundStatus where
         _prsLatestTimeout <- get
         return PersistentRoundStatus{..}
 
+instance ToProto PersistentRoundStatus where
+    type Output PersistentRoundStatus = Proto.PersistentRoundStatus
+    toProto PersistentRoundStatus{..} = Proto.make $ do
+        mapM_ (assign ProtoFields.lastSignedQuorumMessage . toProto) _prsLastSignedQuorumMessage
+        mapM_ (assign ProtoFields.lastSignedTimeoutMessage . toProto) _prsLastSignedTimeoutMessage
+        ProtoFields.lastBakedRound .= toProto _prsLastBakedRound
+        mapM_ (assign ProtoFields.latestTimeout . toProto) _prsLatestTimeout
+
 -- | The 'PersistentRoundStatus' at genesis.
 initialPersistentRoundStatus :: PersistentRoundStatus
 initialPersistentRoundStatus =
@@ -359,6 +373,12 @@ data RoundTimeout (pv :: ProtocolVersion) = RoundTimeout
     }
     deriving (Eq, Show)
 
+instance ToProto (RoundTimeout pv) where
+    type Output (RoundTimeout pv) = Proto.RoundTimeout
+    toProto RoundTimeout{..} = Proto.make $ do
+        ProtoFields.timeoutCertificate .= toProto rtTimeoutCertificate
+        ProtoFields.quorumCertificate .= toProto (cbQuorumCertificate rtCertifiedBlock)
+
 -- | The current round status.
 --  Note that it can be the case that both the 'QuorumSignatureMessage' and the
 --  'TimeoutSignatureMessage' are present.
@@ -408,6 +428,19 @@ data RoundStatus (pv :: ProtocolVersion) = RoundStatus
 
 makeLenses ''RoundStatus
 
+instance ToProto (RoundStatus pv) where
+    type Output (RoundStatus pv) = Proto.RoundStatus
+    toProto RoundStatus{..} = Proto.make $ do
+        ProtoFields.currentRound .= toProto _rsCurrentRound
+        ProtoFields.highestCertifiedBlock .= toProto (cbQuorumCertificate _rsHighestCertifiedBlock)
+        forM_ _rsPreviousRoundTimeout $ \timeout ->
+            ProtoFields.previousRoundTimeout .= toProto timeout
+        ProtoFields.roundEligibleToBake .= _rsRoundEligibleToBake
+        ProtoFields.currentEpoch .= toProto _rsCurrentEpoch
+        forM_ _rsLastEpochFinalizationEntry $ \finEntry ->
+            ProtoFields.lastEpochFinalizationEntry .= toProto finEntry
+        ProtoFields.currentTimeout .= toProto _rsCurrentTimeout
+
 -- | The 'RoundStatus' for consensus at genesis.
 initialRoundStatus ::
     -- | The base timeout.
@@ -444,6 +477,19 @@ data BakersAndFinalizers = BakersAndFinalizers
 
 makeLenses ''BakersAndFinalizers
 
+instance ToProto BakersAndFinalizers where
+    type Output BakersAndFinalizers = Proto.BakersAndFinalizers
+    toProto BakersAndFinalizers{..} = Proto.make $ do
+        ProtoFields.bakers .= fmap toProto (toList . fullBakerInfos $ _bfBakers)
+        ProtoFields.finalizers
+            .= fmap (toProto . finalizerBakerId) (toList . committeeFinalizers $ _bfFinalizers)
+        ProtoFields.bakerTotalStake .= toProto (bakerTotalStake _bfBakers)
+        ProtoFields.finalizerTotalStake
+            .= toProto (weightAsAmount $ committeeTotalWeight _bfFinalizers)
+        ProtoFields.finalizationCommitteeHash .= toProto _bfFinalizerHash
+      where
+        weightAsAmount (VoterPower w) = Amount w
+
 -- | The bakers and finalizers associated with the previous, current and next epochs (with respect
 --  to a particular epoch). Note that the current epoch referred to here is typically the epoch
 --  of the last finalized block, which is distinct from the current epoch as recorded in the
@@ -464,6 +510,16 @@ data EpochBakers = EpochBakers
     }
 
 makeClassy ''EpochBakers
+
+instance ToProto EpochBakers where
+    type Output EpochBakers = Proto.EpochBakers
+    toProto EpochBakers{..} = Proto.make $ do
+        ProtoFields.previousEpochBakers .= toProto _previousEpochBakers
+        unless (_currentEpochBakers == _previousEpochBakers) $
+            ProtoFields.currentEpochBakers .= toProto _currentEpochBakers
+        unless (_nextEpochBakers == _currentEpochBakers) $
+            ProtoFields.nextEpochBakers .= toProto _nextEpochBakers
+        ProtoFields.nextPayday .= toProto _nextPayday
 
 -- | Quorum messages collected for a round.
 data QuorumMessages = QuorumMessages
@@ -501,3 +557,12 @@ data TimeoutMessages
         tmSecondEpochTimeouts :: !(Map.Map FinalizerIndex TimeoutMessage)
       }
     deriving (Eq, Show)
+
+instance ToProto TimeoutMessages where
+    type Output TimeoutMessages = Proto.TimeoutMessages
+    toProto TimeoutMessages{..} = Proto.make $ do
+        ProtoFields.firstEpoch .= toProto tmFirstEpoch
+        ProtoFields.firstEpochTimeouts
+            .= fmap toProto (toList tmFirstEpochTimeouts)
+        ProtoFields.secondEpochTimeouts
+            .= fmap toProto (toList tmSecondEpochTimeouts)

--- a/concordium-node/build.rs
+++ b/concordium-node/build.rs
@@ -269,6 +269,15 @@ fn build_grpc2(proto_root_input: &str) -> std::io::Result<()> {
         )
         .method(
             tonic_build::manual::Method::builder()
+                .name("get_consensus_detailed_status")
+                .route_name("GetConsensusDetailedStatus")
+                .input_type("crate::grpc2::types::ConsensusDetailedStatusQuery")
+                .output_type("Vec<u8>")
+                .codec_path("crate::grpc2::RawCodec")
+                .build(),
+        )
+        .method(
+            tonic_build::manual::Method::builder()
                 .name("get_ancestors")
                 .route_name("GetAncestors")
                 .input_type("crate::grpc2::types::AncestorsRequest")


### PR DESCRIPTION
## Purpose

Add a new GRPC endpoint to get detailed consensus status information.

Depends on:
- https://github.com/Concordium/concordium-grpc-api/pull/64
- https://github.com/Concordium/concordium-base/pull/565

## Changes

- Add the new endpoint.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
