### PR TITLE
Introducing SuspensionInfo and suspension chain parameters

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/DummyData.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/DummyData.hs
@@ -364,6 +364,14 @@ dummyFinalizationCommitteeParameters =
           _fcpFinalizerRelativeStakeThreshold = PartsPerHundredThousands 10000
         }
 
+-- | Validator score parameters for the second consensus protocol.
+dummyValidatorScoreParameters :: ValidatorScoreParameters
+dummyValidatorScoreParameters =
+    ValidatorScoreParameters
+        { -- Maximal number of missed rounds before a validator gets suspended.
+          _vspMaxMissedRounds = 1
+        }
+
 dummyChainParameters :: forall cpv. (IsChainParametersVersion cpv) => ChainParameters' cpv
 dummyChainParameters = case chainParametersVersion @cpv of
     SChainParametersV0 ->
@@ -382,7 +390,8 @@ dummyChainParameters = case chainParametersVersion @cpv of
                 PoolParametersV0
                     { _ppBakerStakeThreshold = 300000000000
                     },
-              _cpFinalizationCommitteeParameters = NoParam
+              _cpFinalizationCommitteeParameters = NoParam,
+              _cpValidatorScoreParameters = NoParam
             }
     SChainParametersV1 ->
         ChainParameters
@@ -420,7 +429,8 @@ dummyChainParameters = case chainParametersVersion @cpv of
                               _transactionCommissionRange = fullRange
                             }
                     },
-              _cpFinalizationCommitteeParameters = NoParam
+              _cpFinalizationCommitteeParameters = NoParam,
+              _cpValidatorScoreParameters = NoParam
             }
     SChainParametersV2 ->
         ChainParameters
@@ -458,7 +468,8 @@ dummyChainParameters = case chainParametersVersion @cpv of
                               _transactionCommissionRange = fullRange
                             }
                     },
-              _cpFinalizationCommitteeParameters = SomeParam dummyFinalizationCommitteeParameters
+              _cpFinalizationCommitteeParameters = SomeParam dummyFinalizationCommitteeParameters,
+              _cpValidatorScoreParameters = NoParam
             }
     SChainParametersV3 ->
         ChainParameters
@@ -496,7 +507,8 @@ dummyChainParameters = case chainParametersVersion @cpv of
                               _transactionCommissionRange = fullRange
                             }
                     },
-              _cpFinalizationCommitteeParameters = SomeParam dummyFinalizationCommitteeParameters
+              _cpFinalizationCommitteeParameters = SomeParam dummyFinalizationCommitteeParameters,
+              _cpValidatorScoreParameters = SomeParam dummyValidatorScoreParameters
             }
   where
     fullRange = InclusiveRange (makeAmountFraction 0) (makeAmountFraction 100000)

--- a/concordium-consensus/src/Concordium/GlobalState/DummyData.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/DummyData.hs
@@ -364,7 +364,7 @@ dummyFinalizationCommitteeParameters =
           _fcpFinalizerRelativeStakeThreshold = PartsPerHundredThousands 10000
         }
 
--- | Validator score parameters for the second consensus protocol.
+-- | Dummy validator score parameters for the second consensus protocol.
 dummyValidatorScoreParameters :: ValidatorScoreParameters
 dummyValidatorScoreParameters =
     ValidatorScoreParameters

--- a/concordium-consensus/src/Concordium/GlobalState/Parameters.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Parameters.hs
@@ -187,6 +187,8 @@ data UpdateValue (cpv :: ChainParametersVersion) where
     UVBlockEnergyLimit :: (IsSupported 'PTBlockEnergyLimit cpv ~ 'True) => !Energy -> UpdateValue cpv
     -- | Updates to the finalization committee parameters for chain parameters version 2.
     UVFinalizationCommitteeParameters :: (IsSupported 'PTFinalizationCommitteeParameters cpv ~ 'True) => !FinalizationCommitteeParameters -> UpdateValue cpv
