### PR TITLE
Expose the update sequence number for PLTs

### DIFF
--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -1008,9 +1008,9 @@ getBlockFinalizationSummary = liftSkovQueryBHI getFinSummarySkovM (\_ -> return 
 getNextUpdateSequenceNumbers :: forall finconf. BlockHashInput -> MVR finconf (BHIQueryResponse NextUpdateSequenceNumbers)
 getNextUpdateSequenceNumbers = liftSkovQueryStateBHI query
   where
-    -- Get the next sequence number or 1, if not supported.
+    -- Get the next sequence number or minUpdateSequenceNumber (1), if not supported.
     mNextSequenceNumber :: UQ.OUpdateQueue pt cpv e -> U.UpdateSequenceNumber
-    mNextSequenceNumber NoParam = 1
+    mNextSequenceNumber NoParam = minUpdateSequenceNumber
     mNextSequenceNumber (SomeParam q) = UQ._uqNextSequenceNumber q
     query bs = do
         updates <- BS.getUpdates bs

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -88,6 +88,7 @@ import Concordium.Skov as Skov (
     evalSkovT,
  )
 import Concordium.Types.Option
+import Concordium.Types.Updates (minUpdateSequenceNumber)
 import Control.Monad.State.Class
 import Data.Time
 
@@ -1007,7 +1008,10 @@ getNextUpdateSequenceNumbers = liftSkovQueryStateBHI query
   where
     query bs = do
         updates <- BS.getUpdates bs
-        return $ updateQueuesNextSequenceNumbers $ UQ._pendingUpdates updates
+        return
+            $ updateQueuesNextSequenceNumbers
+                (UQ._pendingUpdates updates)
+            $ maybeWhenSupported minUpdateSequenceNumber id (UQ._pltUpdateSequenceNumber updates)
 
 -- | Get the index of accounts with scheduled releases.
 getScheduledReleaseAccounts ::


### PR DESCRIPTION
## Purpose

Ref COR-1344.

Related PR for grpc: https://github.com/Concordium/concordium-grpc-api/pull/91
Related PR for base: https://github.com/Concordium/concordium-base/pull/625

## Changes

- Inline `updateQueuesNextSequenceNumbers` from `concordium-base`
