### PR TITLE
Delay handler execution till after state update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 - Use a persistent LMDB-backed store to track the finalized module map.
 - Fix a bug that affects setting up the account map correctly for non-finalized certified blocks
   that contain account creations (#1329).
+- Fix a bug that can occasionally result in a crash if `GetBlockInfo` is invoked during a protocol
+  update ([#1352](https://github.com/Concordium/concordium-node/issues/1352)). The fix delays
+  executing the on-block and on-finalization handlers until after the state update has been
+  committed. This also should also result in better consistency in the gRPC API (i.e. if a client
+  is notified that a block has arrived, `GetBlockInfo` should not result in `NOT_FOUND` for thatb
+  block).
 
 ## 8.0.3
 

--- a/concordium-consensus/src/Concordium/KonsensusV1/SkovMonad.hs
+++ b/concordium-consensus/src/Concordium/KonsensusV1/SkovMonad.hs
@@ -21,6 +21,7 @@ import Control.Monad
 import Control.Monad.Catch
 import Control.Monad.RWS.Strict
 import Control.Monad.Trans.Reader hiding (ask)
+import qualified Data.Sequence as Seq
 import Lens.Micro.Platform
 
 import Concordium.Types
@@ -60,8 +61,15 @@ import Concordium.TimerMonad
 
 -- * 'SkovV1T'
 
+-- | A 'HandlerEvent' is used to execute a handler after the current update has been processed.
+data HandlerEvent pv
+    = -- | Trigger the event handler for a block arriving.
+      OnBlock !(BlockPointer pv)
+    | -- | Trigger the event handler for a finalization.
+      OnFinalize !(FinalizationEntry pv) ![BlockPointer pv]
+
 -- | The inner type of the 'SkovV1T' monad.
-type InnerSkovV1T pv m = RWST (SkovV1Context pv m) () (SkovV1State pv) m
+type InnerSkovV1T pv m = RWST (SkovV1Context pv m) (Seq.Seq (HandlerEvent pv)) (SkovV1State pv) m
 
 -- | A type-alias that is used for deriving block state monad implementations for 'SkovV1T'.
 --  @PersistentBlockStateMonadHelper pv m a@ is representationally equivalent to @SkovV1T pv m a@.
@@ -119,16 +127,23 @@ newtype SkovV1T pv m a = SkovV1T
         (BlockStateTypes, ContractStateOperations, ModuleQuery)
         via (PersistentBlockStateMonadHelper pv m)
 
--- | Run a 'SkovV1T' operation, given the context and state, returning the updated state.
-runSkovT :: (Monad m) => SkovV1T pv m a -> SkovV1Context pv m -> SkovV1State pv -> m (a, SkovV1State pv)
+-- | Run a 'SkovV1T' operation, given the context and state, returning the updated state and any
+--  handler events that were generated.
+runSkovT ::
+    (Monad m) =>
+    SkovV1T pv m a ->
+    SkovV1Context pv m ->
+    SkovV1State pv ->
+    m (a, SkovV1State pv, Seq.Seq (HandlerEvent pv))
 runSkovT comp ctx st = do
-    (ret, st', _) <- runRWST (runSkovT' comp) ctx st
-    return (ret, st')
+    (ret, st', evs) <- runRWST (runSkovT' comp) ctx st
+    return (ret, st', evs)
 
--- | Run a 'SkovV1T' operation, given the context and state, discarding the updated state.
---  This can be used for queries, but should generally not be used when the state is updated as
---  changes to the 'SkovData' will be discarded, but changes to the disk-backed databases will
---  persist.
+-- | Run a 'SkovV1T' operation, given the context and state, discarding the updated state and any
+--  handler events that were generated. This can be used for queries, but should generally not be
+--  used when the state is updated as changes to the 'SkovData' will be discarded, but changes to
+--  the disk-backed databases will persist. It is also expected that no handler events should be
+--  generated.
 evalSkovT :: (Monad m) => SkovV1T pv m a -> SkovV1Context pv m -> SkovV1State pv -> m a
 evalSkovT comp ctx st = do
     (ret, _) <- evalRWST (runSkovT' comp) ctx st
@@ -152,18 +167,7 @@ data HandlerContext (pv :: ProtocolVersion) m = HandlerContext
       -- | Handler to broadcast a quorum message.
       _sendQuorumHandler :: QuorumMessage -> m (),
       -- | Handler to broadcast a block.
-      _sendBlockHandler :: SignedBlock pv -> m (),
-      -- | An event handler called when a block becomes live.
-      _onBlockHandler :: BlockPointer pv -> m (),
-      -- | An event handler called per finalization. It is called with the
-      --  finalization entry, and the list of all blocks finalized by the entry
-      --  in increasing order of block height. It returns a `SkovV1T pv m ()` in order to have
-      --  access to the state, in particular whether consensus has shutdown.
-      _onFinalizeHandler :: FinalizationEntry pv -> [BlockPointer pv] -> SkovV1T pv m (),
-      -- | An event handler called when a pending block becomes live. This is intended to trigger
-      --  sending a catch-up status message to peers, as pending blocks are not relayed when they
-      --  are first received.
-      _onPendingLiveHandler :: m ()
+      _sendBlockHandler :: SignedBlock pv -> m ()
     }
 
 -- | Context used by the 'SkovV1T' monad.
@@ -294,12 +298,8 @@ instance (Monad m) => MonadBroadcast (SkovV1T pv m) where
         lift $ handler sb
 
 instance (Monad m) => MonadConsensusEvent (SkovV1T pv m) where
-    onBlock bp = do
-        handler <- view onBlockHandler
-        lift $ handler bp
-    onFinalize fe bp = do
-        handler <- view onFinalizeHandler
-        handler fe bp
+    onBlock bp = SkovV1T $ tell $ Seq.singleton $ OnBlock bp
+    onFinalize fe bp = SkovV1T $ tell $ Seq.singleton $ OnFinalize fe bp
 
 instance (MonadIO m, MonadLogger m, MonadCatch m) => TimerMonad (SkovV1T pv m) where
     type Timer (SkovV1T pv m) = ThreadTimer

--- a/concordium-consensus/src/Concordium/MultiVersion.hs
+++ b/concordium-consensus/src/Concordium/MultiVersion.hs
@@ -258,11 +258,9 @@ data Callbacks = Callbacks
 --  be populated with a configuration for the genesis index prior to calling this function.
 skovV1Handlers ::
     forall pv finconf.
-    (IsConsensusV1 pv, IsProtocolVersion pv) =>
     GenesisIndex ->
-    AbsoluteBlockHeight ->
     SkovV1.HandlerContext pv (MVR finconf)
-skovV1Handlers gi genHeight = SkovV1.HandlerContext{..}
+skovV1Handlers gi = SkovV1.HandlerContext{..}
   where
     _sendTimeoutHandler timeoutMsg = MVR $ \mvr -> do
         broadcastFinalizationMessage
@@ -280,50 +278,63 @@ skovV1Handlers gi genHeight = SkovV1.HandlerContext{..}
             gi
             (runPut (KonsensusV1.putSignedBlock block))
 
-    _onBlockHandler :: SkovV1.BlockPointer pv -> MVR finconf ()
-    _onBlockHandler block = do
-        -- Notice that isHomeBaked (in the code below) represents whether this block is baked by the
-        -- baker ID of this node and it could be the case that the block was not baked by this node,
-        -- if another node using the same baker ID.
-        -- The information is used to count the number of baked blocks exposed by a prometheus metric.
-        -- An alternative implementation would be to extend the @onBlock@ handler (part of @OnSkov@)
-        -- to take an extra argument indicating whether the block was just baked or processed as part of a received
-        -- block. This would mean that only blocks baked since start by this node would be counted,
-        -- not blocks received as part of catchup. However the same cannot be done for finalized blocks as easily
-        -- and so for consistency between these two methods we chose to also count blocks received as part of catchup
-        -- in both.
-        asks (notifyBlockArrived . mvCallbacks) >>= \case
+-- | Handler for a block arriving. This is used to notify the network layer that a block has
+--  arrived. This ultimately calls @notify_callback@, which is used to notify any gRPC clients
+--  listening for block arrivals, and to update metrics.
+skovV1BlockHandler ::
+    -- | Height of the genesis block
+    AbsoluteBlockHeight ->
+    -- | The newly-arrived block.
+    SkovV1.BlockPointer pv ->
+    MVR finconf ()
+skovV1BlockHandler genHeight block = do
+    -- Notice that isHomeBaked (in the code below) represents whether this block is baked by the
+    -- baker ID of this node and it could be the case that the block was not baked by this node,
+    -- if another node using the same baker ID.
+    -- The information is used to count the number of baked blocks exposed by a prometheus metric.
+    -- An alternative implementation would be to extend the @onBlock@ handler (part of @OnSkov@)
+    -- to take an extra argument indicating whether the block was just baked or processed as part of a received
+    -- block. This would mean that only blocks baked since start by this node would be counted,
+    -- not blocks received as part of catchup. However the same cannot be done for finalized blocks as easily
+    -- and so for consistency between these two methods we chose to also count blocks received as part of catchup
+    -- in both.
+    asks (notifyBlockArrived . mvCallbacks) >>= \case
+        Nothing -> return ()
+        Just notifyCallback -> do
+            let height = localToAbsoluteBlockHeight genHeight (SkovV1.blockHeight block)
+            nodeBakerIdMaybe <- asks (fmap (bakerId . bakerIdentity) . mvBaker)
+            let isHomeBaked = case nodeBakerIdMaybe of
+                    Nothing -> False
+                    Just nodeBakerId ->
+                        Present nodeBakerId
+                            == (KonsensusV1.blockBaker <$> KonsensusV1.blockBakedData block)
+            liftIO (notifyCallback (getHash block) height isHomeBaked)
+
+-- | Handler for block finalization. This first notifies the network layer, ultimately calling
+--  @notify_callback@, which is used to notify any gRPC clients listening for block finalizations,
+--  and to update metrics. It then checks for protocol updates.
+skovV1FinalizeHandler ::
+    (IsProtocolVersion pv, IsConsensusV1 pv) =>
+    -- | Height of the genesis block
+    AbsoluteBlockHeight ->
+    KonsensusV1.FinalizationEntry pv ->
+    [SkovV1.BlockPointer pv] ->
+    VersionedSkovV1M finconf pv ()
+skovV1FinalizeHandler genHeight _ finalizedBlocks = do
+    lift $
+        asks (notifyBlockFinalized . mvCallbacks) >>= \case
             Nothing -> return ()
             Just notifyCallback -> do
-                let height = localToAbsoluteBlockHeight genHeight (SkovV1.blockHeight block)
                 nodeBakerIdMaybe <- asks (fmap (bakerId . bakerIdentity) . mvBaker)
-                let isHomeBaked = case nodeBakerIdMaybe of
-                        Nothing -> False
-                        Just nodeBakerId ->
-                            Present nodeBakerId
-                                == (KonsensusV1.blockBaker <$> KonsensusV1.blockBakedData block)
-                liftIO (notifyCallback (getHash block) height isHomeBaked)
-
-    _onFinalizeHandler _ finalizedBlocks = do
-        lift $
-            asks (notifyBlockFinalized . mvCallbacks) >>= \case
-                Nothing -> return ()
-                Just notifyCallback -> do
-                    nodeBakerIdMaybe <- asks (fmap (bakerId . bakerIdentity) . mvBaker)
-                    forM_ finalizedBlocks $ \bp -> do
-                        let height = localToAbsoluteBlockHeight genHeight (SkovV1.blockHeight bp)
-                        let isHomeBaked = case nodeBakerIdMaybe of
-                                Nothing -> False
-                                Just nodeBakerId ->
-                                    Present nodeBakerId
-                                        == (KonsensusV1.blockBaker <$> KonsensusV1.blockBakedData bp)
-                        liftIO (notifyCallback (getHash bp) height isHomeBaked)
-        checkForProtocolUpdateV1
-
-    _onPendingLiveHandler = do
-        -- Notify peers of our catch-up status, since they may not be aware of the now-live pending
-        -- blocks.
-        bufferedSendCatchUpStatus
+                forM_ finalizedBlocks $ \bp -> do
+                    let height = localToAbsoluteBlockHeight genHeight (SkovV1.blockHeight bp)
+                    let isHomeBaked = case nodeBakerIdMaybe of
+                            Nothing -> False
+                            Just nodeBakerId ->
+                                Present nodeBakerId
+                                    == (KonsensusV1.blockBaker <$> KonsensusV1.blockBakedData bp)
+                    liftIO (notifyCallback (getHash bp) height isHomeBaked)
+    checkForProtocolUpdateV1
 
 -- | Baker identity and baking thread 'MVar'.
 data Baker = Baker
@@ -740,7 +751,7 @@ newGenesis (PVGenesisData (gd :: GenesisData pv)) genesisHeight = case consensus
                         unliftSkov a = do
                             config <- readMVar configRef
                             runMVR (runSkovV1Transaction config a) mvr
-                    let !handlers = skovV1Handlers vc1Index genesisHeight
+                    let !handlers = skovV1Handlers vc1Index
                     let genesisBlockHeightInfo =
                             KonsensusV1.GenesisBlockHeightInfo
                                 { gbhiAbsoluteHeight = genesisHeight,
@@ -864,7 +875,7 @@ checkForProtocolUpdateV0 = liftSkov body
                             unliftSkov a = do
                                 config <- readMVar configRef
                                 runMVR (runSkovV1Transaction config a) mvr
-                        let !handlers = skovV1Handlers vc1Index vc1GenesisHeight
+                        let !handlers = skovV1Handlers vc1Index
                         -- get the last finalized block state
                         lastFinBlockState <- Skov.queryBlockState =<< Skov.lastFinalizedBlock
                         -- the existing persistent block state context.
@@ -1039,7 +1050,7 @@ checkForProtocolUpdateV1 = body
                             unliftSkov a = do
                                 config <- readMVar configRef
                                 runMVR (runSkovV1Transaction config a) mvr
-                        let !handlers = skovV1Handlers vc1Index vc1GenesisHeight
+                        let !handlers = skovV1Handlers vc1Index
                         let genesisBlockHeightInfo =
                                 KonsensusV1.GenesisBlockHeightInfo
                                     { gbhiAbsoluteHeight = vc1GenesisHeight,
@@ -1317,7 +1328,7 @@ startupSkov genesis = do
                                 loadLoop nextSPV activateThis (genIndex + 1) (lastFinalizedHeight + 1)
                     Nothing -> activateLast
             ConsensusV1 -> do
-                let !handlers = skovV1Handlers genIndex genHeight
+                let !handlers = skovV1Handlers genIndex
                 let genesisBlockHeightInfo =
                         KonsensusV1.GenesisBlockHeightInfo
                             { gbhiAbsoluteHeight = genHeight,
@@ -1552,14 +1563,26 @@ liftSkovV0Update vc a = MVR $ \mvr -> do
 --  'VersionedConfigurationV1'. Note that this does not acquire the write lock: the caller must
 --  ensure that the lock is held.
 liftSkovV1Update ::
+    (IsProtocolVersion pv, IsConsensusV1 pv) =>
     VersionedConfigurationV1 finconf pv ->
     VersionedSkovV1M finconf pv a ->
     MVR finconf a
 liftSkovV1Update vc a = MVR $ \mvr -> do
     oldState <- readIORef (vc1State vc)
-    (res, newState) <- runMVR (SkovV1.runSkovT a (vc1Context vc) oldState) mvr
+    (res, newState, evs) <- runMVR (SkovV1.runSkovT a (vc1Context vc) oldState) mvr
     writeIORef (vc1State vc) $! newState
+    let
+        handleEvent st (SkovV1.OnBlock bp) = do
+            runMVR (skovV1BlockHandler genHeight bp) mvr
+            return st
+        handleEvent st (SkovV1.OnFinalize finEntry bp) = do
+            (_, st', _) <- runMVR (SkovV1.runSkovT (skovV1FinalizeHandler genHeight finEntry bp) (vc1Context vc) st) mvr
+            writeIORef (vc1State vc) $! st'
+            return st'
+    foldM_ handleEvent newState evs
     return $! res
+  where
+    genHeight = vc1GenesisHeight vc
 
 -- | Run a version-0 consensus transaction that may affect the state.
 --  This acquires the write lock for the duration of the operation.
@@ -1576,6 +1599,7 @@ runSkovV0Transaction vc a = withWriteLock $ liftSkovV0Update vc a
 --  If the action throws an exception, the state will not be updated,
 --  but the lock is guaranteed to be released.
 runSkovV1Transaction ::
+    (IsProtocolVersion pv, IsConsensusV1 pv) =>
     VersionedConfigurationV1 finconf pv ->
     VersionedSkovV1M finconf pv a ->
     MVR finconf a


### PR DESCRIPTION
## Purpose

Closes #1352

This defers the execution of on-block and on-finalization handlers until after the consensus state has been committed. This in particular ensures that in the case of a protocol update, the consensus state is committed before the protocol update occurs (as this is part of the on-finalization handling). Consequently, a `GetBlockInfo` that queries the genesis block of a new consensus (created in the protocol update) will always be able to see the terminal block (which is available once the consensus state is committed).

This also ensures that if gRPC clients are notified of block arrivals, queries about those blocks will not fail, which was previously a theoretical possibility.

## Changes

- The `SkovT` implementation uses the `MonadWriter` aspect to produce a sequence of `HandlerEvent`s rather than directly invoking a handler callback.
- The handlers `onBlockHandler`, `onFinalizationHandler` and `onPendingLiveHandler` are removed from the `HandlerContext`, as the events will be used instead. (`onPendingLiveHandler` was not used anyway.)
- The handler implementations are promoted from being part of the `HandlerContext` implementation to separate functions `skovV1BlockHandler` and `skovV1FinalizeHandler`.
- These handlers are called as part of `liftSkovV1Update`, and are run after updating the state.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
