### PR TITLE
NOD-525: Optimize PoolRewards with cached hashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased changes
+- Replace `BufferedRef` with `HashedBufferedRef` in `PoolRewards`
+  `bakerPoolRewardDetails::LFMBTree` field to cache computed hashes.
 
 ## 8.0.3
 

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/PoolRewards.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/PoolRewards.hs
@@ -55,7 +55,7 @@ data PoolRewards (bhv :: BlockHashVersion) (av :: AccountVersion) = PoolRewards
       currentCapital :: !(CapitalDistributionRef bhv),
       -- | The details of rewards accruing to baker pools.
       --  These are indexed by the index of the baker in the capital distribution (_not_ the BakerId).
-      bakerPoolRewardDetails :: !(LFMBT.LFMBTree Word64 BufferedRef (BakerPoolRewardDetails av)),
+      bakerPoolRewardDetails :: !(LFMBT.LFMBTree Word64 HashedBufferedRef (BakerPoolRewardDetails av)),
       -- | The transaction reward amount accruing to the passive delegators.
       passiveDelegationTransactionRewards :: !Amount,
       -- | The transaction reward fraction accruing to the foundation.
@@ -140,7 +140,7 @@ migratePoolRewardsP1 curBakers nextBakers blockCounts npEpoch npMintRate = do
                   passiveDelegatorsCapital = Vec.empty
                 }
     makeBakerCapital (bid, amt) = BakerCapital bid amt Vec.empty
-    makePRD :: (BakerId, a) -> m (BufferedRef (BakerPoolRewardDetails av))
+    makePRD :: (BakerId, a) -> m (HashedBufferedRef (BakerPoolRewardDetails av))
     makePRD (bid, _) = do
         let bprd =
                 BakerPoolRewardDetails


### PR DESCRIPTION
Replace BufferedRef with HashedBufferedRef in PoolRewards' bakerPoolRewardDetails  LFMBTree to cache computed hashes. This optimization eliminates redundant hash calculations previously performed for each block.

Technical details:
- Switched from BufferedRef to HashedBufferedRef
- Affects bakerPoolRewardDetails tree in PoolRewards data

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
