### PR TITLE
suspension via computeBakerStakesAndCapital

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased changes
 
 - Add support for suspend/resume to validator configuration updates.
+- Validators that are suspended are paused from participating in the consensus algorithm.
 - Add `GetConsensusDetailedStatus` gRPC endpoint for getting detailed information on the status
   of the consensus, at consensus version 1.
 - Update Rust version to 1.82.

--- a/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
@@ -734,7 +734,11 @@ data ActiveBakerInfo' bakerInfoRef = ActiveBakerInfo
       activeBakerPendingChange :: !(StakePendingChange' Timestamp),
       -- | Information about the delegators to the baker in ascending order of 'DelegatorId'.
       --  (There must be no duplicate 'DelegatorId's.)
-      activeBakerDelegators :: ![ActiveDelegatorInfo]
+      activeBakerDelegators :: ![ActiveDelegatorInfo],
+      -- | A flag indicating whether the baker is suspended.
+      activeBakerIsSuspended :: !Bool,
+      -- | The id of the baker.
+      activeBakerId :: !BakerId
     }
     deriving (Eq, Show)
 

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -84,6 +84,7 @@ import Concordium.Types
 import Concordium.Types.Accounts (AccountBaker (..))
 import qualified Concordium.Types.Accounts as BaseAccounts
 import qualified Concordium.Types.AnonymityRevokers as ARS
+import Concordium.Types.Conditionally
 import Concordium.Types.Execution (DelegationTarget (..), TransactionIndex, TransactionSummary)
 import qualified Concordium.Types.Execution as Transactions
 import Concordium.Types.HashableTo
@@ -1336,7 +1337,9 @@ doGetActiveBakersAndDelegators pbs = do
                           activeBakerEquityCapital = theBaker ^. BaseAccounts.stakedAmount,
                           activeBakerPendingChange =
                             BaseAccounts.pendingChangeEffectiveTimestamp <$> theBaker ^. BaseAccounts.bakerPendingChange,
-                          activeBakerDelegators = abd
+                          activeBakerDelegators = abd,
+                          activeBakerIsSuspended = fromCondDef (BaseAccounts._bieAccountIsSuspended $ BaseAccounts._accountBakerInfo $ theBaker) False,
+                          activeBakerId = BaseAccounts._bakerIdentity $ BaseAccounts._bieBakerInfo $ BaseAccounts._accountBakerInfo $ theBaker
                         }
     mkActiveDelegatorInfo :: BlockStatePointers pv -> DelegatorId -> m ActiveDelegatorInfo
     mkActiveDelegatorInfo bsp activeDelegatorId@(DelegatorId acct) =

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -1338,8 +1338,18 @@ doGetActiveBakersAndDelegators pbs = do
                           activeBakerPendingChange =
                             BaseAccounts.pendingChangeEffectiveTimestamp <$> theBaker ^. BaseAccounts.bakerPendingChange,
                           activeBakerDelegators = abd,
-                          activeBakerIsSuspended = fromCondDef (BaseAccounts._bieAccountIsSuspended $ BaseAccounts._accountBakerInfo $ theBaker) False,
-                          activeBakerId = BaseAccounts._bakerIdentity $ BaseAccounts._bieBakerInfo $ BaseAccounts._accountBakerInfo $ theBaker
+                          activeBakerIsSuspended =
+                            fromCondDef
+                                ( BaseAccounts._bieAccountIsSuspended $
+                                    BaseAccounts._accountBakerInfo $
+                                        theBaker
+                                )
+                                False,
+                          activeBakerId =
+                            BaseAccounts._bakerIdentity $
+                                BaseAccounts._bieBakerInfo $
+                                    BaseAccounts._accountBakerInfo $
+                                        theBaker
                         }
     mkActiveDelegatorInfo :: BlockStatePointers pv -> DelegatorId -> m ActiveDelegatorInfo
     mkActiveDelegatorInfo bsp activeDelegatorId@(DelegatorId acct) =

