### PR TITLE
extend BakerPoolStatus/PoolCurrentPayday info with suspension info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   rounds in the previous payday.
 - Add support for suspend/resume to validator configuration updates.
 - Validators that are suspended are paused from participating in the consensus algorithm.
+- Add suspension info to `BakerPoolStatus` / `CurrentPaydayBakerPoolStatus` query results.
 - Add `GetConsensusDetailedStatus` gRPC endpoint for getting detailed information on the status
   of the consensus, at consensus version 1.
 - Update Rust version to 1.82.

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -3362,9 +3362,9 @@ doGetPoolStatus pbs psBakerId@(BakerId aid) = case delegationChainParameters @pv
                                                 currentEpochBaker
                                                     ^. BaseAccounts.bieBakerPoolInfo
                                                         . BaseAccounts.poolCommissionRates,
-                                              bpsIsPrimedForSuspension = 
+                                              bpsIsPrimedForSuspension =
                                                 fromCondDef (fmap (Just . primedForSuspension) suspensionInfo) Nothing,
-                                              bpsMissedRounds = 
+                                              bpsMissedRounds =
                                                 fromCondDef (fmap (Just . missedRounds) suspensionInfo) Nothing
                                             },
                                       isSuspended

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -3346,7 +3346,7 @@ doGetPoolStatus pbs psBakerId@(BakerId aid) = case delegationChainParameters @pv
                                         ++ " is present in the current epoch bakers, but not \
                                            \the current epoch capital distribution."
                             Just (bc, BakerPoolRewardDetails{..}) -> do
-                                return $
+                                return
                                     ( Just
                                         CurrentPaydayBakerPoolStatus
                                             { bpsBlocksBaked = blockCount,

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -3331,10 +3331,12 @@ doGetPoolStatus pbs psBakerId@(BakerId aid) = case delegationChainParameters @pv
                     return $! ActiveBakerPoolStatus{..}
                 epochBakers <- refLoad (_birkCurrentEpochBakers $ bspBirkParameters bsp)
                 mepochBaker <- epochBaker psBakerId epochBakers
-                psCurrentPaydayStatus <- case mepochBaker of
-                    Nothing -> return Nothing
+                (psCurrentPaydayStatus, psIsSuspended) <- case mepochBaker of
+                    Nothing -> return (Nothing, Nothing)
                     Just (currentEpochBaker, effectiveStake) -> do
                         poolRewards <- refLoad (bspPoolRewards bsp)
+                        let isSuspended =
+                                fromCondDef (Just <$> BaseAccounts._bieIsSuspended currentEpochBaker) Nothing
                         mbcr <- lookupBakerCapitalAndRewardDetails psBakerId poolRewards
                         case mbcr of
                             Nothing ->
@@ -3345,7 +3347,7 @@ doGetPoolStatus pbs psBakerId@(BakerId aid) = case delegationChainParameters @pv
                                            \the current epoch capital distribution."
                             Just (bc, BakerPoolRewardDetails{..}) -> do
                                 return $
-                                    Just
+                                    ( Just
                                         CurrentPaydayBakerPoolStatus
                                             { bpsBlocksBaked = blockCount,
                                               bpsFinalizationLive = finalizationAwake,
@@ -3359,8 +3361,14 @@ doGetPoolStatus pbs psBakerId@(BakerId aid) = case delegationChainParameters @pv
                                               bpsCommissionRates =
                                                 currentEpochBaker
                                                     ^. BaseAccounts.bieBakerPoolInfo
-                                                        . BaseAccounts.poolCommissionRates
-                                            }
+                                                        . BaseAccounts.poolCommissionRates,
+                                              bpsIsPrimedForSuspension = 
+                                                fromCondDef (fmap (Just . primedForSuspension) suspensionInfo) Nothing,
+                                              bpsMissedRounds = 
+                                                fromCondDef (fmap (Just . missedRounds) suspensionInfo) Nothing
+                                            },
+                                      isSuspended
+                                    )
                 if isJust psActiveStatus || isJust psCurrentPaydayStatus
                     then return $ Just BakerPoolStatus{..}
                     else return Nothing


### PR DESCRIPTION
## Purpose

Extend BakerPoolStatus/PoolCurrentPayday info with suspension info. Depends on https://github.com/Concordium/concordium-grpc-api/pull/74 and https://github.com/Concordium/concordium-base/pull/587.

## Changes

See above

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
