### PR TITLE
Queries for accounts with scheduled releases or cooldowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Add `GetScheduledReleaseAccounts` endpoint for querying the list of accounts that
   have scheduled releases.
 - Add `GetCooldownAccounts`, `GetPreCooldownAccounts` and `GetPrePreCooldownAccounts`
-  endpoints for querying the lists of account that have pending cooldowns in protocol
+  endpoints for querying the lists of accounts that have pending cooldowns in protocol
   version 7 onwards.
 
 ## 7.0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   of the consensus, at consensus version 1.
 - Update Rust version to 1.82.
 - Update GHC version to 9.6.6 (LTS-22.39).
+- Add `GetScheduledReleaseAccounts` endpoint for querying the list of accounts that
+  have scheduled releases.
+- Add `GetCooldownAccounts`, `GetPreCooldownAccounts` and `GetPrePreCooldownAccounts`
+  endpoints for querying the lists of account that have pending cooldowns in protocol
+  version 7 onwards.
 
 ## 7.0.5
 

--- a/concordium-consensus/lib.def
+++ b/concordium-consensus/lib.def
@@ -56,6 +56,10 @@ EXPORTS
  getBlockTransactionEventsV2
  getBlockSpecialEventsV2
  getBlockPendingUpdatesV2
+ getScheduledReleaseAccountsV2
+ getCooldownAccountsV2
+ getPreCooldownAccountsV2
+ getPrePreCooldownAccountsV2
  getNextUpdateSequenceNumbersV2
  getBlockChainParametersV2
  getBlockFinalizationSummaryV2

--- a/concordium-consensus/src-lib/Concordium/External/GRPC2.hs
+++ b/concordium-consensus/src-lib/Concordium/External/GRPC2.hs
@@ -944,6 +944,78 @@ getNextUpdateSequenceNumbersV2 cptr blockType blockHashPtr outHash outVec copier
     result <- runMVR (Q.getNextUpdateSequenceNumbers bhi) mvr
     returnMessageWithBlock (copier outVec) outHash result
 
+getScheduledReleaseAccountsV2 ::
+    StablePtr Ext.ConsensusRunner ->
+    Ptr SenderChannel ->
+    -- | Block type.
+    Word8 ->
+    -- | Block hash.
+    Ptr Word8 ->
+    -- | Out pointer for writing the block hash that was used.
+    Ptr Word8 ->
+    FunPtr ChannelSendCallback ->
+    IO Int64
+getScheduledReleaseAccountsV2 cptr channel blockType blockHashPtr outHash cbk = do
+    Ext.ConsensusRunner mvr <- deRefStablePtr cptr
+    let sender = callChannelSendCallback cbk
+    bhi <- decodeBlockHashInput blockType blockHashPtr
+    response <- runMVR (Q.getScheduledReleaseAccounts bhi) mvr
+    returnStreamWithBlock (sender channel) outHash response
+
+getCooldownAccountsV2 ::
+    StablePtr Ext.ConsensusRunner ->
+    Ptr SenderChannel ->
+    -- | Block type.
+    Word8 ->
+    -- | Block hash.
+    Ptr Word8 ->
+    -- | Out pointer for writing the block hash that was used.
+    Ptr Word8 ->
+    FunPtr ChannelSendCallback ->
+    IO Int64
+getCooldownAccountsV2 cptr channel blockType blockHashPtr outHash cbk = do
+    Ext.ConsensusRunner mvr <- deRefStablePtr cptr
+    let sender = callChannelSendCallback cbk
+    bhi <- decodeBlockHashInput blockType blockHashPtr
+    response <- runMVR (Q.getCooldownAccounts bhi) mvr
+    returnStreamWithBlock (sender channel) outHash response
+
+getPreCooldownAccountsV2 ::
+    StablePtr Ext.ConsensusRunner ->
+    Ptr SenderChannel ->
+    -- | Block type.
+    Word8 ->
+    -- | Block hash.
+    Ptr Word8 ->
+    -- | Out pointer for writing the block hash that was used.
+    Ptr Word8 ->
+    FunPtr ChannelSendCallback ->
+    IO Int64
+getPreCooldownAccountsV2 cptr channel blockType blockHashPtr outHash cbk = do
+    Ext.ConsensusRunner mvr <- deRefStablePtr cptr
+    let sender = callChannelSendCallback cbk
+    bhi <- decodeBlockHashInput blockType blockHashPtr
+    response <- runMVR (Q.getPreCooldownAccounts bhi) mvr
+    returnStreamWithBlock (sender channel) outHash response
+
+getPrePreCooldownAccountsV2 ::
+    StablePtr Ext.ConsensusRunner ->
+    Ptr SenderChannel ->
+    -- | Block type.
+    Word8 ->
+    -- | Block hash.
+    Ptr Word8 ->
+    -- | Out pointer for writing the block hash that was used.
+    Ptr Word8 ->
+    FunPtr ChannelSendCallback ->
+    IO Int64
+getPrePreCooldownAccountsV2 cptr channel blockType blockHashPtr outHash cbk = do
+    Ext.ConsensusRunner mvr <- deRefStablePtr cptr
+    let sender = callChannelSendCallback cbk
+    bhi <- decodeBlockHashInput blockType blockHashPtr
+    response <- runMVR (Q.getPrePreCooldownAccounts bhi) mvr
+    returnStreamWithBlock (sender channel) outHash response
+
 getBlockChainParametersV2 ::
     StablePtr Ext.ConsensusRunner ->
     -- | Block type.
@@ -1665,6 +1737,58 @@ foreign export ccall
         Ptr Word8 ->
         Ptr ReceiverVec ->
         FunPtr CopyToVecCallback ->