--- a/concordium-consensus/src/Concordium/KonsensusV1/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Scheduler.hs
@@ -235,7 +235,7 @@ doEpochTransition True epochDuration theState0 = do
                     applyPendingChanges av (<= epochEnd)
                         <$> bsoGetActiveBakersAndDelegators theState7
                 let BakerStakesAndCapital{..} =
-                        computeBakerStakesAndCapital @m
+                        computeBakerStakesAndCapital
                             (chainParams ^. cpPoolParameters)
                             activeBakers
                             passiveDelegators

--- a/concordium-consensus/src/Concordium/KonsensusV1/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Scheduler.hs
@@ -235,7 +235,7 @@ doEpochTransition True epochDuration theState0 = do
                     applyPendingChanges av (<= epochEnd)
                         <$> bsoGetActiveBakersAndDelegators theState7
                 let BakerStakesAndCapital{..} =
-                        computeBakerStakesAndCapital
+                        computeBakerStakesAndCapital @m
                             (chainParams ^. cpPoolParameters)
                             activeBakers
                             passiveDelegators
@@ -244,8 +244,7 @@ doEpochTransition True epochDuration theState0 = do
                         theState7
                         bakerStakes
                         (chainParams ^. cpFinalizationCommitteeParameters)
-                capDist <- capitalDistributionM
-                theState9 <- bsoSetNextCapitalDistribution theState8 capDist
+                theState9 <- bsoSetNextCapitalDistribution theState8 capitalDistribution
                 -- From P7 onwards, we transition pre-pre-cooldowns into pre-cooldowns, so that
                 -- at the next payday they will enter cooldown.
                 case sSupportsFlexibleCooldown (sAccountVersionFor (protocolVersion @(MPV m))) of

--- a/concordium-consensus/src/Concordium/Kontrol/Bakers.hs
+++ b/concordium-consensus/src/Concordium/Kontrol/Bakers.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -175,12 +174,11 @@ data BakerStakesAndCapital bakerInfoRef = BakerStakesAndCapital
 
 -- | Compute the baker stakes and capital distribution.
 computeBakerStakesAndCapital ::
-    forall m.
-    (AccountOperations m) =>
+    forall bakerInfoRef.
     PoolParameters' 'PoolParametersVersion1 ->
-    [ActiveBakerInfo m] ->
+    [ActiveBakerInfo' bakerInfoRef] ->
     [ActiveDelegatorInfo] ->
-    BakerStakesAndCapital (BakerInfoRef m)
+    BakerStakesAndCapital bakerInfoRef
 computeBakerStakesAndCapital poolParams activeBakers passiveDelegators = BakerStakesAndCapital{..}
   where
     leverage = poolParams ^. ppLeverageBound
@@ -239,7 +237,7 @@ generateNextBakers paydayEpoch bs0 = do
     -- are no blocks in this epoch, 'getSlotBakersP4' does not apply any updates.)
     cps <- bsoGetChainParameters bs0
     let BakerStakesAndCapital{..} =
-            computeBakerStakesAndCapital @m
+            computeBakerStakesAndCapital
                 (cps ^. cpPoolParameters)
                 activeBakers
                 passiveDelegators
@@ -391,7 +389,7 @@ getSlotBakersP4 genData bs slot =
                                         ePoolParams pp' updates
                                 ePoolParams pp _ = pp
                                 effectivePoolParameters = ePoolParams (chainParams ^. cpPoolParameters) pendingPoolParams
-                                bsc = computeBakerStakesAndCapital @m effectivePoolParameters activeBakers passiveDelegators
+                                bsc = computeBakerStakesAndCapital effectivePoolParameters activeBakers passiveDelegators
                             let mkFullBaker (biRef, _bakerStake) = do
                                     _theBakerInfo <- derefBakerInfo biRef
                                     return FullBakerInfo{..}

