### PR TITLE
Fix timing of payday after P7->P8 protocol update.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased changes
 
+## 8.0.2
+
+- Fix a bug where the P7->P8 protocol update affects payday timing.
+
 ## 8.0.1
 
 - Fix a bug in computing the number of missed rounds in the event of a timeout.

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -628,10 +628,10 @@ migrateBlockRewardDetails StateMigrationParametersP6ToP7{} _ _ (SomeParam TimePa
     (BlockRewardDetailsV1 hbr) ->
         BlockRewardDetailsV1
             <$> migrateHashedBufferedRef (migratePoolRewardsP6 oldEpoch _tpRewardPeriodLength) hbr
-migrateBlockRewardDetails StateMigrationParametersP7ToP8{} _ _ (SomeParam TimeParametersV1{..}) _ = \case
+migrateBlockRewardDetails StateMigrationParametersP7ToP8{} _ _ (SomeParam TimeParametersV1{..}) oldEpoch = \case
     (BlockRewardDetailsV1 hbr) ->
         BlockRewardDetailsV1
-            <$> migrateHashedBufferedRef (migratePoolRewards (rewardPeriodEpochs _tpRewardPeriodLength)) hbr
+            <$> migrateHashedBufferedRef (migratePoolRewardsP6 oldEpoch _tpRewardPeriodLength) hbr
 
 instance
     (MonadBlobStore m, IsBlockHashVersion bhv, IsAccountVersion av) =>

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_node"
-version = "8.0.1"
+version = "8.0.2"
 dependencies = [
  "anyhow",
  "app_dirs2",

--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium_node"
-version = "8.0.1" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
+version = "8.0.2" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
 description = "Concordium Node"
 authors = ["Concordium <developers@concordium.com>"]
 exclude = [".gitignore", ".gitlab-ci.yml", "test/**/*","**/**/.gitignore","**/**/.gitlab-ci.yml"]

--- a/docs/grpc2.md
+++ b/docs/grpc2.md
@@ -64,6 +64,7 @@ If these are enabled then the following options become available
   instance_state_lookup = true
   get_next_account_sequence_number = true
   get_consensus_info = true
+  get_consensus_detailed_status = true
   get_ancestors = true
   get_block_item_status = true
   invoke_instance = true


### PR DESCRIPTION
## Purpose

Closes #1317

Fix a bug where the P7->P8 protocol update affects payday timing.

## Changes

- Use `migratePoolRewardsP6` instead of `migratePoolRewards` in the P7->P8 migration. This is the version of the function that is intended to be used for consensus version 1, and ensures that payday timings are properly preserved.
- Update base (unrelated)
- Small documentation fix
- Bump version to 8.0.2

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
