### PR TITLE
Extend ValidatorAdd with a suspended field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Automatically suspend validators from the consensus that missed too many
   rounds in the previous payday.
 - Add support for suspend/resume to validator configuration updates.
+- Add support to add a validator in a suspended state.
 - Validators that are suspended are paused from participating in the consensus algorithm.
 - Add suspension info to `BakerPoolStatus` / `CurrentPaydayBakerPoolStatus` query results.
 - Add `GetConsensusDetailedStatus` gRPC endpoint for getting detailed information on the status

--- a/concordium-consensus/src/Concordium/GlobalState/BakerInfo.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BakerInfo.hs
@@ -219,8 +219,9 @@ data ValidatorAdd = ValidatorAdd
       -- | The metadata URL for the validator.
       vaMetadataURL :: !UrlText,
       -- | The commission rates for the validator.
-      vaCommissionRates :: !CommissionRates
-      -- TODO (drsk) Github issue #1246. Support suspend/resume for ValidatorAdd.
+      vaCommissionRates :: !CommissionRates,
+      -- | Whether the validator should be added as suspended.
+      vaSuspended :: !Bool
     }
     deriving (Eq, Show)
 

--- a/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
@@ -1084,8 +1084,15 @@ class (BlockStateQuery m) => BlockStateOperations m where
     --        (2) update the account's finalization reward commission rate to the the supplied value @frc@;
     --
     --        (3) append @BakerConfigureFinalizationRewardCommission frc@ to @events@.
+
+    --  7. (>= P8) If the suspended/resumed flag is set:
+
+    --        (1) Suspend/resume the validator according to the flag.
+
+    --        (2) Append @BakerConfigureSuspended@ or @BakerConfigureResumed@ accordingly to @events@.
     --
-    --  7. If the capital is supplied: if there is a pending change to the baker's capital, return
+    --
+    --  8. If the capital is supplied: if there is a pending change to the baker's capital, return
     --     @VCFChangePending@; otherwise:
     --
     --       * if the capital is 0
@@ -1120,12 +1127,6 @@ class (BlockStateQuery m) => BlockStateOperations m where
     --         @BakerConfigureStakeIncreased capital@ to @events@. From P7, the increase in stake
     --         is (preferentially) reactivated from the inactive stake, updating the global indices
     --         accordingly.
-    --
-    --  8. (>= P8) If the suspended/resumed flag is set:
-
-    --        (1) Suspend/resume the validator according to the flag.
-
-    --        (2) Append @BakerConfigureSuspended@ or @BakerConfigureResumed@ accordingly to @events@.
     --
     --  9. Return @events@ with the updated block state.
     bsoUpdateValidator ::

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -1632,7 +1632,7 @@ newAddValidator pbs ai va@ValidatorAdd{..} = do
             BaseAccounts.BakerInfoExV1
                 { _bieBakerPoolInfo = poolInfo,
                   _bieBakerInfo = bakerInfo,
-                  _bieIsSuspended = conditionally hasValidatorSuspension False
+                  _bieIsSuspended = conditionally hasValidatorSuspension vaSuspended
                 }
     -- The precondition guaranties that the account exists
     acc <- fromJust <$> Accounts.indexedAccount ai (bspAccounts bsp)

--- a/concordium-consensus/src/Concordium/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler.hs
@@ -2114,6 +2114,7 @@ handleConfigureBaker
             let vaCommissionRates = CommissionRates{..}
             vaOpenForDelegation <- cbOpenForDelegation
             vaMetadataURL <- cbMetadataURL