+        IO Int64
+
+foreign export ccall
+    getScheduledReleaseAccountsV2 ::
+        StablePtr Ext.ConsensusRunner ->
+        Ptr SenderChannel ->
+        -- | Block type.
+        Word8 ->
+        -- | Block hash.
+        Ptr Word8 ->
+        -- | Out pointer for writing the block hash that was used.
+        Ptr Word8 ->
+        FunPtr ChannelSendCallback ->
+        IO Int64
+
+foreign export ccall
+    getCooldownAccountsV2 ::
+        StablePtr Ext.ConsensusRunner ->
+        Ptr SenderChannel ->
+        -- | Block type.
+        Word8 ->
+        -- | Block hash.
+        Ptr Word8 ->
+        -- | Out pointer for writing the block hash that was used.
+        Ptr Word8 ->
+        FunPtr ChannelSendCallback ->
+        IO Int64
+
+foreign export ccall
+    getPreCooldownAccountsV2 ::
+        StablePtr Ext.ConsensusRunner ->
+        Ptr SenderChannel ->
+        -- | Block type.
+        Word8 ->
+        -- | Block hash.
+        Ptr Word8 ->
+        -- | Out pointer for writing the block hash that was used.
+        Ptr Word8 ->
+        FunPtr ChannelSendCallback ->
+        IO Int64
+
+foreign export ccall
+    getPrePreCooldownAccountsV2 ::
+        StablePtr Ext.ConsensusRunner ->
+        Ptr SenderChannel ->
+        -- | Block type.
+        Word8 ->
+        -- | Block hash.
+        Ptr Word8 ->
+        -- | Out pointer for writing the block hash that was used.
+        Ptr Word8 ->
+        FunPtr ChannelSendCallback ->
         IO Int64
 
 foreign export ccall

--- a/concordium-consensus/src-lib/Concordium/External/GRPC2.hs
+++ b/concordium-consensus/src-lib/Concordium/External/GRPC2.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -147,12 +148,7 @@ getAccountListV2 ::
     Ptr Word8 ->
     FunPtr (Ptr SenderChannel -> Ptr Word8 -> Int64 -> IO Int32) ->
     IO Int64
-getAccountListV2 cptr channel blockType blockHashPtr outHash cbk = do
-    Ext.ConsensusRunner mvr <- deRefStablePtr cptr
-    let sender = callChannelSendCallback cbk
-    bhi <- decodeBlockHashInput blockType blockHashPtr
-    response <- runMVR (Q.getAccountList bhi) mvr
-    returnStreamWithBlock (sender channel) outHash response
+getAccountListV2 = blockStreamHelper Q.getAccountList
 
 getModuleListV2 ::
     StablePtr Ext.ConsensusRunner ->
@@ -165,12 +161,7 @@ getModuleListV2 ::
     Ptr Word8 ->
     FunPtr (Ptr SenderChannel -> Ptr Word8 -> Int64 -> IO Int32) ->
     IO Int64
-getModuleListV2 cptr channel blockType blockHashPtr outHash cbk = do
-    Ext.ConsensusRunner mvr <- deRefStablePtr cptr
-    let sender = callChannelSendCallback cbk
-    bhi <- decodeBlockHashInput blockType blockHashPtr
-    response <- runMVR (Q.getModuleList bhi) mvr
-    returnStreamWithBlock (sender channel) outHash response
+getModuleListV2 = blockStreamHelper Q.getModuleList
 
 getModuleSourceV2 ::
     StablePtr Ext.ConsensusRunner ->
@@ -205,12 +196,7 @@ getInstanceListV2 ::
     Ptr Word8 ->
     FunPtr (Ptr SenderChannel -> Ptr Word8 -> Int64 -> IO Int32) ->
     IO Int64
-getInstanceListV2 cptr channel blockType blockHashPtr outHash cbk = do
-    Ext.ConsensusRunner mvr <- deRefStablePtr cptr
-    let sender = callChannelSendCallback cbk
-    bhi <- decodeBlockHashInput blockType blockHashPtr
-    response <- runMVR (Q.getInstanceList bhi) mvr
-    returnStreamWithBlock (sender channel) outHash response
+getInstanceListV2 = blockStreamHelper Q.getInstanceList
 
 getInstanceInfoV2 ::
     StablePtr Ext.ConsensusRunner ->
@@ -541,12 +527,7 @@ getBakerListV2 ::
     Ptr Word8 ->
     FunPtr ChannelSendCallback ->
     IO Int64
-getBakerListV2 cptr channel blockType blockHashPtr outHash cbk = do
-    Ext.ConsensusRunner mvr <- deRefStablePtr cptr
-    let sender = callChannelSendCallback cbk
-    bhi <- decodeBlockHashInput blockType blockHashPtr
-    response <- runMVR (Q.getRegisteredBakers bhi) mvr
-    returnStreamWithBlock (sender channel) outHash response
+getBakerListV2 = blockStreamHelper Q.getRegisteredBakers
 
 getPoolInfoV2 ::
     StablePtr Ext.ConsensusRunner ->
@@ -803,12 +784,7 @@ getIdentityProvidersV2 ::
     Ptr Word8 ->
     FunPtr ChannelSendCallback ->
     IO Int64
-getIdentityProvidersV2 cptr channel blockType blockHashPtr outHash cbk = do
-    Ext.ConsensusRunner mvr <- deRefStablePtr cptr
-    let sender = callChannelSendCallback cbk
-    bhi <- decodeBlockHashInput blockType blockHashPtr
-    response <- runMVR (Q.getAllIdentityProviders bhi) mvr
-    returnStreamWithBlock (sender channel) outHash response
+getIdentityProvidersV2 = blockStreamHelper Q.getAllIdentityProviders
 
 getAnonymityRevokersV2 ::
     StablePtr Ext.ConsensusRunner ->
@@ -821,12 +797,7 @@ getAnonymityRevokersV2 ::
     Ptr Word8 ->
     FunPtr ChannelSendCallback ->
     IO Int64
-getAnonymityRevokersV2 cptr channel blockType blockHashPtr outHash cbk = do
-    Ext.ConsensusRunner mvr <- deRefStablePtr cptr
-    let sender = callChannelSendCallback cbk
-    bhi <- decodeBlockHashInput blockType blockHashPtr
-    response <- runMVR (Q.getAllAnonymityRevokers bhi) mvr
-    returnStreamWithBlock (sender channel) outHash response
+getAnonymityRevokersV2 = blockStreamHelper Q.getAllAnonymityRevokers
 
 getAccountNonFinalizedTransactionsV2 ::
     StablePtr Ext.ConsensusRunner ->
@@ -855,12 +826,7 @@ getBlockItemsV2 ::
     Ptr Word8 ->
     FunPtr ChannelSendCallback ->
     IO Int64
