### PR TITLE
Use an LMDB-backed module map.

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -166,7 +166,7 @@ jobs:
         components: clippy
         target: x86_64-pc-windows-gnu
     - name: Cache cargo dependencies and targets
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry
@@ -190,7 +190,7 @@ jobs:
 
     - name: Cache stack global package DB
       id: stack-global
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.stack
         key: ${{ runner.os }}-${{ env.dummy }}-stack-global-${{ matrix.plan.ghc }}-${{ hashFiles('**.yaml') }}
@@ -198,14 +198,14 @@ jobs:
           ${{ runner.os }}-${{ env.dummy }}-stack-global-${{ matrix.plan.ghc }}
     - name: Cache stack-installed programs in '~/.local/bin'
       id: stack-programs
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.local/bin
         key: ${{ runner.os }}-${{ env.dummy }}-stack-programs-${{ matrix.plan.ghc }}-${{ hashFiles('**.yaml') }}
         restore-keys: |
           ${{ runner.os }}-${{ env.dummy }}-stack-programs-${{ matrix.plan.ghc }}
     - name: Cache '.stack-work'
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           .stack-work

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   `bakerPoolRewardDetails::LFMBTree` field to cache computed hashes.
 - Improvements to the loading of modules. This particularly improves the performance of
   `GetModuleSource` in certain cases, and can also reduce start-up time.
