### PR TITLE
Be lazier when loading modules.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased changes
 
+- Improvements to the loading of modules. This particularly improves the performance of
+  `GetModuleSource` in certain cases, and can also reduce start-up time.
+
 ## 8.0.3
 
 - Fix a bug where, after a protocol update in consensus version 1 (P6 onwards), a node may


### PR DESCRIPTION
## Purpose

Closes #1325

This revises how the module table is loaded to avoid eagerly recompiling modules. While loading the modules does reconstruct the module map (from `ModuleRef`s to `ModuleIndex`es), it no longer fully loads each module to do so (which may incur the cost of recompiling the module, and also loads the module into the cache). Also, when querying the module source, we bypass recompiling the module and do not cache the module.

## Changes

- Introduce the `DirectBlobHashable` class. This provides one function `loadHash :: BlobRef a -> m h` that directly obtains a hash from a `BlobRef`. There is a blanket, overlappable implementation of this as `loadHash = getHashM <=< loadDirect`. This allows overlapping instances to be defined where there is a more efficient way to get the hash directly.
- Define an instance `DirectBlobHashable m Hash Module` that simply deserializes the module hash without loading the module (and potentially recompiling it).
- Factor `loadModuleDirect` out of the `loadDirect` implementation for `Module`. `loadModuleDirect` loads the module, but will not recompile it (as might be necessary to use the artifact). `loadDirect` will recompile if necessary.
- Define `openHashedCachedRef` that will return the value stored at the reference if it is in memory/cached, and otherwise return the `BlobRef` for it.
- Revise `getSource` to use `openHashedCachedRef` and `loadModuleDirect` to bypass recompiling the module.
- Define `mfoldRef` on `LFMBTree` to allow folding over the leaf references of the tree.
- Revise `load` for `HashedCachedRef` to use `loadHash` instead of loading and caching the value at the reference.
- Revise `load` for `Modules` to build the module map by using `mfoldRef` over the table and `getHashM` on the `HashedCachedRef`s in the leaves. This avoids loading the full module and only loads the hash.

Note, the change to the way `load` works for `HashedCachedRef` has implications for the accounts table. Specifically, when the account table fully loaded into memory, it won't cache each account.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