-getBlockItemsV2 cptr channel blockType blockHashPtr outHash cbk = do
-    Ext.ConsensusRunner mvr <- deRefStablePtr cptr
-    let sender = callChannelSendCallback cbk
-    bhi <- decodeBlockHashInput blockType blockHashPtr
-    response <- runMVR (Q.getBlockItems bhi) mvr
-    returnStreamWithBlock (sender channel) outHash response
+getBlockItemsV2 = blockStreamHelper Q.getBlockItems
 
 getBlockTransactionEventsV2 ::
     StablePtr Ext.ConsensusRunner ->
@@ -918,12 +884,7 @@ getBlockPendingUpdatesV2 ::
     Ptr Word8 ->
     FunPtr ChannelSendCallback ->
     IO Int64
-getBlockPendingUpdatesV2 cptr channel blockType blockHashPtr outHash cbk = do
-    Ext.ConsensusRunner mvr <- deRefStablePtr cptr
-    let sender = callChannelSendCallback cbk
-    bhi <- decodeBlockHashInput blockType blockHashPtr
-    response <- runMVR (Q.getBlockPendingUpdates bhi) mvr
-    returnStreamWithBlock (sender channel) outHash response
+getBlockPendingUpdatesV2 = blockStreamHelper Q.getBlockPendingUpdates
 
 getNextUpdateSequenceNumbersV2 ::
     StablePtr Ext.ConsensusRunner ->
@@ -955,12 +916,7 @@ getScheduledReleaseAccountsV2 ::
     Ptr Word8 ->
     FunPtr ChannelSendCallback ->
     IO Int64
-getScheduledReleaseAccountsV2 cptr channel blockType blockHashPtr outHash cbk = do
-    Ext.ConsensusRunner mvr <- deRefStablePtr cptr
-    let sender = callChannelSendCallback cbk
-    bhi <- decodeBlockHashInput blockType blockHashPtr
-    response <- runMVR (Q.getScheduledReleaseAccounts bhi) mvr
-    returnStreamWithBlock (sender channel) outHash response
+getScheduledReleaseAccountsV2 = blockStreamHelper Q.getScheduledReleaseAccounts
 
 getCooldownAccountsV2 ::
     StablePtr Ext.ConsensusRunner ->
@@ -973,12 +929,7 @@ getCooldownAccountsV2 ::
     Ptr Word8 ->
     FunPtr ChannelSendCallback ->
     IO Int64
-getCooldownAccountsV2 cptr channel blockType blockHashPtr outHash cbk = do
-    Ext.ConsensusRunner mvr <- deRefStablePtr cptr
-    let sender = callChannelSendCallback cbk
-    bhi <- decodeBlockHashInput blockType blockHashPtr
-    response <- runMVR (Q.getCooldownAccounts bhi) mvr
-    returnStreamWithBlock (sender channel) outHash response
+getCooldownAccountsV2 = blockStreamHelper Q.getCooldownAccounts
 
 getPreCooldownAccountsV2 ::
     StablePtr Ext.ConsensusRunner ->
@@ -991,12 +942,7 @@ getPreCooldownAccountsV2 ::
     Ptr Word8 ->
     FunPtr ChannelSendCallback ->
     IO Int64
-getPreCooldownAccountsV2 cptr channel blockType blockHashPtr outHash cbk = do
-    Ext.ConsensusRunner mvr <- deRefStablePtr cptr
-    let sender = callChannelSendCallback cbk
-    bhi <- decodeBlockHashInput blockType blockHashPtr
-    response <- runMVR (Q.getPreCooldownAccounts bhi) mvr
-    returnStreamWithBlock (sender channel) outHash response
+getPreCooldownAccountsV2 = blockStreamHelper Q.getPreCooldownAccounts
 
 getPrePreCooldownAccountsV2 ::
     StablePtr Ext.ConsensusRunner ->
@@ -1009,12 +955,7 @@ getPrePreCooldownAccountsV2 ::
     Ptr Word8 ->
     FunPtr ChannelSendCallback ->
     IO Int64
-getPrePreCooldownAccountsV2 cptr channel blockType blockHashPtr outHash cbk = do
-    Ext.ConsensusRunner mvr <- deRefStablePtr cptr
-    let sender = callChannelSendCallback cbk
-    bhi <- decodeBlockHashInput blockType blockHashPtr
-    response <- runMVR (Q.getPrePreCooldownAccounts bhi) mvr
-    returnStreamWithBlock (sender channel) outHash response
+getPrePreCooldownAccountsV2 = blockStreamHelper Q.getPrePreCooldownAccounts
 
 getBlockChainParametersV2 ::
     StablePtr Ext.ConsensusRunner ->
@@ -1201,6 +1142,32 @@ returnMessageRaw copier v = do
     let encoded = Proto.encodeMessage v
     BS.unsafeUseAsCStringLen encoded (\(ptr, len) -> copier (castPtr ptr) (fromIntegral len))
     return $ queryResultCode QRSuccess
+
+-- | A helper for defining queries that take a block hash input and return a stream of
+--  protobuf messages.
+blockStreamHelper ::
+    (Proto.Message (Output a), ToProto a) =>
+    -- | Wrapped query function.
+    (forall finconf. BlockHashInput -> MVR finconf (Q.BHIQueryResponse [a])) ->
+    -- | Consensus pointer.
+    StablePtr Ext.ConsensusRunner ->
+    -- | Channel to send messages to.
+    Ptr SenderChannel ->
+    -- | Block type.
+    Word8 ->
+    -- | Block hash.
+    Ptr Word8 ->
+    -- | Out pointer for writing the block hash that was used.
+    Ptr Word8 ->
+    -- | Callback to output data to the channel.
+    FunPtr ChannelSendCallback ->
+    IO Int64
+blockStreamHelper query cptr channel blockType blockHashPtr outHash cbk = do
+    Ext.ConsensusRunner mvr <- deRefStablePtr cptr
+    let sender = callChannelSendCallback cbk
+    bhi <- decodeBlockHashInput blockType blockHashPtr
+    response <- runMVR (query bhi) mvr
+    returnStreamWithBlock (sender channel) outHash response
 
 returnStreamWithBlock ::
     (Proto.Message (Output a), ToProto a) =>

--- a/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
@@ -663,6 +663,18 @@ class (ContractStateOperations m, AccountOperations m, ModuleQuery m) => BlockSt
         BlockState m ->
         m PassiveDelegationStatus
 
