### PR TITLE
Introduce global index types for PLTs

### DIFF
--- a/collector/src/bin/collector.rs
+++ b/collector/src/bin/collector.rs
@@ -13,6 +13,9 @@ extern crate log;
 
 #[allow(clippy::large_enum_variant, clippy::enum_variant_names)]
 mod grpc {
+    mod plt {
+        tonic::include_proto!("concordium.v2.plt");
+    }
     tonic::include_proto!("concordium.v2");
 }
 use grpc::{node_info::node::ConsensusStatus, tokenomics_info::Tokenomics};

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/ProtocolLevelTokens.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/ProtocolLevelTokens.hs
@@ -16,7 +16,6 @@ import Data.Word
 import qualified Concordium.Crypto.SHA256 as SHA256
 import Concordium.Types
 import Concordium.Types.HashableTo
-import Concordium.Types.ProtocolVersion
 import Concordium.Utils
 import Concordium.Utils.Serialization
 
@@ -104,7 +103,10 @@ instance HashableTo PLTConfigurationHash PLTConfiguration where
 
 instance (Monad m) => MHashableTo m PLTConfigurationHash PLTConfiguration
 
+-- | The type of keys in the token state key-value map.
 type TokenStateKey = SBS.ShortByteString
+
+-- | The type of values in the token state key-value map.
 type TokenStateValue = BS.ByteString
 
 -- | The state of a particular protocol-level token.