+- Use a persistent LMDB-backed store to track the finalized module map.
 - Fix a bug that affects setting up the account map correctly for non-finalized certified blocks
   that contain account creations (#1329).
 

--- a/concordium-consensus/src/Concordium/GlobalState/AccountMap/DifferenceMap.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/AccountMap/DifferenceMap.hs
@@ -207,11 +207,7 @@ refInsertFresh k v ref = liftIO $ do
 --  PRECONDITION: The provided 'AccountAddress' MUST be the canonical address, and MUST NOT
 --  be present in the difference map.
 insertFreshAccount :: AccountAddress -> AccountIndex -> AccountDifferenceMap -> AccountDifferenceMap
-insertFreshAccount addr accIndex m =
-    m
-        { dmMap = HM.insert (accountAddressEmbed addr) (accIndex, addr) $ dmMap m,
-          dmMapSize = dmMapSize m + 1
-        }
+insertFreshAccount addr accIndex = insertFresh (accountAddressEmbed addr) (accIndex, addr)
 
 -- | Create an 'AccountDifferenceMap' with the provided parent and list of account addresses and account indices.
 fromAccountList :: IORef (Option AccountDifferenceMap) -> [(AccountAddress, AccountIndex)] -> AccountDifferenceMap

--- a/concordium-consensus/src/Concordium/GlobalState/AccountMap/DifferenceMap.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/AccountMap/DifferenceMap.hs
@@ -15,17 +15,29 @@ module Concordium.GlobalState.AccountMap.DifferenceMap (
     newEmptyReference,
     flatten,
     empty,
+    lookup,
+    refLookup,
+    insertFresh,
+    refInsertFresh,
     fromList,
-    insert,
-    lookupViaEquivalenceClass,
-    lookupExact,
     clearReferences,
+
+    -- * Account specific
+    AccountDifferenceMap,
+    AccountDifferenceMapReference,
+    lookupAccountEquiv,
+    lookupAccountExact,
+    flattenAccounts,
+    insertFreshAccount,
+    fromAccountList,
 ) where
 
 import Control.Monad.IO.Class
 import qualified Data.HashMap.Strict as HM
+import Data.Hashable
 import Data.IORef
 import Data.Tuple (swap)
+import Data.Word
 import Prelude hiding (lookup)
 
 import Concordium.Types
@@ -37,32 +49,36 @@ import Concordium.Types.Option (Option (..))
 --
 --  The 'IORef' enables us to clear any child difference maps
 --  when a block is finalized.
-type DifferenceMapReference = IORef (Option DifferenceMap)
+type DifferenceMapReference k v = IORef (Option (DifferenceMap k v))
 
 -- | Create a new empty reference.
-newEmptyReference :: (MonadIO m) => m DifferenceMapReference
+newEmptyReference :: (MonadIO m) => m (DifferenceMapReference k v)
 newEmptyReference = liftIO $ newIORef Absent
 
--- | A difference map that indicates newly added accounts for
---  a block identified by a 'BlockHash' and its associated 'BlockHeight'.
---  The difference map only contains accounts that were added since the '_dmParentMapRef'.
-data DifferenceMap = DifferenceMap
-    { -- | Accounts added in a block keyed by their equivalence class and
-      --  the @AccountIndex@ and canonical account adddress as values.
-      dmAccounts :: !(HM.HashMap AccountAddressEq (AccountIndex, AccountAddress)),
+-- | A difference map that indicates newly added map entries for
+--  a block that has not yet been finalized.
+--  @dmMap@ only contains accounts that were added since the 'dmParentMapRef'.
+data DifferenceMap k v = DifferenceMap
+    { -- | The map of entries added in the current block.
+      dmMap :: !(HM.HashMap k v),
+      -- | The size of 'dmMap'. This is maintained as computing @HM.size@ is O(n).
+      --
+      --  prop> dmMapSize = HM.size dmMap
+      dmMapSize :: !Word64,
       -- | Parent map of non-finalized blocks.
       --  In other words, if the parent block is finalized,
-      --  then the parent map is @Absent@ as the LMDB account map
-      --  should be consulted instead.
-      dmParentMapRef :: !DifferenceMapReference
+      --  then the parent map is @Absent@ as the persistent (LMDB) map should be consulted instead.
+      dmParentMapRef :: !(DifferenceMapReference k v)
     }
     deriving (Eq)
 
--- | Gather all accounts from the provided 'DifferenceMap' and its parent maps.
---  Accounts are returned in ascending order of their 'AccountAddress'.
+type AccountDifferenceMapReference = DifferenceMapReference AccountAddressEq (AccountIndex, AccountAddress)
+type AccountDifferenceMap = DifferenceMap AccountAddressEq (AccountIndex, AccountAddress)
+
+-- | Gather all entries from the provided 'DifferenceMap' and its parent maps.
 --
 --  Note. This function does not guarantee the order of the returned pairs.
-flatten :: (MonadIO m) => DifferenceMap -> m [(AccountAddress, AccountIndex)]
+flatten :: (MonadIO m) => DifferenceMap k v -> m [(k, v)]
 flatten dmap = go dmap []
   where
     go diffMap !accum = do
@@ -71,32 +87,48 @@ flatten dmap = go dmap []
             Absent -> return collectedAccounts
             Present parentMap -> go parentMap collectedAccounts
       where
-        collectedAccounts = map swap (HM.elems $ dmAccounts diffMap) <> accum
+        collectedAccounts = HM.toList (dmMap diffMap) <> accum
+
+-- | Gather all accounts from the provided 'AccountDifferenceMap' and its parent maps.
+--
+--  Note. This function does not guarantee the order of the returned pairs.
+flattenAccounts :: (MonadIO m) => AccountDifferenceMap -> m [(AccountAddress, AccountIndex)]
+flattenAccounts = fmap (map (swap . snd)) . flatten
 
 -- | Create a new empty 'DifferenceMap' potentially based on the difference map of
 -- the parent.
-empty :: DifferenceMapReference -> DifferenceMap
+empty :: DifferenceMapReference k v -> DifferenceMap k v
 empty mParentDifferenceMap =
     DifferenceMap
-        { dmAccounts = HM.empty,
+        { dmMap = HM.empty,
+          dmMapSize = 0,
           dmParentMapRef = mParentDifferenceMap
         }
 
--- | Internal helper function for looking up an entry in @dmAccounts@.
---  Returns @Right AccountIndex AccountAddress Word64@ if the account could be looked up,
---  and otherwise @Left Word64@, where the number indicates how many accounts are present in the difference map
---  and potentially any parent difference maps.
-lookupViaEquivalenceClass' :: (MonadIO m) => AccountAddressEq -> DifferenceMap -> m (Either Int (AccountIndex, AccountAddress))
-lookupViaEquivalenceClass' addr = check 0
+-- | Lookup an entry in the difference map or any of the parent difference maps.
+--  Returns @Right v@ if the account could be looked up, and otherwise @Left n@,
+--  where @n@ is the number of entries in the difference map and any parent difference maps.
+lookup :: (MonadIO m, Hashable k) => k -> DifferenceMap k v -> m (Either Word64 v)
+lookup addr = check 0
   where
-    check !accum diffMap = case HM.lookup addr (dmAccounts diffMap) of
+    check !accum diffMap = case HM.lookup addr (dmMap diffMap) of
         Nothing -> do
             mParentMap <- liftIO $ readIORef (dmParentMapRef diffMap)
-            let !accum' = accum + HM.size (dmAccounts diffMap)
+            let !accum' = accum + dmMapSize diffMap
             case mParentMap of
                 Absent -> return $ Left accum'
                 Present parentMap -> check accum' parentMap
         Just res -> return $ Right res
+
+-- | Lookup an entry in the difference map reference or any of the parent difference maps.
+--  Returns @Right v@ if the account could be looked up, and otherwise @Left n@,
+--  where @n@ is the number of entries in the difference map and any parent difference maps.
+refLookup :: (MonadIO m, Hashable k) => k -> DifferenceMapReference k v -> m (Either Word64 v)
+refLookup addr ref = do
+    oDiffMap <- liftIO $ readIORef ref
+    case oDiffMap of
+        Absent -> return $ Left 0
+        Present diffMap -> lookup addr diffMap
 
 -- | Lookup an account in the difference map or any of the parent
 --  difference maps using the account address equivalence class.
@@ -106,8 +138,8 @@ lookupViaEquivalenceClass' addr = check 0
 --  Precondition: As this implementation uses the 'AccountAddressEq' equivalence
 --  class for looking up an 'AccountIndex', then it MUST only be used
 --  when account aliases are supported.
-lookupViaEquivalenceClass :: (MonadIO m) => AccountAddressEq -> DifferenceMap -> m (Either Int AccountIndex)
-lookupViaEquivalenceClass addr dm = fmap fst <$> lookupViaEquivalenceClass' addr dm
+lookupAccountEquiv :: (MonadIO m) => AccountAddressEq -> AccountDifferenceMap -> m (Either Word64 AccountIndex)
+lookupAccountEquiv addr dm = fmap fst <$> lookup addr dm
 
 -- | Lookup an account in the difference map or any of the parent
 --  difference maps via an exactness check.
@@ -116,9 +148,9 @@ lookupViaEquivalenceClass addr dm = fmap fst <$> lookupViaEquivalenceClass' addr
 --  difference map(s).
 --  Note that this function also returns @Nothing@ if the provided 'AccountAddress'
 --  is an alias but not the canonical address.
-lookupExact :: (MonadIO m) => AccountAddress -> DifferenceMap -> m (Either Int AccountIndex)
-lookupExact addr diffMap =
-    lookupViaEquivalenceClass' (accountAddressEmbed addr) diffMap >>= \case
+lookupAccountExact :: (MonadIO m) => AccountAddress -> AccountDifferenceMap -> m (Either Word64 AccountIndex)
+lookupAccountExact addr diffMap =
+    lookup (accountAddressEmbed addr) diffMap >>= \case
         Left noAccounts -> return $ Left noAccounts
         Right (accIdx, actualAddr) ->
             if actualAddr == addr
@@ -128,28 +160,63 @@ lookupExact addr diffMap =
                     -- hence the extra flatten here justifies the simpler implementation and optimization
                     -- towards the normal use case.
                     size <- length <$> flatten diffMap
-                    return $ Left size
+                    return $ Left $ fromIntegral size
+
+-- | Insert a fresh key-value pair into the difference map.
+--
+--  PRECONDITION: The provided key MUST NOT be present in the difference map.
+insertFresh :: (Hashable k) => k -> v -> DifferenceMap k v -> DifferenceMap k v
+insertFresh k v m =
+    m
+        { dmMap = HM.insert k v $ dmMap m,
+          dmMapSize = dmMapSize m + 1
+        }
+
+-- | Insert a fresh key-value pair into the difference map reference.
+--
+--  PRECONDITION: The provided key MUST NOT be present in the difference map.
+refInsertFresh :: (Hashable k, MonadIO m) => k -> v -> DifferenceMapReference k v -> m ()
+refInsertFresh k v ref = liftIO $ do
+    readIORef ref >>= \case
+        Absent -> do
+            newRef <- newIORef Absent
+            atomicWriteIORef ref $ Present $ insertFresh k v (empty newRef)
+        Present diffMap -> atomicWriteIORef ref $ Present $ insertFresh k v diffMap
 
 -- | Insert an account into the difference map.
 --  Note that it is up to the caller to ensure only the canonical 'AccountAddress' is inserted.
-insert :: AccountAddress -> AccountIndex -> DifferenceMap -> DifferenceMap
-insert addr accIndex m = m{dmAccounts = HM.insert (accountAddressEmbed addr) (accIndex, addr) $ dmAccounts m}
-
--- | Create a 'DifferenceMap' with the provided parent and list of account addresses and account indices.
-fromList :: IORef (Option DifferenceMap) -> [(AccountAddress, AccountIndex)] -> DifferenceMap
-fromList parentRef listOfAccountsAndIndices =
-    DifferenceMap
-        { dmAccounts = HM.fromList $ map mkKeyVal listOfAccountsAndIndices,
-          dmParentMapRef = parentRef
+--
+--  PRECONDITION: The provided 'AccountAddress' MUST be the canonical address, and MUST NOT
+--  be present in the difference map.
+insertFreshAccount :: AccountAddress -> AccountIndex -> AccountDifferenceMap -> AccountDifferenceMap
+insertFreshAccount addr accIndex m =
+    m
+        { dmMap = HM.insert (accountAddressEmbed addr) (accIndex, addr) $ dmMap m,
+          dmMapSize = dmMapSize m + 1
         }
+
+-- | Create an 'AccountDifferenceMap' with the provided parent and list of account addresses and account indices.
+fromAccountList :: IORef (Option AccountDifferenceMap) -> [(AccountAddress, AccountIndex)] -> AccountDifferenceMap
+fromAccountList parentRef = fromList parentRef . map mkKeyVal
   where
     -- Make a key value pair to put in the @dmAccounts@.
     mkKeyVal (accAddr, accIdx) = (accountAddressEmbed accAddr, (accIdx, accAddr))
 
+-- | Create a 'DifferenceMap' with the provided parent and list of key-value pairs.
+fromList :: (Hashable k) => DifferenceMapReference k v -> [(k, v)] -> DifferenceMap k v
+fromList parentRef keyValList =
+    DifferenceMap
+        { dmMap = theMap,
+          dmMapSize = fromIntegral $ HM.size theMap,
+          dmParentMapRef = parentRef
+        }
+  where
+    theMap = HM.fromList keyValList
+
 -- | Clear the reference to the parent difference map (if any).
 --  Note that if there is a parent map then this function clears the remaining parent references
 --  recursively.
-clearReferences :: (MonadIO m) => DifferenceMap -> m ()
+clearReferences :: (MonadIO m) => DifferenceMap k v -> m ()
 clearReferences DifferenceMap{..} = do
     oParentDiffMap <- liftIO $ readIORef dmParentMapRef
     case oParentDiffMap of

--- a/concordium-consensus/src/Concordium/GlobalState/AccountMap/DifferenceMap.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/AccountMap/DifferenceMap.hs
@@ -15,6 +15,7 @@ module Concordium.GlobalState.AccountMap.DifferenceMap (
     newEmptyReference,
     flatten,
     empty,
+    newChildReference,
     lookup,
     refLookup,
     insertFresh,
@@ -104,6 +105,12 @@ empty mParentDifferenceMap =
           dmMapSize = 0,
           dmParentMapRef = mParentDifferenceMap
         }
+
+-- | Create a new 'DifferenceMapReference' that is a child of the provided difference map reference.
+--  The new child difference map is empty, but inherits via reference from the parent
+--  difference map.
+newChildReference :: (MonadIO m) => DifferenceMapReference k v -> m (DifferenceMapReference k v)
+newChildReference = liftIO . newIORef . Present . empty
 
 -- | Lookup an entry in the difference map or any of the parent difference maps.
 --  Returns @Right v@ if the account could be looked up, and otherwise @Left n@,

--- a/concordium-consensus/src/Concordium/GlobalState/AccountMap/LMDB.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/AccountMap/LMDB.hs
@@ -125,20 +125,7 @@ instance (Monad (t m), MonadTrans t, MonadAccountMapStore m) => MonadAccountMapS
 deriving via (MGSTrans (StateT s) m) instance (MonadAccountMapStore m) => MonadAccountMapStore (StateT s m)
 deriving via (MGSTrans (ExceptT e) m) instance (MonadAccountMapStore m) => MonadAccountMapStore (ExceptT e m)
 deriving via (MGSTrans (WriterT w) m) instance (Monoid w, MonadAccountMapStore m) => MonadAccountMapStore (WriterT w m)
-
-instance (MonadAccountMapStore m) => MonadAccountMapStore (PutT m) where
-    insertAccounts accs = lift $ insertAccounts accs
-    lookupAccountIndexViaEquivalence = lift . lookupAccountIndexViaEquivalence
-    lookupAccountIndexViaExactness = lift . lookupAccountIndexViaExactness
-    getAllAccounts = lift . getAllAccounts
-    getNumberOfAccounts = lift getNumberOfAccounts
-    reconstruct = lift . reconstruct
-    {-# INLINE insertAccounts #-}
-    {-# INLINE lookupAccountIndexViaEquivalence #-}
-    {-# INLINE lookupAccountIndexViaExactness #-}
-    {-# INLINE getAllAccounts #-}
-    {-# INLINE getNumberOfAccounts #-}
-    {-# INLINE reconstruct #-}
+deriving via (MGSTrans PutT m) instance (MonadAccountMapStore m) => MonadAccountMapStore (PutT m)
 
 -- * Database stores
 

--- a/concordium-consensus/src/Concordium/GlobalState/AccountMap/LMDB.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/AccountMap/LMDB.hs
@@ -29,6 +29,9 @@
 --  whenever the node starts up and the account map is not populated, then it will be
 --  initialized on startup via the existing ‘PersistentAccountMap’.
 --
+--  The account map database also stores the module map, which maps module references
+--  to their corresponding module indices.
+--
 --  Invariants:
 --      * Only accounts that are in finalized blocks are present in the ‘AccountMap’
 module Concordium.GlobalState.AccountMap.LMDB where
@@ -51,6 +54,7 @@ import Database.LMDB.Raw
 import Lens.Micro.Platform
 import System.Directory
 
+import qualified Concordium.GlobalState.AccountMap.ModuleMap as ModuleMap
 import Concordium.GlobalState.Classes
 import Concordium.GlobalState.LMDB.Helpers
 import Concordium.Logger
@@ -149,21 +153,33 @@ instance MDBDatabase AccountMapStore where
     type DBKey AccountMapStore = AccountAddress
     type DBValue AccountMapStore = AccountIndex
 
+-- | Store that retains the module reference -> module index mappings.
+newtype ModuleMapStore = ModuleMapStore MDB_dbi'
+
+-- | Name of the table used for storing the map from module references to module indices.
+moduleMapStoreName :: String
+moduleMapStoreName = "moduleMap"
+
+instance MDBDatabase ModuleMapStore where
+    type DBKey ModuleMapStore = ModuleRef
+    type DBValue ModuleMapStore = ModuleMap.ModuleIndex
+
 -- | Datbase handlers to interact with the account map lmdb
 --  database. Create via 'makeDatabasehandlers'.
 data DatabaseHandlers = DatabaseHandlers
     { -- | The underlying lmdb store environment.
       _dbhStoreEnv :: !StoreEnv,
-      -- | The only store for this lmdb database.
-      --  The account map functions as a persistent @AccountAddress -> Maybe AccountIndex@ mapping.
-      _dbhAccountMapStore :: !AccountMapStore
+      -- | The account map functions as a persistent @AccountAddress -> Maybe AccountIndex@ mapping.
+      _dbhAccountMapStore :: !AccountMapStore,
+      -- | The module map functions as a persistent @ModuleRef -> Maybe ModuleIndex@ mapping.
+      _dbhModuleMapStore :: !ModuleMapStore
     }
 
 makeClassy ''DatabaseHandlers
 
 -- | The number of stores in the LMDB environment for 'DatabaseHandlers'.
 databaseCount :: Int
-databaseCount = 1
+databaseCount = 2
 
 -- | Database growth size increment.
 --  This is currently set at 4MB, and must be a multiple of the page size.
@@ -197,6 +213,12 @@ makeDatabaseHandlers accountMapDir readOnly = do
                 <$> mdb_dbi_open'
                     txn
                     (Just accountMapStoreName)
+                    [MDB_CREATE | not readOnly]
+        _dbhModuleMapStore <-
+            ModuleMapStore
+                <$> mdb_dbi_open'
+                    txn
+                    (Just moduleMapStoreName)
                     [MDB_CREATE | not readOnly]
         return DatabaseHandlers{..}
 
@@ -287,3 +309,47 @@ instance
             deleteAll txn (dbh ^. dbhAccountMapStore)
             forM_ accounts $ \(accAddr, accIndex) -> do
                 storeRecord txn (dbh ^. dbhAccountMapStore) accAddr accIndex
+
+instance
+    ( MonadReader r m,
+      HasDatabaseHandlers r,
+      MonadIO m,
+      MonadLogger m
+    ) =>
+    ModuleMap.MonadModuleMapStore (AccountMapStoreMonad m)
+    where
+    insertModules mods = do
+        dbh <- ask
+        asWriteTransaction (dbh ^. dbhStoreEnv) $ \txn -> do
+            forM_ mods $ \(modRef, modIndex) -> do
+                storeRecord txn (dbh ^. dbhModuleMapStore) modRef modIndex
+
+    lookupModuleIndex modRef = do
+        dbh <- ask
+        asReadTransaction (dbh ^. dbhStoreEnv) $ \txn ->
+            loadRecord txn (dbh ^. dbhModuleMapStore) modRef
+
+    getAllModules maxModuleIndex = do
+        dbh <- ask
+        asReadTransaction (dbh ^. dbhStoreEnv) $ \txn ->
+            withCursor txn (dbh ^. dbhModuleMapStore) $ \cursor ->
+                let go !accum Nothing = return accum
+                    go !accum (Just (Right mdl@(_, modIdx))) = do
+                        -- We only accumulate modules which have an @ModuleIndex@ at most
+                        -- the provided one.
+                        if modIdx <= maxModuleIndex
+                            then go (mdl : accum) =<< getCursor CursorNext cursor
+                            else go accum =<< getCursor CursorNext cursor
+                    go _ (Just (Left err)) = throwM $ DatabaseInvariantViolation err
+                in  go [] =<< getCursor CursorFirst cursor
+
+    getNumberOfModules = do
+        dbh <- ask
+        asReadTransaction (dbh ^. dbhStoreEnv) $ \txn -> databaseSize txn (dbh ^. dbhModuleMapStore)
+
+    reconstruct mods = do
+        dbh <- ask
+        asWriteTransaction (dbh ^. dbhStoreEnv) $ \txn -> do
+            deleteAll txn (dbh ^. dbhModuleMapStore)
+            forM_ mods $ \(modRef, modIndex) -> do
+                storeRecord txn (dbh ^. dbhModuleMapStore) modRef modIndex

--- a/concordium-consensus/src/Concordium/GlobalState/AccountMap/ModuleMap.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/AccountMap/ModuleMap.hs
@@ -87,15 +87,7 @@ deriving via
     (MGSTrans (ReaderT w) m)
     instance
         (MonadModuleMapStore m) => MonadModuleMapStore (ReaderT w m)
-
-instance (MonadModuleMapStore m) => MonadModuleMapStore (PutT m) where
-    insertModules mods = lift $ insertModules mods
-    lookupModuleIndex = lift . lookupModuleIndex
-    getAllModules = lift . getAllModules
-    getNumberOfModules = lift getNumberOfModules
-    reconstruct = lift . reconstruct
-    {-# INLINE insertModules #-}
-    {-# INLINE lookupModuleIndex #-}
-    {-# INLINE getAllModules #-}
-    {-# INLINE getNumberOfModules #-}
-    {-# INLINE reconstruct #-}
+deriving via
+    (MGSTrans PutT m)
+    instance
+        (MonadModuleMapStore m) => MonadModuleMapStore (PutT m)

--- a/concordium-consensus/src/Concordium/GlobalState/AccountMap/ModuleMap.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/AccountMap/ModuleMap.hs
@@ -1,6 +1,12 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE StandaloneDeriving #-}
 
+-- | This module defines types and interfaces for the module map, which maps module references to
+--  module indices. In particular, it defines the 'MonadModuleMapStore' class, which provides
+--  operations for inserting and looking up modules in the LMDB-persisted module map, representing
+--  the finalized modules. Additionally, it defines the 'ModuleDifferenceMapReference' type, which
+--  is used to record the mapping from module references to module indices for modules added since
+--  the last finalized block.
 module Concordium.GlobalState.AccountMap.ModuleMap where
 
 import Control.Monad.Reader

--- a/concordium-consensus/src/Concordium/GlobalState/AccountMap/ModuleMap.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/AccountMap/ModuleMap.hs
@@ -1,0 +1,95 @@
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+module Concordium.GlobalState.AccountMap.ModuleMap where
+
+import Control.Monad.Reader
+import Control.Monad.State.Strict
+import Control.Monad.Trans.Except
+import Control.Monad.Trans.Writer.Strict
+import Data.Word
+
+import Concordium.Types
+import Concordium.Utils.Serialization.Put
+
+import qualified Concordium.GlobalState.AccountMap.DifferenceMap as DiffMap
+import Concordium.GlobalState.Classes
+
+-- | Index of the module in the module table. Reflects when the module was added
+--  to the table.
+type ModuleIndex = Word64
+
+-- | An updatable reference to a module difference map, which is used to record the mapping
+--  from module references to module indices for modules added since the last finalized block.
+type ModuleDifferenceMapReference = DiffMap.DifferenceMapReference ModuleRef ModuleIndex
+
+-- | Monad for inserting and looking up modules in the finalized module map.
+--  This maps module references to their corresponding module indices.
+--
+--  An implementation should ensure atomicity of operations.
+--
+--  Invariants:
+--      * All modules in the store are finalized.
+class (Monad m) => MonadModuleMapStore m where
+    -- | Inserts the modules into the underlying store.
+    insertModules :: [(ModuleRef, ModuleIndex)] -> m ()
+
+    -- | Looks up the 'ModuleIndex' for the provided 'ModuleRef'.
+    --  Returns @Just i@ if the module is present in the module table with index @i@,
+    --  and returns @Nothing@ if it is not present.
+    lookupModuleIndex :: ModuleRef -> m (Maybe ModuleIndex)
+
+    -- | Return all 'ModuleRef's and their corresponding 'ModuleIndex'es in the
+    -- module map where the @ModuleIndex@ is less than or equal to the provided
+    -- @ModuleIndex@.
+    getAllModules :: ModuleIndex -> m [(ModuleRef, ModuleIndex)]
+
+    -- | Get number of entries in the module map.
+    getNumberOfModules :: m Word64
+
+    -- | Clear and set the modules to the ones provided.
+    reconstruct :: [(ModuleRef, ModuleIndex)] -> m ()
+
+instance
+    (Monad (t m), MonadTrans t, MonadModuleMapStore m) =>
+    MonadModuleMapStore (MGSTrans t m)
+    where
+    insertModules mods = lift $ insertModules mods
+    lookupModuleIndex = lift . lookupModuleIndex
+    getAllModules = lift . getAllModules
+    getNumberOfModules = lift getNumberOfModules
+    reconstruct = lift . reconstruct
+    {-# INLINE insertModules #-}
+    {-# INLINE lookupModuleIndex #-}
+    {-# INLINE getAllModules #-}
+    {-# INLINE getNumberOfModules #-}
+    {-# INLINE reconstruct #-}
+
+deriving via
+    (MGSTrans (StateT s) m)
+    instance
+        (MonadModuleMapStore m) => MonadModuleMapStore (StateT s m)
+deriving via
+    (MGSTrans (ExceptT e) m)
+    instance
+        (MonadModuleMapStore m) => MonadModuleMapStore (ExceptT e m)
+deriving via
+    (MGSTrans (WriterT w) m)
+    instance
+        (Monoid w, MonadModuleMapStore m) => MonadModuleMapStore (WriterT w m)
+deriving via
+    (MGSTrans (ReaderT w) m)
+    instance
+        (MonadModuleMapStore m) => MonadModuleMapStore (ReaderT w m)
+
+instance (MonadModuleMapStore m) => MonadModuleMapStore (PutT m) where
+    insertModules mods = lift $ insertModules mods
+    lookupModuleIndex = lift . lookupModuleIndex
+    getAllModules = lift . getAllModules
+    getNumberOfModules = lift getNumberOfModules
+    reconstruct = lift . reconstruct
+    {-# INLINE insertModules #-}
+    {-# INLINE lookupModuleIndex #-}
+    {-# INLINE getAllModules #-}
+    {-# INLINE getNumberOfModules #-}
+    {-# INLINE reconstruct #-}

--- a/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
@@ -1600,11 +1600,12 @@ class (BlockStateOperations m, FixedSizeSerialization (BlockStateRef m)) => Bloc
     -- | Ensure that a block state is stored and return a reference to it.
     saveBlockState :: BlockState m -> m (BlockStateRef m)
 
-    -- | Ensure that any accounts created in a block are persisted.
+    -- | Add all accounts created and modules added since the last finalized block to the
+    --  global account and module maps.
     --  This should be called when a block is being finalized.
     --
     --  Precondition: The block state must be in memory and it must not have been archived.
-    saveAccounts :: BlockState m -> m ()
+    saveGlobalMaps :: BlockState m -> m ()
 
     -- | Reconstructs the account difference map and return it.
     --  This function is used for blocks that are stored but are not finalized (in particular, certified blocks)
@@ -1973,7 +1974,7 @@ instance (Monad (t m), MonadTrans t, BlockStateStorage m) => BlockStateStorage (
     purgeBlockState = lift . purgeBlockState
     archiveBlockState = lift . archiveBlockState
     saveBlockState = lift . saveBlockState
-    saveAccounts = lift . saveAccounts
+    saveGlobalMaps = lift . saveGlobalMaps
     reconstructAccountDifferenceMap bs parentMap = lift . reconstructAccountDifferenceMap bs parentMap
     reconstructModuleDifferenceMap bs = lift . reconstructModuleDifferenceMap bs
     loadBlockState hsh = lift . loadBlockState hsh

--- a/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
@@ -87,6 +87,7 @@ import Concordium.Types.Transactions hiding (BareBlockItem (..))
 import qualified Concordium.Types.UpdateQueues as UQ
 
 import Concordium.Crypto.EncryptedTransfers
+import Concordium.GlobalState.AccountMap.ModuleMap (ModuleDifferenceMapReference)
 import Concordium.GlobalState.ContractStateFFIHelpers (LoadCallback)
 import qualified Concordium.GlobalState.ContractStateV1 as StateV1
 import Concordium.GlobalState.CooldownQueue (Cooldowns)
@@ -522,6 +523,9 @@ class (ContractStateOperations m, AccountOperations m, ModuleQuery m) => BlockSt
 
     -- | Get the list of addresses of modules existing in the given block state.
     getModuleList :: BlockState m -> m [ModuleRef]
+
+    -- | Get the size of the module table.
+    getModuleCount :: BlockState m -> m Word64
 
     -- | Get the list of account addresses existing in the given block state.
     --  This returns the canonical addresses.
@@ -1620,11 +1624,32 @@ class (BlockStateOperations m, FixedSizeSerialization (BlockStateRef m)) => Bloc
         -- | The block state to reconstruct the difference map for.
         BlockState m ->
         -- | The difference map reference from the parent block's state.
-        DiffMap.DifferenceMapReference ->
+        DiffMap.AccountDifferenceMapReference ->
         -- | The account addresses created in the block, in order of creation.
         [AccountAddress] ->
         -- | Reference to the new difference map for the block.
-        m DiffMap.DifferenceMapReference
+        m DiffMap.AccountDifferenceMapReference
+
+    -- | Reconstruct the module difference map and return it.
+    --  This function is used for blocks that are stored but are not finalized (in particular,
+    --  certified blocks) since only the modules for finalized blocks are stored in the LMDB store.
+    --
+    --  Preconditions:
+    --  * This function MUST only be called on a certified block.
+    --  * This function MUST only be called on a block state that does not already have
+    --    a difference map.
+    --  * The provided difference map reference MUST be the one of the parent block.
+    --
+    --  This function should only be used when starting from an already initialized state, and hence
+    --  we need to reconstruct the difference map since the modules are not yet finalized.
+    reconstructModuleDifferenceMap ::
+        -- | The block state to reconstruct the difference map for.
+        BlockState m ->
+        -- | The difference map reference from the parent block's state, and size of its
+        --  module table.
+        (ModuleDifferenceMapReference, Word64) ->
+        -- | Reference to the new difference map for the block, and size of its module table.
+        m (ModuleDifferenceMapReference, Word64)
 
     -- | Load a block state from a reference, given its state hash if provided,
     --  otherwise calculate the state hash upon loading.
@@ -1647,11 +1672,14 @@ class (BlockStateOperations m, FixedSizeSerialization (BlockStateRef m)) => Bloc
     --  the next "update sequence numbers".
     cacheBlockStateAndGetTransactionTable :: BlockState m -> m TransactionTable
 
-    -- | Populate the LMDB account map if it has not already been initialized.
-    --  If the lmdb store has already been initialized, then this function does nothing.
-    --  Otherwise this function populates the lmdb backed account map with the accounts
-    --  present in the account table of the block state.
-    tryPopulateAccountMap :: BlockState m -> m ()
+    -- | Populate the LMDB account map and module map if they are not already initialized.
+    --  If either map contains fewer entries than the corresponding table in the block state,
+    --  then the map is reconstructed afresh from the table.
+    --
+    --  The provided block is expected to be the last finalized block. It is assumed that
+    --  any entries in the existing maps are based on finalized accounts and modules, and
+    --  hence will be correct for all future blocks.
+    tryPopulateGlobalMaps :: BlockState m -> m ()
 
 instance (Monad (t m), MonadTrans t, ModuleQuery m) => ModuleQuery (MGSTrans t m) where
     getModuleArtifact = lift . getModuleArtifact
@@ -1671,6 +1699,7 @@ instance (Monad (t m), MonadTrans t, BlockStateQuery m) => BlockStateQuery (MGST
     getBakerAccount s = lift . getBakerAccount s
     getContractInstance s = lift . getContractInstance s
     getModuleList = lift . getModuleList
+    getModuleCount = lift . getModuleCount
     getAccountList = lift . getAccountList
     getContractInstanceList = lift . getContractInstanceList
     getSeedState = lift . getSeedState
@@ -1715,6 +1744,7 @@ instance (Monad (t m), MonadTrans t, BlockStateQuery m) => BlockStateQuery (MGST
     {-# INLINE getBakerAccount #-}
     {-# INLINE getContractInstance #-}
     {-# INLINE getModuleList #-}
+    {-# INLINE getModuleCount #-}
     {-# INLINE getAccountList #-}
     {-# INLINE getContractInstanceList #-}
     {-# INLINE getSeedState #-}
@@ -1945,12 +1975,13 @@ instance (Monad (t m), MonadTrans t, BlockStateStorage m) => BlockStateStorage (
     saveBlockState = lift . saveBlockState
     saveAccounts = lift . saveAccounts
     reconstructAccountDifferenceMap bs parentMap = lift . reconstructAccountDifferenceMap bs parentMap
+    reconstructModuleDifferenceMap bs = lift . reconstructModuleDifferenceMap bs
     loadBlockState hsh = lift . loadBlockState hsh
     blockStateLoadCallback = lift blockStateLoadCallback
     collapseCaches = lift collapseCaches
     cacheBlockState = lift . cacheBlockState
     cacheBlockStateAndGetTransactionTable = lift . cacheBlockStateAndGetTransactionTable
-    tryPopulateAccountMap = lift . tryPopulateAccountMap
+    tryPopulateGlobalMaps = lift . tryPopulateGlobalMaps
     {-# INLINE thawBlockState #-}
     {-# INLINE freezeBlockState #-}
     {-# INLINE dropUpdatableBlockState #-}
@@ -1958,12 +1989,13 @@ instance (Monad (t m), MonadTrans t, BlockStateStorage m) => BlockStateStorage (
     {-# INLINE archiveBlockState #-}
     {-# INLINE saveBlockState #-}
     {-# INLINE reconstructAccountDifferenceMap #-}
+    {-# INLINE reconstructModuleDifferenceMap #-}
     {-# INLINE loadBlockState #-}
     {-# INLINE blockStateLoadCallback #-}
     {-# INLINE collapseCaches #-}
     {-# INLINE cacheBlockState #-}
     {-# INLINE cacheBlockStateAndGetTransactionTable #-}
-    {-# INLINE tryPopulateAccountMap #-}
+    {-# INLINE tryPopulateGlobalMaps #-}
 
 deriving via (MGSTrans MaybeT m) instance (BlockStateQuery m) => BlockStateQuery (MaybeT m)
 deriving via (MGSTrans MaybeT m) instance (AccountOperations m) => AccountOperations (MaybeT m)

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/MigrationState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/MigrationState.hs
@@ -26,6 +26,7 @@ import Concordium.Types.Conditionally
 import Concordium.Utils
 
 import qualified Concordium.GlobalState.AccountMap.LMDB as LMDBAccountMap
+import Concordium.GlobalState.AccountMap.ModuleMap (MonadModuleMapStore)
 import Concordium.GlobalState.Persistent.Account
 import Concordium.GlobalState.Persistent.Account.MigrationStateInterface
 import Concordium.GlobalState.Persistent.Accounts
@@ -180,6 +181,7 @@ newtype
           MonadState (AccountMigrationState oldpv pv),
           MonadIO,
           LMDBAccountMap.MonadAccountMapStore,
+          MonadModuleMapStore,
           MonadLogger
         )
 

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Accounts.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Accounts.hs
@@ -128,7 +128,7 @@ data Accounts (pv :: ProtocolVersion) = Accounts
       --  added in blocks which are not yet finalized.
       --  In particular the difference map retains accounts created, but not
       --  yet stored in the LMDB backed account map.
-      accountDiffMapRef :: !DiffMap.DifferenceMapReference
+      accountDiffMapRef :: !DiffMap.AccountDifferenceMapReference
     }
 
 instance (IsProtocolVersion pv) => Show (Accounts pv) where
@@ -156,7 +156,7 @@ writeAccountsCreated :: (SupportsPersistentAccount pv m) => Accounts pv -> m ()
 writeAccountsCreated Accounts{..} = do
     mAccountsCreated <- liftIO $ readIORef accountDiffMapRef
     forM_ mAccountsCreated $ \accountsCreated -> do
-        listOfAccountsCreated <- liftIO $ DiffMap.flatten accountsCreated
+        listOfAccountsCreated <- liftIO $ DiffMap.flattenAccounts accountsCreated
         -- Write all accounts from the difference map to the lmdb backed account map.
         LMDBAccountMap.insertAccounts listOfAccountsCreated
         -- Finally, clear the difference map for this block state and all parent block states.
@@ -186,20 +186,22 @@ mkNewChildDifferenceMap accts@Accounts{..} = do
 reconstructDifferenceMap ::
     (SupportsPersistentAccount pv m) =>
     -- | Reference to the parent difference map.
-    DiffMap.DifferenceMapReference ->
+    DiffMap.AccountDifferenceMapReference ->
     -- | Account addresses to add to the difference map.
     --  The list MUST be in ascending order of 'AccountIndex'.
     [AccountAddress] ->
     -- | The accounts to write difference map to.
     Accounts pv ->
     -- | Reference to the newly created difference map.
-    m DiffMap.DifferenceMapReference
+    m DiffMap.AccountDifferenceMapReference
 reconstructDifferenceMap parentRef listOfAccounts Accounts{..} = do
     -- As it is presumed that the account table already yields any accounts added, then
     -- in order to the obtain the account indices we subtract the number of accounts missing
     -- missing in the lmdb account map from the total number of accounts, hence obtaining the first @AccountIndex@
     -- to use for adding new accounts to the lmdb backed account map.
-    let diffMap' = DiffMap.fromList parentRef $ zip listOfAccounts [AccountIndex (L.size accountTable - fromIntegral (length listOfAccounts)) ..]
+    let diffMap' =
+            DiffMap.fromAccountList parentRef $
+                zip listOfAccounts [AccountIndex (L.size accountTable - fromIntegral (length listOfAccounts)) ..]
     liftIO $ atomicWriteIORef accountDiffMapRef $ Present diffMap'
     return accountDiffMapRef
 
@@ -282,10 +284,10 @@ putNewAccount !acct a0@Accounts{..} = do
                 Absent -> do
                     -- create a difference map for this block state with an @Absent@ as the parent.
                     freshDifferenceMap <- liftIO DiffMap.newEmptyReference
-                    return $ DiffMap.insert addr accIdx $ DiffMap.empty freshDifferenceMap
+                    return $ DiffMap.insertFreshAccount addr accIdx $ DiffMap.empty freshDifferenceMap
                 Present accDiffMap -> do
                     -- reuse the already existing difference map for this block state.
-                    return $ DiffMap.insert addr accIdx accDiffMap
+                    return $ DiffMap.insertFreshAccount addr accIdx accDiffMap
             liftIO $ atomicWriteIORef accountDiffMapRef (Present accountDiffMap')
             return (Just accIdx, a0{accountTable = newAccountTable})
 
@@ -323,11 +325,11 @@ getAccountIndex addr Accounts{..} = do
         Present accDiffMap ->
             if supportsAccountAliases (protocolVersion @pv)
                 then
-                    DiffMap.lookupViaEquivalenceClass (accountAddressEmbed addr) accDiffMap >>= \case
+                    DiffMap.lookupAccountEquiv (accountAddressEmbed addr) accDiffMap >>= \case
                         Right accIdx -> return $ Just accIdx
                         Left diffMapSize -> lookupDisk $ fromIntegral diffMapSize
                 else
-                    DiffMap.lookupExact addr accDiffMap >>= \case
+                    DiffMap.lookupAccountExact addr accDiffMap >>= \case
                         Right accIdx -> return $ Just accIdx
                         Left diffMapSize -> lookupDisk $ fromIntegral diffMapSize
   where
@@ -450,7 +452,7 @@ allAccounts accounts = do
         Absent -> LMDBAccountMap.getAllAccounts $ (AccountIndex . L.size) (accountTable accounts) - 1
         Present accDiffMap -> do
             -- Get all persisted accounts from the account map up to and including the last account of the account table minus what we found the in the difference map.
-            flattenedDiffMapAccounts <- DiffMap.flatten accDiffMap
+            flattenedDiffMapAccounts <- DiffMap.flattenAccounts accDiffMap
             persistedAccs <- LMDBAccountMap.getAllAccounts . AccountIndex $ L.size (accountTable accounts) - (1 + fromIntegral (length flattenedDiffMapAccounts))
             return $! persistedAccs <> flattenedDiffMapAccounts
 

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
@@ -173,6 +173,7 @@ import Concordium.Wasm
 
 import qualified Concordium.Crypto.SHA256 as H
 import qualified Concordium.GlobalState.AccountMap.LMDB as LMDBAccountMap
+import Concordium.GlobalState.AccountMap.ModuleMap (MonadModuleMapStore)
 import Concordium.Types.HashableTo
 
 -- | A @BlobRef a@ represents an offset on a file, at
@@ -603,6 +604,12 @@ deriving via
     instance
         (MonadIO m, MonadLogger m, LMDBAccountMap.HasDatabaseHandlers r) =>
         LMDBAccountMap.MonadAccountMapStore (BlobStoreT r m)
+
+deriving via
+    (LMDBAccountMap.AccountMapStoreMonad (BlobStoreT r m))
+    instance
+        (MonadIO m, MonadLogger m, LMDBAccountMap.HasDatabaseHandlers r) =>
+        MonadModuleMapStore (BlobStoreT r m)
 
 -- | Apply a given function to modify the context of a 'BlobStoreT' operation.
 alterBlobStoreT :: (r1 -> r2) -> BlobStoreT r2 m a -> BlobStoreT r1 m a

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -4595,11 +4595,11 @@ instance (IsProtocolVersion pv, PersistentState av pv r m) => BlockStateStorage 
         -- potentially non-finalized parent blocks.
         -- Note that this also empties the difference map for the
         -- block.
-        void $ Accounts.writeAccountsCreated (bspAccounts pbs)
+        Accounts.writeAccountsCreated (bspAccounts pbs)
         -- Write the modules that were added in the block and
         -- potentially non-finalized parent blocks.
         -- This also empties the module difference maps.
-        void $ Modules.writeModulesAdded =<< refLoad (bspModules pbs)
+        Modules.writeModulesAdded =<< refLoad (bspModules pbs)
 
     reconstructAccountDifferenceMap HashedPersistentBlockState{..} parentDifferenceMap listOfAccounts = do
         accs <- bspAccounts <$> loadPBS hpbsPointers
@@ -4784,7 +4784,7 @@ doThawBlockState HashedPersistentBlockState{..} = do
     bspAccounts' <- Accounts.mkNewChildDifferenceMap bspAccounts
     -- Since 'Modules.mkNewChild' only affects the difference map, which is not relevant to the
     -- blob store representation or hashing of the 'Modules', we can exploit 'liftCache' to
-    -- update the reference without creating a new on-disk reference.
+    -- update the in-memory value without creating a new on-disk reference.
     bspModules' <- liftCache Modules.mkNewChild bspModules
     let bsp' = bsp{bspAccounts = bspAccounts', bspModules = bspModules'}
     liftIO $ newIORef =<< makeBufferedRef bsp'

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -4772,9 +4772,10 @@ migrateBlockPointers migration BlockStatePointers{..} = do
 --  This function wraps the underlying 'PersistentBlockState' of the provided 'HashedPersistentBlockState' in a new 'IORef'
 --  such that changes to the thawed block state does not propagate into the parent state.
 --
---  Further the 'DiffMap.DifferenceMap' of the accounts structure in the provided block state is
---  "bumped" in the sense that a new one is created for the new thawed block with a pointer to the parent difference map.
---  The parent difference map is empty if the parent is persisted otherwise it may contain new accounts created in that block.
+--  Further the 'DiffMap.DifferenceMap's of the accounts and modules structures in the provided
+--  block state are "bumped" in the sense that new ones are created for the new thawed block with
+--  a pointer to the parent difference maps. The parent difference map is empty if the parent is
+--  finalized, otherwise it may contain new accounts created in that block.
 doThawBlockState ::
     (SupportsPersistentState pv m) =>
     HashedPersistentBlockState pv ->

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/Modules.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/Modules.hs
@@ -363,6 +363,8 @@ instance (MonadProtocolVersion m, SupportsPersistentModule m) => Cacheable m Mod
 emptyModules :: (MonadIO m) => m Modules
 emptyModules = Modules LFMB.empty <$> DiffMap.newEmptyReference
 
+-- | Get the 'ModuleIndex' for a module reference. This first consults the difference map,
+--  and then the LMDB map if the module is not in the difference map.
 getModuleIndex :: (SupportsPersistentModule m) => ModuleRef -> Modules -> m (Maybe ModuleIndex)
 getModuleIndex ref mods = do
     -- First, look up in the difference map

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/Modules.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/Modules.hs
@@ -25,13 +25,18 @@ module Concordium.GlobalState.Persistent.BlockState.Modules (
     getModuleReference,
     putInterface,
     moduleRefList,
+    moduleCount,
     newModuleCache,
     unsafeToModuleV,
+    tryPopulateModuleLMDB,
+    reconstructDifferenceMap,
     migrateModules,
 ) where
 
 import Concordium.Crypto.SHA256
 import Concordium.Genesis.Data (StateMigrationParameters (..))
+import qualified Concordium.GlobalState.AccountMap.DifferenceMap as DiffMap
+import Concordium.GlobalState.AccountMap.ModuleMap
 import Concordium.GlobalState.BlockState (ModulesHash (..))
 import Concordium.GlobalState.Persistent.BlobStore
 import Concordium.GlobalState.Persistent.Cache
@@ -44,21 +49,18 @@ import qualified Concordium.Scheduler.WasmIntegration as WasmV0
 import qualified Concordium.Scheduler.WasmIntegration.V1 as WasmV1
 import Concordium.Types
 import Concordium.Types.HashableTo
+import Concordium.Types.Option
 import Concordium.Utils
 import Concordium.Utils.Serialization
 import Concordium.Wasm
+import Control.Monad
 import Control.Monad.Trans
 import qualified Data.ByteString as BS
 import Data.Coerce
-import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
+import Data.IORef
 import Data.Serialize
 import Data.Word
 import Lens.Micro.Platform
-
--- | Index of the module in the module table. Reflects when the module was added
---  to the table.
-type ModuleIndex = Word64
 
 --------------------------------------------------------------------------------
 
@@ -306,8 +308,13 @@ newModuleCache :: Int -> IO ModuleCache
 newModuleCache = newCache
 
 -- | Make sure that a monad supports the `MonadBlobStore` and `MonadCache`
---  for the modules cache.
-type SupportsPersistentModule m = (MonadLogger m, MonadBlobStore m, MonadCache ModuleCache m)
+--  for the modules cache, as well having a module map store.
+type SupportsPersistentModule m =
+    ( MonadLogger m,
+      MonadBlobStore m,
+      MonadCache ModuleCache m,
+      MonadModuleMapStore m
+    )
 
 -- | The collection of modules stored in a block state.
 data Modules = Modules
@@ -318,8 +325,9 @@ data Modules = Modules
       --  serves the purpose of not loading the artifact before it is required
       --  by the rust wasm execution engine.
       _modulesTable :: !(LFMBTree' ModuleIndex HashedBufferedRef CachedModule),
-      -- | A map of ModuleRef to ModuleIndex.
-      _modulesMap :: !(Map ModuleRef ModuleIndex)
+      -- | Reference to the difference map that maps module references to module indices for
+      --  modules added since the last finalized block.
+      _modulesDifferenceMap :: !ModuleDifferenceMapReference
     }
 
 makeLenses ''Modules
@@ -336,14 +344,15 @@ instance (MonadProtocolVersion m, SupportsPersistentModule m) => BlobStorable m 
         table <- load
         return $ do
             _modulesTable <- table
-            (_modulesMap, _) <-
-                LFMB.mfoldRef
-                    ( \(m, idx) modHCR -> do
-                        modRef <- ModuleRef <$> getHashM modHCR
-                        return $!! (Map.insert modRef idx m, idx + 1)
-                    )
-                    (Map.empty, 0)
-                    _modulesTable
+            -- (_modulesMap, _) <-
+            --     LFMB.mfoldRef
+            --         ( \(m, idx) modHCR -> do
+            --             modRef <- ModuleRef <$> getHashM modHCR
+            --             return $!! (Map.insert modRef idx m, idx + 1)
+            --         )
+            --         (Map.empty, 0)
+            --         _modulesTable
+            _modulesDifferenceMap <- DiffMap.newEmptyReference
             return Modules{..}
     storeUpdate m@Modules{..} = do
         (pModulesTable, _modulesTable') <- storeUpdate _modulesTable
@@ -357,8 +366,22 @@ instance (MonadProtocolVersion m, SupportsPersistentModule m) => Cacheable m Mod
 --------------------------------------------------------------------------------
 
 -- | The empty collection of modules
-emptyModules :: Modules
-emptyModules = Modules LFMB.empty Map.empty
+emptyModules :: (MonadIO m) => m Modules
+emptyModules = Modules LFMB.empty <$> DiffMap.newEmptyReference
+
+getModuleIndex :: (SupportsPersistentModule m) => ModuleRef -> Modules -> m (Maybe ModuleIndex)
+getModuleIndex ref mods = do
+    -- First, look up in the difference map
+    DiffMap.refLookup ref (mods ^. modulesDifferenceMap) >>= \case
+        Left diffSize -> do
+            -- Not in the difference map, so look up in the LMDB map.
+            lookupModuleIndex ref <&> \mmref -> do
+                mref <- mmref
+                -- The index must be less than the size of the modules table minus the size of
+                -- the difference map, as otherwise it cannot be in the table.
+                guard $ mref < LFMB.size (mods ^. modulesTable) - diffSize
+                return mref
+        Right midx -> return $ Just midx
 
 -- | Try to add interfaces to the module table. If a module with the given
 --  reference exists returns @Nothing@.
@@ -368,35 +391,30 @@ putInterface ::
     Modules ->
     m (Maybe Modules)
 putInterface (modul, src) m =
-    if Map.member mref (m ^. modulesMap)
-        then return Nothing
-        else do
+    getModuleIndex mref m >>= \case
+        Just _ -> return Nothing
+        Nothing -> do
             src' <- storeRef src
             (idx, modulesTable') <- LFMB.append (toModule modul src') $ m ^. modulesTable
-            return $
-                Just $
-                    m
-                        & modulesTable .~ modulesTable'
-                        & modulesMap %~ Map.insert mref idx
+            DiffMap.refInsertFresh mref idx (m ^. modulesDifferenceMap)
+            return $ Just $ m & modulesTable .~ modulesTable'
   where
     mref = GSWasm.moduleReference modul
 
 getModule :: (MonadProtocolVersion m, SupportsPersistentModule m) => ModuleRef -> Modules -> m (Maybe Module)
 getModule ref mods =
-    let modIdx = Map.lookup ref (mods ^. modulesMap)
-    in  case modIdx of
-            Nothing -> return Nothing
-            Just idx -> LFMB.lookup idx (mods ^. modulesTable)
+    getModuleIndex ref mods >>= \case
+        Nothing -> return Nothing
+        Just idx -> LFMB.lookup idx (mods ^. modulesTable)
 
 -- | Gets the 'HashedCachedRef' to a module as stored in the module table
 --  to be given to instances when associating them with the interface.
 --  The reason we return the reference here is to allow for sharing of the reference.
 getModuleReference :: (MonadProtocolVersion m, SupportsPersistentModule m) => ModuleRef -> Modules -> m (Maybe CachedModule)
 getModuleReference ref mods =
-    let modIdx = Map.lookup ref (mods ^. modulesMap)
-    in  case modIdx of
-            Nothing -> return Nothing
-            Just idx -> LFMB.lookupRef idx (mods ^. modulesTable)
+    getModuleIndex ref mods >>= \case
+        Nothing -> return Nothing
+        Just idx -> LFMB.lookupRef idx (mods ^. modulesTable)
 
 -- | Get an interface by module reference.
 getInterface ::
@@ -428,8 +446,61 @@ getSource ref mods = do
 
 -- | Get the list of all currently deployed modules.
 --  The order of the list is not specified.
-moduleRefList :: Modules -> [ModuleRef]
-moduleRefList mods = Map.keys (mods ^. modulesMap)
+moduleRefList :: (MonadProtocolVersion m, SupportsPersistentModule m) => Modules -> m [ModuleRef]
+moduleRefList mods =
+    LFMB.mfoldRef (\l m -> (: l) . ModuleRef <$> getHashM m) [] (mods ^. modulesTable)
+
+-- | Get the size of the module table.
+moduleCount :: Modules -> Word64
+moduleCount = LFMB.size . _modulesTable
+
+-- | Initialize the LMDB-backed module map if it is not already initialized.
+--  If the module map contains fewer modules than the module table, it is wiped and repopulated
+--  with the modules in the table. Otherwise, the module map is left unchanged.
+tryPopulateModuleLMDB :: (MonadProtocolVersion m, SupportsPersistentModule m) => Modules -> m ()
+tryPopulateModuleLMDB mods = do
+    lmdbModuleCount <- getNumberOfModules
+    let tableSize = LFMB.size (mods ^. modulesTable)
+    when (lmdbModuleCount < tableSize) $ do
+        logEvent GlobalState LLInfo "Repopulating global module map"
+        reconstruct =<< allModules
+  where
+    allModules =
+        fst
+            <$> LFMB.mfoldRef
+                ( \(l, !idx) modRef -> do
+                    modRef' <- ModuleRef <$> getHashM modRef
+                    return ((modRef', idx) : l, idx + 1)
+                )
+                ([], 0)
+                (mods ^. modulesTable)
+
+-- | Reconstruct the difference map from the modules table.
+--  This is based on the assumption that the modules table is an extension of the parent's
+--  modules table, so only modules with index at least the size of the parent's modules table
+--  need to be added to the difference map.
+reconstructDifferenceMap ::
+    forall m.
+    (MonadProtocolVersion m, SupportsPersistentModule m) =>
+    -- | The difference map reference and module table size from the parent block.
+    (ModuleDifferenceMapReference, Word64) ->
+    Modules ->
+    -- | The (updated) difference map reference and the module table size of this block.
+    m (ModuleDifferenceMapReference, Word64)
+reconstructDifferenceMap (parentDiffMap, parentModulesCount) Modules{..} = do
+    -- Tie the difference map to the parent.
+    liftIO $ writeIORef _modulesDifferenceMap $ Present $ DiffMap.empty parentDiffMap
+    -- Traverse from the end of the modules table and insert the new modules in the difference map.
+    LFMB.traverseWhileDescRef trav _modulesTable
+    return (_modulesDifferenceMap, LFMB.size _modulesTable)
+  where
+    trav :: ModuleIndex -> CachedModule -> m Bool
+    trav midx theMod
+        | midx < parentModulesCount = return False
+        | otherwise = do
+            modRef <- ModuleRef <$> getHashM theMod
+            DiffMap.refInsertFresh modRef midx _modulesDifferenceMap
+            return True
 
 --------------------------------------------------------------------------------
 
@@ -449,7 +520,7 @@ migrateModules migration mods = do
     newModulesTable <- LFMB.migrateLFMBTree migrateCachedModule (_modulesTable mods)
     return
         Modules
-            { _modulesMap = _modulesMap mods,
+            { _modulesDifferenceMap = _modulesDifferenceMap mods,
               _modulesTable = newModulesTable
             }
   where

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Genesis.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Genesis.hs
@@ -222,7 +222,7 @@ buildGenesisBlockState vcgp GenesisData.GenesisState{..} = do
                                 }
 
     -- Module
-    modules <- Blob.refMakeFlushed Modules.emptyModules
+    modules <- Blob.refMakeFlushed =<< Modules.emptyModules
 
     -- Identity providers and anonymity revokers
     identityProviders <- Blob.bufferHashed $ Types.makeHashed genesisIdentityProviders

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Instances.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Instances.hs
@@ -27,6 +27,7 @@ import Concordium.Types.HashableTo
 import Concordium.Utils
 import qualified Concordium.Wasm as Wasm
 
+import Concordium.GlobalState.AccountMap.ModuleMap (MonadModuleMapStore)
 import Concordium.GlobalState.BlockState (
     InstanceInfoType (..),
     InstanceInfoTypeV (..),
@@ -465,7 +466,7 @@ conditionalSetBit :: (Bits a) => Int -> Bool -> a -> a
 conditionalSetBit _ False x = x
 conditionalSetBit b True x = setBit x b
 
-instance (MonadLogger m, MonadProtocolVersion m, IsProtocolVersion pv, MPV m ~ pv, BlobStorable m r, Cache.MonadCache ModuleCache m) => BlobStorable m (IT pv r) where
+instance (MonadLogger m, MonadProtocolVersion m, IsProtocolVersion pv, MPV m ~ pv, BlobStorable m r, Cache.MonadCache ModuleCache m, MonadModuleMapStore m) => BlobStorable m (IT pv r) where
     storeUpdate (Branch{..}) = do
         (pl, l') <- storeUpdate branchLeft
         (pr, r') <- storeUpdate branchRight

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
@@ -499,9 +499,9 @@ activateSkovPersistentData pbsc uninitState =
         tt <- cacheBlockStateAndGetTransactionTable bps
         logEvent GlobalState LLTrace "Done caching last finalized block"
         -- initialize the account map if it has not already been so.
-        logEvent GlobalState LLDebug "Initializing LMDB account map"
-        void $ tryPopulateAccountMap bps
-        logEvent GlobalState LLDebug "Finished initializing LMDB account map"
+        logEvent GlobalState LLDebug "Initializing LMDB account map and module map"
+        void $ tryPopulateGlobalMaps bps
+        logEvent GlobalState LLDebug "Finished initializing LMDB account map and module map"
         return $! uninitState{_transactionTable = tt}
   where
     runBlockState a = runReaderT (PBS.runPersistentBlockStateMonad @pv a) pbsc

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
@@ -729,9 +729,9 @@ instance
     markFinalized bh fr =
         use (skovPersistentData . blockTable . liveMap . at' bh) >>= \case
             Just (BlockAlive bp) -> do
-                -- Save the block state and write the accounts out to disk.
+                -- Save the block state and write the accounts and modules out to disk.
                 st <- saveBlockState (_bpState bp)
-                void $ saveAccounts (_bpState bp)
+                void $ saveGlobalMaps (_bpState bp)
                 -- NB: Removing the block from the in-memory cache only makes
                 -- sense if no block lookups are done between the call to this
                 -- function and 'wrapUpFinalization'. This is currently the case,

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/TreeState.hs
@@ -500,7 +500,7 @@ activateSkovPersistentData pbsc uninitState =
         logEvent GlobalState LLTrace "Done caching last finalized block"
         -- initialize the account map if it has not already been so.
         logEvent GlobalState LLDebug "Initializing LMDB account map and module map"
-        void $ tryPopulateGlobalMaps bps
+        tryPopulateGlobalMaps bps
         logEvent GlobalState LLDebug "Finished initializing LMDB account map and module map"
         return $! uninitState{_transactionTable = tt}
   where
@@ -731,7 +731,7 @@ instance
             Just (BlockAlive bp) -> do
                 -- Save the block state and write the accounts and modules out to disk.
                 st <- saveBlockState (_bpState bp)
-                void $ saveGlobalMaps (_bpState bp)
+                saveGlobalMaps (_bpState bp)
                 -- NB: Removing the block from the in-memory cache only makes
                 -- sense if no block lookups are done between the call to this
                 -- function and 'wrapUpFinalization'. This is currently the case,

--- a/concordium-consensus/src/Concordium/KonsensusV1/Consensus/Finality.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/Consensus/Finality.hs
@@ -207,7 +207,7 @@ makeStoredBlock ::
     m (LowLevel.StoredBlock (MPV m))
 makeStoredBlock finalized blockPtr = do
     statePointer <- saveBlockState (bpState blockPtr)
-    when finalized $ saveAccounts (bpState blockPtr)
+    when finalized $ saveGlobalMaps (bpState blockPtr)
     return
         LowLevel.StoredBlock
             { stbInfo = blockMetadata blockPtr,

--- a/concordium-consensus/src/Concordium/KonsensusV1/SkovMonad.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/SkovMonad.hs
@@ -577,7 +577,7 @@ initialiseNewSkovV1 genData genesisBlockHeightInfo bakerCtx handlerCtx unliftSko
                 Right genState -> return genState
             logEvent GlobalState LLTrace "Writing persistent global state"
             stateRef <- saveBlockState pbs
-            saveAccounts pbs
+            saveGlobalMaps pbs
             logEvent GlobalState LLTrace "Creating persistent global state context"
             let genHash = genesisBlockHash genData
             let genMeta =

--- a/concordium-consensus/src/Concordium/KonsensusV1/SkovMonad.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/SkovMonad.hs
@@ -33,6 +33,7 @@ import Concordium.GlobalState.BlockMonads
 import Concordium.GlobalState.BlockState
 
 import qualified Concordium.GlobalState.AccountMap.LMDB as LMDBAccountMap
+import Concordium.GlobalState.AccountMap.ModuleMap (MonadModuleMapStore)
 import qualified Concordium.GlobalState.BlockState as PBS
 import Concordium.GlobalState.Parameters hiding (getChainParameters)
 import Concordium.GlobalState.Persistent.Account
@@ -418,7 +419,8 @@ newtype InitMonad pv a = InitMonad {runInitMonad' :: InnerInitMonad pv a}
           ModuleQuery,
           MonadBlobStore,
           Cache.MonadCache Modules.ModuleCache,
-          LMDBAccountMap.MonadAccountMapStore
+          LMDBAccountMap.MonadAccountMapStore,
+          MonadModuleMapStore
         )
         via (PersistentBlockStateMonad pv (InitContext pv) (InnerInitMonad pv))
 
@@ -643,9 +645,9 @@ activateSkovV1State = do
     bps <- use $ lastFinalized . to bpState
     !tt <- cacheBlockStateAndGetTransactionTable bps
     transactionTable .= tt
-    logEvent GlobalState LLDebug "Initializing LMDB account map"
-    void $ PBS.tryPopulateAccountMap bps
-    logEvent GlobalState LLDebug "Finished initializing LMDB account map"
+    logEvent GlobalState LLDebug "Initializing LMDB account map and module map"
+    void $ PBS.tryPopulateGlobalMaps bps
+    logEvent GlobalState LLDebug "Finished initializing LMDB account map and module map"
     logEvent GlobalState LLTrace "Loading certified blocks"
     loadCertifiedBlocks
     logEvent GlobalState LLTrace "Done activating global state"

--- a/concordium-consensus/src/Concordium/KonsensusV1/TestMonad.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TestMonad.hs
@@ -177,7 +177,7 @@ runTestMonad _tcBakerContext _tcCurrentTime genData (TestMonad a) =
                                   _nextPayday = payday
                                 }
                     genStateRef <- saveBlockState genState
-                    void $ saveAccounts genState
+                    void $ saveGlobalMaps genState
                     return (genState, genStateRef, initTT, genTimeoutBase, genEpochBakers)
         let genMetadata =
                 GenesisMetadata

--- a/concordium-consensus/src/Concordium/KonsensusV1/TreeState/StartUp.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TreeState/StartUp.hs
@@ -10,6 +10,7 @@ import Control.Monad.Catch
 import Control.Monad.IO.Class
 import Control.Monad.State.Strict
 import qualified Data.Map.Strict as Map
+import Data.Word
 
 import Data.Maybe
 import qualified Data.Sequence as Seq
@@ -25,6 +26,7 @@ import Concordium.Types.Updates
 import Concordium.Utils
 
 import qualified Concordium.GlobalState.AccountMap.DifferenceMap as DiffMap
+import Concordium.GlobalState.AccountMap.ModuleMap (ModuleDifferenceMapReference)
 import Concordium.GlobalState.BlockState
 import Concordium.GlobalState.Parameters hiding (getChainParameters)
 import qualified Concordium.GlobalState.Persistent.BlockState as PBS
@@ -299,6 +301,8 @@ loadSkovData _genesisBlockHeight _runtimeParameters didRollback = do
             else return (Absent, Nothing)
     return (SkovData{..}, protocolUpdate)
 
+type MapInfo = (DiffMap.AccountDifferenceMapReference, (ModuleDifferenceMapReference, Word64))
+
 -- | Load the certified blocks from the low-level database into the tree state.
 --  This caches their block states, adds them to the block table and branches,
 --  adds their transactions to the transaction table and pending transaction table,
@@ -329,7 +333,7 @@ loadCertifiedBlocks = do
     -- Load all certified blocks
     -- This sets the skov state, puts transactions in the transaction table,
     -- and reconstructs the account map difference maps for the certified blocks.
-    foldM_ (flip loadCertBlock) (HM.empty :: HM.HashMap BlockHash DiffMap.DifferenceMapReference) certBlocks
+    foldM_ (flip loadCertBlock) (HM.empty :: HM.HashMap BlockHash MapInfo) certBlocks
     oLastTimeout <- use $ persistentRoundStatus . prsLatestTimeout
     forM_ oLastTimeout $ \lastTimeout -> do
         curRound <- use $ roundStatus . rsCurrentRound
@@ -434,27 +438,35 @@ loadCertifiedBlocks = do
     getAccountAddressFromDeployment bi = case bi of
         WithMetadata{wmdData = CredentialDeployment{biCred = AccountCreation{..}}} -> (Just . addressFromRegId . credId) credential
         _ -> Nothing
+    loadCertBlock ::
+        (LowLevel.StoredBlock (MPV m), QuorumCertificate) ->
+        HM.HashMap BlockHash MapInfo ->
+        m (HM.HashMap BlockHash MapInfo)
     loadCertBlock (storedBlock, qc) loadedBlocks = do
         blockPointer <- mkBlockPointer storedBlock
         -- As only finalized accounts are stored in the account map, then
         -- we need to reconstruct the 'DiffMap.DifferenceMap' here for the certified block we're loading.
         let accountsToInsert = mapMaybe getAccountAddressFromDeployment (blockTransactions storedBlock)
-        --  If a parent cannot be looked up in the @loadedBlocks@ it must mean that parent block is finalized,
-        --  and as a result we simply set the parent reference for the difference map to be empty.
-        -- This is alright as the certified blocks we're folding over are in order of ascending round number.
-        parentDiffMapReference <- case blockBakedData storedBlock of
-            -- If the parent is a genesis block then there is no difference map for it.
-            Absent -> liftIO DiffMap.newEmptyReference
-            Present b -> do
-                let parentHash = qcBlock $ bbQuorumCertificate $ sbBlock b
-                -- If the parent cannot be looked up, then it must be finalized and hence no
-                -- difference map exists.
-                case HM.lookup parentHash loadedBlocks of
-                    Nothing -> liftIO DiffMap.newEmptyReference
-                    Just diffMapReference -> return diffMapReference
-        newDifferenceMap <- reconstructAccountDifferenceMap (bpState blockPointer) parentDiffMapReference accountsToInsert
+
+        parentBP <- gets parentOfLive <*> pure blockPointer
+
+        let parentHash = getHash parentBP
+        (parentADMRef, parentMDMInfo) <- case HM.lookup parentHash loadedBlocks of
+            Nothing -> do
+                -- If a parent cannot be looked up in the @loadedBlocks@ it must mean that parent
+                -- block is finalized, and as a result we simply set the parent reference for the
+                -- difference map to be empty. This is alright as the certified blocks we're
+                -- folding over are in order of ascending round number.
+                parentADMRef <- liftIO DiffMap.newEmptyReference
+                parentMDMRef <- liftIO DiffMap.newEmptyReference
+                parentModCount <- getModuleCount (bpState parentBP)
+                return (parentADMRef, (parentMDMRef, parentModCount))
+            Just mapInfo -> return mapInfo
+        newADMRef <- reconstructAccountDifferenceMap (bpState blockPointer) parentADMRef accountsToInsert
+        newMDMInfo <- reconstructModuleDifferenceMap (bpState blockPointer) parentMDMInfo
+
         -- append to the accumulator with this new difference map reference
-        let loadedBlocks' = HM.insert (getHash storedBlock) newDifferenceMap loadedBlocks
+        let loadedBlocks' = HM.insert (getHash storedBlock) (newADMRef, newMDMInfo) loadedBlocks
 
         cacheBlockState (bpState blockPointer)
         blockTable . liveMap . at' (getHash blockPointer) ?=! blockPointer

--- a/concordium-consensus/src/Concordium/KonsensusV1/TreeState/StartUp.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/TreeState/StartUp.hs
@@ -301,6 +301,9 @@ loadSkovData _genesisBlockHeight _runtimeParameters didRollback = do
             else return (Absent, Nothing)
     return (SkovData{..}, protocolUpdate)
 
+-- | The parent block's account difference map reference, module difference map reference, and
+--  module count. This is used to reconstruct the difference maps for a block when loading a
+--  certified block.
 type MapInfo = (DiffMap.AccountDifferenceMapReference, (ModuleDifferenceMapReference, Word64))
 
 -- | Load the certified blocks from the low-level database into the tree state.

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/Accounts.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/Accounts.hs
@@ -240,7 +240,7 @@ runAccountAction Reconstruct (ba, pa) = do
             let ref = DiffMap.dmParentMapRef paDiffMap
                 -- Note that we sort them by ascending account index such that the order
                 -- matches the insertion order.
-                accs = map snd $ sortOn fst $ HM.elems $ DiffMap.dmAccounts paDiffMap
+                accs = map snd $ sortOn fst $ HM.elems $ DiffMap.dmMap paDiffMap
             return (ref, accs)
     -- create pa' which is the same as pa, but with an empty difference map.
     emptyRef <- liftIO DiffMap.newEmptyReference

--- a/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
@@ -41,6 +41,7 @@ import qualified Concordium.Wasm as Wasm
 import qualified Concordium.Common.Time as Time
 import qualified Concordium.Cost as Cost
 import qualified Concordium.GlobalState.AccountMap.LMDB as LMDBAccountMap
+import qualified Concordium.GlobalState.AccountMap.ModuleMap as ModuleMap
 import qualified Concordium.GlobalState.BlockState as BS
 import qualified Concordium.GlobalState.DummyData as DummyData
 import qualified Concordium.GlobalState.Persistent.Account as BS
@@ -109,6 +110,7 @@ deriving instance (Types.IsProtocolVersion pv) => BS.ContractStateOperations (Pe
 deriving instance (Types.IsProtocolVersion pv) => Blob.MonadBlobStore (PersistentBSM pv)
 deriving instance (Types.IsProtocolVersion pv) => MonadCache BS.ModuleCache (PersistentBSM pv)
 deriving instance (Types.IsProtocolVersion pv) => LMDBAccountMap.MonadAccountMapStore (PersistentBSM pv)
+deriving instance (Types.IsProtocolVersion pv) => ModuleMap.MonadModuleMapStore (PersistentBSM pv)
 
 deriving instance
     (Types.AccountVersionFor pv ~ av) =>

--- a/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
@@ -163,7 +163,7 @@ createTestBlockStateWithAccounts accounts = do
             DummyData.dummyChainParameters
     -- save block state and accounts.
     void $ BS.saveBlockState bs
-    void $ BS.saveAccounts bs
+    void $ BS.saveGlobalMaps bs
     return bs
   where
     keys = Types.withIsAuthorizationsVersionForPV (Types.protocolVersion @pv) $ DummyData.dummyKeyCollection
@@ -393,7 +393,7 @@ reloadBlockState ::
 reloadBlockState persistentState = do
     frozen <- BS.freezeBlockState persistentState
     br <- BS.saveBlockState frozen
-    void $ BS.saveAccounts frozen
+    void $ BS.saveGlobalMaps frozen
     BS.thawBlockState =<< BS.loadBlockState ((Just . BS.hpbsHash) frozen) br
 
 -- | Takes a function for checking the block state, which is then run on the block state, the block

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "6.0.0"
+version = "7.0.0"
 dependencies = [
  "aes",
  "anyhow",


### PR DESCRIPTION
## Purpose

Closes #1326

This introduces an LMDB-persisted module map table, that records the mapping of finalized module references to module indexes. This is analogous to how the account map is handled.

## Changes

- The difference map types are generalised to support both accounts and modules. Some functions are renamed for clarity.
- The account map LMDB adds a new "moduleMap" database for recording the finalized module ref -> module index mapping.
- A new `MondModuleMapStore` class defines the interface to the LMDB moduleMap database.
- `getModuleCount` is added to block state query. This in particular is used for reconstructing the module difference maps for certified blocks on start up.
- `reconstructModuleDifferenceMap` is added to `BlockStateStorage`. This reconstructs the module difference maps for certified blocks. This is somewhat analogous to `reconstructAccountDifferenceMap`, however, instead of taking in the list of new modules, it takes the size of the module table of the parent. The new modules are inferred as those in the block's module table starting from the appropriate index.
- `tryPopulateAccountMap` is renamed to `tryPopulateGlobalMaps` and now also populates the module map.
- `saveAccounts` is renamed to `saveGlobalMaps` and similarly writes both the account and module maps to the LMDB store.
- The `_modulesMap` in `Modules` is replaced with `_modulesDifferenceMap` -- a reference to a module difference map tracking the modules added in each block since the last finalized block.
- Loading the `Modules` from the blob store produces an empty difference map, which is correct for finalized blocks.
- `loadCertifiedBlocks` reconstructs both the account and module difference maps.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
