### PR TITLE
Move suspended flag

### DIFF
--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -32,7 +32,6 @@ import Concordium.Types
 import Concordium.Types.Accounts
 import Concordium.Types.AnonymityRevokers
 import Concordium.Types.Block (absoluteToLocalBlockHeight, localToAbsoluteBlockHeight)
-import Concordium.Types.Conditionally
 import Concordium.Types.Execution (TransactionSummary)
 import Concordium.Types.HashableTo
 import Concordium.Types.IdentityProviders
@@ -1091,14 +1090,6 @@ getAccountInfoHelper getASI getCooldowns acct bs = do
         aiAccountAddress <- BS.getAccountCanonicalAddress acc
         aiAccountCooldowns <- getCooldowns acc
         aiAccountAvailableAmount <- BS.getAccountAvailableAmount acc
-        aiAccountIsSuspended <- do
-            mAccBaker <- BS.getAccountBaker acc
-            case mAccBaker of
-                -- If the account doesn't have an associated validator, then it can't be suspended.
-                Nothing -> return False
-                Just accBaker ->
-                    return $
-                        fromCondDef (_bieAccountIsSuspended $ _accountBakerInfo accBaker) False
         return AccountInfo{..}
 
 -- | Get the details of a smart contract instance in the block state.


### PR DESCRIPTION
## Purpose

This removes code that was setting the suspended flag in `AccountInfo`. Since the flag has been moved in `concordium-base` it's not needed anymore.

## Changes

See above.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
