### PR TITLE
Get suspended status from the active baker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Fix a bug where the suspended status of a baker pool would be omitted when it was suspended.
+
 ## 8.0.0
 
 - Add P7 -> P8 update.


### PR DESCRIPTION

## Purpose

Closes: https://github.com/Concordium/concordium-node/issues/1309
Depends on: https://github.com/Concordium/concordium-grpc-api/pull/76 https://github.com/Concordium/concordium-base/pull/590

## Changes

- Derive suspended status (in `doGetPoolStatus`) from the active baker status.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
