### PR TITLE
Correctly construct account difference map for certified blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
 ## Unreleased changes
+
 - Replace `BufferedRef` with `HashedBufferedRef` in `PoolRewards`
   `bakerPoolRewardDetails::LFMBTree` field to cache computed hashes.
-
 - Improvements to the loading of modules. This particularly improves the performance of
   `GetModuleSource` in certain cases, and can also reduce start-up time.
+- Fix a bug that affects setting up the account map correctly for non-finalized certified blocks
+  that contain account creations (#1329).
 
 ## 8.0.3
 

--- a/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
@@ -1608,6 +1608,8 @@ class (BlockStateOperations m, FixedSizeSerialization (BlockStateRef m)) => Bloc
     --
     --  Preconditions:
     --  * This function MUST only be called on a certified block.
+    --  * The block state MUST already be cached (with 'cacheBlockState'). Otherwise the update to
+    --    the difference map may not be retained.
     --  * This function MUST only be called on a block state that does not already
     --    have a difference map.
     --  * The provided list of accounts MUST correspond to the accounts created in the block,

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Accounts.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Accounts.hs
@@ -173,7 +173,7 @@ mkNewChildDifferenceMap accts@Accounts{..} = do
     return accts{accountDiffMapRef = newDiffMapRef}
 
 -- | Create and set the 'DiffMap.DifferenceMap' for the provided @Accounts pv@.
---  This function constructs the difference map for the block such that the assoicated difference map
+--  This function constructs the difference map for the block such that the associated difference map
 --  and lmdb backed account map are consistent with the account table.
 --
 --  The function is highly unsafe and can cause state invariant failures if not all of the


### PR DESCRIPTION
## Purpose

Closes #1329 

This fixes a bug where the account difference map for certified blocks that contain account credential deployments is incorrect. The problem was caused by the fact that the block state was not cached before the account difference map was constructed. This meant that, while the difference map was reconstructed, it was dropped, since before caching only a `BlobRef` is held for the block state. By caching first, the `BlockStatePointers` are loaded into memory, which ensures that subsequent reads will use the same pointer for the account difference map.

## Changes

- In `loadCertifiedBlocks`, ensure that `cacheBlockState` is called before `reconstructAccountDifferenceMap`.
- Add a check that the account difference map is constructed correctly.
- Refine the documentation of `reconstructAccountDifferenceMap`.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