+            let vaSuspended = fromMaybe False cbSuspend
             return
                 CBCAdd
                     { cbcRemoveDelegator = removeDelegator,

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/ConfigureDelegator.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/ConfigureDelegator.hs
@@ -531,3 +531,6 @@ tests = parallel $ describe "Configure delegator" $ do
     describe "P7" $ do
         it "bsoAddDelegator" $ testAddDelegator SP7
         it "bsoUpdateDelegator" $ testUpdateDelegator SP7
+    describe "P8" $ do
+        it "bsoAddDelegator" $ testAddDelegator SP8
+        it "bsoUpdateDelegator" $ testUpdateDelegator SP8

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/ConfigureValidator.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/ConfigureValidator.hs
@@ -105,10 +105,12 @@ testAddValidatorAllCases ::
     Spec
 testAddValidatorAllCases spv = describe "bsoAddValidator" $ do
     forM_ validatorConditions $ \vc -> do
-        it (show vc) $ runTest False vc
-        when supportCooldown $ it (show vc <> " with cooldown") $ runTest True vc
+        it (show vc) $ runTest False False vc
+        when supportCooldown $ it (show vc <> " with cooldown") $ runTest True False vc
+        when supportSuspension $ it (show vc <> " with suspended validator") $ runTest True True vc
   where
     supportCooldown = supportsFlexibleCooldown $ accountVersionFor $ demoteProtocolVersion (protocolVersion @pv)
+    supportSuspension = supportsValidatorSuspension $ accountVersionFor $ demoteProtocolVersion (protocolVersion @pv)
     minEquity = 1_000_000_000
     chainParams =
         DummyData.dummyChainParameters @(ChainParametersVersionFor pv)
@@ -129,7 +131,7 @@ testAddValidatorAllCases spv = describe "bsoAddValidator" $ do
                 DummyData.dummyArs
                 (withIsAuthorizationsVersionForPV spv DummyData.dummyKeyCollection)
                 chainParams
-    runTest withCooldown ValidatorConditions{..} = runTestBlockState @pv $ do
+    runTest withCooldown suspended ValidatorConditions{..} = runTestBlockState @pv $ do
         let va =
                 ValidatorAdd
                     { vaKeys = if vcAggregationKeyDuplicate then badKeys else goodKeys,
@@ -143,7 +145,7 @@ testAddValidatorAllCases spv = describe "bsoAddValidator" $ do
                               _bakingCommission = makeAmountFraction $ if vcBakingRewardNotInRange then 100 else 500,
                               _transactionCommission = makeAmountFraction $ if vcTransactionFeeNotInRange then 300 else 100
                             },
-                      vaSuspended = False
+                      vaSuspended = suspended
                     }
         initialAccounts <- mapM makeDummyAccount (addValidatorTestAccounts withCooldown)
         initialBS <- mkInitialState initialAccounts
@@ -190,7 +192,7 @@ testAddValidatorAllCases spv = describe "bsoAddValidator" $ do
                                           _poolMetadataUrl = vaMetadataURL va,
                                           _poolCommissionRates = vaCommissionRates va
                                         },
-                                  _bieIsSuspended = conditionally (sSupportsValidatorSuspension (accountVersion @(AccountVersionFor pv))) False
+                                  _bieIsSuspended = conditionally (sSupportsValidatorSuspension (accountVersion @(AccountVersionFor pv))) suspended
                                 }
                         }
             bkr <- getAccountBaker (fromJust acc)
@@ -578,3 +580,7 @@ tests lvl = parallel $ describe "Validator" $ do
         testAddValidatorAllCases SP7
         testUpdateValidator SP7 (lvl > 1)
         testUpdateValidatorOverlappingCommissions SP7
+    describe "P8" $ do
+        testAddValidatorAllCases SP8
+        testUpdateValidator SP8 (lvl > 1)
+        testUpdateValidatorOverlappingCommissions SP8

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/ConfigureValidator.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/ConfigureValidator.hs
@@ -142,7 +142,8 @@ testAddValidatorAllCases spv = describe "bsoAddValidator" $ do
                             { _finalizationCommission = makeAmountFraction $ if vcFinalizationRewardNotInRange then 100 else 300,
                               _bakingCommission = makeAmountFraction $ if vcBakingRewardNotInRange then 100 else 500,
                               _transactionCommission = makeAmountFraction $ if vcTransactionFeeNotInRange then 300 else 100
-                            }
+                            },
+                      vaSuspended = False
                     }
         initialAccounts <- mapM makeDummyAccount (addValidatorTestAccounts withCooldown)
         initialBS <- mkInitialState initialAccounts

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/Updates.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/Updates.hs
@@ -143,7 +143,8 @@ addBakerWith am (bs, ai) = do
                         { _transactionCommission = makeAmountFraction 0,
                           _finalizationCommission = makeAmountFraction 0,
                           _bakingCommission = makeAmountFraction 0
-                        }
+                        },
+                  vaSuspended = False
                 }
     res <- bsoAddValidator bs ai conf
     return ((,ai) <$> res)


### PR DESCRIPTION
## Purpose

Closes #1246 . Validators can now be added already suspended.

## Changes

Extends the `ValidatorAdd` field with a new `vaSuspended` field.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