+    -- | Get the index of accounts with scheduled releases.
+    getScheduledReleaseAccounts :: BlockState m -> m (Map.Map Timestamp (Set.Set AccountIndex))
+
+    -- | Get the index of accounts with stake in cooldown.
+    getCooldownAccounts :: BlockState m -> m (Map.Map Timestamp (Set.Set AccountIndex))
+
+    -- | Get the index of accounts in pre-cooldown.
+    getPreCooldownAccounts :: BlockState m -> m [AccountIndex]
+
+    -- | Get the index of accounts in pre-pre-cooldown.
+    getPrePreCooldownAccounts :: BlockState m -> m [AccountIndex]
+
 -- | Distribution of newly-minted GTU.
 data MintAmounts = MintAmounts
     { -- | Minted amount allocated to the BakingRewardAccount
@@ -1665,6 +1677,10 @@ instance (Monad (t m), MonadTrans t, BlockStateQuery m) => BlockStateQuery (MGST
     getPaydayEpoch = lift . getPaydayEpoch
     getPoolStatus s = lift . getPoolStatus s
     getPassiveDelegationStatus = lift . getPassiveDelegationStatus
+    getScheduledReleaseAccounts = lift . getScheduledReleaseAccounts
+    getCooldownAccounts = lift . getCooldownAccounts
+    getPreCooldownAccounts = lift . getPreCooldownAccounts
+    getPrePreCooldownAccounts = lift . getPrePreCooldownAccounts
     {-# INLINE getModule #-}
     {-# INLINE getAccount #-}
     {-# INLINE accountExists #-}
@@ -1699,6 +1715,10 @@ instance (Monad (t m), MonadTrans t, BlockStateQuery m) => BlockStateQuery (MGST
     {-# INLINE getUpdateKeysCollection #-}
     {-# INLINE getExchangeRates #-}
     {-# INLINE getChainParameters #-}
+    {-# INLINE getScheduledReleaseAccounts #-}
+    {-# INLINE getCooldownAccounts #-}
+    {-# INLINE getPreCooldownAccounts #-}
+    {-# INLINE getPrePreCooldownAccounts #-}
 
 instance (Monad (t m), MonadTrans t, AccountOperations m) => AccountOperations (MGSTrans t m) where
     getAccountCanonicalAddress = lift . getAccountCanonicalAddress

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -4105,6 +4105,59 @@ doSetRewardAccounts pbs rewards = do
     bsp <- loadPBS pbs
     storePBS pbs bsp{bspBank = bspBank bsp & unhashed . Rewards.rewardAccounts .~ rewards}
 
+-- | Get the index of accounts with scheduled releases.
+doGetScheduledReleaseAccounts :: (SupportsPersistentState pv m) => PersistentBlockState pv -> m (Map.Map Timestamp (Set.Set AccountIndex))
+doGetScheduledReleaseAccounts pbs = do
+    bsp <- loadPBS pbs
+    let resolveAddress addr = do
+            mIndex <- Accounts.getAccountIndex addr (bspAccounts bsp)
+            case mIndex of
+                Just index -> return index
+                Nothing -> error "Invariant violation: account address not found"
+    releasesMap resolveAddress (bspReleaseSchedule bsp)
+
+-- | Get the index of accounts with stake in cooldown.
+doGetCooldownAccounts ::
+    forall pv m.
+    (SupportsPersistentState pv m) =>
+    PersistentBlockState pv ->
+    m (Map.Map Timestamp (Set.Set AccountIndex))
+doGetCooldownAccounts pbs = case sSupportsFlexibleCooldown sav of
+    STrue -> do
+        bsp <- loadPBS pbs
+        newReleasesMap (bspAccountsInCooldown bsp ^. accountsInCooldown . cooldown)
+    SFalse -> return Map.empty
+  where
+    sav = sAccountVersionFor (protocolVersion @pv)
+
+-- | Get the index of accounts in pre-cooldown.
+doGetPreCooldownAccounts ::
+    forall pv m.
+    (SupportsPersistentState pv m) =>
+    PersistentBlockState pv ->
+    m [AccountIndex]
+doGetPreCooldownAccounts pbs = case sSupportsFlexibleCooldown sav of
+    STrue -> do
+        bsp <- loadPBS pbs
+        loadAccountList $ bspAccountsInCooldown bsp ^. accountsInCooldown . preCooldown
+    SFalse -> return []
+  where
+    sav = sAccountVersionFor (protocolVersion @pv)
+
+-- | Get the index of accounts in pre-pre-cooldown.
+doGetPrePreCooldownAccounts ::
+    forall pv m.
+    (SupportsPersistentState pv m) =>
+    PersistentBlockState pv ->
+    m [AccountIndex]
+doGetPrePreCooldownAccounts pbs = case sSupportsFlexibleCooldown sav of
+    STrue -> do
+        bsp <- loadPBS pbs
+        loadAccountList $ bspAccountsInCooldown bsp ^. accountsInCooldown . prePreCooldown
+    SFalse -> return []
+  where
+    sav = sAccountVersionFor (protocolVersion @pv)
+
 -- | Context that supports the persistent block state.
 data PersistentBlockStateContext pv = PersistentBlockStateContext
     { -- | The 'BlobStore' used for storing the persistent state.
@@ -4238,6 +4291,10 @@ instance (IsProtocolVersion pv, PersistentState av pv r m) => BlockStateQuery (P
     getPaydayEpoch = doGetPaydayEpoch . hpbsPointers
     getPoolStatus = doGetPoolStatus . hpbsPointers
     getPassiveDelegationStatus = doGetPassiveDelegationStatus . hpbsPointers
+    getScheduledReleaseAccounts = doGetScheduledReleaseAccounts . hpbsPointers
+    getCooldownAccounts = doGetCooldownAccounts . hpbsPointers
+    getPreCooldownAccounts = doGetPreCooldownAccounts . hpbsPointers
+    getPrePreCooldownAccounts = doGetPrePreCooldownAccounts . hpbsPointers
 
 instance (MonadIO m, PersistentState av pv r m) => ContractStateOperations (PersistentBlockStateMonad pv r m) where
     thawContractState (Instances.InstanceStateV0 inst) = return inst

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/ReleaseSchedule.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/ReleaseSchedule.hs
@@ -426,6 +426,9 @@ releasesMap ::
 releasesMap resolveAddr (ReleaseScheduleP0 rsRef) = do
     LegacyReleaseSchedule{..} <- refLoad rsRef
     forM lrsMap $ fmap Set.fromList . mapM resolveAddr . Set.toList
-releasesMap _ (ReleaseScheduleP5 rs) = do
+releasesMap _ (ReleaseScheduleP5 rs) = newReleasesMap rs
+
+newReleasesMap :: (MonadBlobStore m) => NewReleaseSchedule -> m (Map Timestamp (Set AccountIndex))
+newReleasesMap rs = do
     m <- Trie.toMap (nrsMap rs)
     return (theAccountSet <$> m)

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -956,6 +956,8 @@ getCooldownAccounts = liftSkovQueryStateBHI query
     query bs = do
         cooldowns <- BS.getCooldownAccounts bs
         let processAtTimestamp ts accs = ([AccountPending acc ts | acc <- Set.toList accs] ++)
+        -- Right-fold here ensures that the set at each timestamp is converted lazily as
+        -- the resulting list is consumed.
         return $ Map.foldrWithKey processAtTimestamp [] cooldowns
 
 -- | Get the index of accounts in pre-cooldown.

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -934,6 +934,44 @@ getNextUpdateSequenceNumbers = liftSkovQueryStateBHI query
         updates <- BS.getUpdates bs
         return $ updateQueuesNextSequenceNumbers $ UQ._pendingUpdates updates
 
+-- | Get the index of accounts with scheduled releases.
+getScheduledReleaseAccounts ::
+    forall finconf.
+    BlockHashInput ->
+    MVR finconf (BHIQueryResponse [AccountPending])
+getScheduledReleaseAccounts = liftSkovQueryStateBHI query
+  where
+    query bs = do
+        releases <- BS.getScheduledReleaseAccounts bs
+        let processAtTimestamp ts accs = ([AccountPending acc ts | acc <- Set.toList accs] ++)
+        return $ Map.foldrWithKey processAtTimestamp [] releases
+
+-- | Get the index of accounts with stake in cooldown.
+getCooldownAccounts ::
+    forall finconf.
+    BlockHashInput ->
+    MVR finconf (BHIQueryResponse [AccountPending])
+getCooldownAccounts = liftSkovQueryStateBHI query
+  where
+    query bs = do
+        cooldowns <- BS.getCooldownAccounts bs
+        let processAtTimestamp ts accs = ([AccountPending acc ts | acc <- Set.toList accs] ++)
+        return $ Map.foldrWithKey processAtTimestamp [] cooldowns
+
+-- | Get the index of accounts in pre-cooldown.
+getPreCooldownAccounts ::
+    forall finconf.
+    BlockHashInput ->
+    MVR finconf (BHIQueryResponse [AccountIndex])
+getPreCooldownAccounts = liftSkovQueryStateBHI BS.getPreCooldownAccounts
+
+-- | Get the index of accounts in pre-pre-cooldown.
+getPrePreCooldownAccounts ::
+    forall finconf.
+    BlockHashInput ->
+    MVR finconf (BHIQueryResponse [AccountIndex])
+getPrePreCooldownAccounts = liftSkovQueryStateBHI BS.getPrePreCooldownAccounts
+
 -- | Get the total amount of CCD in existence and status of the reward accounts.
 getRewardStatus :: BlockHashInput -> MVR finconf (BHIQueryResponse RewardStatus)
 getRewardStatus =

--- a/concordium-node/build.rs
+++ b/concordium-node/build.rs
@@ -497,6 +497,46 @@ fn build_grpc2(proto_root_input: &str) -> std::io::Result<()> {
         )
         .method(
             tonic_build::manual::Method::builder()
+                .name("get_scheduled_release_accounts")
+                .route_name("GetScheduledReleaseAccounts")
+                .input_type("crate::grpc2::types::BlockHashInput")
+                .output_type("Vec<u8>")
+                .codec_path("crate::grpc2::RawCodec")
+                .server_streaming()
+                .build(),
+        )
+        .method(
+            tonic_build::manual::Method::builder()
+                .name("get_cooldown_accounts")
+                .route_name("GetCooldownAccounts")
+                .input_type("crate::grpc2::types::BlockHashInput")
+                .output_type("Vec<u8>")
+                .codec_path("crate::grpc2::RawCodec")
+                .server_streaming()
+                .build(),
+        )
+        .method(
+            tonic_build::manual::Method::builder()
+                .name("get_pre_cooldown_accounts")
+                .route_name("GetPreCooldownAccounts")
+                .input_type("crate::grpc2::types::BlockHashInput")
+                .output_type("Vec<u8>")
+                .codec_path("crate::grpc2::RawCodec")
+                .server_streaming()
+                .build(),
+        )
+        .method(
+            tonic_build::manual::Method::builder()
+                .name("get_pre_pre_cooldown_accounts")
+                .route_name("GetPrePreCooldownAccounts")
+                .input_type("crate::grpc2::types::BlockHashInput")
+                .output_type("Vec<u8>")
+                .codec_path("crate::grpc2::RawCodec")
+                .server_streaming()
+                .build(),
+        )
+        .method(
+            tonic_build::manual::Method::builder()
                 .name("get_baker_earliest_win_time")
                 .route_name("GetBakerEarliestWinTime")
                 .input_type("crate::grpc2::types::BakerId")

--- a/concordium-node/src/consensus_ffi/ffi.rs
+++ b/concordium-node/src/consensus_ffi/ffi.rs
@@ -1299,6 +1299,107 @@ extern "C" {
         copier: CopyToVecCallback,
     ) -> i64;
 
+    /// Get all accounts that have scheduled releases, with the timestamp of the
+    /// first pending scheduled release for that account.
+    /// The stream will end when all the accounts that have scheduled releases
+    /// have been returned.
+    ///
+    /// * `consensus` - Pointer to the current consensus.
+    /// * `stream` - Pointer to the response stream.
+    /// * `block_id_type` - Type of block identifier.
+    /// * `block_id` - Location with the block identifier. Length must match the
+    ///   corresponding type of block identifier.
+    /// * `out_hash` - Location to write the block hash used in the query.
+    /// * `callback` - Callback for writing to the response stream.
+    pub fn getScheduledReleaseAccountsV2(
+        consensus: *mut consensus_runner,
+        stream: *mut futures::channel::mpsc::Sender<Result<Vec<u8>, tonic::Status>>,
+        block_id_type: u8,
+        block_id: *const u8,
+        out_hash: *mut u8,
+        callback: extern "C" fn(
+            *mut futures::channel::mpsc::Sender<Result<Vec<u8>, tonic::Status>>,
+            *const u8,
+            i64,
+        ) -> i32,
+    ) -> i64;
+
+    /// Get all accounts that have stake in cooldown, with the timestamp of the
+    /// first pending cooldown expiry for each account.
+    /// The stream will end when all the accounts that have stake in cooldown
+    /// have been returned.
+    /// Prior to protocol version 7, the resulting stream will always be empty.
+    ///
+    /// * `consensus` - Pointer to the current consensus.
+    /// * `stream` - Pointer to the response stream.
+    /// * `block_id_type` - Type of block identifier.
+    /// * `block_id` - Location with the block identifier. Length must match the
+    ///   corresponding type of block identifier.
+    /// * `out_hash` - Location to write the block hash used in the query.
+    /// * `callback` - Callback for writing to the response stream.
+    pub fn getCooldownAccountsV2(
+        consensus: *mut consensus_runner,
+        stream: *mut futures::channel::mpsc::Sender<Result<Vec<u8>, tonic::Status>>,
+        block_id_type: u8,
+        block_id: *const u8,
+        out_hash: *mut u8,
+        callback: extern "C" fn(
+            *mut futures::channel::mpsc::Sender<Result<Vec<u8>, tonic::Status>>,
+            *const u8,
+            i64,
+        ) -> i32,
+    ) -> i64;
+
+    /// Get all accounts (by account index) that have stake in pre-cooldown.
+    /// The stream will end when all the accounts that have stake in
+    /// pre-cooldown have been returned.
+    /// Prior to protocol version 7, the resulting stream will always be empty.
+    ///
+    /// * `consensus` - Pointer to the current consensus.
+    /// * `stream` - Pointer to the response stream.
+    /// * `block_id_type` - Type of block identifier.
+    /// * `block_id` - Location with the block identifier. Length must match the
+    ///   corresponding type of block identifier.
+    /// * `out_hash` - Location to write the block hash used in the query.
+    /// * `callback` - Callback for writing to the response stream.
+    pub fn getPreCooldownAccountsV2(
+        consensus: *mut consensus_runner,
+        stream: *mut futures::channel::mpsc::Sender<Result<Vec<u8>, tonic::Status>>,
+        block_id_type: u8,
+        block_id: *const u8,
+        out_hash: *mut u8,
+        callback: extern "C" fn(
+            *mut futures::channel::mpsc::Sender<Result<Vec<u8>, tonic::Status>>,
+            *const u8,
+            i64,
+        ) -> i32,
+    ) -> i64;
+
+    /// Get all accounts (by account index) that have stake in pre-pre-cooldown.
+    /// The stream will end when all the accounts that have stake in
+    /// pre-pre-cooldown have been returned.
+    /// Prior to protocol version 7, the resulting stream will always be empty.
+    ///
+    /// * `consensus` - Pointer to the current consensus.
+    /// * `stream` - Pointer to the response stream.
+    /// * `block_id_type` - Type of block identifier.
+    /// * `block_id` - Location with the block identifier. Length must match the
+    ///   corresponding type of block identifier.
+    /// * `out_hash` - Location to write the block hash used in the query.
+    /// * `callback` - Callback for writing to the response stream.
+    pub fn getPrePreCooldownAccountsV2(
+        consensus: *mut consensus_runner,
+        stream: *mut futures::channel::mpsc::Sender<Result<Vec<u8>, tonic::Status>>,
+        block_id_type: u8,
+        block_id: *const u8,
+        out_hash: *mut u8,
+        callback: extern "C" fn(
+            *mut futures::channel::mpsc::Sender<Result<Vec<u8>, tonic::Status>>,
+            *const u8,
+            i64,
+        ) -> i32,
+    ) -> i64;
+
     /// Get the chain parameters that are in effect in the given block.
     ///
     /// * `consensus` - Pointer to the current consensus.
@@ -3198,6 +3299,121 @@ impl ConsensusContainer {
         .try_into()?;
         response.ensure_ok("block")?;
         Ok((out_hash, out_data))
+    }
+
+    /// Get accounts with scheduled releases at the end of a given block.
+    /// The stream will end when all accounts with scheduled releases have been
+    /// returned.
+    pub fn get_scheduled_release_accounts_v2(
+        &self,
+        request: &crate::grpc2::types::BlockHashInput,
+        sender: futures::channel::mpsc::Sender<Result<Vec<u8>, tonic::Status>>,
+    ) -> Result<[u8; 32], tonic::Status> {
+        use crate::grpc2::Require;
+        let sender = Box::new(sender);
+        let consensus = self.consensus.load(Ordering::SeqCst);
+        let mut buf = [0u8; 32];
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(request).require()?;
+        let (block_id_type, block_hash) = bhi.to_ptr();
+        let response: ConsensusQueryResponse = unsafe {
+            getScheduledReleaseAccountsV2(
+                consensus,
+                Box::into_raw(sender),
+                block_id_type,
+                block_hash.as_ptr(),
+                buf.as_mut_ptr(),
+                enqueue_bytearray_callback,
+            )
+        }
+        .try_into()?;
+        response.ensure_ok("block")?;
+        Ok(buf)
+    }
+
+    /// Get accounts in cooldown at the end of a given block.
+    /// The stream will end when all accounts in cooldown have been returned.
+    pub fn get_cooldown_accounts_v2(
+        &self,
+        request: &crate::grpc2::types::BlockHashInput,
+        sender: futures::channel::mpsc::Sender<Result<Vec<u8>, tonic::Status>>,
+    ) -> Result<[u8; 32], tonic::Status> {
+        use crate::grpc2::Require;
+        let sender = Box::new(sender);
+        let consensus = self.consensus.load(Ordering::SeqCst);
+        let mut buf = [0u8; 32];
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(request).require()?;
+        let (block_id_type, block_hash) = bhi.to_ptr();
+        let response: ConsensusQueryResponse = unsafe {
+            getCooldownAccountsV2(
+                consensus,
+                Box::into_raw(sender),
+                block_id_type,
+                block_hash.as_ptr(),
+                buf.as_mut_ptr(),
+                enqueue_bytearray_callback,
+            )
+        }
+        .try_into()?;
+        response.ensure_ok("block")?;
+        Ok(buf)
+    }
+
+    /// Get accounts in pre-cooldown at the end of a given block.
+    /// The stream will end when all accounts in pre-cooldown have been
+    /// returned.
+    pub fn get_pre_cooldown_accounts_v2(
+        &self,
+        request: &crate::grpc2::types::BlockHashInput,
+        sender: futures::channel::mpsc::Sender<Result<Vec<u8>, tonic::Status>>,
+    ) -> Result<[u8; 32], tonic::Status> {
+        use crate::grpc2::Require;
+        let sender = Box::new(sender);
+        let consensus = self.consensus.load(Ordering::SeqCst);
+        let mut buf = [0u8; 32];
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(request).require()?;
+        let (block_id_type, block_hash) = bhi.to_ptr();
+        let response: ConsensusQueryResponse = unsafe {
+            getPreCooldownAccountsV2(
+                consensus,
+                Box::into_raw(sender),
+                block_id_type,
+                block_hash.as_ptr(),
+                buf.as_mut_ptr(),
+                enqueue_bytearray_callback,
+            )
+        }
+        .try_into()?;
+        response.ensure_ok("block")?;
+        Ok(buf)
+    }
+
+    /// Get accounts in pre-pre-cooldown at the end of a given block.
+    /// The stream will end when all accounts in pre-pre-cooldown have been
+    /// returned.
+    pub fn get_pre_pre_cooldown_accounts_v2(
+        &self,
+        request: &crate::grpc2::types::BlockHashInput,
+        sender: futures::channel::mpsc::Sender<Result<Vec<u8>, tonic::Status>>,
+    ) -> Result<[u8; 32], tonic::Status> {
+        use crate::grpc2::Require;
+        let sender = Box::new(sender);
+        let consensus = self.consensus.load(Ordering::SeqCst);
+        let mut buf = [0u8; 32];
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(request).require()?;
+        let (block_id_type, block_hash) = bhi.to_ptr();
+        let response: ConsensusQueryResponse = unsafe {
+            getPrePreCooldownAccountsV2(
+                consensus,
+                Box::into_raw(sender),
+                block_id_type,
+                block_hash.as_ptr(),
+                buf.as_mut_ptr(),
+                enqueue_bytearray_callback,
+            )
+        }
+        .try_into()?;
+        response.ensure_ok("block")?;
+        Ok(buf)
     }
 
     /// Get chain parameters for the given block.

--- a/concordium-node/src/grpc2.rs
+++ b/concordium-node/src/grpc2.rs
@@ -676,6 +676,14 @@ struct ServiceConfig {
     #[serde(default)]
     get_next_update_sequence_numbers: bool,
     #[serde(default)]
+    get_scheduled_release_accounts: bool,
+    #[serde(default)]
+    get_cooldown_accounts: bool,
+    #[serde(default)]
+    get_pre_cooldown_accounts: bool,
+    #[serde(default)]
+    get_pre_pre_cooldown_accounts: bool,
+    #[serde(default)]
     get_block_chain_parameters: bool,
     #[serde(default)]
     get_block_finalization_summary: bool,
@@ -758,6 +766,10 @@ impl ServiceConfig {
             get_block_special_events: true,
             get_block_pending_updates: true,
             get_next_update_sequence_numbers: true,
+            get_scheduled_release_accounts: true,
+            get_cooldown_accounts: true,
+            get_pre_cooldown_accounts: true,
+            get_pre_pre_cooldown_accounts: true,
             get_block_chain_parameters: true,
             get_block_finalization_summary: true,
             shutdown: true,
@@ -1332,6 +1344,18 @@ pub mod server {
         type GetBlockItemsStream = futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
         /// Return type for the 'GetBlockPendingUpdates' method.
         type GetBlockPendingUpdatesStream =
+            futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
+        /// Return type for the 'GetScheduledReleaseAccounts' method.
+        type GetScheduledReleaseAccountsStream =
+            futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
+        /// Return type for the 'GetCooldownAccounts' method.
+        type GetCooldownAccountsStream =
+            futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
+        /// Return type for the 'GetPreCooldownAccounts' method.
+        type GetPreCooldownAccountsStream =
+            futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
+        /// Return type for the 'GetPrePreCooldowneleaseAccounts' method.
+        type GetPrePreCooldownAccountsStream =
             futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
         /// Return type for the 'GetBlockSpecialEvents' method.
         type GetBlockSpecialEventsStream =
@@ -2097,6 +2121,86 @@ pub mod server {
                 })
                 .await?;
             let mut response = tonic::Response::new(response);
+            add_hash(&mut response, hash)?;
+            Ok(response)
+        }
+
+        async fn get_scheduled_release_accounts(
+            &self,
+            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+        ) -> Result<tonic::Response<Self::GetScheduledReleaseAccountsStream>, tonic::Status> {
+            if !self.service_config.get_scheduled_release_accounts {
+                return Err(tonic::Status::unimplemented(
+                    "`GetScheduledReleaseAccounts` is not enabled.",
+                ));
+            }
+            let (sender, receiver) = futures::channel::mpsc::channel(10);
+            let hash = self
+                .run_blocking(move |consensus| {
+                    consensus.get_scheduled_release_accounts_v2(request.get_ref(), sender)
+                })
+                .await?;
+            let mut response = tonic::Response::new(receiver);
+            add_hash(&mut response, hash)?;
+            Ok(response)
+        }
+
+        async fn get_cooldown_accounts(
+            &self,
+            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+        ) -> Result<tonic::Response<Self::GetCooldownAccountsStream>, tonic::Status> {
+            if !self.service_config.get_cooldown_accounts {
+                return Err(tonic::Status::unimplemented(
+                    "`GetCooldownAccounts` is not enabled.",
+                ));
+            }
+            let (sender, receiver) = futures::channel::mpsc::channel(10);
+            let hash = self
+                .run_blocking(move |consensus| {
+                    consensus.get_cooldown_accounts_v2(request.get_ref(), sender)
+                })
+                .await?;
+            let mut response = tonic::Response::new(receiver);
+            add_hash(&mut response, hash)?;
+            Ok(response)
+        }
+
+        async fn get_pre_cooldown_accounts(
+            &self,
+            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+        ) -> Result<tonic::Response<Self::GetPreCooldownAccountsStream>, tonic::Status> {
+            if !self.service_config.get_pre_cooldown_accounts {
+                return Err(tonic::Status::unimplemented(
+                    "`GetPreCooldownAccounts` is not enabled.",
+                ));
+            }
+            let (sender, receiver) = futures::channel::mpsc::channel(10);
+            let hash = self
+                .run_blocking(move |consensus| {
+                    consensus.get_pre_cooldown_accounts_v2(request.get_ref(), sender)
+                })
+                .await?;
+            let mut response = tonic::Response::new(receiver);
+            add_hash(&mut response, hash)?;
+            Ok(response)
+        }
+
+        async fn get_pre_pre_cooldown_accounts(
+            &self,
+            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+        ) -> Result<tonic::Response<Self::GetPrePreCooldownAccountsStream>, tonic::Status> {
+            if !self.service_config.get_pre_pre_cooldown_accounts {
+                return Err(tonic::Status::unimplemented(
+                    "`GetPrePreCooldownAccounts` is not enabled.",
+                ));
+            }
+            let (sender, receiver) = futures::channel::mpsc::channel(10);
+            let hash = self
+                .run_blocking(move |consensus| {
+                    consensus.get_pre_pre_cooldown_accounts_v2(request.get_ref(), sender)
+                })
+                .await?;
+            let mut response = tonic::Response::new(receiver);
             add_hash(&mut response, hash)?;
             Ok(response)
         }

--- a/concordium-node/src/grpc2.rs
+++ b/concordium-node/src/grpc2.rs
@@ -1345,18 +1345,6 @@ pub mod server {
         /// Return type for the 'GetBlockPendingUpdates' method.
         type GetBlockPendingUpdatesStream =
             futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
-        /// Return type for the 'GetScheduledReleaseAccounts' method.
-        type GetScheduledReleaseAccountsStream =
-            futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
-        /// Return type for the 'GetCooldownAccounts' method.
-        type GetCooldownAccountsStream =
-            futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
-        /// Return type for the 'GetPreCooldownAccounts' method.
-        type GetPreCooldownAccountsStream =
-            futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
-        /// Return type for the 'GetPrePreCooldowneleaseAccounts' method.
-        type GetPrePreCooldownAccountsStream =
-            futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
         /// Return type for the 'GetBlockSpecialEvents' method.
         type GetBlockSpecialEventsStream =
             futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
@@ -1366,6 +1354,9 @@ pub mod server {
         /// Return type for the 'Blocks' method.
         type GetBlocksStream =
             tokio_stream::wrappers::ReceiverStream<Result<Arc<[u8]>, tonic::Status>>;
+        /// Return type for the 'GetCooldownAccounts' method.
+        type GetCooldownAccountsStream =
+            futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
         /// Return type for the 'FinalizedBlocks' method.
         type GetFinalizedBlocksStream =
             tokio_stream::wrappers::ReceiverStream<Result<Arc<[u8]>, tonic::Status>>;
@@ -1392,6 +1383,15 @@ pub mod server {
             futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
         /// Return type for the 'GetPoolDelegators' method.
         type GetPoolDelegatorsStream =
+            futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
+        /// Return type for the 'GetPreCooldownAccounts' method.
+        type GetPreCooldownAccountsStream =
+            futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
+        /// Return type for the 'GetPrePreCooldowneleaseAccounts' method.
+        type GetPrePreCooldownAccountsStream =
+            futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
+        /// Return type for the 'GetScheduledReleaseAccounts' method.
+        type GetScheduledReleaseAccountsStream =
             futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
         /// Return type for the 'GetWinningBakersEpoch' method.
         type GetWinningBakersEpochStream =
@@ -2128,7 +2128,8 @@ pub mod server {
         async fn get_scheduled_release_accounts(
             &self,
             request: tonic::Request<crate::grpc2::types::BlockHashInput>,
-        ) -> Result<tonic::Response<Self::GetScheduledReleaseAccountsStream>, tonic::Status> {
+        ) -> Result<tonic::Response<Self::GetScheduledReleaseAccountsStream>, tonic::Status>
+        {
             if !self.service_config.get_scheduled_release_accounts {
                 return Err(tonic::Status::unimplemented(
                     "`GetScheduledReleaseAccounts` is not enabled.",
@@ -2150,9 +2151,7 @@ pub mod server {
             request: tonic::Request<crate::grpc2::types::BlockHashInput>,
         ) -> Result<tonic::Response<Self::GetCooldownAccountsStream>, tonic::Status> {
             if !self.service_config.get_cooldown_accounts {
-                return Err(tonic::Status::unimplemented(
-                    "`GetCooldownAccounts` is not enabled.",
-                ));
+                return Err(tonic::Status::unimplemented("`GetCooldownAccounts` is not enabled."));
             }
             let (sender, receiver) = futures::channel::mpsc::channel(10);
             let hash = self

--- a/docs/grpc2.md
+++ b/docs/grpc2.md
@@ -87,6 +87,10 @@ If these are enabled then the following options become available
   get_block_special_events = true
   get_block_pending_updates = true
   get_next_update_sequence_numbers = true
+  get_scheduled_release_accounts = true
+  get_cooldown_accounts = true
+  get_pre_cooldown_accounts = true
+  get_pre_pre_cooldown_accounts = true
   get_block_chain_parameters = true
   get_block_finalization_summary = true
   get_baker_earliest_win_time = true


### PR DESCRIPTION
## Purpose

Closes: https://github.com/Concordium/concordium-node/issues/1263
Depends on: https://github.com/Concordium/concordium-grpc-api/pull/67 https://github.com/Concordium/concordium-base/pull/575

Add gRPC endpoints for getting the lists of accounts with scheduled releases or cooldowns.

## Changes

-    GetScheduledReleaseAccounts endpoint
-    GetCooldownAccounts endpoint
-    GetPreCooldownAccounts endpoint
-    GetPrePreCooldownAccounts endpoint


## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
