### PR TITLE
Primed for suspension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Automatically suspend validators from the consensus that missed too many
+  rounds in the previous payday.
 - Add support for suspend/resume to validator configuration updates.
 - Validators that are suspended are paused from participating in the consensus algorithm.
 - Add `GetConsensusDetailedStatus` gRPC endpoint for getting detailed information on the status

--- a/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
@@ -1532,7 +1532,7 @@ class (BlockStateQuery m) => BlockStateOperations m where
 
     -- | Mark given validators for possible suspension at the next snapshot
     --  epoch. Returns the subset of the given validator ids whose missed rounds
-    --  exceeded the given threshold and are now priMed for suspension.
+    --  exceeded the given threshold and are now primed for suspension.
     bsoPrimeForSuspension :: (PVSupportsDelegation (MPV m), PVSupportsValidatorSuspension (MPV m)) => UpdatableBlockState m -> Word64 -> [BakerId] -> m ([BakerId], UpdatableBlockState m)
 
     -- | Suspend validators with the given account indices, if

--- a/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
@@ -1535,12 +1535,13 @@ class (BlockStateQuery m) => BlockStateOperations m where
     --  exceeded the given threshold and are now priMed for suspension.
     bsoPrimeForSuspension :: (PVSupportsDelegation (MPV m), PVSupportsValidatorSuspension (MPV m)) => UpdatableBlockState m -> Word64 -> [BakerId] -> m ([BakerId], UpdatableBlockState m)
 
-    -- \| Suspend validators with the given account indices, if
+    -- | Suspend validators with the given account indices, if
     --  1) the account index points to an existing account
     --  2) the account belongs to a validator
     --  3) the account was not already suspended
-    --  Returns the subset of account indices that were suspended.
-    bsoSuspendValidators :: (PVSupportsValidatorSuspension (MPV m)) => UpdatableBlockState m -> [AccountIndex] -> m ([AccountIndex], UpdatableBlockState m)
+    --  Returns the subset of account indices that were suspended together with their canonical
+    --  addresses.
+    bsoSuspendValidators :: (PVSupportsValidatorSuspension (MPV m)) => UpdatableBlockState m -> [AccountIndex] -> m ([(AccountIndex, AccountAddress)], UpdatableBlockState m)
 
     -- | A snapshot of the block state that can be used to roll back to a previous state.
     type StateSnapshot m

--- a/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
@@ -1530,7 +1530,9 @@ class (BlockStateQuery m) => BlockStateOperations m where
     --  round did timeout.
     bsoUpdateMissedRounds :: (PVSupportsDelegation (MPV m), PVSupportsValidatorSuspension (MPV m)) => UpdatableBlockState m -> Map.Map BakerId Word64 -> m (UpdatableBlockState m)
 
-    -- | Mark given validators for possible suspension at the next snapshot epoch.
+    -- | Mark given validators for possible suspension at the next snapshot
+    --  epoch. Returns the subset of the given validator ids whose missed rounds
+    --  exceeded the given threshold and are now priMed for suspension.
     bsoPrimeForSuspension :: (PVSupportsDelegation (MPV m), PVSupportsValidatorSuspension (MPV m)) => UpdatableBlockState m -> Word64 -> [BakerId] -> m ([BakerId], UpdatableBlockState m)
 
     -- \| Suspend validators with the given account indices, if

--- a/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
@@ -1533,7 +1533,16 @@ class (BlockStateQuery m) => BlockStateOperations m where
     -- | Mark given validators for possible suspension at the next snapshot
     --  epoch. Returns the subset of the given validator ids whose missed rounds
     --  exceeded the given threshold and are now primed for suspension.
