### PR TITLE
Token Module: PLT Initialization

### DIFF
--- a/concordium-consensus/package.yaml
+++ b/concordium-consensus/package.yaml
@@ -30,7 +30,6 @@ dependencies:
 - base >= 4.7 && < 5
 - bytestring >= 0.10
 - random >= 1.1
-- cborg >= 0.2
 - cereal >= 0.5.7
 - data-fix >= 0.3
 - exceptions >= 0.10

--- a/concordium-consensus/package.yaml
+++ b/concordium-consensus/package.yaml
@@ -30,6 +30,7 @@ dependencies:
 - base >= 4.7 && < 5
 - bytestring >= 0.10
 - random >= 1.1
+- cborg >= 0.2
 - cereal >= 0.5.7
 - data-fix >= 0.3
 - exceptions >= 0.10

--- a/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
@@ -1645,7 +1645,8 @@ class (BlockStateQuery m, PLTQuery (UpdatableBlockState m) m) => BlockStateOpera
     --
     --  PRECONDITION: The 'TokenId' of the given configuration MUST NOT already be in use
     --  by a protocol-level token, i.e. @getTokenIndex s (_pltTokenId cfg)@ should return
-    --  @Nothing@.
+    --  @Nothing@. The 'PLTConfiguration' MUST be valid, and in particular the
+    --  '_pltGovernanceAccountIndex' MUST reference a valid account.
     bsoCreateToken ::
         (PVSupportsPLT (MPV m)) =>
         -- | The current block state @s@.

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/ProtocolLevelTokens.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/ProtocolLevelTokens.hs
@@ -32,7 +32,7 @@ import qualified Concordium.GlobalState.Persistent.LFMBTree as LFMBTree
 
 -- | Represents the raw amount of a token. This is the amount of the token in its smallest unit.
 newtype TokenRawAmount = TokenRawAmount {theTokenRawAmount :: Word64}
-    deriving newtype (Eq, Ord, Show, Num, Real)
+    deriving newtype (Eq, Ord, Show, Num, Real, Bounded, Enum, Integral)
 
 -- | Serialization of 'TokenRawAmount' is as a variable length quantity (VLQ). We disallow
 --  0-padding to enforce canonical serialization.
@@ -78,7 +78,9 @@ data PLTConfiguration = PLTConfiguration
       -- | The token module reference.
       _pltModule :: !TokenModuleRef,
       -- | The number of decimal places used in the representation of the token.
-      _pltDecimals :: !Word8
+      _pltDecimals :: !Word8,
+      -- | The index of the account authorized to perform token governance operations.
+      _pltGovernanceAccountIndex :: !AccountIndex
     }
     deriving (Eq, Ord, Show)
 
@@ -87,10 +89,12 @@ instance Serialize PLTConfiguration where
         put _pltTokenId
         put _pltModule
         put _pltDecimals
+        put _pltGovernanceAccountIndex
     get = do
         _pltTokenId <- get
         _pltModule <- get
         _pltDecimals <- get
+        _pltGovernanceAccountIndex <- get
         return PLTConfiguration{..}
 
 instance (MonadBlobStore m) => BlobStorable m PLTConfiguration

--- a/concordium-consensus/src/Concordium/Scheduler/Environment.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/Environment.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -43,7 +44,9 @@ import qualified Concordium.TransactionVerification as TVer
 import Control.Exception (assert)
 
 import qualified Concordium.GlobalState.ContractStateV1 as StateV1
+import Concordium.GlobalState.Persistent.BlockState.ProtocolLevelTokens (PLTConfiguration, TokenIndex)
 import qualified Concordium.ID.Types as ID
+import Concordium.Scheduler.ProtocolLevelTokens.Kernel (PLTKernelFail, PLTKernelPrivilegedUpdate)
 import qualified Concordium.Scheduler.WasmIntegration.V1 as V1
 import Concordium.Wasm (IsWasmVersion)
 import qualified Concordium.Wasm as GSWasm
@@ -357,6 +360,32 @@ class
     --  and any queued updates of the given type with a later effective
     --  time are cancelled.
     enqueueUpdate :: TransactionTime -> UpdateValue (ChainParametersVersionFor (MPV m)) -> m ()
+
+    -- | Take a snapshot of the current block state, and run the given computation. If the result
+    --  is @Left e@, then the block state is reverted to the snapshot. Otherwise, any changes to
+    --  the block state are retained. The return value is the result of the computation.
+    withBlockStateRollback :: m (Either e a) -> m (Either e a)
+
+    -- | Run a PLT operation that invokes the PLT kernel.
+    --
+    --  PRECONDITION: The 'TokenIndex' must be for a PLT that exists in the current state.
+    runPLT ::
+        (PVSupportsPLT (MPV m)) =>
+        TokenIndex ->
+        (forall m1. (Monad m1, PLTKernelPrivilegedUpdate m1, PLTKernelFail e m1) => m1 a) ->
+        m (Either e a)
+
+    -- | Get the 'TokenIndex' for a protocol-layer token with the given 'TokenId', if it exists.
+    getPLTIndex :: (PVSupportsPLT (MPV m)) => TokenId -> m (Maybe TokenIndex)
+
+    -- | Create a new protocol-layer token with the given 'PLTConfiguration'.
+    --
+    --  PRECONDITION: There MUST NOT already be a token with the specified token ID.
+    --  The governance account index MUST reference a valid account.
+    createPLT ::
+        (PVSupportsPLT (MPV m)) =>
+        PLTConfiguration ->
+        m TokenIndex
 
 -- | Contract state that is lazily thawed. This is used in the scheduler when
 --  looking up contracts. When looking them up first time we don't convert the

--- a/concordium-consensus/src/Concordium/Scheduler/EnvironmentImplementation.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/EnvironmentImplementation.hs
@@ -12,6 +12,9 @@ module Concordium.Scheduler.EnvironmentImplementation where
 
 import Control.Monad
 import Control.Monad.RWS.Strict
