### PR TITLE
Add account address to transaction outcomes and special events.

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
@@ -1535,12 +1535,13 @@ class (BlockStateQuery m) => BlockStateOperations m where
     --  exceeded the given threshold and are now priMed for suspension.
     bsoPrimeForSuspension :: (PVSupportsDelegation (MPV m), PVSupportsValidatorSuspension (MPV m)) => UpdatableBlockState m -> Word64 -> [BakerId] -> m ([BakerId], UpdatableBlockState m)
 
-    -- \| Suspend validators with the given account indices, if
+    -- | Suspend validators with the given account indices, if
     --  1) the account index points to an existing account
     --  2) the account belongs to a validator
     --  3) the account was not already suspended
-    --  Returns the subset of account indices that were suspended.
-    bsoSuspendValidators :: (PVSupportsValidatorSuspension (MPV m)) => UpdatableBlockState m -> [AccountIndex] -> m ([AccountIndex], UpdatableBlockState m)
+    --  Returns the subset of account indices that were suspended together with their canonical
+    --  addresses.
+    bsoSuspendValidators :: (PVSupportsValidatorSuspension (MPV m)) => UpdatableBlockState m -> [AccountIndex] -> m ([(AccountIndex, AccountAddress)], UpdatableBlockState m)
 
     -- | A snapshot of the block state that can be used to roll back to a previous state.
     type StateSnapshot m

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -3548,14 +3548,15 @@ doPrimeForSuspension pbs threshold bids = do
 --  1) the account index points to an existing account
 --  2) the account belongs to a validator
 --  3) the account was not already suspended
---  Returns the subset of account indeces that were suspended.
+--  Returns the subset of account indices that were suspended together with their canonical account
+--  addresses.
 doSuspendValidators ::
     forall pv m.
     ( SupportsPersistentState pv m
     ) =>
     PersistentBlockState pv ->
     [AccountIndex] ->
-    m ([AccountIndex], PersistentBlockState pv)
+    m ([(AccountIndex, AccountAddress)], PersistentBlockState pv)
 doSuspendValidators pbs ais =
     case hasValidatorSuspension of
         STrue -> do
@@ -3576,7 +3577,8 @@ doSuspendValidators pbs ais =
                                             uncond $ BaseAccounts._bieAccountIsSuspended $ _accountBakerInfo ba -> do
                                             newAcc <- setAccountValidatorSuspended True acc
                                             newAccounts <- Accounts.setAccountAtIndex ai newAcc (bspAccounts bsp)
-                                            return (ai : aisSusp, bsp{bspAccounts = newAccounts})
+                                            address <- accountCanonicalAddress newAcc
+                                            return ((ai, address) : aisSusp, bsp{bspAccounts = newAccounts})
                                         -- The validator is already suspended, nothing to do
                                         | otherwise -> return res
                     )

--- a/concordium-consensus/src/Concordium/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler.hs
@@ -2241,8 +2241,8 @@ handleConfigureBaker
                         BakerSetBakingRewardCommission bid senderAddress bakingRewardCommission
                     BI.BakerConfigureFinalizationRewardCommission finalizationRewardCommission ->
                         BakerSetFinalizationRewardCommission bid senderAddress finalizationRewardCommission
-                    BI.BakerConfigureSuspended -> BakerSuspended bid
-                    BI.BakerConfigureResumed -> BakerResumed bid
+                    BI.BakerConfigureSuspended -> BakerSuspended bid senderAddress
+                    BI.BakerConfigureResumed -> BakerResumed bid senderAddress
         rejectResult failure =
             TxReject $! case failure of
                 BI.VCFStakeUnderThreshold -> StakeUnderMinimumThresholdForBaking

--- a/concordium-consensus/tests/scheduler/SchedulerTests/ConfigureBaker.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/ConfigureBaker.hs
@@ -1311,8 +1311,8 @@ testUpdateBakerSuspendResumeOk spv pvString suspendOrResume accM =
     accountBaker _ x = pure x
     events =
         [ if suspendOrResume == Suspend
-            then BakerSuspended{ebsBakerId = 4}
-            else BakerResumed{ebrBakerId = 4}
+            then BakerSuspended{ebsBakerId = 4, ebsAccount = baker4Address}
+            else BakerResumed{ebrBakerId = 4, ebrAccount = baker4Address}
         ]
 
 tests :: Spec


### PR DESCRIPTION
## Purpose

Closes #1253
Depends on: https://github.com/Concordium/concordium-base/pull/581

Add the account address to `BakerSuspended` and `BakerResumed` transaction outcomes, and to `ValidatorSuspended` and `ValidatorPrimedForSuspension` special outcomes.

## Changes

- `bsoSuspendValidators` returns account addresses for convenience in constructing `ValidatorSuspended` outcomes.
- Account addresses are added when generating `ValidatorSuspended` and `ValidatorPrimedForSuspension` outcomes.
- Account addresses are included when generating `BakerSuspended` and `BakerResumed` events.
- Testing is updated to reflect the changes.


## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