-    bsoPrimeForSuspension :: (PVSupportsDelegation (MPV m), PVSupportsValidatorSuspension (MPV m)) => UpdatableBlockState m -> Word64 -> [BakerId] -> m ([BakerId], UpdatableBlockState m)
+    bsoPrimeForSuspension ::
+        (PVSupportsDelegation (MPV m), PVSupportsValidatorSuspension (MPV m)) =>
+        UpdatableBlockState m ->
+        -- | The threshold for maximal missed rounds
+        Word64 ->
+        -- | The set of validators that are considered for suspension. This
+        --  should be the current payday validators.
+        [BakerId] ->
+        -- | Returns the subset of primed validator ids and the updated block state
+        m ([BakerId], UpdatableBlockState m)
 
     -- | Suspend validators with the given account indices, if
     --  1) the account index points to an existing account

--- a/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
@@ -1531,17 +1531,16 @@ class (BlockStateQuery m) => BlockStateOperations m where
     bsoUpdateMissedRounds :: (PVSupportsDelegation (MPV m), PVSupportsValidatorSuspension (MPV m)) => UpdatableBlockState m -> Map.Map BakerId Word64 -> m (UpdatableBlockState m)
 
     -- | Mark given validators for possible suspension at the next snapshot
-    --  epoch. Returns the subset of the given validator ids whose missed rounds
-    --  exceeded the given threshold and are now primed for suspension.
+    --  epoch. Returns the subset of the current epoch validator ids whose
+    --  missed rounds exceeded the given threshold and are now primed for
+    --  suspension.
     bsoPrimeForSuspension ::
         (PVSupportsDelegation (MPV m), PVSupportsValidatorSuspension (MPV m)) =>
         UpdatableBlockState m ->
         -- | The threshold for maximal missed rounds
         Word64 ->
-        -- | The set of validators that are considered for suspension. This
-        --  should be the current payday validators.
-        [BakerId] ->
-        -- | Returns the subset of primed validator ids and the updated block state
+        -- | Returns the subset of primed validator ids of the current epoch
+        --  validators and the updated block state
         m ([BakerId], UpdatableBlockState m)
 
     -- | Suspend validators with the given account indices, if
@@ -1872,7 +1871,7 @@ instance (Monad (t m), MonadTrans t, BlockStateOperations m) => BlockStateOperat
     bsoSetRewardAccounts s = lift . bsoSetRewardAccounts s
     bsoIsProtocolUpdateEffective = lift . bsoIsProtocolUpdateEffective
     bsoUpdateMissedRounds s = lift . bsoUpdateMissedRounds s
-    bsoPrimeForSuspension s t = lift . bsoPrimeForSuspension s t
+    bsoPrimeForSuspension s = lift . bsoPrimeForSuspension s
     bsoSuspendValidators s = lift . bsoSuspendValidators s
     type StateSnapshot (MGSTrans t m) = StateSnapshot m
     bsoSnapshotState = lift . bsoSnapshotState

--- a/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
@@ -1530,6 +1530,16 @@ class (BlockStateQuery m) => BlockStateOperations m where
     --  round did timeout.
     bsoUpdateMissedRounds :: (PVSupportsDelegation (MPV m), PVSupportsValidatorSuspension (MPV m)) => UpdatableBlockState m -> Map.Map BakerId Word64 -> m (UpdatableBlockState m)
 
+    -- | Mark given validators for possible suspension at the next snapshot epoch.
+    bsoPrimeForSuspension :: (PVSupportsDelegation (MPV m), PVSupportsValidatorSuspension (MPV m)) => UpdatableBlockState m -> Word64 -> [BakerId] -> m ([BakerId], UpdatableBlockState m)
+
+    -- \| Suspend validators with the given account indices, if
+    --  1) the account index points to an existing account
+    --  2) the account belongs to a validator
+    --  3) the account was not already suspended
+    --  Returns the subset of account indices that were suspended.
+    bsoSuspendValidators :: (PVSupportsValidatorSuspension (MPV m)) => UpdatableBlockState m -> [AccountIndex] -> m ([AccountIndex], UpdatableBlockState m)
+
     -- | A snapshot of the block state that can be used to roll back to a previous state.
     type StateSnapshot m
 
