### PR TITLE
implement migratePersistentEpochBakers for P7->P8

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Bakers.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Bakers.hs
@@ -152,9 +152,11 @@ migratePersistentEpochBakers migration PersistentEpochBakers{..} = do
             StateMigrationParametersP2P3 -> NoParam
             StateMigrationParametersP3ToP4{} -> NoParam
             StateMigrationParametersP4ToP5 -> NoParam
-            (StateMigrationParametersP5ToP6 P6.StateMigrationData{..}) -> SomeParam $ P6.updateFinalizationCommitteeParameters migrationProtocolUpdateData
+            (StateMigrationParametersP5ToP6 P6.StateMigrationData{..}) ->
+                SomeParam $ P6.updateFinalizationCommitteeParameters migrationProtocolUpdateData
             StateMigrationParametersP6ToP7{} -> _bakerFinalizationCommitteeParameters
-            StateMigrationParametersP7ToP8{} -> error "TODO(drsk). github #1223. Implement migratePersistentEpochBakers p7 -> p8"
+            StateMigrationParametersP7ToP8{} ->
+                SomeParam $ unOParam $ _bakerFinalizationCommitteeParameters
     return
         PersistentEpochBakers
             { _bakerInfos = newBakerInfos,


### PR DESCRIPTION
## Purpose

Fixes #1223. Implements `migratePersistentEpochBakers` for P7 -> P8.
## Changes

See above.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