--- a/concordium-consensus/src/Concordium/Kontrol/Bakers.hs
+++ b/concordium-consensus/src/Concordium/Kontrol/Bakers.hs
@@ -167,7 +167,7 @@ effectiveTest' genData paydayEpoch = (<= paydayEpochTime)
 --  constructing them together can avoid unnecessary duplication of work.
 data BakerStakesAndCapital m = BakerStakesAndCapital
     { -- | The baker info and stake for each baker.
-      bakerStakes :: [(BakerInfoRef m, Amount)],
+      bakerStakes :: [(bakerInfoRef, Amount)],
       -- | Determine the capital distribution.
       capitalDistribution :: CapitalDistribution
     }

--- a/concordium-consensus/src/Concordium/Kontrol/Bakers.hs
+++ b/concordium-consensus/src/Concordium/Kontrol/Bakers.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
 -- We suppress redundant constraint warnings since GHC does not detect when a constraint is used
 -- for pattern matching. (See: https://gitlab.haskell.org/ghc/ghc/-/issues/20896)
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
@@ -165,7 +166,7 @@ effectiveTest' genData paydayEpoch = (<= paydayEpochTime)
 -- | A helper datatype for computing the stake and capital distribution.
 --  This is intentionally lazy, as the caller may not wish to evaluate all of the fields, but
 --  constructing them together can avoid unnecessary duplication of work.
-data BakerStakesAndCapital m = BakerStakesAndCapital
+data BakerStakesAndCapital bakerInfoRef = BakerStakesAndCapital
     { -- | The baker info and stake for each baker.
       bakerStakes :: [(bakerInfoRef, Amount)],
       -- | Determine the capital distribution.
@@ -179,7 +180,7 @@ computeBakerStakesAndCapital ::
     PoolParameters' 'PoolParametersVersion1 ->
     [ActiveBakerInfo m] ->
     [ActiveDelegatorInfo] ->
-    BakerStakesAndCapital m
+    BakerStakesAndCapital (BakerInfoRef m)
 computeBakerStakesAndCapital poolParams activeBakers passiveDelegators = BakerStakesAndCapital{..}
   where
     leverage = poolParams ^. ppLeverageBound

--- a/concordium-consensus/src/Concordium/Kontrol/Bakers.hs
+++ b/concordium-consensus/src/Concordium/Kontrol/Bakers.hs
@@ -195,9 +195,9 @@ computeBakerStakesAndCapital poolParams activeBakers passiveDelegators = BakerSt
               capLimit
             ]
         )
-    activeBakers' = [abi | abi@ActiveBakerInfo{..} <- activeBakers, not activeBakerIsSuspended]
-    poolCapitals' = poolCapital <$> activeBakers'
-    bakerStakes = zipWith makeBakerStake activeBakers' poolCapitals'
+    filteredActiveBakers = [abi | abi@ActiveBakerInfo{..} <- activeBakers, not activeBakerIsSuspended]
+    filteredPoolCapitals = poolCapital <$> filteredActiveBakers
+    bakerStakes = zipWith makeBakerStake filteredActiveBakers filteredPoolCapitals
     delegatorCapital ActiveDelegatorInfo{..} = DelegatorCapital activeDelegatorId activeDelegatorStake
     bakerCapital ActiveBakerInfo{..} =
         BakerCapital
@@ -205,7 +205,7 @@ computeBakerStakesAndCapital poolParams activeBakers passiveDelegators = BakerSt
               bcBakerEquityCapital = activeBakerEquityCapital,
               bcDelegatorCapital = Vec.fromList $ delegatorCapital <$> activeBakerDelegators
             }
-    bakerPoolCapital = Vec.fromList $ bakerCapital <$> activeBakers'
+    bakerPoolCapital = Vec.fromList $ bakerCapital <$> filteredActiveBakers
     passiveDelegatorsCapital = Vec.fromList $ delegatorCapital <$> passiveDelegators
     capitalDistribution = CapitalDistribution{..}
 

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/LeaderElectionTest.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/LeaderElectionTest.hs
@@ -157,7 +157,7 @@ testComputeMissedRounds :: Spec
 testComputeMissedRounds =
     describe "computeMissedRounds" $ do
         it "no timeout" $