+    -- | Updates to the validator score parameters for chain parameters version 3.
+    UVValidatorScoreParameters :: (IsSupported 'PTValidatorScoreParameters cpv ~ 'True) => !ValidatorScoreParameters -> UpdateValue cpv
 
 deriving instance Eq (UpdateValue cpv)
 deriving instance Show (UpdateValue cpv)

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
@@ -1563,6 +1563,7 @@ instance (MonadBlobStore m, IsCooldownParametersVersion cpv) => BlobStorable m (
 instance (MonadBlobStore m) => BlobStorable m Parameters.TimeParameters
 instance (MonadBlobStore m) => BlobStorable m Parameters.TimeoutParameters
 instance (MonadBlobStore m) => BlobStorable m Parameters.FinalizationCommitteeParameters
+instance (MonadBlobStore m) => BlobStorable m Parameters.ValidatorScoreParameters
 instance (MonadBlobStore m) => BlobStorable m Duration
 instance (MonadBlobStore m) => BlobStorable m Energy
 instance (MonadBlobStore m) => BlobStorable m (Map AccountAddress Timestamp)

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/Updates.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/Updates.hs
@@ -1613,6 +1613,11 @@ lookupNextUpdateSequenceNumber uref uty = withCPVConstraints (chainParametersVer
                 (pure minUpdateSequenceNumber)
                 (fmap uqNextSequenceNumber . refLoad)
                 (pFinalizationCommitteeParametersQueue pendingUpdates)
+        UpdateValidatorScoreParameters ->
+            maybeWhenSupported
+                (pure minUpdateSequenceNumber)
+                (fmap uqNextSequenceNumber . refLoad)
+                (pValidatorScoreParametersQueue pendingUpdates)
 
 -- | Enqueue an update in the appropriate queue.
 enqueueUpdate ::
@@ -1665,6 +1670,10 @@ enqueueUpdate effectiveTime payload uref = withCPVConstraints (chainParametersVe
             SomeParam q ->
                 enqueue effectiveTime v q
                     <&> \newQ -> p{pFinalizationCommitteeParametersQueue = SomeParam newQ}
+        UVValidatorScoreParameters v -> case pValidatorScoreParametersQueue of
+            SomeParam q ->
+                enqueue effectiveTime v q
+                    <&> \newQ -> p{pValidatorScoreParametersQueue = SomeParam newQ}
     refMake u{pendingUpdates = newPendingUpdates}
 
 -- | Overwrite the election difficulty with the specified value and remove

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/PoolRewards.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/PoolRewards.hs
@@ -147,7 +147,7 @@ migratePoolRewardsP1 curBakers nextBakers blockCounts npEpoch npMintRate = do
                     { blockCount = Map.findWithDefault 0 bid blockCounts,
                       transactionFeesAccrued = 0,
                       finalizationAwake = False,
-                      missedRounds = conditionally hasValidatorSuspension 0
+                      suspensionInfo = conditionally hasValidatorSuspension emptySuspensionInfo
                     }
         (!newRef, _) <- refFlush =<< refMake bprd
         return newRef
@@ -295,7 +295,7 @@ rotateCapitalDistribution oldPoolRewards = do
         buildRewardDetails (newId : newIds) (oldId : oldIds) (r : rs) = case compare newId oldId of
             LT -> emptyBakerPoolRewardDetails : buildRewardDetails newIds (oldId : oldIds) (r : rs)
             EQ ->
-                (emptyBakerPoolRewardDetails @av){missedRounds = missedRounds r}
+                (emptyBakerPoolRewardDetails @av){suspensionInfo = suspensionInfo r}
                     : buildRewardDetails newIds oldIds rs
             GT -> buildRewardDetails (newId : newIds) oldIds rs
         buildRewardDetails _ _ _ =

--- a/concordium-consensus/src/Concordium/GlobalState/PoolRewards.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/PoolRewards.hs
@@ -46,7 +46,7 @@ data BakerPoolRewardDetails (av :: AccountVersion) = BakerPoolRewardDetails
       transactionFeesAccrued :: !Amount,
       -- | Whether the pool contributed to a finalization proof in the reward period
       finalizationAwake :: !Bool,
-      -- | Information for deciding whether a validator will be suspended the next snapshot epoch.
+      -- | Information for deciding whether a validator will be suspended at the next snapshot epoch.
       suspensionInfo :: !(Conditionally (SupportsValidatorSuspension av) SuspensionInfo)
     }
     deriving (Eq, Show)

--- a/concordium-consensus/src/Concordium/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler.hs
@@ -2241,8 +2241,8 @@ handleConfigureBaker
                         BakerSetBakingRewardCommission bid senderAddress bakingRewardCommission
                     BI.BakerConfigureFinalizationRewardCommission finalizationRewardCommission ->
                         BakerSetFinalizationRewardCommission bid senderAddress finalizationRewardCommission
-                    BI.BakerConfigureSuspended -> BakerSuspended bid
-                    BI.BakerConfigureResumed -> BakerResumed bid
+                    BI.BakerConfigureSuspended -> BakerSuspended bid senderAddress
+                    BI.BakerConfigureResumed -> BakerResumed bid senderAddress
         rejectResult failure =
             TxReject $! case failure of
                 BI.VCFStakeUnderThreshold -> StakeUnderMinimumThresholdForBaking

--- a/concordium-consensus/src/Concordium/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler.hs
@@ -2745,6 +2745,9 @@ handleChainUpdate (WithMetadata{wmdData = ui@UpdateInstruction{..}, ..}, mVerRes
                                 FinalizationCommitteeParametersUpdatePayload u -> case sIsSupported SPTFinalizationCommitteeParameters scpv of
                                     STrue -> checkSigAndEnqueue $ UVFinalizationCommitteeParameters u
                                     SFalse -> return $ TxInvalid NotSupportedAtCurrentProtocolVersion
+                                ValidatorScoreParametersUpdatePayload u -> case sIsSupported SPTValidatorScoreParameters scpv of
+                                    STrue -> checkSigAndEnqueue $ UVValidatorScoreParameters u
+                                    SFalse -> return $ TxInvalid NotSupportedAtCurrentProtocolVersion
   where
     scpv :: SChainParametersVersion (ChainParametersVersionFor (MPV m))
     scpv = chainParametersVersion

--- a/concordium-consensus/test-runners/app/Main.hs
+++ b/concordium-consensus/test-runners/app/Main.hs
@@ -342,7 +342,8 @@ main = do
                     PoolParametersV0
                         { _ppBakerStakeThreshold = 300000000000
                         },
-                  _cpFinalizationCommitteeParameters = NoParam
+                  _cpFinalizationCommitteeParameters = NoParam,
+                  _cpValidatorScoreParameters = NoParam
                 }
     let (genesisData, bakerIdentities, _) =
             makeGenesisDataV0 @PV

--- a/concordium-consensus/test-runners/catchup/Main.hs
+++ b/concordium-consensus/test-runners/catchup/Main.hs
@@ -371,7 +371,8 @@ main = do
                     PoolParametersV0
                         { _ppBakerStakeThreshold = 300000000000
                         },
-                  _cpFinalizationCommitteeParameters = NoParam
+                  _cpFinalizationCommitteeParameters = NoParam,
+                  _cpValidatorScoreParameters = NoParam
                 }
     let (genesisData, bakerIdentities, _) =
             makeGenesisDataV0 @PV

--- a/concordium-consensus/tests/scheduler/SchedulerTests/ConfigureBaker.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/ConfigureBaker.hs
@@ -1311,8 +1311,8 @@ testUpdateBakerSuspendResumeOk spv pvString suspendOrResume accM =
     accountBaker _ x = pure x
     events =
         [ if suspendOrResume == Suspend
-            then BakerSuspended{ebsBakerId = 4}
-            else BakerResumed{ebrBakerId = 4}
+            then BakerSuspended{ebsBakerId = 4, ebsAccount = baker4Address}
+            else BakerResumed{ebrBakerId = 4, ebrAccount = baker4Address}
         ]
 
 tests :: Spec

--- a/concordium-consensus/tests/scheduler/SchedulerTests/KonsensusV1/EpochTransition.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/KonsensusV1/EpochTransition.hs
@@ -721,7 +721,8 @@ testMissedRoundsUpdate accountConfigs = runTestBlockState @P8 $ do
     bprd <- bsoGetBakerPoolRewardDetails bs0
     let missedRounds0 = Map.fromList $ zip (Map.keys bprd) [1 ..]
     bs1 <- bsoUpdateMissedRounds bs0 missedRounds0
-    missedRounds1 <- fmap (uncond . missedRounds) <$> bsoGetBakerPoolRewardDetails bs1
+    missedRounds1 <-
+        fmap (missedRounds . uncond . suspensionInfo) <$> bsoGetBakerPoolRewardDetails bs1
     liftIO $
         assertEqual
             "Current epoch missed rounds should be updated as expeceted."
@@ -738,7 +739,8 @@ testMissedRoundsUpdate accountConfigs = runTestBlockState @P8 $ do
     bs2 <- bsoSetNextEpochBakers bs1 newBakerStake (chainParams ^. cpFinalizationCommitteeParameters)
     bs3 <- bsoSetNextCapitalDistribution bs2 CapitalDistribution{bakerPoolCapital = newPoolCapital, ..}
     bs4 <- bsoRotateCurrentCapitalDistribution =<< bsoRotateCurrentEpochBakers bs3
-    missedRounds2 <- fmap (uncond . missedRounds) <$> bsoGetBakerPoolRewardDetails bs4
+    missedRounds2 <-
+        fmap (missedRounds . uncond . suspensionInfo) <$> bsoGetBakerPoolRewardDetails bs4
     liftIO $
         assertEqual
             "Missed rounds should be carried over when rotating current capital distribution with new validators"
@@ -750,7 +752,8 @@ testMissedRoundsUpdate accountConfigs = runTestBlockState @P8 $ do
             (all (== 0) $ Map.elems $ missedRounds2 `Map.difference` missedRounds1)
     bs5 <- bsoSetNextEpochBakers bs4 bakerStakes (chainParams ^. cpFinalizationCommitteeParameters)
     bs6 <- bsoSetNextCapitalDistribution bs5 CapitalDistribution{..}
-    missedRounds3 <- fmap (uncond . missedRounds) <$> bsoGetBakerPoolRewardDetails bs6
+    missedRounds3 <-
+        fmap (missedRounds . uncond . suspensionInfo) <$> bsoGetBakerPoolRewardDetails bs6
     liftIO $
         assertEqual
             "Missed rounds should be carried over when rotating current capital distribution with new validators"


### PR DESCRIPTION
## Purpose

These are the corresponding changes for the newly introduced validator suspension chain parameters in the node repo. Also a data structure `SuspensionInfo` is introduced that gathers the missed rounds and whether a validator is primed for suspension at the next snapshot.

## Changes

See above

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