+import Control.Monad.Trans.Cont
+import Control.Monad.Trans.Reader (ReaderT (..))
+import Data.Either
 import Data.HashMap.Strict as Map
 import qualified Data.Kind as DK
 import Lens.Micro.Platform
@@ -19,9 +22,11 @@ import Lens.Micro.Platform
 import Concordium.GlobalState.Account
 import qualified Concordium.GlobalState.BakerInfo as BI
 import qualified Concordium.GlobalState.BlockState as BS
+import Concordium.GlobalState.Persistent.BlockState.ProtocolLevelTokens (PLTConfiguration (..), TokenIndex)
 import Concordium.GlobalState.TreeState
 import Concordium.Logger
 import Concordium.Scheduler.Environment
+import Concordium.Scheduler.ProtocolLevelTokens.Kernel
 import Concordium.Scheduler.Types
 import Concordium.TimeMonad
 import qualified Concordium.TransactionVerification as TVer
@@ -420,6 +425,29 @@ instance
         s' <- lift (BS.bsoEnqueueUpdate s tt p)
         ssBlockState .= s'
 
+    withBlockStateRollback op = do
+        s0 <- use ssBlockState
+        snapshot <- lift $ BS.bsoSnapshotState s0
+        res <- op
+        when (isLeft res) $ do
+            s1 <- use ssBlockState
+            s2 <- lift $ BS.bsoRollback s1 snapshot
+            ssBlockState .= s2
+        return res
+
+    runPLT tokenIx op = do
+        runKernelT op tokenIx
+
+    getPLTIndex tokenId = do
+        s <- use ssBlockState
+        lift $ BS.getTokenIndex s tokenId
+
+    createPLT pltConfig = do
+        s <- use ssBlockState
+        (tokenIx, s') <- lift $ BS.bsoCreateToken s pltConfig
+        ssBlockState .= s'
+        return tokenIx
+
 -- | Execute the computation using the provided context and scheduler state.
 -- The return value is the value produced by the computation and the updated state of the scheduler.
 runSchedulerT ::
@@ -431,3 +459,77 @@ runSchedulerT ::
 runSchedulerT computation contextState initialState = do
     (value, resultingState, ()) <- runRWST (_runSchedulerT computation) contextState initialState
     return (value, resultingState)
+
+newtype KernelT fail ret m a = KernelT {runKernelT' :: ReaderT TokenIndex (ContT (Either fail ret) (SchedulerT m)) a}
+    deriving
+        ( Functor,
+          Applicative,
+          Monad,
+          MonadState (SchedulerState m),
+          MonadReader TokenIndex
+        )
+
+runKernelT :: (Monad m) => KernelT fail a m a -> TokenIndex -> SchedulerT m (Either fail a)
+runKernelT a tokenIx = runContT (runReaderT (runKernelT' a) tokenIx) (return . Right)
+
+instance MonadTrans (KernelT fail ret) where
+    lift = KernelT . lift . lift . lift
+
+-- | The block state types for `KernelT fail ret m` are derived from the base monad `m`.
+deriving via (MGSTrans (KernelT fail ret) m) instance BlockStateTypes (KernelT fail ret m)
+
+instance (BS.BlockStateOperations m, PVSupportsPLT (MPV m)) => PLTKernelQuery (KernelT fail ret m) where
+    type PLTAccount (KernelT fail ret m) = IndexedAccount m
+    getTokenState key = do
+        tokenIx <- ask
+        bs <- use ssBlockState
+        lift $ BS.getTokenState bs tokenIx key
+    getAccount addr = do
+        bs <- use ssBlockState
+        lift $ BS.bsoGetAccount bs addr
+    getAccountBalance _acct = do
+        -- TODO: implement
+        return Nothing
+    getAccountState _acct _key = do
+        -- TODO: implement
+        return Nothing
+    getAccountCanonicalAddress acct = do
+        lift $ BS.getAccountCanonicalAddress (snd acct)
+    getGovernanceAccount = do
+        tokenIx <- ask
+        bs <- use ssBlockState
+        lift $ do
+            config <- BS.getTokenConfiguration bs tokenIx
+            let govIndex = _pltGovernanceAccountIndex config
+            BS.bsoGetAccountByIndex bs govIndex >>= \case
+                Nothing -> error "getGovernanceAccount: Governance account does not exist"
+                Just acc -> return (govIndex, acc)
+    getCirculatingSupply = do
+        tokenIx <- ask
+        bs <- use ssBlockState
+        lift $ BS.getTokenCirculatingSupply bs tokenIx
+    getDecimals = do
+        tokenIx <- ask
+        bs <- use ssBlockState
+        lift $ _pltDecimals <$> BS.getTokenConfiguration bs tokenIx
+
+instance (BS.BlockStateOperations m, PVSupportsPLT (MPV m)) => PLTKernelUpdate (KernelT fail ret m) where
+    setTokenState key mValue = do
+        tokenIx <- ask
+        bs <- use ssBlockState
+        newBS <- lift $ BS.bsoSetTokenState bs tokenIx key mValue
+        ssBlockState .= newBS
+    setAccountState _ _ _ = do
+        -- TODO: implement
+        return ()
+    transfer _ _ _ _ = do
+        -- TODO: implement
+        return False
+
+instance (BS.BlockStateOperations m, PVSupportsPLT (MPV m)) => PLTKernelPrivilegedUpdate (KernelT fail ret m) where
+    mint _ _ = return False -- TODO: implement
+    burn _ _ = return False -- TODO: implement
+
+instance (Monad m) => (PLTKernelFail fail (KernelT fail ret m)) where
+    -- To abort, we simply drop the continuation and return the error.
+    pltError err = KernelT $ ReaderT $ \_ -> ContT $ \_ -> return (Left err)

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Kernel.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Kernel.hs
@@ -1,0 +1,48 @@
+module Concordium.Scheduler.ProtocolLevelTokens.Kernel where
+
+import Data.Word
+
+import Concordium.Types
+
+import Concordium.GlobalState.Persistent.BlockState.ProtocolLevelTokens
+import Concordium.GlobalState.Types
+
+class PLTKernelQuery m where
+    getTokenState :: TokenStateKey -> m (Maybe TokenStateValue)
+    getAccount :: AccountAddress -> m (Maybe (Account m))
+    getAccountBalance :: Account m -> m (Maybe TokenRawAmount)
+    getAccountState :: Account m -> TokenStateKey -> m (Maybe TokenStateValue)
+    getAccountCanonicalAddress :: Account m -> m AccountAddress
+    getGovernanceAccount :: m (Account m)
+    getCirculatingSupply :: m TokenRawAmount
+    getDecimals :: m Word8
+
+class (PLTKernelQuery m) => PLTKernelUpdate m where
+    setTokenState :: TokenStateKey -> Maybe TokenStateValue -> m ()
+    setAccountState :: Account m -> TokenStateKey -> Maybe TokenStateValue -> m ()
+
+    -- | Transfer a token amount from one account to another, with an optional memo.
+    --  The return value indicates if the transfer was successful.
+    --  The transfer can fail if the sender has insufficient balance.
+    transfer ::
+        -- | Sender
+        Account m ->
+        -- | Receiver
+        Account m ->
+        -- | Amount
+        TokenRawAmount ->
+        -- | Memo
+        Maybe Memo ->
+        -- | Returns 'True' if successful, 'False' if the sender had insufficient balance.
+        m Bool
+
+class (PLTKernelUpdate m) => PLTKernelPrivilegedUpdate m where
+    -- | Mint a specified amount and deposit it in the specified account.
+    --  The return value indicates if this was successful.
+    --  Minting can fail if the total supply would exceed the representable amount.
+    mint :: Account m -> TokenRawAmount -> m Bool
+
+    -- | Burn a specified amount from a specified account.
+    --  The return value indicates if this was successful.
+    --  Burning can fail if the amount in the account is less than the specified amount to burn.
+    burn :: Account m -> TokenRawAmount -> m Bool

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Module.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Module.hs
@@ -12,30 +12,17 @@ import Concordium.Types.Tokens
 
 import Concordium.Scheduler.ProtocolLevelTokens.Kernel
 
--- | Class for constructing a 'TokenModuleRejectReason' given the 'TokenId'.
-class MakeTokenModuleRejectReason e where
-    -- | Construct a 'TokenModuleRejectReason'.
-    makeTokenModuleRejectReason :: TokenId -> e -> TokenModuleRejectReason
-
 -- | Represents the reasons why 'initializeToken' can fail.
 data InitializeTokenError
     = ITEDeserializationFailure !String
     | ITEInvalidMintAmount
-    deriving (Eq, Show)
+    deriving (Eq)
 
-instance MakeTokenModuleRejectReason InitializeTokenError where
-    makeTokenModuleRejectReason tmrrTokenSymbol (ITEDeserializationFailure _) =
-        TokenModuleRejectReason
-            { tmrrType = TokenEventType "parameterDeserializationFailure",
-              tmrrDetails = Nothing,
-              ..
-            }
-    makeTokenModuleRejectReason tmrrTokenSymbol ITEInvalidMintAmount =
-        TokenModuleRejectReason
-            { tmrrType = TokenEventType "invalidMintAmount",
-              tmrrDetails = Nothing,
-              ..
-            }
+instance Show InitializeTokenError where
+    show (ITEDeserializationFailure reason) =
+        "Token initialization parameters could not be deserialized: " ++ reason
+    show ITEInvalidMintAmount =
+        "The initial mint amount was outside of the representable range."
 
 -- | Try to convert a 'TokenAmount' to a 'TokenRawAmount'. The latter is represented in the
 --  smallest subdivision allowed for the current token.

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Module.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Module.hs
@@ -2,15 +2,13 @@
 
 module Concordium.Scheduler.ProtocolLevelTokens.Module where
 
-import Codec.CBOR.Read
 import Control.Monad
-import Control.Monad.Error.Class
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as LBS
+import qualified Data.ByteString.Builder as BS.Builder
 import qualified Data.Text.Encoding as Text
 
 import Concordium.Types
 import Concordium.Types.ProtocolLevelTokens.CBOR
+import Concordium.Types.Tokens
 
 import Concordium.Scheduler.ProtocolLevelTokens.Kernel
 
@@ -18,38 +16,40 @@ data InitializeTokenError
     = ITEDeserializationFailure !String
     | ITEInvalidMintAmount
 
-toTokenRawAmount :: TokenAmount -> m (Maybe TokenRawAmount)
+toTokenRawAmount :: (PLTKernelQuery m, Monad m) => TokenAmount -> m (Maybe TokenRawAmount)
 toTokenRawAmount TokenAmount{..} = do
     actualDecimals <- getDecimals
     case compare nrDecimals (fromIntegral actualDecimals) of
         EQ -> return (Just (TokenRawAmount digits))
         GT -> return Nothing
         LT -> do
-            let factor = 10 ^ (fromIntegral actualDecimals - fromIntegral nrDecimals)
+            let factor = 10 ^ (fromIntegral actualDecimals - nrDecimals)
             let rawAmountInteger = factor * toInteger digits
             if rawAmountInteger > fromIntegral (maxBound :: TokenRawAmount)
                 then return Nothing
-                else return (fromIntegral rawAmountInteger)
+                else return (Just (fromIntegral rawAmountInteger))
 
 initializeToken ::
-    (PLTKernelPrivilegedUpdate m, MonadError InitializeTokenError m) =>
-    BS.ByteString ->
+    (PLTKernelPrivilegedUpdate m, PLTKernelFail InitializeTokenError m, Monad m) =>
+    TokenParameter ->
     m ()
 initializeToken tokenParam = do
-    case deserialiseFromBytes decodeTokenInitializationParameters (LBS.fromStrict tokenParam) of
-        Left failureReason -> throwError $ ITEDeserializationFailure (show failureReason)
-        Right (remaining, TokenInitializationParameters{..})
-            | not (LBS.null remaining) -> throwError $ ITEDeserializationFailure "Parameter was not fully consumed"
-            | otherwise -> do
-                setTokenState "name" (Just $ Text.encodeUtf8 tipName)
-                setTokenState "metadata" (Just $ Text.encodeUtf8 tipMetadata)
-                when tipAllowList $ setTokenState "allowList" (Just "")
-                when tipDenyList $ setTokenState "denyList" (Just "")
-                when tipMintable $ setTokenState "mintable" (Just "")
-                when tipBurnable $ setTokenState "burnable" (Just "")
-                forM_ tipInitialSupply $ \initSupply -> do
-                    case toTokenRawAmount initSupply of
-                        Nothing -> throwError ITEInvalidMintAmount
-                        Just amt -> do
-                            govAccount <- getGovernanceAccount
-                            mint govAccount amt
+    case tokenInitializationParametersFromBytes tokenParamLBS of
+        Left failureReason -> pltError $ ITEDeserializationFailure failureReason
+        Right TokenInitializationParameters{..} -> do
+            setTokenState "name" (Just $ Text.encodeUtf8 tipName)
+            setTokenState "metadata" (Just $ Text.encodeUtf8 tipMetadata)
+            when tipAllowList $ setTokenState "allowList" (Just "")
+            when tipDenyList $ setTokenState "denyList" (Just "")
+            when tipMintable $ setTokenState "mintable" (Just "")
+            when tipBurnable $ setTokenState "burnable" (Just "")
+            forM_ tipInitialSupply $ \initSupply -> do
+                toTokenRawAmount initSupply >>= \case
+                    Nothing -> pltError ITEInvalidMintAmount
+                    Just amt -> do
+                        govAccount <- getGovernanceAccount
+                        mintOK <- mint govAccount amt
+                        unless mintOK $ pltError ITEInvalidMintAmount
+  where
+    tokenParamLBS =
+        BS.Builder.toLazyByteString $ BS.Builder.shortByteString $ parameterBytes tokenParam

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Module.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Module.hs
@@ -12,11 +12,37 @@ import Concordium.Types.Tokens
 
 import Concordium.Scheduler.ProtocolLevelTokens.Kernel
 
+-- | Class for constructing a 'TokenModuleRejectReason' given the 'TokenId'.
+class MakeTokenModuleRejectReason e where
+    -- | Construct a 'TokenModuleRejectReason'.
+    makeTokenModuleRejectReason :: TokenId -> e -> TokenModuleRejectReason
+
+-- | Represents the reasons why 'initializeToken' can fail.
 data InitializeTokenError
     = ITEDeserializationFailure !String
     | ITEInvalidMintAmount
     deriving (Eq, Show)
 
+instance MakeTokenModuleRejectReason InitializeTokenError where
+    makeTokenModuleRejectReason tmrrTokenSymbol (ITEDeserializationFailure _) =
+        TokenModuleRejectReason
+            { tmrrType = TokenEventType "parameterDeserializationFailure",
+              tmrrDetails = Nothing,
+              ..
+            }
+    makeTokenModuleRejectReason tmrrTokenSymbol ITEInvalidMintAmount =
+        TokenModuleRejectReason
+            { tmrrType = TokenEventType "invalidMintAmount",
+              tmrrDetails = Nothing,
+              ..
+            }
+
+-- | Try to convert a 'TokenAmount' to a 'TokenRawAmount'. The latter is represented in the
+--  smallest subdivision allowed for the current token.
+--  This can fail if:
+--
+--   - The token amount specifies more decimals than the token allows in its representation.
+--   - The amount would be outside of the representable range as a 'TokenRawAmount'.
 toTokenRawAmount :: (PLTKernelQuery m, Monad m) => TokenAmount -> m (Maybe TokenRawAmount)
 toTokenRawAmount TokenAmount{..} = do
     actualDecimals <- getDecimals
@@ -30,6 +56,8 @@ toTokenRawAmount TokenAmount{..} = do
                 then return Nothing
                 else return (Just (fromIntegral rawAmountInteger))
 
+-- | Initialize a PLT by recording the relevant configuration parameters in the state and
+--  (if necessary) minting the initial supply to the token governance account.
 initializeToken ::
     (PLTKernelPrivilegedUpdate m, PLTKernelFail InitializeTokenError m, Monad m) =>
     TokenParameter ->

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Module.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Module.hs
@@ -15,6 +15,7 @@ import Concordium.Scheduler.ProtocolLevelTokens.Kernel
 data InitializeTokenError
     = ITEDeserializationFailure !String
     | ITEInvalidMintAmount
+    deriving (Eq, Show)
 
 toTokenRawAmount :: (PLTKernelQuery m, Monad m) => TokenAmount -> m (Maybe TokenRawAmount)
 toTokenRawAmount TokenAmount{..} = do

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Module.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Module.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Concordium.Scheduler.ProtocolLevelTokens.Module where
+
+import Codec.CBOR.Read
+import Control.Monad
+import Control.Monad.Error.Class
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Text.Encoding as Text
+
+import Concordium.Types
+import Concordium.Types.ProtocolLevelTokens.CBOR
+
+import Concordium.Scheduler.ProtocolLevelTokens.Kernel
+
+data InitializeTokenError
+    = ITEDeserializationFailure !String
+    | ITEInvalidMintAmount
+
+toTokenRawAmount :: TokenAmount -> m (Maybe TokenRawAmount)
+toTokenRawAmount TokenAmount{..} = do
+    actualDecimals <- getDecimals
+    case compare nrDecimals (fromIntegral actualDecimals) of
+        EQ -> return (Just (TokenRawAmount digits))
+        GT -> return Nothing
+        LT -> do
+            let factor = 10 ^ (fromIntegral actualDecimals - fromIntegral nrDecimals)
+            let rawAmountInteger = factor * toInteger digits
+            if rawAmountInteger > fromIntegral (maxBound :: TokenRawAmount)
+                then return Nothing
+                else return (fromIntegral rawAmountInteger)
+
+initializeToken ::
+    (PLTKernelPrivilegedUpdate m, MonadError InitializeTokenError m) =>
+    BS.ByteString ->
+    m ()
+initializeToken tokenParam = do
+    case deserialiseFromBytes decodeTokenInitializationParameters (LBS.fromStrict tokenParam) of
+        Left failureReason -> throwError $ ITEDeserializationFailure (show failureReason)
+        Right (remaining, TokenInitializationParameters{..})
+            | not (LBS.null remaining) -> throwError $ ITEDeserializationFailure "Parameter was not fully consumed"
+            | otherwise -> do
+                setTokenState "name" (Just $ Text.encodeUtf8 tipName)
+                setTokenState "metadata" (Just $ Text.encodeUtf8 tipMetadata)
+                when tipAllowList $ setTokenState "allowList" (Just "")
+                when tipDenyList $ setTokenState "denyList" (Just "")
+                when tipMintable $ setTokenState "mintable" (Just "")
+                when tipBurnable $ setTokenState "burnable" (Just "")
+                forM_ tipInitialSupply $ \initSupply -> do
+                    case toTokenRawAmount initSupply of
+                        Nothing -> throwError ITEInvalidMintAmount
+                        Just amt -> do
+                            govAccount <- getGovernanceAccount
+                            mint govAccount amt

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/ProtocolLevelTokens.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/ProtocolLevelTokens.hs
@@ -77,7 +77,8 @@ configABC =
     PLTConfiguration
         { _pltTokenId = tokenABC,
           _pltModule = TokenModuleRef (SHA256.hash "abc"),
-          _pltDecimals = 6
+          _pltDecimals = 6,
+          _pltGovernanceAccountIndex = 0
         }
 
 configDEF :: PLTConfiguration
@@ -85,7 +86,8 @@ configDEF =
     PLTConfiguration
         { _pltTokenId = tokenDEF,
           _pltModule = TokenModuleRef (SHA256.hash "def"),
-          _pltDecimals = 0
+          _pltDecimals = 0,
+          _pltGovernanceAccountIndex = 0
         }
 
 emptyPLTPV :: (MonadBlobStore m) => m (ProtocolLevelTokensForPV 'P9)

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TokenModule.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TokenModule.hs
@@ -1,0 +1,378 @@
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | This module defines tests for 'Concordium.Scheduler.ProtocolLevelTokens.Module', which
+--  implements the token module. These tests are implemented by modelling interactions between
+--  the Token Module and the Token Kernel by traces. A trace specifies a call by the Module into
+--  the Kernel with particular arguments, and defines the response from the Kernel (which can
+--  be a return value or aborting the execution).
+module SchedulerTests.TokenModule where
+
+import qualified Data.ByteString.Short as SBS
+import Data.Typeable
+import Data.Word
+import Test.HUnit
+import Test.Hspec
+
+import Concordium.Types
+
+import Concordium.GlobalState.Persistent.BlockState.ProtocolLevelTokens
+import Concordium.Scheduler.ProtocolLevelTokens.Kernel
+import Concordium.Scheduler.ProtocolLevelTokens.Module (InitializeTokenError (..), initializeToken)
+import Concordium.Types.ProtocolLevelTokens.CBOR
+import Concordium.Types.Tokens
+
+-- | A value of type @PLTKernelQueryCall acct ret@ represents an invocation of an operation
+--  in a 'PLTKernelQuery' monad where @PLTAccount m ~ acct@. The parameter @ret@ is the type
+--  of the return value expected.
+data PLTKernelQueryCall acct ret where
+    GetTokenState :: TokenStateKey -> PLTKernelQueryCall acct (Maybe TokenStateValue)
+    GetAccount :: AccountAddress -> PLTKernelQueryCall acct (Maybe acct)
+    GetAccountBalance :: acct -> PLTKernelQueryCall acct (Maybe TokenRawAmount)
+    GetAccountState :: acct -> TokenStateKey -> PLTKernelQueryCall acct (Maybe TokenStateValue)
+    GetAccountCanonicalAddress :: acct -> PLTKernelQueryCall acct AccountAddress
+    GetGovernanceAccount :: PLTKernelQueryCall acct acct
+    GetCirculatingSupply :: PLTKernelQueryCall acct TokenRawAmount
+    GetDecimals :: PLTKernelQueryCall acct Word8
+
+deriving instance (Show acct) => Show (PLTKernelQueryCall acct ret)
+deriving instance (Eq acct) => Eq (PLTKernelQueryCall acct ret)
+
+-- | A value of type @PLTKernelUpdateCall acct ret@ represents an invocation of an operation
+--  in a 'PLTKernelUpdate' monad, where @PLTAccount m ~ acct@. The parameter @ret@ is the type
+--  of the return value expected.
+data PLTKernelUpdateCall acct ret where
+    SetTokenState :: TokenStateKey -> Maybe TokenStateValue -> PLTKernelUpdateCall acct ()
+    SetAccountState :: acct -> TokenStateKey -> Maybe TokenStateValue -> PLTKernelUpdateCall acct ()
+    Transfer :: acct -> acct -> TokenRawAmount -> Maybe Memo -> PLTKernelUpdateCall acct Bool
+
+deriving instance (Show acct) => Show (PLTKernelUpdateCall acct ret)
+deriving instance (Eq acct) => Eq (PLTKernelUpdateCall acct ret)
+
+-- | A value of type @PLTKernelPrivilegedUpdateCall acct ret@ represents an invocation of an
+--  operation in a 'PLTKernelPrivilegedUpdate' monad, where @PLTAccount m ~ acct@. The parameter
+--  @ret@ is the type of the return value expected.
+data PLTKernelPrivilegedUpdateCall acct ret where
+    Mint :: acct -> TokenRawAmount -> PLTKernelPrivilegedUpdateCall acct Bool
+    Burn :: acct -> TokenRawAmount -> PLTKernelPrivilegedUpdateCall acct Bool
+
+deriving instance (Show acct) => Show (PLTKernelPrivilegedUpdateCall acct ret)
+deriving instance (Eq acct) => Eq (PLTKernelPrivilegedUpdateCall acct ret)
+
+-- | A value of type @PLTKernelFailCall e ret@ represents an invocation of an operation in a
+--  @PLTKernelFail e@ monad. The parameter @ret@ is the type of the return value expected.
+data PLTKernelFailCall e ret where
+    PLTError :: e -> PLTKernelFailCall e ()
+
+deriving instance (Show e) => Show (PLTKernelFailCall e ret)
+deriving instance (Eq e) => Eq (PLTKernelFailCall e ret)
+
+-- | A union type that combines the calls for all of the PLT-related monads.
+data PLTCall e acct ret
+    = -- | A 'PLTKernelQuery' call
+      PLTQ (PLTKernelQueryCall acct ret)
+    | -- | A 'PLTKernelUpdate' call
+      PLTU (PLTKernelUpdateCall acct ret)
+    | -- | A 'PLTKernelPrivilegedUpdate' call
+      PLTPU (PLTKernelPrivilegedUpdateCall acct ret)
+    | -- | A 'PLTKernelFail' call.
+      PLTF (PLTKernelFailCall e ret)
+
+deriving instance (Show e, Show acct) => Show (PLTCall e acct ret)
+deriving instance (Eq e, Eq acct) => Eq (PLTCall e acct ret)
+
+-- | A @TraceEvent call@ is a pair of a call of type @call ret@ and a return value of type @ret@.
+--  This models a call of a (monadic) operation that returns a specific value.
+--  The return type @ret@ is existentially quantified. The constraints ensure that values can be
+--  shown and we can discriminate on the types.
+data TraceEvent call
+    = forall ret.
+        (Show (call ret), Show ret, Typeable call, Typeable ret) =>
+      call ret :-> ret
+
+infix 8 :->
+
+deriving instance (Show (TraceEvent call))
+
+-- | An @AbortEvent call@ is a call of type @call ret@ with no return value. This models a call of
+--  a (monadic) operation where the implementation aborts execution.
+--  The return type @ret@ is existentially quantified. The constraints ensure that values can be
+--  shown and we can discriminate on the types.
+data AbortEvent call = forall ret. (Show (call ret), Typeable call, Typeable ret) => AbortCall (call ret)
+
+deriving instance Show (AbortEvent call)
+
+-- | A trace consisting of a sequence of call-return interactions between a function and the
+--  mocked environment and ending in either a call for which the environment aborts execution, or
+--  the function returning a value.
+data Trace call ret
+    = -- | A trace event followed by the rest of the trace
+      TraceEvent call :>>: Trace call ret
+    | -- | A call that ends the trace by aborting execution.
+      Abort (AbortEvent call)
+    | -- | The trace exits normally producing a return value.
+      Done ret
+    deriving (Show, Functor)
+
+infixr 4 :>>:
+
+type TraceException = String
+
+-- | The @TraceM call res ret@ monad is a continuation-based monad that (partially) consumes an
+--  event trace of type @Trace call ret@. A value is a function that is parametrised by:
+--
+--   1. The continuation to invoke on an exception. This is used to indicate that the code under
+--      test did not conform to the specified trace.
+--
+--   2. The continuation in the event of an abort by the environment. This is used to indicate that
+--      the environment terminated execution, and does not indicate any fault in the code under
+--      test.
+--
+--   3. The continuation in the event of normal execution. This takes the updated trace and the
+--      return value.
+--
+--   4. The current event trace.
+newtype TraceM call res ret a = TraceM
+    { runTraceM ::
+        (TraceException -> res) ->
+        res ->
+        (Trace call ret -> a -> res) ->
+        Trace call ret ->
+        res
+    }
+    deriving (Functor)
+
+instance Applicative (TraceM call res ret) where
+    pure r = TraceM $ \_ _ cont t -> cont t r
+    m1 <*> m2 =
+        TraceM $ \except abort cont t ->
+            runTraceM
+                m1
+                except
+                abort
+                (\t1 x1 -> runTraceM m2 except abort (\t2 x2 -> cont t2 (x1 x2)) t1)
+                t
+
+instance Monad (TraceM call res ret) where
+    m1 >>= m2 = TraceM $ \except abort cont t ->
+        runTraceM m1 except abort (\t1 x1 -> runTraceM (m2 x1) except abort cont t1) t
+
+instance MonadFail (TraceM call res ret) where
+    fail e = TraceM $ \except _ _ _ -> except e
+
+-- | Check that a trace is consistent with an operation. The result is @Left e@ if the trace is
+--  not consistent with the operation, where @e@ describes the inconsistency. Otherwise, @Right ()@
+--  indicates the trace is consistent with the operation.
+checkTrace :: (Eq ret, Show ret) => Trace call ret -> TraceM call (Either TraceException ()) ret ret -> Either TraceException ()
+checkTrace expected op = runTraceM op Left (Right ()) checkDone expected
+  where
+    checkDone (Done r) r'
+        | r == r' = Right ()
+        | otherwise = Left $ "Trace produced incorrect result. Expected: " ++ show r' ++ " Actual: " ++ show r
+    checkDone t r = Left $ "Trace terminated prematurely (with result " ++ show r ++ "). Expected continuation: " ++ show t
+
+-- | Handle a single event, ensuring that it matches the next event in the trace.
+--
+--  - If it does not match, or no further events are expected, an exception is raised indicating
+--    what was expected and what occurred. (Implemented by calling the exception continuation with
+--    the description of the exception.)
+--  - If it matches and the event is a 'TraceEvent', then the return value specified by the event
+--    is returned. (Implemented by calling the success continuation with the updated trace (after
+--    removing the first event) and the specified return value.)
+--  - If it matches and the event is an 'AbortEvent', then the execution aborts. (Implemented by
+--    calling the abort continuation.)
+--
+--  Note that we use type-safe casting (courtesy of 'Typeable') since the event result types are
+--  existentially quantified in the trace. This is necessary, since we wish to model operations with
+--  different return types.
+handleEvent ::
+    (Eq (call a), Show (call a), Typeable call, Typeable ret, Typeable a, Show ret) =>
+    call a ->
+    TraceM call res ret a
+handleEvent actualCall = TraceM $ \except abort cont -> \case
+    (expectedCall :-> result :>>: t) -> case cast (expectedCall, result) of
+        Just (expectedCall', result') | expectedCall' == actualCall -> cont t result'
+        _ -> except $ "Expected trace call " ++ show expectedCall ++ " but saw " ++ show actualCall
+    (Abort (AbortCall expectedCall)) -> case cast expectedCall of
+        Just expectedCall' | expectedCall' == actualCall -> abort
+        _ -> except $ "Expected trace call " ++ show expectedCall ++ " but saw " ++ show actualCall
+    (Done r) -> except $ "Trace should end (with result" ++ show r ++ "). But saw event: " ++ show actualCall
+
+instance
+    (Eq e, Eq acct, Show e, Show acct, Show ret, Typeable e, Typeable acct, Typeable ret) =>
+    PLTKernelQuery (TraceM (PLTCall e acct) res ret)
+    where
+    type PLTAccount (TraceM (PLTCall e acct) res ret) = acct
+    getTokenState key = handleEvent $ PLTQ $ GetTokenState key
+    getAccount addr = handleEvent $ PLTQ $ GetAccount addr
+    getAccountBalance acct = handleEvent $ PLTQ $ GetAccountBalance acct
+    getAccountState acct key = handleEvent $ PLTQ $ GetAccountState acct key
+    getAccountCanonicalAddress acct = handleEvent $ PLTQ $ GetAccountCanonicalAddress acct
+    getGovernanceAccount = handleEvent $ PLTQ GetGovernanceAccount
+    getCirculatingSupply = handleEvent $ PLTQ GetCirculatingSupply
+    getDecimals = handleEvent $ PLTQ GetDecimals
+
+instance
+    (Eq e, Eq acct, Show e, Show acct, Show ret, Typeable e, Typeable acct, Typeable ret) =>
+    PLTKernelUpdate (TraceM (PLTCall e acct) res ret)
+    where
+    setTokenState key mValue = handleEvent $ PLTU $ SetTokenState key mValue
+    setAccountState acct key mValue = handleEvent $ PLTU $ SetAccountState acct key mValue
+    transfer sender receiver amount mMemo = handleEvent $ PLTU $ Transfer sender receiver amount mMemo
+
+instance
+    (Eq e, Eq acct, Show e, Show acct, Show ret, Typeable e, Typeable acct, Typeable ret) =>
+    PLTKernelPrivilegedUpdate (TraceM (PLTCall e acct) res ret)
+    where
+    mint acct amount = handleEvent $ PLTPU $ Mint acct amount
+    burn acct amount = handleEvent $ PLTPU $ Burn acct amount
+
+instance
+    (Eq e, Eq acct, Show e, Show acct, Show ret, Typeable e, Typeable acct, Typeable ret) =>
+    PLTKernelFail e (TraceM (PLTCall e acct) res ret)
+    where
+    pltError e = handleEvent $ PLTF $ PLTError e
+
+-- | Assert that calling a given operation results in the given trace.
+assertTrace :: (Eq ret, Show ret) => TraceM call (Either TraceException ()) ret ret -> Trace call ret -> IO ()
+assertTrace op trace = case checkTrace trace op of
+    Left e -> assertFailure e
+    Right () -> return ()
+
+-- | Helper to generate a trace that aborts as a result of a 'PLTError' call.
+abortPLTError :: (Show e, Show acct, Typeable e, Typeable acct) => e -> Trace (PLTCall e acct) ret
+abortPLTError = Abort . AbortCall . PLTF . PLTError
+
+-- | Tests for 'initializeToken'.
+testInitializeToken :: Spec
+testInitializeToken = describe "intializeToken" $ do
+    -- In this example, the parameters are not a valid encoding.
+    it "invalid parameters" $ do
+        let trace :: Trace (PLTCall InitializeTokenError AccountIndex) ()
+            trace =
+                abortPLTError $
+                    ITEDeserializationFailure "DeserialiseFailure 0 \"end of input\""
+        assertTrace
+            (initializeToken (TokenParameter mempty))
+            trace
+    -- An example with valid parameters (no minting).
+    it "valid1" $ do
+        let params =
+                TokenInitializationParameters
+                    { tipName = "Protocol-level token",
+                      tipMetadata = "https://plt.token",
+                      tipAllowList = True,
+                      tipDenyList = False,
+                      tipInitialSupply = Nothing,
+                      tipMintable = True,
+                      tipBurnable = True
+                    }
+            tokenParam = TokenParameter $ SBS.toShort $ tokenInitializationParametersToBytes params
+            trace :: Trace (PLTCall InitializeTokenError AccountIndex) ()
+            trace =
+                (PLTU (SetTokenState "name" $ Just "Protocol-level token") :-> ())
+                    :>>: (PLTU (SetTokenState "metadata" $ Just "https://plt.token") :-> ())
+                    :>>: (PLTU (SetTokenState "allowList" $ Just "") :-> ())
+                    :>>: (PLTU (SetTokenState "mintable" $ Just "") :-> ())
+                    :>>: (PLTU (SetTokenState "burnable" $ Just "") :-> ())
+                    :>>: Done ()
+        assertTrace (initializeToken tokenParam) trace
+    -- An example with valid parameters and minting.
+    it "valid2" $ do
+        let params =
+                TokenInitializationParameters
+                    { tipName = "Protocol-level token2",
+                      tipMetadata = "https://plt2.token",
+                      tipAllowList = False,
+                      tipDenyList = True,
+                      tipInitialSupply = Just TokenAmount{digits = 500000, nrDecimals = 2},
+                      tipMintable = False,
+                      tipBurnable = False
+                    }
+            tokenParam = TokenParameter $ SBS.toShort $ tokenInitializationParametersToBytes params
+            trace :: Trace (PLTCall InitializeTokenError AccountIndex) ()
+            trace =
+                (PLTU (SetTokenState "name" $ Just "Protocol-level token2") :-> ())
+                    :>>: (PLTU (SetTokenState "metadata" $ Just "https://plt2.token") :-> ())
+                    :>>: (PLTU (SetTokenState "denyList" $ Just "") :-> ())
+                    :>>: (PLTQ GetDecimals :-> 6)
+                    :>>: (PLTQ GetGovernanceAccount :-> AccountIndex 50)
+                    :>>: (PLTPU (Mint (AccountIndex 50) (TokenRawAmount 5000000000)) :-> True)
+                    :>>: Done ()
+        assertTrace (initializeToken tokenParam) trace
+    -- In this test, the amount to mint exceeds what is representable in the 'TokenRawAmount',
+    -- so it should fail.
+    it "mint too large" $ do
+        let params =
+                TokenInitializationParameters
+                    { tipName = "Protocol-level token2",
+                      tipMetadata = "https://plt2.token",
+                      tipAllowList = False,
+                      tipDenyList = False,
+                      tipInitialSupply = Just TokenAmount{digits = 500000, nrDecimals = 2},
+                      tipMintable = False,
+                      tipBurnable = False
+                    }
+            tokenParam = TokenParameter $ SBS.toShort $ tokenInitializationParametersToBytes params
+            trace :: Trace (PLTCall InitializeTokenError AccountIndex) ()
+            trace =
+                (PLTU (SetTokenState "name" $ Just "Protocol-level token2") :-> ())
+                    :>>: (PLTU (SetTokenState "metadata" $ Just "https://plt2.token") :-> ())
+                    :>>: (PLTQ GetDecimals :-> 50)
+                    :>>: abortPLTError ITEInvalidMintAmount
+        assertTrace (initializeToken tokenParam) trace
+    -- In this test, the Kernel responds to the minting request indicating that it failed.
+    it "mint fails" $ do
+        let params =
+                TokenInitializationParameters
+                    { tipName = "Protocol-level token2",
+                      tipMetadata = "https://plt2.token",
+                      tipAllowList = False,
+                      tipDenyList = False,
+                      tipInitialSupply = Just TokenAmount{digits = 500000, nrDecimals = 2},
+                      tipMintable = False,
+                      tipBurnable = False
+                    }
+            tokenParam = TokenParameter $ SBS.toShort $ tokenInitializationParametersToBytes params
+            trace :: Trace (PLTCall InitializeTokenError AccountIndex) ()
+            trace =
+                (PLTU (SetTokenState "name" $ Just "Protocol-level token2") :-> ())
+                    :>>: (PLTU (SetTokenState "metadata" $ Just "https://plt2.token") :-> ())
+                    :>>: (PLTQ GetDecimals :-> 2)
+                    :>>: (PLTQ GetGovernanceAccount :-> AccountIndex 2)
+                    :>>: (PLTPU (Mint (AccountIndex 2) (TokenRawAmount 500000)) :-> False)
+                    :>>: abortPLTError ITEInvalidMintAmount
+        assertTrace (initializeToken tokenParam) trace
+    -- In this example, the parameters specify an initial supply with higher precision than the
+    -- token allows. (nrDecimals is 6, but GetDecimals returns 2.)
+    it "too many decimals specified" $ do
+        let params =
+                TokenInitializationParameters
+                    { tipName = "Protocol-level token2",
+                      tipMetadata = "https://plt2.token",
+                      tipAllowList = False,
+                      tipDenyList = False,
+                      tipInitialSupply = Just TokenAmount{digits = 500000, nrDecimals = 6},
+                      tipMintable = False,
+                      tipBurnable = False
+                    }
+            tokenParam = TokenParameter $ SBS.toShort $ tokenInitializationParametersToBytes params
+            trace :: Trace (PLTCall InitializeTokenError AccountIndex) ()
+            trace =
+                (PLTU (SetTokenState "name" $ Just "Protocol-level token2") :-> ())
+                    :>>: (PLTU (SetTokenState "metadata" $ Just "https://plt2.token") :-> ())
+                    :>>: (PLTQ GetDecimals :-> 2)
+                    :>>: abortPLTError ITEInvalidMintAmount
+        assertTrace (initializeToken tokenParam) trace
+
+-- | Tests for the Token Module implementation.
+tests :: Spec
+tests = parallel $ describe "TokenModule" $ do
+    testInitializeToken

--- a/concordium-consensus/tests/scheduler/Spec.hs
+++ b/concordium-consensus/tests/scheduler/Spec.hs
@@ -20,6 +20,7 @@ import qualified SchedulerTests.RejectReasonsRustContract (tests)
 import qualified SchedulerTests.SimpleTransferSpec (tests)
 import qualified SchedulerTests.SimpleTransfersTest (tests)
 import qualified SchedulerTests.StakedAmountLocked (tests)
+import qualified SchedulerTests.TokenModule (tests)
 import qualified SchedulerTests.TransactionExpirySpec (tests)
 import qualified SchedulerTests.TransactionGroupingSpec2 (tests)
 import qualified SchedulerTests.TransfersWithScheduleTest (tests)
@@ -112,3 +113,4 @@ main = hspec $ do
     SchedulerTests.SmartContracts.V1.InspectModuleReferenceAndContractName.tests
     SchedulerTests.SmartContracts.V1.Caller.tests
     SchedulerTests.KonsensusV1.EpochTransition.tests
+    SchedulerTests.TokenModule.tests


### PR DESCRIPTION
## Purpose

Closes [COR-698](https://linear.app/concordium/issue/COR-698/token-module-basic-plt-initialization)

Depends on: https://github.com/Concordium/concordium-grpc-api/pull/90
Depends on: https://github.com/Concordium/concordium-base/pull/623

Implement PLT initialization in the Token Module.

## Changes

- Add the governance account index to the `PLTConfiguration`.
- `handleCreatePLT` invokes token module.
- `SchedulerMonad` functions:
  - `withBlockStateRollback`: execute some operation allowing for rolling back the block state changes in the event of failure.
  - `runPLT`: run operations that use the PLT kernel.
  - `createToken`: create a new PLT with the specified configuration.
- Introduce token kernel classes and provide an implementation based on the scheduler.
- Token module implementation of `initializeToken`.
- Testing for the token module implementation.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