@@ -1850,6 +1860,8 @@ instance (Monad (t m), MonadTrans t, BlockStateOperations m) => BlockStateOperat
     bsoSetRewardAccounts s = lift . bsoSetRewardAccounts s
     bsoIsProtocolUpdateEffective = lift . bsoIsProtocolUpdateEffective
     bsoUpdateMissedRounds s = lift . bsoUpdateMissedRounds s
+    bsoPrimeForSuspension s t = lift . bsoPrimeForSuspension s t
+    bsoSuspendValidators s = lift . bsoSuspendValidators s
     type StateSnapshot (MGSTrans t m) = StateSnapshot m
     bsoSnapshotState = lift . bsoSnapshotState
     bsoRollback s = lift . bsoRollback s
@@ -1907,6 +1919,8 @@ instance (Monad (t m), MonadTrans t, BlockStateOperations m) => BlockStateOperat
     {-# INLINE bsoGetCurrentEpochBakers #-}
     {-# INLINE bsoIsProtocolUpdateEffective #-}
     {-# INLINE bsoUpdateMissedRounds #-}
+    {-# INLINE bsoPrimeForSuspension #-}
+    {-# INLINE bsoSuspendValidators #-}
     {-# INLINE bsoSnapshotState #-}
     {-# INLINE bsoRollback #-}
 

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -3509,6 +3509,82 @@ doUpdateMissedRounds pbs rds = do
             (Map.toList rds)
     storePBS pbs bsp'
 
+doPrimeForSuspension ::
+    ( PVSupportsDelegation pv,
+      SupportsPersistentState pv m
+    ) =>
+    PersistentBlockState pv ->
+    Word64 ->
+    [BakerId] ->
+    m ([BakerId], PersistentBlockState pv)
+doPrimeForSuspension pbs threshold bids = do
+    bprds <- doGetBakerPoolRewardDetails pbs
+    bsp0 <- loadPBS pbs
+    (bidsUpd, bsp') <- do
+        foldM
+            ( \res@(acc, bsp) bId -> do
+                let mBprd = Map.lookup bId bprds
+                case mBprd of
+                    Just bprd
+                        | CTrue SuspensionInfo{..} <- suspensionInfo bprd,
+                          missedRounds > threshold -> do
+                            bsp' <-
+                                modifyBakerPoolRewardDetailsInPoolRewards
+                                    bsp
+                                    bId
+                                    (\bpr -> bpr{suspensionInfo = (\suspInfo -> suspInfo{primedForSuspension = True}) <$> suspensionInfo bpr})
+                            return (bId : acc, bsp')
+                    _otherwise -> return res
+            )
+            ([], bsp0)
+            bids
+    pbs' <- storePBS pbs bsp'
+    return (bidsUpd, pbs')
+
+-- | Suspend validators with the given account indices, if
+--  1) the account index points to an existing account
+--  2) the account belongs to a validator
+--  3) the account was not already suspended
+--  Returns the subset of account indeces that were suspended.
+doSuspendValidators ::
+    forall pv m.
+    ( SupportsPersistentState pv m
+    ) =>
+    PersistentBlockState pv ->
+    [AccountIndex] ->
+    m ([AccountIndex], PersistentBlockState pv)
+doSuspendValidators pbs ais =
+    case hasValidatorSuspension of
+        STrue -> do
+            bsp0 <- loadPBS pbs
+            (aisSusp, bspUpd) <-
+                foldM
+                    ( \res@(aisSusp, bsp) ai -> do
+                        mAcc <- Accounts.indexedAccount ai (bspAccounts bsp)
+                        case mAcc of
+                            Nothing -> return res
+                            Just acc -> do
+                                mValidatorExists <- accountBaker acc
+                                case mValidatorExists of
+                                    Nothing -> return res
+                                    Just ba
+                                        -- The validator is not yet suspended
+                                        | False <-
+                                            uncond $ BaseAccounts._bieAccountIsSuspended $ _accountBakerInfo ba -> do
+                                            newAcc <- setAccountValidatorSuspended True acc
+                                            newAccounts <- Accounts.setAccountAtIndex ai newAcc (bspAccounts bsp)
+                                            return (ai : aisSusp, bsp{bspAccounts = newAccounts})
+                                        -- The validator is already suspended, nothing to do
+                                        | otherwise -> return res
+                    )
+                    ([], bsp0)
+                    ais
+            pbsUpd <- storePBS pbs bspUpd
+            return (aisSusp, pbsUpd)
+        SFalse -> return ([], pbs)
+  where
+    hasValidatorSuspension = sSupportsValidatorSuspension (accountVersion @(AccountVersionFor pv))
+
 doProcessUpdateQueues ::
     forall pv m.
     (SupportsPersistentState pv m) =>
@@ -4455,6 +4531,8 @@ instance (IsProtocolVersion pv, PersistentState av pv r m) => BlockStateOperatio
     bsoSetRewardAccounts = doSetRewardAccounts
     bsoIsProtocolUpdateEffective = doIsProtocolUpdateEffective
     bsoUpdateMissedRounds = doUpdateMissedRounds
+    bsoPrimeForSuspension = doPrimeForSuspension
+    bsoSuspendValidators = doSuspendValidators
     type StateSnapshot (PersistentBlockStateMonad pv r m) = BlockStatePointers pv
     bsoSnapshotState = loadPBS
     bsoRollback = storePBS

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -3509,6 +3509,9 @@ doUpdateMissedRounds pbs rds = do
             (Map.toList rds)
     storePBS pbs bsp'
 
+-- | Prime validators for suspension. Returns the subset of the given validator
+--  ids whose missed rounds exceeded the given threshold and are now primed for
+--  suspension.
 doPrimeForSuspension ::
     ( PVSupportsDelegation pv,
       SupportsPersistentState pv m

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -3548,14 +3548,15 @@ doPrimeForSuspension pbs threshold bids = do
 --  1) the account index points to an existing account
 --  2) the account belongs to a validator
 --  3) the account was not already suspended
---  Returns the subset of account indeces that were suspended.
+--  Returns the subset of account indices that were suspended together with their canonical account
+--  addresses.
 doSuspendValidators ::
     forall pv m.
     ( SupportsPersistentState pv m
     ) =>
     PersistentBlockState pv ->
     [AccountIndex] ->
-    m ([AccountIndex], PersistentBlockState pv)
+    m ([(AccountIndex, AccountAddress)], PersistentBlockState pv)
 doSuspendValidators pbs ais =
     case hasValidatorSuspension of
         STrue -> do
@@ -3576,7 +3577,8 @@ doSuspendValidators pbs ais =
                                             uncond $ BaseAccounts._bieAccountIsSuspended $ _accountBakerInfo ba -> do
                                             newAcc <- setAccountValidatorSuspended True acc
                                             newAccounts <- Accounts.setAccountAtIndex ai newAcc (bspAccounts bsp)
-                                            return (ai : aisSusp, bsp{bspAccounts = newAccounts})
+                                            address <- accountCanonicalAddress newAcc
+                                            return ((ai, address) : aisSusp, bsp{bspAccounts = newAccounts})
                                         -- The validator is already suspended, nothing to do
                                         | otherwise -> return res
                     )

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/Updates.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/Updates.hs
@@ -493,6 +493,7 @@ instance
         hMinBlockTimeQueue <- hashWhenSupported pMinBlockTimeQueue
         hBlockEnergyLimitQueue <- hashWhenSupported pBlockEnergyLimitQueue
         hFinalizationCommitteeParametersQueue <- hashWhenSupported pFinalizationCommitteeParametersQueue
+        hValidatorScoreParametersQueue <- hashWhenSupported pValidatorScoreParametersQueue
         return $!
             H.hash $
                 hRootKeysUpdateQueue
@@ -515,6 +516,7 @@ instance
                     <> hMinBlockTimeQueue
                     <> hBlockEnergyLimitQueue
                     <> hFinalizationCommitteeParametersQueue
+                    <> hValidatorScoreParametersQueue
       where
         hashWhenSupported :: (MHashableTo m H.Hash a) => OParam pt cpv a -> m BS.ByteString
         hashWhenSupported = maybeWhenSupported (return mempty) (fmap H.hashToByteString . getHashM)

--- a/concordium-consensus/src/Concordium/KonsensusV1/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Scheduler.hs
@@ -123,7 +123,7 @@ data PrologueResult m av = PrologueResult
       --  Otherwise, they are 'Nothing'.
       prologuePaydayParameters :: Maybe (PaydayParameters av),
       -- | If the block triggered an epoch transition and the new epoch is a
-      --  snapshot,this field contains the validator ids that are newly suspended.
+      --  snapshot, this field contains the validator ids that are newly suspended.
       -- Otherwise, this is `Nothing`.
       prologueSuspendedBids :: Maybe (Set.Set BakerId)
     }
@@ -161,7 +161,7 @@ data EpochTransitionResult m = EpochTransitionResult
       -- parameters.
       mPaydayParams :: Maybe (PaydayParameters (AccountVersionFor (MPV m))),
       -- If the epoch transition was a snapshot, this contains the set of
-      -- validator ids that will  be newly suspended.
+      -- validator ids that will be newly suspended.
       mSnapshotSuspendedIds :: Maybe (Set.Set BakerId)
     }
 
@@ -400,7 +400,11 @@ processPaydayRewards (Just PaydayParameters{..}) theState0 = do
             case _cpValidatorScoreParameters cps of
                 NoParam -> return theState1
                 SomeParam (ValidatorScoreParameters{..}) -> do
-                    (bids, theState3) <- bsoPrimeForSuspension theState2 _vspMaxMissedRounds (bakerInfoExs paydayBakers ^.. each . bakerIdentity)
+                    (bids, theState3) <-
+                        bsoPrimeForSuspension
+                            theState2
+                            _vspMaxMissedRounds
+                            (bakerInfoExs paydayBakers ^.. each . bakerIdentity)
                     let addOutcome :: UpdatableBlockState m -> BakerId -> m (UpdatableBlockState m)
                         addOutcome theState bid = do
                             -- The account must exist, since it is a validator, so this can't fail

--- a/concordium-consensus/src/Concordium/KonsensusV1/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Scheduler.hs
@@ -157,11 +157,11 @@ paydayHandleCooldowns = case sSupportsFlexibleCooldown (sAccountVersionFor (prot
 
 -- | Result of the epoch transition used for parameter passing.
 data EpochTransitionResult m = EpochTransitionResult
-    { -- If the epoch transition was a payday, this contains the payday
-      -- parameters.
+    { -- | If the epoch transition was a payday, this contains the payday
+      --  parameters.
       mPaydayParams :: Maybe (PaydayParameters (AccountVersionFor (MPV m))),
-      -- If the epoch transition was a snapshot, this contains the set of
-      -- validator ids that will be newly suspended.
+      -- | If the epoch transition was a snapshot, this contains the set of
+      --  validator ids that will be newly suspended.
       mSnapshotSuspendedIds :: Maybe (Set.Set BakerId)
     }
 

--- a/concordium-consensus/src/Concordium/KonsensusV1/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Scheduler.hs
@@ -376,6 +376,8 @@ doMintingP6 mintRate foundationAddr theState0 = do
             }
 
 -- | If a payday has elapsed, this mints and distributes rewards for the payday.
+--  If the protocol version >= 8, all validators of the past payday whose missed rounds
+--  exceed the threshold given in the chain parameters are primed for suspension.
 processPaydayRewards ::
     forall pv m.
     ( pv ~ MPV m,

--- a/concordium-consensus/src/Concordium/KonsensusV1/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Scheduler.hs
@@ -124,7 +124,7 @@ data PrologueResult m av = PrologueResult
       prologuePaydayParameters :: Maybe (PaydayParameters av),
       -- | If the block triggered an epoch transition and the new epoch is a
       --  snapshot, this field contains the validator ids that are newly suspended.
-      -- Otherwise, this is `Nothing`.
+      --  Otherwise, this is `Nothing`.
       prologueSuspendedBids :: Maybe (Set.Set BakerId)
     }
 

--- a/concordium-consensus/src/Concordium/Kontrol/Bakers.hs
+++ b/concordium-consensus/src/Concordium/Kontrol/Bakers.hs
@@ -211,7 +211,8 @@ computeBakerStakesAndCapital poolParams activeBakers passiveDelegators snapshotS
     passiveDelegatorsCapital = Vec.fromList $ delegatorCapital <$> passiveDelegators
     capitalDistribution = CapitalDistribution{..}
 
--- | Generate and set the next epoch bakers and next capital based on the current active bakers.
+-- | Generate and set the next epoch bakers and next capital based on the
+--  current active bakers. This assumes that no validators are suspended.
 generateNextBakers ::
     forall m.
     ( TreeStateMonad m,
@@ -221,10 +222,9 @@ generateNextBakers ::
     ) =>
     -- | The payday epoch
     Epoch ->
-    Set.Set BakerId ->
     UpdatableBlockState m ->
     m (UpdatableBlockState m)
-generateNextBakers paydayEpoch suspendedBids bs0 = do
+generateNextBakers paydayEpoch bs0 = do
     isEffective <- effectiveTest paydayEpoch
     -- Determine the bakers and delegators for the next reward period, accounting for any
     -- stake reductions that are currently pending on active bakers with effective time at
@@ -244,7 +244,7 @@ generateNextBakers paydayEpoch suspendedBids bs0 = do
                 (cps ^. cpPoolParameters)
                 activeBakers
                 passiveDelegators
-                suspendedBids
+                Set.empty
     bs1 <- bsoSetNextEpochBakers bs0 bakerStakes NoParam
     bsoSetNextCapitalDistribution bs1 capitalDistribution
 

--- a/concordium-consensus/src/Concordium/Kontrol/Bakers.hs
+++ b/concordium-consensus/src/Concordium/Kontrol/Bakers.hs
@@ -176,9 +176,15 @@ data BakerStakesAndCapital bakerInfoRef = BakerStakesAndCapital
 -- | Compute the baker stakes and capital distribution.
 computeBakerStakesAndCapital ::
     forall bakerInfoRef.
+    -- | Pool parameters
     PoolParameters' 'PoolParametersVersion1 ->
+    -- | Active validators
     [ActiveBakerInfo' bakerInfoRef] ->
+    -- | Passive delegators
     [ActiveDelegatorInfo] ->
+    -- | Validator ids that will be suspended during the snapshot transition
+    --  because they are primed, but are not yet marked as suspended in their
+    --  `ActiveBakerInfo`.
     Set.Set BakerId ->
     BakerStakesAndCapital bakerInfoRef
 computeBakerStakesAndCapital poolParams activeBakers passiveDelegators snapshotSuspendedBids = BakerStakesAndCapital{..}

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -919,6 +919,7 @@ getBlockPendingUpdates = liftSkovQueryStateBHI query
                 `merge` queueMapperOptional PUEMinBlockTime _pMinBlockTimeQueue
                 `merge` queueMapperOptional PUEBlockEnergyLimit _pBlockEnergyLimitQueue
                 `merge` queueMapperOptional PUEFinalizationCommitteeParameters _pFinalizationCommitteeParametersQueue
+                `merge` queueMapperOptional PUEValidatorScoreParameters _pValidatorScoreParametersQueue
           where
             cpv :: SChainParametersVersion cpv
             cpv = chainParametersVersion

--- a/concordium-consensus/src/Concordium/Scheduler/TreeStateEnvironment.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/TreeStateEnvironment.hs
@@ -20,6 +20,7 @@ import qualified Data.Map as Map
 import Data.Maybe
 import Data.Ratio
 import qualified Data.Sequence as Seq
+import qualified Data.Set as Set
 import Data.Time
 import qualified Data.Vector as Vec
 import Data.Word
@@ -1110,7 +1111,7 @@ updateBirkParameters newSeedState bs0 oldChainParameters updates = case protocol
                     processPaydays pd mrps0 bspp0 = do
                         bspp1 <-
                             if oldSeedState ^. epoch < pd - 1 && pd - 1 <= newSeedState ^. epoch
-                                then generateNextBakers pd bspp0
+                                then generateNextBakers pd Set.empty bspp0
                                 else return bspp0
                         if pd <= newSeedState ^. epoch
                             then do

--- a/concordium-consensus/src/Concordium/Scheduler/TreeStateEnvironment.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/TreeStateEnvironment.hs
@@ -20,7 +20,6 @@ import qualified Data.Map as Map
 import Data.Maybe
 import Data.Ratio
 import qualified Data.Sequence as Seq
-import qualified Data.Set as Set
 import Data.Time
 import qualified Data.Vector as Vec
 import Data.Word
@@ -1111,7 +1110,7 @@ updateBirkParameters newSeedState bs0 oldChainParameters updates = case protocol
                     processPaydays pd mrps0 bspp0 = do
                         bspp1 <-
                             if oldSeedState ^. epoch < pd - 1 && pd - 1 <= newSeedState ^. epoch
-                                then generateNextBakers pd Set.empty bspp0
+                                then generateNextBakers pd bspp0
                                 else return bspp0
                         if pd <= newSeedState ^. epoch
                             then do

--- a/concordium-consensus/tests/scheduler/SchedulerTests/KonsensusV1/EpochTransition.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/KonsensusV1/EpochTransition.hs
@@ -869,13 +869,13 @@ testPrimeForSuspension accountConfigs = runTestBlockState @P8 $ do
     let activeBakerIds0 = Map.keys bprd
     let missedRounds = Map.fromList $ zip activeBakerIds0 [1 ..]
     bs1 <- bsoUpdateMissedRounds bs0 missedRounds
-    (primedBakers, _bs2) <- bsoPrimeForSuspension bs1 0 activeBakerIds0
+    (primedBakers, _bs2) <- bsoPrimeForSuspension bs1 0
     liftIO $
         assertEqual
             "Current active bakers should be primed for suspension as expected"
             (Set.fromList activeBakerIds0)
             (Set.fromList primedBakers)
-    (primedBakers1, _bs2) <- bsoPrimeForSuspension bs1 5 activeBakerIds0
+    (primedBakers1, _bs2) <- bsoPrimeForSuspension bs1 5
     liftIO $
         assertEqual
             "Current active bakers should be primed for suspension as expected"
@@ -893,7 +893,7 @@ testSuspendPrimedNoPaydayNoSnapshot accountConfigs = runTestBlockState @P8 $ do
     let missedRounds = Map.fromList $ zip activeBakerIds0 [2 ..]
     bs1 <- bsoUpdateMissedRounds bs0 missedRounds
     -- The maximum missed rounds threshold in the dummy chain parameters is set to 1.
-    (_primedBakers1, bs2) <- bsoPrimeForSuspension bs1 1 activeBakerIds0
+    (_primedBakers1, bs2) <- bsoPrimeForSuspension bs1 1
     bs3 <- bsoSetPaydayEpoch bs2 (startEpoch + 10)
     (res1, _bs4) <- doEpochTransition True hour bs3
     liftIO $
@@ -913,7 +913,7 @@ testSuspendPrimedSnapshotOnly accountConfigs = runTestBlockState @P8 $ do
     let missedRounds = Map.fromList $ zip activeBakerIds0 [2 ..]
     bs1 <- bsoUpdateMissedRounds bs0 missedRounds
     -- The maximum missed rounds threshold in the dummy chain parameters is set to 1.
-    (primedBakers1, bs2) <- bsoPrimeForSuspension bs1 1 activeBakerIds0
+    (primedBakers1, bs2) <- bsoPrimeForSuspension bs1 1
     bs4 <- bsoSetPaydayEpoch bs2 (startEpoch + 2)
     (res, _bs5) <- doEpochTransition True hour bs4
     liftIO $
@@ -934,7 +934,7 @@ testSuspendPrimedSnapshotPaydayCombo accountConfigs = runTestBlockState @P8 $ do
     let missedRounds = Map.fromList $ zip activeBakerIds0 [2 ..]
     bs1 <- bsoUpdateMissedRounds bs0 missedRounds
     -- The maximum missed rounds threshold in the dummy chain parameters is set to 1.
-    (primedBakers1, bs2) <- bsoPrimeForSuspension bs1 1 activeBakerIds0
+    (primedBakers1, bs2) <- bsoPrimeForSuspension bs1 1
     bs4 <- bsoSetPaydayEpoch bs2 (startEpoch + 1)
     (EpochTransitionResult{..}, _bs5) <- doEpochTransition True hour bs4
     liftIO $

--- a/concordium-consensus/tests/scheduler/SchedulerTests/KonsensusV1/EpochTransition.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/KonsensusV1/EpochTransition.hs
@@ -897,10 +897,9 @@ testSuspendPrimedNoPaydayNoSnapshot accountConfigs = runTestBlockState @P8 $ do
     bs3 <- bsoSetPaydayEpoch bs2 (startEpoch + 10)
     (res1, _bs4) <- doEpochTransition True hour bs3
     liftIO $
-        assertEqual
+        assertBool
             "No validators are getting suspended if epoch transition is not at snapshot"
-            Nothing
-            (mSnapshotSuspendedIds res1)
+            (isNothing $ mSnapshotSuspendedIds res1)
   where
     hour = Duration 3_600_000
     startEpoch = 10
@@ -916,12 +915,12 @@ testSuspendPrimedSnapshotOnly accountConfigs = runTestBlockState @P8 $ do
     -- The maximum missed rounds threshold in the dummy chain parameters is set to 1.
     (primedBakers1, bs2) <- bsoPrimeForSuspension bs1 1 activeBakerIds0
     bs4 <- bsoSetPaydayEpoch bs2 (startEpoch + 2)
-    (res2, _bs5) <- doEpochTransition True hour bs4
+    (res, _bs5) <- doEpochTransition True hour bs4
     liftIO $
         assertEqual
             "Primed validators are suspended at snapshot"
             (Just $ Set.fromList primedBakers1)
-            (mSnapshotSuspendedIds res2)
+            (mSnapshotSuspendedIds res)
   where
     hour = Duration 3_600_000
     startEpoch = 10


### PR DESCRIPTION
## Purpose

This is the implementation of automatic suspension for validators that missed too many rounds. Suspension happens at snapshot, while priming new validators for suspension at payday.

We compute the to be suspended validators during epoch transition at snapshot before we prime validators for future suspension. This is to avoid priming and then immediately suspending validators when the length of the payday is one.

## Changes
- two block state operations: `bsoPrimeValidators` and `bsoSuspendValidators`
- automatic suspend logic in the scheduler
- change `computeBakerStakesAndCapital` to ignore newly suspended validators at snapshot
- a bit of boilerplate code for the chain parameters version 3 slipped in this PR
- tests
## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
