### PR TITLE
Use binary flatc in CI

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -145,13 +145,9 @@ jobs:
     - name: Install system packages and protoc
       run: |
         sudo apt-get update && sudo apt-get -y install liblmdb-dev gcc-mingw-w64-x86-64 binutils-mingw-w64-x86-64
-        wget https://github.com/google/flatbuffers/archive/refs/tags/v22.12.06.zip
-        unzip v22.12.06.zip
-        cd flatbuffers-22.12.06
-        cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release
-        make
-        sudo make install
-        cd ..
+        wget https://github.com/google/flatbuffers/releases/download/v22.12.06/Linux.flatc.binary.g++-10.zip
+        unzip Linux.flatc.binary.g++-10.zip
+        sudo mv ./flatc /usr/bin/flatc
         flatc --version
         wget https://github.com/protocolbuffers/protobuf/releases/download/v3.15.3/protoc-3.15.3-linux-x86_64.zip
         unzip protoc-3.15.3-linux-x86_64.zip


### PR DESCRIPTION

## Purpose

Download a binary image of `flatc` instead of building it from source in the CI pipeline. This should reduce the runtime for the pipeline by a few (~3-4) minutes.
