### PR TITLE
Bump version to 8.0.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+## 8.0.1
+
 - Fix a bug in computing the number of missed rounds in the event of a timeout.
 - Fix a bug where the suspended status of a baker pool would be omitted when it was suspended.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Fix a bug in computing the number of missed rounds in the event of a timeout.
 - Fix a bug where the suspended status of a baker pool would be omitted when it was suspended.
+- Fix a bug where `GetBlockChainParameters` returns a `ChainParametersV2` in cases where it should
+  return `ChainParametersV3`.
 
 ## 8.0.0
 

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_node"
-version = "8.0.0"
+version = "8.0.1"
 dependencies = [
  "anyhow",
  "app_dirs2",

--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium_node"
-version = "8.0.0" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
+version = "8.0.1" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
 description = "Concordium Node"
 authors = ["Concordium <developers@concordium.com>"]
 exclude = [".gitignore", ".gitlab-ci.yml", "test/**/*","**/**/.gitignore","**/**/.gitlab-ci.yml"]


### PR DESCRIPTION
## Purpose

Closes: https://github.com/Concordium/concordium-node/issues/1312

Fix a bug where `GetBlockChainParameters` returns a `ChainParametersV2` in cases where it should return `ChainParametersV3`.
Bump version to 8.0.1.


## Changes

- Update base (minor changes & bug fix).
- Update version.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