-            ( Map.toList $
+            Map.toList ( 
                 computeMissedRounds
                     Absent
                     dummyFullBakers
@@ -166,7 +166,7 @@ testComputeMissedRounds =
             )
                 `shouldBe` []
         it "timeout present, 1 missed round" $
-            ( Map.toList $
+            Map.toList (
                 computeMissedRounds
                     (Present $ dummyTimeoutCertificate 5)
                     dummyFullBakers
@@ -175,7 +175,7 @@ testComputeMissedRounds =
             )
                 `shouldBe` [(1, 1)]
         it "timeout present, 3 missed rounds" $
-            ( Map.toList $
+            Map.toList (
                 computeMissedRounds
                     (Present $ dummyTimeoutCertificate 5)
                     dummyFullBakers
@@ -184,7 +184,7 @@ testComputeMissedRounds =
             )
                 `shouldBe` [(1, 2), (2, 1)]
         it "timeout present, 95 missed rounds" $
-            ( Map.toList $
+            Map.toList (
                 computeMissedRounds
                     (Present $ dummyTimeoutCertificate 5)
                     dummyFullBakers

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/LeaderElectionTest.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/LeaderElectionTest.hs
@@ -157,40 +157,40 @@ testComputeMissedRounds :: Spec
 testComputeMissedRounds =
     describe "computeMissedRounds" $ do
         it "no timeout" $
-            Map.toList ( 
-                computeMissedRounds
+            Map.toList
+                ( computeMissedRounds
                     Absent
                     dummyFullBakers
                     (read "ba3aba3b6c31fb6b0251a19c83666cd90da9a0835a2b54dc4f01c6d451ab24e8")
                     6
-            )
+                )
                 `shouldBe` []
         it "timeout present, 1 missed round" $
-            Map.toList (
-                computeMissedRounds
+            Map.toList
+                ( computeMissedRounds
                     (Present $ dummyTimeoutCertificate 5)
                     dummyFullBakers
                     (read "ba3aba3b6c31fb6b0251a19c83666cd90da9a0835a2b54dc4f01c6d451ab24e8")
                     6
-            )
+                )
                 `shouldBe` [(1, 1)]
         it "timeout present, 3 missed rounds" $
-            Map.toList (
-                computeMissedRounds
+            Map.toList
+                ( computeMissedRounds
                     (Present $ dummyTimeoutCertificate 5)
                     dummyFullBakers
                     (read "ba3aba3b6c31fb6b0251a19c83666cd90da9a0835a2b54dc4f01c6d451ab24e8")
                     8
-            )
+                )
                 `shouldBe` [(1, 2), (2, 1)]
         it "timeout present, 95 missed rounds" $
-            Map.toList (
-                computeMissedRounds
+            Map.toList
+                ( computeMissedRounds
                     (Present $ dummyTimeoutCertificate 5)
                     dummyFullBakers
                     (read "ba3aba3b6c31fb6b0251a19c83666cd90da9a0835a2b54dc4f01c6d451ab24e8")
                     100
-            )
+                )
                 `shouldBe` [(1, 46), (2, 49)]
 
 tests :: Spec

--- a/concordium-consensus/tests/scheduler/SchedulerTests/KonsensusV1/EpochTransition.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/KonsensusV1/EpochTransition.hs
@@ -764,7 +764,7 @@ testMissedRoundsUpdate accountConfigs = runTestBlockState @P8 $ do
     startEpoch = 10
     startTriggerTime = 1000
 
--- Test that suspended validators have zero stake.
+-- | Test that suspended validators have zero stake.
 testComputeBakerStakesAndCapital :: [AccountConfig 'AccountV4] -> Assertion
 testComputeBakerStakesAndCapital accountConfigs = runTestBlockState @P8 $ do
     bs0 <- makeInitialState accountConfigs (transitionalSeedState startEpoch startTriggerTime) 24


### PR DESCRIPTION
## Purpose

Set stake to zero of suspended validators.

## Changes

As described above. To facilitate the change, a suspended flag and validator id field are added to `ActiveBakerInfo`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