@@ -112,7 +114,7 @@ data PLT = PLT
     { -- | The token configuration.
       _pltConfiguration :: !(HashedBufferedRef' PLTConfigurationHash PLTConfiguration),
       -- | The token-level state of the PLT.
-      -- TODO: Replace with trie-based state.
+      -- TODO: Replace with trie-based state. https://linear.app/concordium/issue/NOD-700/switch-plt-key-value-maps-to-trie-implementation
       _pltState :: !(Map.Map TokenStateKey TokenStateValue),
       -- | The total amount of the token that exists in circulation.
       _pltCirculatingSupply :: !TokenRawAmount

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/ProtocolLevelTokens.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/ProtocolLevelTokens.hs
@@ -1,0 +1,298 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DerivingVia #-}
+
+module Concordium.GlobalState.Persistent.BlockState.ProtocolLevelTokens where
+
+import Control.Monad
+import Data.Bits
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Short as SBS
+import qualified Data.Map.Strict as Map
+import Data.Serialize
+import Data.Word
+
+import qualified Concordium.Crypto.SHA256 as SHA256
+import Concordium.Types.HashableTo
+import Concordium.Utils
+import Concordium.Utils.Serialization
+
+import Concordium.GlobalState.Persistent.BlobStore
+import qualified Concordium.GlobalState.Persistent.LFMBTree as LFMBTree
+
+-- | Represents the raw amount of a token. This is the amount of the token in its smallest unit.
+newtype TokenRawAmount = TokenRawAmount {theTokenRawAmount :: Word64}
+    deriving newtype (Eq, Ord, Show)
+
+-- | Serialization of 'TokenRawAmount' is as a variable length quantity (VLQ). We disallow
+--  0-padding to enforce canonical serialization.
+instance Serialize TokenRawAmount where
+    put (TokenRawAmount amt) = do
+        mapM_ putWord8 (chunk amt [])
+      where
+        chunk num []
+            | num == 0 = [0]
+            | otherwise = chunk (num `shiftR` 7) [fromIntegral $ num .&. 0x7f]
+        chunk num l
+            | num == 0 = l
+            | otherwise = chunk (num `shiftR` 7) (fromIntegral (0x80 .|. (num .&. 0x7f)) : l)
+    get = TokenRawAmount <$> loop 0
+      where
+        loop accum = do
+            b <- getWord8
+            when (b == 0x80 && accum == 0) $
+                fail "Padding bytes are not allowed"
+            when (accum > maxBound `shiftR` 7) $
+                fail "Value out of range"
+            let accum' = accum `shiftL` 7 .|. fromIntegral (b .&. 0x7f)
+            if testBit b 7
+                then loop accum'
+                else return accum'
+
+instance (MonadBlobStore m) => BlobStorable m TokenRawAmount
+
+-- FIXME: Refactor to base.
+newtype TokenId = TokenId SBS.ShortByteString
+    deriving newtype (Eq, Ord, Serialize, Show)
+
+-- | A token index is the index of a token in the 'ProtocolLevelTokens' table.
+newtype TokenIndex = TokenIndex {theTokenIndex :: Word64}
+    deriving newtype (Eq, Ord, Serialize, Show, Num, Real, Enum, Integral, Bounded, Bits)
+
+-- | A hash that identifies the specific implementation to use for a token.
+newtype TokenModuleRef = TokenModuleRef {theTokenModuleRef :: SHA256.Hash}
+    deriving newtype (Eq, Ord, Serialize, Show)
+
+-- | The configuration of a protocol-level token that is generally not expected to change.
+data PLTConfiguration = PLTConfiguration
+    { -- | The token ID.
+      _pltTokenId :: !TokenId,
+      -- | The token module reference.
+      _pltModule :: !TokenModuleRef,
+      -- | The number of decimal places used in the representation of the token.
+      _pltDecimals :: !Word8
+    }
+    deriving (Eq, Ord, Show)
+
+instance Serialize PLTConfiguration where
+    put PLTConfiguration{..} = do
+        put _pltTokenId
+        put _pltModule
+        put _pltDecimals
+    get = do
+        _pltTokenId <- get
+        _pltModule <- get
+        _pltDecimals <- get
+        return PLTConfiguration{..}
+
+instance (MonadBlobStore m) => BlobStorable m PLTConfiguration
+
+instance (MonadBlobStore m) => Cacheable m PLTConfiguration
+
+newtype PLTConfigurationHash = PLTConfigurationHash SHA256.Hash
+    deriving newtype (Eq, Ord, Show, Serialize)
+
+instance HashableTo PLTConfigurationHash PLTConfiguration where
+    getHash = PLTConfigurationHash . SHA256.hashLazy . runPutLazy . put
+
+instance (Monad m) => MHashableTo m PLTConfigurationHash PLTConfiguration
+
+type TokenStateKey = SBS.ShortByteString
+type TokenStateValue = BS.ByteString
+
+-- | The state of a particular protocol-level token.
+data PLT = PLT
+    { -- | The token configuration.
+      _pltConfiguration :: !(HashedBufferedRef' PLTConfigurationHash PLTConfiguration),
+      -- | The token-level state of the PLT.
+      -- TODO: Replace with trie-based state.
+      _pltState :: !(Map.Map TokenStateKey TokenStateValue),
+      -- | The total amount of the token that exists in circulation.
+      _pltCirculatingSupply :: !TokenRawAmount
+    }
+
+instance (MonadBlobStore m) => BlobStorable m PLT where
+    load = do
+        configRef <- load
+        _pltState <- getSafeMapOf get get
+        _pltCirculatingSupply <- get
+        return $ do
+            _pltConfiguration <- configRef
+            return PLT{..}
+    storeUpdate plt = do
+        (putConfig, newConfig) <- storeUpdate (_pltConfiguration plt)
+        let thePutter = do
+                putConfig
+                putSafeMapOf put put (_pltState plt)
+                put (_pltCirculatingSupply plt)
+        return $!! (thePutter, plt{_pltConfiguration = newConfig})
+
+instance (MonadBlobStore m) => Cacheable m PLT where
+    cache plt = do
+        cachedConfiguration <- cache (_pltConfiguration plt)
+        return plt{_pltConfiguration = cachedConfiguration}
+
+instance (MonadBlobStore m) => MHashableTo m SHA256.Hash PLT where
+    getHashM PLT{..} = do
+        (PLTConfigurationHash configHash) <- getHashM _pltConfiguration
+
+        let stateHash = SHA256.hashLazy $ runPutLazy $ do
+                putSafeMapOf put put _pltState
+                put _pltCirculatingSupply
+
+        return $! SHA256.hashOfHashes configHash stateHash
+
+type TokenRef = HashedBufferedRef PLT
+
+-- | The table holding the protocol level token state.
+data ProtocolLevelTokens = ProtocolLevelTokens
+    { -- | The table of PLTs.
+      _pltTable :: !(LFMBTree.LFMBTree' TokenIndex HashedBufferedRef TokenRef),
+      -- | A map from 'TokenId's to 'TokenIndex'es. This is constructed, rather than stored.
+      -- TODO: In future it would likely make sense to handle this with a difference map and store
+      -- the finalized map in the LMDB database. (As, for instance, for modules.)
+      -- This is not necessary if the number of tokens remains small.
+      _pltMap :: !(Map.Map TokenId TokenIndex)
+    }
+
+instance (MonadBlobStore m) => BlobStorable m ProtocolLevelTokens where
+    load = do
+        loadTable <- load
+        return $ do
+            _pltTable <- loadTable
+            -- We construct the map by simply iterating over the LFMBTree.
+            let f (nxtIndex, m) v = do
+                    config <- refLoad (_pltConfiguration v)
+                    return $!! (nxtIndex + 1, Map.insert (_pltTokenId config) nxtIndex m)
+            (_, _pltMap) <- LFMBTree.mfold f (0, Map.empty) _pltTable
+
+            return ProtocolLevelTokens{..}
+    storeUpdate plts = do
+        (putTable, newTable) <- storeUpdate (_pltTable plts)
+        return (putTable, plts{_pltTable = newTable})
+
+instance (MonadBlobStore m) => Cacheable m ProtocolLevelTokens where
+    cache ProtocolLevelTokens{..} = do
+        pltTable' <- cache _pltTable
+        return ProtocolLevelTokens{_pltTable = pltTable', ..}
+
+-- | Get the 'TokenIndex' for a 'TokenId'. Returns @Nothing@ if there is no token with the given
+-- 'TokenId'.
+getTokenIndex :: (MonadBlobStore m) => TokenId -> ProtocolLevelTokens -> m (Maybe TokenIndex)
+getTokenIndex tokId plts = return $ Map.lookup tokId (_pltMap plts)
+
+-- | Get the 'PLT' with the given 'TokenIndex'.
+--
+--  PRECONDITION: The 'TokenIndex' MUST exist in the given 'ProtocolLevelTokens'.
+lookupPLT :: (MonadBlobStore m) => TokenIndex -> ProtocolLevelTokens -> m PLT
+lookupPLT index plts = do
+    mPLT <- LFMBTree.lookup index (_pltTable plts)
+    case mPLT of
+        Just plt -> return plt
+        Nothing ->
+            error $ "lookupPLT: TokenIndex (" ++ show index ++ ") not found in ProtocolLevelTokens"
+
+-- | Get the state of a token for a given 'TokenStateKey'. Returns @Nothing@ if the token does not
+--  have a state for the given key.
+--
+-- PRECONDITION: The 'TokenIndex' MUST exist in the given 'ProtocolLevelTokens'.
+getTokenState ::
+    (MonadBlobStore m) =>
+    TokenIndex ->
+    TokenStateKey ->
+    ProtocolLevelTokens ->
+    m (Maybe TokenStateValue)
+getTokenState index key plts = do
+    plt <- lookupPLT index plts
+    return $ Map.lookup key (_pltState plt)
+
+-- | Set the state of a token for a given 'TokenStateKey'. If the value is @Nothing@, the key is
+--  removed from the token state. Otherwise, the key is set to the given value.
+--  Returns the updated 'ProtocolLevelTokens'.
+--
+-- PRECONDITION: The 'TokenIndex' MUST exist in the given 'ProtocolLevelTokens'.
+setTokenState ::
+    (MonadBlobStore m) =>
+    TokenIndex ->
+    TokenStateKey ->
+    Maybe TokenStateValue ->
+    ProtocolLevelTokens ->
+    m ProtocolLevelTokens
+setTokenState index key mValue plts = do
+    LFMBTree.update upd index (_pltTable plts) >>= \case
+        Nothing ->
+            error $
+                "setTokenState: TokenIndex (" ++ show index ++ ") not found in ProtocolLevelTokens"
+        Just (_, newTable) -> return plts{_pltTable = newTable}
+  where
+    upd plt = do
+        let !newState = case mValue of
+                Nothing -> Map.delete key (_pltState plt)
+                Just v -> Map.insert key v (_pltState plt)
+        return ((), plt{_pltState = newState})
+
+-- | Get the configuration data of a token for a given 'TokenIndex'.
+--
+--  PRECONDITION: The 'TokenIndex' MUST exist in the given 'ProtocolLevelTokens'.
+getTokenConfiguration ::
+    (MonadBlobStore m) =>
+    TokenIndex ->
+    ProtocolLevelTokens ->
+    m PLTConfiguration
+getTokenConfiguration index plts = do
+    plt <- lookupPLT index plts
+    refLoad (_pltConfiguration plt)
+
+-- | Get the circulating supply of a token for a given 'TokenIndex'.
+--
+--  PRECONDITION: The 'TokenIndex' MUST exist in the given 'ProtocolLevelTokens'.
+getTokenCirculatingSupply ::
+    (MonadBlobStore m) =>
+    TokenIndex ->
+    ProtocolLevelTokens ->
+    m TokenRawAmount
+getTokenCirculatingSupply index plts = do
+    plt <- lookupPLT index plts
+    return $ _pltCirculatingSupply plt
+
+-- | Set the circulating supply of a token for a given 'TokenIndex'.
+--  Returns the updated 'ProtocolLevelTokens'.
+--
+-- PRECONDITION: The 'TokenIndex' MUST exist in the given 'ProtocolLevelTokens'.
+setTokenCirculatingSupply ::
+    (MonadBlobStore m) =>
+    TokenIndex ->
+    TokenRawAmount ->
+    ProtocolLevelTokens ->
+    m ProtocolLevelTokens
+setTokenCirculatingSupply index newSupply plts = do
+    LFMBTree.update upd index (_pltTable plts) >>= \case
+        Nothing ->
+            error $
+                "setTokenCirculatingSupply: TokenIndex ("
+                    ++ show index
+                    ++ ") not found in ProtocolLevelTokens"
+        Just (_, newTable) -> return plts{_pltTable = newTable}
+  where
+    upd plt = return ((), plt{_pltCirculatingSupply = newSupply})
+
+-- | Create a new token with the given configuration. The initial state will be empty and the
+--  initial supply will be 0. Returns the token index and the updated 'ProtocolLevelTokens'.
+--
+--  PRECONDITION: The 'TokenId' of the given configuration MUST NOT already exist in the
+--  'ProtocolLevelTokens'.
+createToken ::
+    (MonadBlobStore m) =>
+    PLTConfiguration ->
+    ProtocolLevelTokens ->
+    m (TokenIndex, ProtocolLevelTokens)
+createToken config plts = do
+    newConfigRef <- refMake config
+    let plt =
+            PLT
+                { _pltConfiguration = newConfigRef,
+                  _pltState = Map.empty,
+                  _pltCirculatingSupply = TokenRawAmount 0
+                }
+    (tokIndex, newTable) <- LFMBTree.append plt (_pltTable plts)
+    let newMap = Map.insert (_pltTokenId config) tokIndex (_pltMap plts)
+    return (tokIndex, ProtocolLevelTokens{_pltTable = newTable, _pltMap = newMap})

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/LFMBTree.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/LFMBTree.hs
@@ -379,7 +379,7 @@ appendV value (NonEmpty s t) = do
 
 -- | Update a value at a given key.
 --
--- If the key is not present in the tree, the same tree is returned.
+-- If the key is not present in the tree, @Nothing@ is returned.
 -- Otherwise, the value is loaded, modified with the given function and stored again.
 --
 -- @update@ will also recompute the hashes on the way up to the root.

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -1241,6 +1241,8 @@ getAccountInfoHelper getASI getCooldowns acct bs = do
         aiAccountAddress <- BS.getAccountCanonicalAddress acc
         aiAccountCooldowns <- getCooldowns acc
         aiAccountAvailableAmount <- BS.getAccountAvailableAmount acc
+        -- TODO: Get the actual protocol layer tokens. Issue #1342
+        let aiTokens = []
         return AccountInfo{..}
 
 -- | Get the details of a smart contract instance in the block state.

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/ProtocolLevelTokens.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/ProtocolLevelTokens.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE TypeApplications #-}
+
+module GlobalStateTests.ProtocolLevelTokens where
+
+import Control.Monad
+import qualified Data.ByteString as BS
+import Data.Serialize
+import Test.Hspec
+import Test.QuickCheck as QuickCheck
+
+import Concordium.GlobalState.Persistent.BlockState.ProtocolLevelTokens
+
+genTokenRawAmount :: Gen TokenRawAmount
+genTokenRawAmount = TokenRawAmount <$> arbitrary
+
+-- | Deserialize a value, ensuring that the input it fully consumed.
+decodeFull :: (Serialize a) => BS.ByteString -> Either String a
+decodeFull =
+    runGet
+        ( do
+            g <- get
+            done <- isEmpty
+            unless done $ fail "Input was not fully consumed"
+            return g
+        )
+
+testEncodeDecode :: Property
+testEncodeDecode = forAll genTokenRawAmount $ \a ->
+    let encoded = encode a
+    in  QuickCheck.label ("encoded length " ++ show (BS.length encoded)) $
+            decodeFull encoded === Right a
+
+testDecodeFailures :: Spec
+testDecodeFailures =
+    describe "Failing TokenRawAmount deserialization cases" $ mapM_ testFail examples
+  where
+    testFail (bytes, expct) =
+        it ("Decoding " ++ show bytes) $ decodeFull @TokenRawAmount (BS.pack bytes) `shouldBe` Left expct
+    examples =
+        [ ([0x80], noPadding),
+          ([0x80, 0x00], noPadding),
+          ([0x81], unexpectedEnd),
+          ([0x82, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x00], outOfRange),
+          ([0x82, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80], outOfRange),
+          ([0x81, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x00], outOfRange)
+        ]
+    noPadding = "Failed reading: Padding bytes are not allowed\nEmpty call stack\n"
+    unexpectedEnd = "too few bytes\nFrom:\tdemandInput\n\n"
+    outOfRange = "Failed reading: Value out of range\nEmpty call stack\n"
+
+tests :: Spec
+tests = describe "GlobalStateTests.ProtocolLevelTokens" $ do
+    it "Encode and decode TokenRawAmount" $ withMaxSuccess 10000 testEncodeDecode
+    testDecodeFailures

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/ProtocolLevelTokens.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/ProtocolLevelTokens.hs
@@ -12,6 +12,7 @@ import Test.Hspec
 import Test.QuickCheck as QuickCheck
 
 import qualified Concordium.Crypto.SHA256 as SHA256
+import Concordium.Types
 import Concordium.Types.HashableTo
 
 import Concordium.GlobalState.Persistent.BlobStore

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/ProtocolLevelTokens.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/ProtocolLevelTokens.hs
@@ -1,15 +1,23 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 
 module GlobalStateTests.ProtocolLevelTokens where
 
 import Control.Monad
+import Control.Monad.Trans.Class
 import qualified Data.ByteString as BS
 import Data.Serialize
+import Test.HUnit
 import Test.Hspec
 import Test.QuickCheck as QuickCheck
 
+import qualified Concordium.Crypto.SHA256 as SHA256
+import Concordium.Types.HashableTo
+
+import Concordium.GlobalState.Persistent.BlobStore
 import Concordium.GlobalState.Persistent.BlockState.ProtocolLevelTokens
 
+-- | Generate a 'TokenRawAmount' value.
 genTokenRawAmount :: Gen TokenRawAmount
 genTokenRawAmount = TokenRawAmount <$> arbitrary
 
@@ -24,12 +32,14 @@ decodeFull =
             return g
         )
 
+-- | Test that encoding and decoding a 'TokenRawAmount' value works as expected.
 testEncodeDecode :: Property
 testEncodeDecode = forAll genTokenRawAmount $ \a ->
     let encoded = encode a
     in  QuickCheck.label ("encoded length " ++ show (BS.length encoded)) $
             decodeFull encoded === Right a
 
+-- | Test cases where decoding a 'TokenRawAmount' fails.
 testDecodeFailures :: Spec
 testDecodeFailures =
     describe "Failing TokenRawAmount deserialization cases" $ mapM_ testFail examples
@@ -48,7 +58,146 @@ testDecodeFailures =
     unexpectedEnd = "too few bytes\nFrom:\tdemandInput\n\n"
     outOfRange = "Failed reading: Value out of range\nEmpty call stack\n"
 
+-- | Run an action in the 'MemBlobStoreT' monad transformer from an empty store.
+runBlobStore :: MemBlobStoreT IO a -> IO a
+runBlobStore a = do
+    mbs <- newMemBlobStore
+    runMemBlobStoreT a mbs
+
+tokenABC :: TokenId
+tokenABC = TokenId "ABC"
+
+tokenDEF :: TokenId
+tokenDEF = TokenId "DEF"
+
+configABC :: PLTConfiguration
+configABC =
+    PLTConfiguration
+        { _pltTokenId = tokenABC,
+          _pltModule = TokenModuleRef (SHA256.hash "abc"),
+          _pltDecimals = 6
+        }
+
+configDEF :: PLTConfiguration
+configDEF =
+    PLTConfiguration
+        { _pltTokenId = tokenDEF,
+          _pltModule = TokenModuleRef (SHA256.hash "def"),
+          _pltDecimals = 0
+        }
+
+testCreateToken :: Assertion
+testCreateToken = runBlobStore $ do
+    (idx, tokens) <- createToken configABC emptyProtocolLevelTokens
+    checks0 idx tokens
+    (idx', tokens') <- createToken configDEF tokens
+    checks1 idx idx' tokens'
+    tokens'' <- loadRef =<< storeRef tokens'
+    checks1 idx idx' tokens''
+  where
+    checks0 idx tokens = do
+        lift (assertEqual "ABC Token index" 0 idx)
+        lift . assertEqual "getTokenIndex for ABC returns expected index" (Just idx)
+            =<< getTokenIndex tokenABC tokens
+        lift . assertEqual "getTokenIndex for DEF returns Nothing" Nothing
+            =<< getTokenIndex tokenDEF tokens
+        lift . assertEqual "getTokenCirculatingSupply for ABC returns expected amount" 0
+            =<< getTokenCirculatingSupply idx tokens
+        lift . assertEqual "getTokenConfiguration for ABC returns expected configuration" configABC
+            =<< getTokenConfiguration idx tokens
+    checks1 idx idx' tokens' = do
+        lift (assertEqual "DEF Token index" 1 idx')
+        lift . assertEqual "getTokenIndex for ABC returns expected index" (Just idx)
+            =<< getTokenIndex tokenABC tokens'
+        lift . assertEqual "getTokenIndex for DEF returns expected index" (Just idx')
+            =<< getTokenIndex tokenDEF tokens'
+        lift . assertEqual "getTokenCirculatingSupply for ABC returns expected amount" 0
+            =<< getTokenCirculatingSupply idx tokens'
+        lift . assertEqual "getTokenConfiguration for ABC returns expected configuration" configABC
+            =<< getTokenConfiguration idx tokens'
+        lift . assertEqual "getTokenCirculatingSupply for DEF returns expected amount" 0
+            =<< getTokenCirculatingSupply idx' tokens'
+        lift . assertEqual "getTokenConfiguration for DEF returns expected configuration" configDEF
+            =<< getTokenConfiguration idx' tokens'
+
+testSetTokenCirculatingSupply :: Assertion
+testSetTokenCirculatingSupply = runBlobStore $ do
+    (idxABC, tokens0) <- createToken configABC emptyProtocolLevelTokens
+    (idxDEF, tokens1) <- createToken configDEF tokens0
+    tokens2 <- setTokenCirculatingSupply idxABC 100 tokens1
+    lift . assertEqual "getTokenCirculatingSupply for ABC returns expected amount" 100
+        =<< getTokenCirculatingSupply idxABC tokens2
+    lift . assertEqual "getTokenCirculatingSupply for DEF returns expected amount" 0
+        =<< getTokenCirculatingSupply idxDEF tokens2
+    hash2 <- getHashM @_ @ProtocolLevelTokensHash tokens2
+    tokens3 <- setTokenCirculatingSupply idxDEF 200 tokens2
+    lift . assertEqual "getTokenCirculatingSupply for ABC returns expected amount" 100
+        =<< getTokenCirculatingSupply idxABC tokens3
+    lift . assertEqual "getTokenCirculatingSupply for DEF returns expected amount" 200
+        =<< getTokenCirculatingSupply idxDEF tokens3
+    hash3 <- getHashM @_ @ProtocolLevelTokensHash tokens3
+    lift $ assertBool "Hash of tokens2 and tokens3 should be different" (hash2 /= hash3)
+    tokens4 <- setTokenCirculatingSupply idxABC 0 tokens3
+    lift . assertEqual "getTokenCirculatingSupply for ABC returns expected amount" 0
+        =<< getTokenCirculatingSupply idxABC tokens4
+    lift . assertEqual "getTokenCirculatingSupply for DEF returns expected amount" 200
+        =<< getTokenCirculatingSupply idxDEF tokens4
+    tokens5 <- cache =<< loadRef =<< storeRef tokens4
+    lift . assertEqual "getTokenCirculatingSupply for ABC returns expected amount" 0
+        =<< getTokenCirculatingSupply idxABC tokens5
+    lift . assertEqual "getTokenCirculatingSupply for DEF returns expected amount" 200
+        =<< getTokenCirculatingSupply idxDEF tokens5
+    tokens6 <- setTokenCirculatingSupply idxABC 100 tokens5
+    lift . assertEqual "getTokenCirculatingSupply for ABC returns expected amount" 100
+        =<< getTokenCirculatingSupply idxABC tokens6
+    lift . assertEqual "getTokenCirculatingSupply for DEF returns expected amount" 200
+        =<< getTokenCirculatingSupply idxDEF tokens6
+    hash6 <- getHashM tokens6
+    lift $ assertEqual "Hash of tokens3 and tokens6 should be the same" hash3 hash6
+
+testSetTokenState :: Assertion
+testSetTokenState = runBlobStore $ do
+    (idxABC, tokens0) <- createToken configABC emptyProtocolLevelTokens
+    (idxDEF, tokens1) <- createToken configDEF tokens0
+    lift . assertEqual "getTokenState for ABC \"TestKey1\"" Nothing
+        =<< getTokenState idxABC "TestKey1" tokens1
+    tokens2 <- setTokenState idxABC "TestKey1" (Just "0") tokens1
+    lift . assertEqual "getTokenState for ABC \"TestKey1\"" (Just "0")
+        =<< getTokenState idxABC "TestKey1" tokens2
+    lift . assertEqual "getTokenState for DEF \"TestKey1\"" Nothing
+        =<< getTokenState idxDEF "TestKey1" tokens2
+    tokens3 <- setTokenState idxDEF "TestKey1" (Just "1") tokens2
+    lift . assertEqual "getTokenState for ABC \"TestKey1\"" (Just "0")
+        =<< getTokenState idxABC "TestKey1" tokens3
+    lift . assertEqual "getTokenState for DEF \"TestKey1\"" (Just "1")
+        =<< getTokenState idxDEF "TestKey1" tokens3
+    tokens4 <- setTokenState idxABC "TestKey1" (Just "2") tokens3
+    lift . assertEqual "getTokenState for ABC \"TestKey1\"" (Just "2")
+        =<< getTokenState idxABC "TestKey1" tokens4
+    lift . assertEqual "getTokenState for DEF \"TestKey1\"" (Just "1")
+        =<< getTokenState idxDEF "TestKey1" tokens4
+    hash4 <- getHashM @_ @ProtocolLevelTokensHash tokens4
+    tokens5 <- setTokenState idxDEF "TestKey2" (Just "3") tokens4
+    lift . assertEqual "getTokenState for ABC \"TestKey1\"" (Just "2")
+        =<< getTokenState idxABC "TestKey1" tokens5
+    lift . assertEqual "getTokenState for DEF \"TestKey1\"" (Just "1")
+        =<< getTokenState idxDEF "TestKey1" tokens5
+    lift . assertEqual "getTokenState for DEF \"TestKey2\"" (Just "3")
+        =<< getTokenState idxDEF "TestKey2" tokens5
+    tokens6 <- setTokenState idxDEF "TestKey2" Nothing tokens5
+    lift . assertEqual "getTokenState for ABC \"TestKey1\"" (Just "2")
+        =<< getTokenState idxABC "TestKey1" tokens6
+    lift . assertEqual "getTokenState for DEF \"TestKey1\"" (Just "1")
+        =<< getTokenState idxDEF "TestKey1" tokens6
+    lift . assertEqual "getTokenState for DEF \"TestKey2\"" Nothing
+        =<< getTokenState idxDEF "TestKey2" tokens6
+    hash6 <- getHashM tokens6
+    lift $ assertEqual "Hash of tokens4 and tokens6 should be the same" hash4 hash6
+
 tests :: Spec
 tests = describe "GlobalStateTests.ProtocolLevelTokens" $ do
     it "Encode and decode TokenRawAmount" $ withMaxSuccess 10000 testEncodeDecode
     testDecodeFailures
+    it "createToken" testCreateToken
+    it "setTokenCirculatingSupply" testSetTokenCirculatingSupply
+    it "setTokenState" testSetTokenState

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/ProtocolLevelTokens.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/ProtocolLevelTokens.hs
@@ -21,7 +21,7 @@ import Concordium.GlobalState.Persistent.BlockState.ProtocolLevelTokens
 genTokenRawAmount :: Gen TokenRawAmount
 genTokenRawAmount = TokenRawAmount <$> arbitrary
 
--- | Deserialize a value, ensuring that the input it fully consumed.
+-- | Deserialize a value, ensuring that the input is fully consumed.
 decodeFull :: (Serialize a) => BS.ByteString -> Either String a
 decodeFull =
     runGet

--- a/concordium-consensus/tests/globalstate/Spec.hs
+++ b/concordium-consensus/tests/globalstate/Spec.hs
@@ -22,6 +22,7 @@ import qualified GlobalStateTests.Instances (tests)
 import qualified GlobalStateTests.LFMBTree (tests)
 import qualified GlobalStateTests.LMDBAccountMap (tests)
 import qualified GlobalStateTests.PersistentTreeState (tests)
+import qualified GlobalStateTests.ProtocolLevelTokens (tests)
 import qualified GlobalStateTests.Trie (tests)
 import qualified GlobalStateTests.UpdateQueues (tests)
 import qualified GlobalStateTests.Updates (tests)
@@ -63,3 +64,4 @@ main = atLevel $ \lvl -> hspec $ do
     GlobalStateTests.CooldownProcessing.tests
     GlobalStateTests.ConfigureValidator.tests lvl
     GlobalStateTests.ConfigureDelegator.tests
+    GlobalStateTests.ProtocolLevelTokens.tests

--- a/concordium-node/build.rs
+++ b/concordium-node/build.rs
@@ -132,7 +132,11 @@ fn build_grpc2(proto_root_input: &str) -> std::io::Result<()> {
     {
         let types = format!("{}/v2/concordium/types.proto", proto_root_input);
         println!("cargo:rerun-if-changed={}", types);
-        prost_build::compile_protos(&[types], &[proto_root_input])?;
+        let plts = format!("{}/v2/concordium/protocol-level-tokens.proto", proto_root_input);
+        println!("cargo:rerun-if-changed={}", plts);
+        let kernel = format!("{}/v2/concordium/kernel.proto", proto_root_input);
+        println!("cargo:rerun-if-changed={}", kernel);
+        prost_build::compile_protos(&[kernel, plts, types], &[proto_root_input])?;
     }
 
     // Because we serialize messages in Haskell we need to construct the service

--- a/concordium-node/src/grpc2.rs
+++ b/concordium-node/src/grpc2.rs
@@ -25,6 +25,10 @@ pub mod types {
     use concordium_base::{common::Versioned, transactions::PayloadLike};
     use std::convert::{TryFrom, TryInto};
 
+    /// Types generated from the protocol-level-tokens.proto file.
+    pub mod plt {
+        include!(concat!(env!("OUT_DIR"), "/concordium.v2.plt.rs"));
+    }
     include!(concat!(env!("OUT_DIR"), "/concordium.v2.rs"));
 
     /// Convert an account address to a pointer to the content. The length of


### PR DESCRIPTION
## Purpose

Introduce types for the global index of protocol level tokens. (Note: this does not add the index to the block state.)

## Changes

- Introduce `PLT` type representing the global state configuration of a protocol-level token.
- Introduce `ProtocolLevelTokens` type providing a global index of protocol-level tokens.
- Provide operations for creating PLTs, reading and updating state.
- Tests.

## Checklist

- [x] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
