### PR TITLE
Add GetTokenList query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Use a persistent LMDB-backed store to track the finalized module map.
 - Fix a bug that affects setting up the account map correctly for non-finalized certified blocks
   that contain account creations (#1329).
+- Add `GetTokenList` query for getting a list of all protocol level tokens.
 
 ## 8.0.3
 

--- a/concordium-consensus/lib.def
+++ b/concordium-consensus/lib.def
@@ -24,6 +24,7 @@ EXPORTS
 
  getAccountInfoV2
  getAccountListV2
+ getTokenListV2
  getModuleListV2
  getModuleSourceV2
  getInstanceListV2

--- a/concordium-consensus/src-lib/Concordium/External/GRPC2.hs
+++ b/concordium-consensus/src-lib/Concordium/External/GRPC2.hs
@@ -161,7 +161,7 @@ getTokenListV2 ::
     Ptr Word8 ->
     FunPtr (Ptr SenderChannel -> Ptr Word8 -> Int64 -> IO Int32) ->
     IO Int64
-getTokenListV2 = blockStreamHelper Q.getAccountList
+getTokenListV2 = blockStreamHelper Q.getTokenList
 
 getModuleListV2 ::
     StablePtr Ext.ConsensusRunner ->

--- a/concordium-consensus/src-lib/Concordium/External/GRPC2.hs
+++ b/concordium-consensus/src-lib/Concordium/External/GRPC2.hs
@@ -150,6 +150,19 @@ getAccountListV2 ::
     IO Int64
 getAccountListV2 = blockStreamHelper Q.getAccountList
 
+getTokenListV2 ::
+    StablePtr Ext.ConsensusRunner ->
+    Ptr SenderChannel ->
+    -- | Block type.
+    Word8 ->
+    -- | Block hash.
+    Ptr Word8 ->
+    -- | Out pointer for writing the block hash that was used.
+    Ptr Word8 ->
+    FunPtr (Ptr SenderChannel -> Ptr Word8 -> Int64 -> IO Int32) ->
+    IO Int64
+getTokenListV2 = blockStreamHelper Q.getAccountList
+
 getModuleListV2 ::
     StablePtr Ext.ConsensusRunner ->
     Ptr SenderChannel ->
@@ -1233,6 +1246,19 @@ foreign export ccall
 
 foreign export ccall
     getAccountListV2 ::
+        StablePtr Ext.ConsensusRunner ->
+        Ptr SenderChannel ->
+        -- | Block type.
+        Word8 ->
+        -- | Block hash.
+        Ptr Word8 ->
+        -- | Out pointer for writing the block hash that was used.
+        Ptr Word8 ->
+        FunPtr (Ptr SenderChannel -> Ptr Word8 -> Int64 -> IO Int32) ->
+        IO Int64
+
+foreign export ccall
+    getTokenListV2 ::
         StablePtr Ext.ConsensusRunner ->
         Ptr SenderChannel ->
         -- | Block type.

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -1141,6 +1141,10 @@ getAncestors bhi count =
 getAccountList :: BlockHashInput -> MVR finconf (BHIQueryResponse [AccountAddress])
 getAccountList = liftSkovQueryStateBHI BS.getAccountList
 
+-- | Get a list of protocol level tokens that exist at the block state.
+getTokenList :: BlockHashInput -> MVR finconf (BHIQueryResponse [TokenId])
+getTokenList = liftSkovQueryStateBHI BS.getPLTList
+
 -- | Get a list of all smart contract instances in the block state.
 getInstanceList :: BlockHashInput -> MVR finconf (BHIQueryResponse [ContractAddress])
 getInstanceList = liftSkovQueryStateBHI BS.getContractInstanceList

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -1141,7 +1141,7 @@ getAncestors bhi count =
 getAccountList :: BlockHashInput -> MVR finconf (BHIQueryResponse [AccountAddress])
 getAccountList = liftSkovQueryStateBHI BS.getAccountList
 
--- | Get a list of protocol level tokens that exist at the block state.
+-- | Get a list of protocol level tokens that exist in the block state.
 getTokenList :: BlockHashInput -> MVR finconf (BHIQueryResponse [TokenId])
 getTokenList = liftSkovQueryStateBHI BS.getPLTList
 

--- a/concordium-node/build.rs
+++ b/concordium-node/build.rs
@@ -198,6 +198,16 @@ fn build_grpc2(proto_root_input: &str) -> std::io::Result<()> {
         )
         .method(
             tonic_build::manual::Method::builder()
+                .name("get_token_list")
+                .route_name("GetTokenList")
+                .input_type("crate::grpc2::types::BlockHashInput")
+                .output_type("Vec<u8>")
+                .codec_path("crate::grpc2::RawCodec")
+                .server_streaming()
+                .build(),
+        )
+        .method(
+            tonic_build::manual::Method::builder()
                 .name("get_module_list")
                 .route_name("GetModuleList")
                 .input_type("crate::grpc2::types::BlockHashInput")

--- a/concordium-node/src/consensus_ffi/ffi.rs
+++ b/concordium-node/src/consensus_ffi/ffi.rs
@@ -810,6 +810,31 @@ extern "C" {
         ) -> i32,
     ) -> i64;
 
+    /// Get the list of tokens in a given block and, if the block exists,
+    /// enqueue them into the provided [Sender](futures::channel::mpsc::Sender).
+    ///
+    /// Individual account addresses are enqueued using the provided callback.
+    ///
+    /// * `consensus` - Pointer to the current consensus.
+    /// * `stream` - Pointer to the response stream.
+    /// * `block_id_type` - Type of block identifier.
+    /// * `block_id` - Location with the block identifier. Length must match the
+    ///   corresponding type of block identifier.
+    /// * `out_hash` - Location to write the block hash used in the query.
+    /// * `callback` - Callback for writing to the response stream.
+    pub fn getTokenListV2(
+        consensus: *mut consensus_runner,
+        stream: *mut futures::channel::mpsc::Sender<Result<Vec<u8>, tonic::Status>>,
+        block_id_type: u8,
+        block_id: *const u8,
+        out_hash: *mut u8,
+        callback: extern "C" fn(
+            *mut futures::channel::mpsc::Sender<Result<Vec<u8>, tonic::Status>>,
+            *const u8,
+            i64,
+        ) -> i32,
+    ) -> i64;
+
     /// Get an information about a specific block item.
     ///
     /// * `consensus` - Pointer to the current consensus.
@@ -2383,6 +2408,42 @@ impl ConsensusContainer {
     /// The return value is a block hash used for the query. If the requested
     /// block does not exist a [tonic::Status::not_found] is returned.
     pub fn get_account_list_v2(
+        &self,
+        block_hash: &crate::grpc2::types::BlockHashInput,
+        sender: futures::channel::mpsc::Sender<Result<Vec<u8>, tonic::Status>>,
+    ) -> Result<[u8; 32], tonic::Status> {
+        use crate::grpc2::Require;
+        let sender = Box::new(sender);
+        let consensus = self.consensus.load(Ordering::SeqCst);
+        let mut buf = [0u8; 32];
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
+        let (block_id_type, block_hash) = bhi.to_ptr();
+        let sender_ptr = Box::into_raw(sender);
+        let response: ConsensusQueryResponse = unsafe {
+            getAccountListV2(
+                consensus,
+                sender_ptr,
+                block_id_type,
+                block_hash.as_ptr(),
+                buf.as_mut_ptr(),
+                enqueue_bytearray_callback,
+            )
+        }
+        .try_into()?;
+        if let Err(e) = response.ensure_ok("block") {
+            let _ = unsafe { Box::from_raw(sender_ptr) }; // deallocate sender since it is unused by Haskell.
+            Err(e)
+        } else {
+            Ok(buf)
+        }
+    }
+
+    /// Look up tokens in the given block, and return a stream of their
+    /// token ids.
+    ///
+    /// The return value is a block hash used for the query. If the requested
+    /// block does not exist a [tonic::Status::not_found] is returned.
+    pub fn get_token_list_v2(
         &self,
         block_hash: &crate::grpc2::types::BlockHashInput,
         sender: futures::channel::mpsc::Sender<Result<Vec<u8>, tonic::Status>>,

--- a/concordium-node/src/consensus_ffi/ffi.rs
+++ b/concordium-node/src/consensus_ffi/ffi.rs
@@ -2456,7 +2456,7 @@ impl ConsensusContainer {
         let (block_id_type, block_hash) = bhi.to_ptr();
         let sender_ptr = Box::into_raw(sender);
         let response: ConsensusQueryResponse = unsafe {
-            getAccountListV2(
+            getTokenListV2(
                 consensus,
                 sender_ptr,
                 block_id_type,

--- a/concordium-node/src/consensus_ffi/ffi.rs
+++ b/concordium-node/src/consensus_ffi/ffi.rs
@@ -813,7 +813,8 @@ extern "C" {
     /// Get the list of tokens in a given block and, if the block exists,
     /// enqueue them into the provided [Sender](futures::channel::mpsc::Sender).
     ///
-    /// Individual protocol level tokens are enqueued using the provided callback.
+    /// Individual protocol level tokens are enqueued using the provided
+    /// callback.
     ///
     /// * `consensus` - Pointer to the current consensus.
     /// * `stream` - Pointer to the response stream.

--- a/concordium-node/src/consensus_ffi/ffi.rs
+++ b/concordium-node/src/consensus_ffi/ffi.rs
@@ -813,7 +813,7 @@ extern "C" {
     /// Get the list of tokens in a given block and, if the block exists,
     /// enqueue them into the provided [Sender](futures::channel::mpsc::Sender).
     ///
-    /// Individual account addresses are enqueued using the provided callback.
+    /// Individual protocol level tokens are enqueued using the provided callback.
     ///
     /// * `consensus` - Pointer to the current consensus.
     /// * `stream` - Pointer to the response stream.

--- a/concordium-node/src/grpc2.rs
+++ b/concordium-node/src/grpc2.rs
@@ -614,6 +614,8 @@ struct ServiceConfig {
     #[serde(default)]
     get_account_list: bool,
     #[serde(default)]
+    get_token_list: bool,
+    #[serde(default)]
     get_account_info: bool,
     #[serde(default)]
     get_module_list: bool,
@@ -737,6 +739,7 @@ impl ServiceConfig {
             get_finalized_blocks: true,
             get_blocks: true,
             get_account_list: true,
+            get_token_list: true,
             get_account_info: true,
             get_module_list: true,
             get_module_source: true,
@@ -1400,6 +1403,9 @@ pub mod server {
         /// Return type for the 'GetWinningBakersEpoch' method.
         type GetWinningBakersEpochStream =
             futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
+        /// Return type for the 'GetTokenList' method.
+        type GetTokenListStream =
+            futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
 
         async fn get_blocks(
             &self,
@@ -1473,6 +1479,24 @@ pub mod server {
             let hash = self
                 .run_blocking(move |consensus| {
                     consensus.get_account_list_v2(request.get_ref(), sender)
+                })
+                .await?;
+            let mut response = tonic::Response::new(receiver);
+            add_hash(&mut response, hash)?;
+            Ok(response)
+        }
+
+        async fn get_token_list(
+            &self,
+            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+        ) -> Result<tonic::Response<Self::GetTokenListStream>, tonic::Status> {
+            if !self.service_config.get_account_list {
+                return Err(tonic::Status::unimplemented("`GetTokenList` is not enabled."));
+            }
+            let (sender, receiver) = futures::channel::mpsc::channel(100);
+            let hash = self
+                .run_blocking(move |consensus| {
+                    consensus.get_token_list_v2(request.get_ref(), sender)
                 })
                 .await?;
             let mut response = tonic::Response::new(receiver);

--- a/concordium-node/src/grpc2.rs
+++ b/concordium-node/src/grpc2.rs
@@ -1489,7 +1489,7 @@ pub mod server {
             &self,
             request: tonic::Request<crate::grpc2::types::BlockHashInput>,
         ) -> Result<tonic::Response<Self::GetTokenListStream>, tonic::Status> {
-            if !self.service_config.get_account_list {
+            if !self.service_config.get_token_list {
                 return Err(tonic::Status::unimplemented("`GetTokenList` is not enabled."));
             }
             let (sender, receiver) = futures::channel::mpsc::channel(100);

--- a/concordium-node/src/grpc2.rs
+++ b/concordium-node/src/grpc2.rs
@@ -1400,11 +1400,10 @@ pub mod server {
         /// Return type for the 'GetScheduledReleaseAccounts' method.
         type GetScheduledReleaseAccountsStream =
             futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
+        /// Return type for the 'GetTokenList' method.
+        type GetTokenListStream = futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
         /// Return type for the 'GetWinningBakersEpoch' method.
         type GetWinningBakersEpochStream =
-            futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
-        /// Return type for the 'GetTokenList' method.
-        type GetTokenListStream =
             futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
 
         async fn get_blocks(

--- a/docs/grpc2.md
+++ b/docs/grpc2.md
@@ -56,6 +56,7 @@ If these are enabled then the following options become available
   get_blocks = true
   get_account_list = true
   get_account_info = false
+  get_token_list = true
   get_module_list = true
   get_module_source = true
   get_instance_list = true


### PR DESCRIPTION
## Purpose

Closes https://github.com/Concordium/concordium-node/issues/1343. Depends on https://github.com/Concordium/concordium-base/pull/619 to be merged.

## Changes

On Haskell side:
- Add `getTokenList` in Queries.hs invoking `getPLTList`
- Expose `getTokenListV2` via ffi. This composes `blockStreamHelper` with `getTokenList`.

On Rust side:
- Add `get_token_list` to build.rs
- Import `getTokenListV2` via ffi.
- Implement `get_token_list_v2` invoking `getTokenListV2`.
- Implement `async fn get_token_list`invoking `get_token_list_v2`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.


