### PR TITLE
Fix the computation of missed rounds on timeout.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Fix a bug in computing the number of missed rounds in the event of a timeout.
+
 ## 8.0.0
 
 - Add P7 -> P8 update.

--- a/concordium-consensus/src/Concordium/KonsensusV1/Consensus/Blocks.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Consensus/Blocks.hs
@@ -725,10 +725,10 @@ processBlock parent VerifiedBlock{vbBlock = pendingBlock, ..}
     checkBlockExecution GenesisMetadata{..} parentBF continue = do
         let missedRounds =
                 computeMissedRounds
+                    (blockQuorumCertificate pendingBlock)
                     (blockTimeoutCertificate pendingBlock)
                     (_bfBakers vbBakersAndFinalizers)
                     vbLeadershipElectionNonce
-                    (blockRound pendingBlock)
         let execData =
                 BlockExecutionData
                     { bedIsNewEpoch = blockEpoch pendingBlock == blockEpoch parent + 1,
@@ -1214,10 +1214,10 @@ bakeBlock BakeBlockInputs{..} = do
             Just bakers -> quorumCertificateSigningBakers (bakers ^. bfFinalizers) bbiQuorumCertificate
     let missedRounds =
             computeMissedRounds
+                bbiQuorumCertificate
                 bbiTimeoutCertificate
                 bbiEpochBakers
                 bbiLeadershipElectionNonce
-                bbiRound
     let executionData =
             BlockExecutionData
                 { bedIsNewEpoch = isPresent bbiEpochFinalizationEntry,

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/LeaderElectionTest.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/LeaderElectionTest.hs
@@ -55,6 +55,17 @@ dummyFullBakers =
     (Right bsk) = decode "\200\SI\250\177\231!\178\142\218\246\152u2\DC1D= b\208\132\245\137\133\206\FS\217)\246q\242\229\235"
     (Right bak) = decode "\x8e\xa8\x59\x44\x28\x81\xdd\xc9\x48\x91\xb1\x99\x3e\x5e\x5d\x18\x44\xe4\x2c\x31\xf1\xf2\x27\x1a\xb4\x50\xff\xb2\x7a\x17\x5b\x42\x39\xaa\xdf\x3c\x4f\xf0\x94\xec\x19\x6e\x5f\xb9\x4f\x73\x7b\x94\x0f\xfb\x0a\x73\x93\x59\x47\x76\xc7\xe6\x7a\x43\x35\x6d\x60\xc8\xf9\x25\x12\x1b\x3b\xf6\x23\xb9\xae\xcb\x4b\x50\xf3\xd9\xe2\xaf\x31\x21\xa1\xd3\xf0\xf8\x7e\xfe\x11\xc5\x83\xf3\x88\xe5\x42\x77"
 
+-- | A dummy `QuorumCertificate` used for testing. The only relevant field is the round.
+dummyQuorumCertificate :: Word64 -> QuorumCertificate
+dummyQuorumCertificate r =
+    QuorumCertificate
+        { qcBlock = BlockHash $ Hash.hash "block",
+          qcRound = Round r,
+          qcEpoch = 0,
+          qcAggregateSignature = mempty,
+          qcSignatories = emptyFinalizerSet
+        }
+
 -- | A dummy `TimeoutCertificate` used for testing.
 dummyTimeoutCertificate :: Word64 -> TimeoutCertificate
 dummyTimeoutCertificate r =
@@ -159,37 +170,37 @@ testComputeMissedRounds =
         it "no timeout" $
             Map.toList
                 ( computeMissedRounds
+                    (dummyQuorumCertificate 4)
                     Absent
                     dummyFullBakers
                     (read "ba3aba3b6c31fb6b0251a19c83666cd90da9a0835a2b54dc4f01c6d451ab24e8")
-                    6
                 )
                 `shouldBe` []
         it "timeout present, 1 missed round" $
             Map.toList
                 ( computeMissedRounds
+                    (dummyQuorumCertificate 4)
                     (Present $ dummyTimeoutCertificate 5)
                     dummyFullBakers
                     (read "ba3aba3b6c31fb6b0251a19c83666cd90da9a0835a2b54dc4f01c6d451ab24e8")
-                    6
                 )
                 `shouldBe` [(1, 1)]
         it "timeout present, 3 missed rounds" $
             Map.toList
                 ( computeMissedRounds
-                    (Present $ dummyTimeoutCertificate 5)
+                    (dummyQuorumCertificate 4)
+                    (Present $ dummyTimeoutCertificate 7)
                     dummyFullBakers
                     (read "ba3aba3b6c31fb6b0251a19c83666cd90da9a0835a2b54dc4f01c6d451ab24e8")
-                    8
                 )
                 `shouldBe` [(1, 2), (2, 1)]
         it "timeout present, 95 missed rounds" $
             Map.toList
                 ( computeMissedRounds
-                    (Present $ dummyTimeoutCertificate 5)
+                    (dummyQuorumCertificate 4)
+                    (Present $ dummyTimeoutCertificate 99)
                     dummyFullBakers
                     (read "ba3aba3b6c31fb6b0251a19c83666cd90da9a0835a2b54dc4f01c6d451ab24e8")
-                    100
                 )
                 `shouldBe` [(1, 46), (2, 49)]
 


### PR DESCRIPTION
## Purpose

Fix the computation of missed rounds on timeout.

## Changes

- Revise `computeMissedRounds` to use the QC and TC of a block to compute the missed rounds. The missed rounds will be from `qcRound + 1` to `tcRound` (inclusive) if the TC is present. (No missed rounds if the TC is absent.)

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
