### PR TITLE
Fix bug in calculation of absolute block height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased changes
 
+## 8.0.3
+
+- Fix a bug where, after a protocol update in consensus version 1 (P6 onwards), a node may
+  miscalculate the absolute height of blocks when it is restarted. (#1319)
+- Fix a bug where `GetBlockInfo` reports the parent block of a genesis block to be the last
+  finalized block of the previous genesis index, instead of the terminal block.
+
 ## 8.0.2
 
 - Fix a bug where the P7->P8 protocol update affects payday timing.

--- a/concordium-consensus/src/Concordium/KonsensusV1/SkovMonad.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/SkovMonad.hs
@@ -465,10 +465,9 @@ data ExistingSkov pv m = ExistingSkov
       esState :: !(SkovV1State pv),
       -- | The hash of the current genesis block.
       esGenesisHash :: !BlockHash,
-      -- | The (relative) height of the last finalized block.
-      esLastFinalizedHeight :: !BlockHeight,
-      -- | The effective protocol update if one has occurred.
-      esProtocolUpdate :: !(Maybe ProtocolUpdate)
+      -- | The effective protocol update if one has occurred, together with the relative
+      --  block height of the terminal block.
+      esProtocolUpdate :: !(Maybe (ProtocolUpdate, BlockHeight))
     }
 
 -- | Internal type used for deriving 'HasDatabaseHandlers' and 'LMDBAccountMap.HasDatabaseHandlers'
@@ -541,8 +540,6 @@ initialiseExistingSkovV1 genesisBlockHeightInfo bakerCtx handlerCtx unliftSkov g
                                           _notifiedProtocolUpdate = Nothing
                                         },
                                   esGenesisHash = initialSkovData ^. currentGenesisHash,
-                                  esLastFinalizedHeight =
-                                    blockHeight (initialSkovData ^. lastFinalized),
                                   esProtocolUpdate = effectiveProtocolUpdate
                                 }
                     return $ Just es

--- a/concordium-consensus/src/Concordium/MultiVersion.hs
+++ b/concordium-consensus/src/Concordium/MultiVersion.hs
@@ -1366,7 +1366,7 @@ startupSkov genesis = do
                                 activateConfiguration (newVersionV1 newEConfig)
                                 liftSkovV1Update newEConfig checkForProtocolUpdateV1
                         case esProtocolUpdate of
-                            Just protocolUpdate
+                            Just (protocolUpdate, terminalBlockHeight)
                                 | Right upd <- ProtocolUpdateV1.checkUpdate @pv protocolUpdate -> do
                                     let nextSPV = ProtocolUpdateV1.updateNextProtocolVersion upd
                                     -- A protocol update has occurred for this configuration, so
@@ -1377,7 +1377,7 @@ startupSkov genesis = do
                                         nextSPV
                                         activateThis
                                         (genIndex + 1)
-                                        (localToAbsoluteBlockHeight genHeight esLastFinalizedHeight + 1)
+                                        (localToAbsoluteBlockHeight genHeight terminalBlockHeight + 1)
                             _ -> do
                                 -- This is still the current configuration (i.e. no protocol update
                                 -- has occurred, or the protocol update is not supported), so

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_node"
-version = "8.0.2"
+version = "8.0.3"
 dependencies = [
  "anyhow",
  "app_dirs2",

--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium_node"
-version = "8.0.2" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
+version = "8.0.3" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
 description = "Concordium Node"
 authors = ["Concordium <developers@concordium.com>"]
 exclude = [".gitignore", ".gitlab-ci.yml", "test/**/*","**/**/.gitignore","**/**/.gitlab-ci.yml"]


### PR DESCRIPTION
## Purpose

Closes #1319

- Fix a bug where, after a protocol update in consensus version 1 (P6 onwards), a node may miscalculate the absolute height of blocks when it is restarted. (#1319)
- Fix a bug where `GetBlockInfo` reports the parent block of a genesis block to be the last finalized block of the previous genesis index, instead of the terminal block.

## Changes

- In `startupSkov`, use the terminal block instead of the last finalized block for calculating the height of a new genesis.
- Revise `loadSkovData` to return the height terminal block in the case of a protocol update. Update the `ExistingSkov` data structure to include this (and drop the height of the last finalized block).
- Revise `getBlockInfo` to use the terminal block as the parent of a genesis block.
- Bump version to 8.0.3

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
