### PR TITLE
Plt module account queries

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
@@ -272,6 +272,23 @@ class (BlockStateTypes m, Monad m) => AccountOperations m where
     -- support protocol level tokens.
     getAccountTokens :: (PVSupportsPLT (MPV m)) => Account m -> m (Map.Map TokenIndex GSAccount.TokenAccountState)
 
+    -- | Get the balance of a protocol-level token held by an account.
+    -- This is only available at protocol versions that support protocol-level tokens.
+    getAccountTokenBalance ::
+        (PVSupportsPLT (MPV m)) =>
+        Account m ->
+        TokenIndex ->
+        m TokenRawAmount
+
+    -- | Look up the 'TokenStateValue' associated with a particular token and key on an account.
+    -- This is only available at protocol versions that support protocol-level tokens.
+    getAccountTokenState ::
+        (PVSupportsPLT (MPV m)) =>
+        Account m ->
+        TokenIndex ->
+        TokenStateKey ->
+        m (Maybe TokenStateValue)
+
 -- * Active, current and next bakers/delegators
 
 --
@@ -1916,6 +1933,8 @@ instance (Monad (t m), MonadTrans t, AccountOperations m) => AccountOperations (
     getAccountHash = lift . getAccountHash
     getAccountCooldowns = lift . getAccountCooldowns
     getAccountTokens = lift . getAccountTokens
+    getAccountTokenBalance acct tokenIx = lift $ getAccountTokenBalance acct tokenIx
+    getAccountTokenState acct tokenIx key = lift $ getAccountTokenState acct tokenIx key
     {-# INLINE getAccountCanonicalAddress #-}
     {-# INLINE getAccountAmount #-}
     {-# INLINE getAccountAvailableAmount #-}
@@ -1932,6 +1951,8 @@ instance (Monad (t m), MonadTrans t, AccountOperations m) => AccountOperations (
     {-# INLINE getAccountHash #-}
     {-# INLINE getAccountCooldowns #-}
     {-# INLINE getAccountTokens #-}
+    {-# INLINE getAccountTokenBalance #-}
+    {-# INLINE getAccountTokenState #-}
 
 instance (Monad (t m), MonadTrans t, ContractStateOperations m) => ContractStateOperations (MGSTrans t m) where
     thawContractState = lift . thawContractState

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
@@ -349,14 +349,6 @@ accountCooldowns (PAV3 acc) = V1.getCooldowns acc
 accountCooldowns (PAV4 acc) = V1.getCooldowns acc
 accountCooldowns (PAV5 acc) = V1.getCooldowns acc
 
--- | Get the state of protocol level tokens owned by an account. This is only available at account
--- versions that support protocol level tokens.
-accountTokens ::
-    (MonadBlobStore m, AVSupportsPLT av) =>
-    PersistentAccount av ->
-    m (Map.Map BlockState.TokenIndex BlockState.TokenAccountState)
-accountTokens (PAV5 acc) = uncond <$> V1.getTokenStateTable acc
-
 -- | Determine if an account has a pre-pre-cooldown.
 accountHasPrePreCooldown ::
     (MonadBlobStore m, AVSupportsFlexibleCooldown av) =>
@@ -374,6 +366,35 @@ accountHash (PAV2 acc) = getHashM acc
 accountHash (PAV3 acc) = getHashM acc
 accountHash (PAV4 acc) = getHashM acc
 accountHash (PAV5 acc) = getHashM acc
+
+-- ** Protocol-level token queries
+
+-- | Get the state of protocol level tokens owned by an account. This is only available at account
+-- versions that support protocol level tokens.
+accountTokens ::
+    (MonadBlobStore m, AVSupportsPLT av) =>
+    PersistentAccount av ->
+    m (Map.Map BlockState.TokenIndex BlockState.TokenAccountState)
+accountTokens (PAV5 acc) = uncond <$> V1.getTokenStateTable acc
+
+-- | Get the balance of a protocol-level token held by an account.
+--  This is only available at account versions that support protocol-level tokens.
+accountTokenBalance ::
+    (MonadBlobStore m, AVSupportsPLT av) =>
+    PersistentAccount av ->
+    BlockState.TokenIndex ->
+    m BlockState.TokenRawAmount
+accountTokenBalance (PAV5 acc) = V1.getTokenBalance acc
+
+-- | Look up the 'TokenStateValue' associated with a particular token and key on an account.
+--  This is only available at account versions that support protocol-level tokens.
+accountTokenState ::
+    (MonadBlobStore m, AVSupportsPLT av) =>
+    PersistentAccount av ->
+    BlockState.TokenIndex ->
+    BlockState.TokenStateKey ->
+    m (Maybe BlockState.TokenStateValue)
+accountTokenState (PAV5 acc) = V1.getTokenState acc
 
 -- ** 'PersistentBakerInfoRef' queries
 

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -4589,6 +4589,8 @@ instance (PersistentState av pv r m, IsProtocolVersion pv) => AccountOperations 
     getAccountCooldowns = accountCooldowns
 
     getAccountTokens = accountTokens
+    getAccountTokenBalance = accountTokenBalance
+    getAccountTokenState = accountTokenState
 
 instance (IsProtocolVersion pv, PersistentState av pv r m) => BlockStateOperations (PersistentBlockStateMonad pv r m) where
     bsoGetModule pbs mref = doGetModule pbs mref

--- a/concordium-consensus/src/Concordium/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler.hs
@@ -2717,7 +2717,7 @@ handleTokenHolder depositContext tokenId tokenOperations =
         m (Either PLTTypes.EncodedTokenRejectReason [(TokenEventType, TokenEventDetails)])
     invokeTokenHolderOperations _ tokenIndex sender parameter = do
         result <- withBlockStateRollback $ do
-            runPLT tokenIndex $ TokenModule.executeTokenHolderTransaction sender parameter
+            runPLT tokenIndex $ TokenModule.executeTokenHolderTransaction (fst sender) parameter
         -- TODO: Generate and handle events: https://linear.app/concordium/issue/COR-705/event-logging
         return ((\() -> []) <$> result)
 

--- a/concordium-consensus/src/Concordium/Scheduler/Environment.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/Environment.hs
@@ -385,7 +385,7 @@ class
     runPLT ::
         (PVSupportsPLT (MPV m)) =>
         Token.TokenIndex ->
-        (forall m1. (Monad m1, PLTKernelPrivilegedUpdate m1, PLTKernelFail e m1, PLTAccount m1 ~ IndexedAccount m) => m1 a) ->
+        (forall m1. (Monad m1, PLTKernelPrivilegedUpdate m1, PLTKernelFail e m1, PLTAccount m1 ~ AccountIndex) => m1 a) ->
         m (Either e a)
 
     -- | Create a new protocol-layer token with the given 'PLTConfiguration'.

--- a/concordium-consensus/src/Concordium/Scheduler/EnvironmentImplementation.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/EnvironmentImplementation.hs
@@ -541,7 +541,7 @@ instance (BS.BlockStateOperations m, PVSupportsPLT (MPV m)) => PLTKernelUpdate (
     setAccountState _ _ _ = do
         -- TODO: implement
         return ()
-    transfer (accIxFrom, _accFrom) (accIxTo, _accTo) amount _mbMemo = do
+    transfer accIxFrom accIxTo amount _mbMemo = do
         -- TODO: the memo should be emitted in an event
         tokenIx <- ask
         bs0 <- use ssBlockState
@@ -570,7 +570,7 @@ instance (BS.BlockStateOperations m, PVSupportsPLT (MPV m)) => PLTKernelUpdate (
                 return True
 
 instance (BS.BlockStateOperations m, PVSupportsPLT (MPV m)) => PLTKernelPrivilegedUpdate (KernelT fail ret m) where
-    mint (accIx, _acc) amount = do
+    mint accIx amount = do
         tokenIx <- ask
         bs <- use ssBlockState
         currentSupply <- lift $ BS.getTokenCirculatingSupply bs tokenIx
@@ -595,7 +595,7 @@ instance (BS.BlockStateOperations m, PVSupportsPLT (MPV m)) => PLTKernelPrivileg
                     Just newBs -> do
                         ssBlockState .= newBs
                         return True
-    burn (accIx, _acc) amount = do
+    burn accIx amount = do
         tokenIx <- ask
         bs0 <- use ssBlockState
         mbs1 <- lift $ BS.bsoUpdateTokenAccountBalance bs0 tokenIx accIx (negativeTokenAmountDelta amount)

--- a/concordium-consensus/src/Concordium/Scheduler/EnvironmentImplementation.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/EnvironmentImplementation.hs
@@ -491,31 +491,37 @@ instance MonadTrans (KernelT fail ret) where
 deriving via (MGSTrans (KernelT fail ret) m) instance BlockStateTypes (KernelT fail ret m)
 
 instance (BS.BlockStateOperations m, PVSupportsPLT (MPV m)) => PLTKernelQuery (KernelT fail ret m) where
-    type PLTAccount (KernelT fail ret m) = IndexedAccount m
+    type PLTAccount (KernelT fail ret m) = AccountIndex
     getTokenState key = do
         tokenIx <- ask
         bs <- use ssBlockState
         lift $ BS.getTokenState bs tokenIx key
     getAccount addr = do
         bs <- use ssBlockState
-        lift $ BS.bsoGetAccount bs addr
-    getAccountBalance _acct = do
-        -- TODO: implement
-        return Nothing
+        lift $ fmap fst <$> BS.bsoGetAccount bs addr
+    getAccountBalance acctIndex = do
+        tokenIx <- ask
+        bs <- use ssBlockState
+        lift $
+            BS.bsoGetAccountByIndex bs acctIndex >>= \case
+                Nothing -> error "getAccountBalance: Account does not exist"
+                Just acct -> BS.getAccountTokenBalance acct tokenIx
     getAccountState _acct _key = do
         -- TODO: implement
         return Nothing
-    getAccountCanonicalAddress acct = do
-        lift $ BS.getAccountCanonicalAddress (snd acct)
+    getAccountCanonicalAddress acctIndex = do
+        bs <- use ssBlockState
+        lift $
+            BS.bsoGetAccountByIndex bs acctIndex >>= \case
+                Nothing -> error "getAccountCanonicalAddress: Account does not exist"
+                Just acct -> BS.getAccountCanonicalAddress acct
     getGovernanceAccount = do
         tokenIx <- ask
         bs <- use ssBlockState
         lift $ do
             config <- BS.getTokenConfiguration bs tokenIx
             let govIndex = _pltGovernanceAccountIndex config
-            BS.bsoGetAccountByIndex bs govIndex >>= \case
-                Nothing -> error "getGovernanceAccount: Governance account does not exist"
-                Just acc -> return (govIndex, acc)
+            return govIndex
     getCirculatingSupply = do
         tokenIx <- ask
         bs <- use ssBlockState

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Kernel.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Kernel.hs
@@ -15,7 +15,7 @@ class PLTKernelQuery m where
     type PLTAccount m
     getTokenState :: TokenStateKey -> m (Maybe TokenStateValue)
     getAccount :: AccountAddress -> m (Maybe (PLTAccount m))
-    getAccountBalance :: PLTAccount m -> m (Maybe TokenRawAmount)
+    getAccountBalance :: PLTAccount m -> m TokenRawAmount
     getAccountState :: PLTAccount m -> TokenStateKey -> m (Maybe TokenStateValue)
     getAccountCanonicalAddress :: PLTAccount m -> m AccountAddress
     getGovernanceAccount :: m (PLTAccount m)

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Module.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Module.hs
@@ -5,7 +5,6 @@ module Concordium.Scheduler.ProtocolLevelTokens.Module where
 
 import Control.Monad
 import qualified Data.ByteString.Builder as BS.Builder
-import Data.Maybe
 import qualified Data.Sequence as Seq
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Module.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Module.hs
@@ -159,7 +159,7 @@ executeTokenHolderTransaction sender tokenParam = do
                         Just recipientAccount -> do
                             success <- transfer sender recipientAccount pthoAmount pthoMemo
                             unless success $ do
-                                availableBalance <- fromMaybe 0 <$> getAccountBalance sender
+                                availableBalance <- getAccountBalance sender
                                 failTH
                                     TokenBalanceInsufficient
                                         { thfOperationIndex = opIndex,

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TokenModule.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TokenModule.hs
@@ -44,7 +44,7 @@ import System.Random
 data PLTKernelQueryCall acct ret where
     GetTokenState :: TokenStateKey -> PLTKernelQueryCall acct (Maybe TokenStateValue)
     GetAccount :: AccountAddress -> PLTKernelQueryCall acct (Maybe acct)
-    GetAccountBalance :: acct -> PLTKernelQueryCall acct (Maybe TokenRawAmount)
+    GetAccountBalance :: acct -> PLTKernelQueryCall acct TokenRawAmount
     GetAccountState :: acct -> TokenStateKey -> PLTKernelQueryCall acct (Maybe TokenStateValue)
     GetAccountCanonicalAddress :: acct -> PLTKernelQueryCall acct AccountAddress
     GetGovernanceAccount :: PLTKernelQueryCall acct acct
@@ -271,7 +271,7 @@ abortPLTError = Abort . AbortCall @_ @ret . PLTF . PLTError
 
 -- | Tests for 'initializeToken'.
 testInitializeToken :: Spec
-testInitializeToken = describe "intializeToken" $ do
+testInitializeToken = describe "initializeToken" $ do
     -- In this example, the parameters are not a valid encoding.
     it "invalid parameters" $ do
         let trace :: Trace (PLTCall InitializeTokenError AccountIndex) ()
@@ -481,7 +481,7 @@ testExecuteTokenHolderTransaction = describe "executeTokenHolderTransaction" $ d
                 (PLTQ GetDecimals :-> 6)
                     :>>: (PLTQ (GetAccount (dummyAccountAddress 1)) :-> Just 4)
                     :>>: (PLTU (Transfer 0 4 10_000_000 (Just cborMemo)) :-> False)
-                    :>>: (PLTQ (GetAccountBalance 0) :-> Nothing)
+                    :>>: (PLTQ (GetAccountBalance 0) :-> 0)
                     :>>: ( abortPLTError . encodeTokenHolderFailure $
                             TokenBalanceInsufficient
                                 { thfOperationIndex = 0,
@@ -503,7 +503,7 @@ testExecuteTokenHolderTransaction = describe "executeTokenHolderTransaction" $ d
                     :>>: (PLTU (Transfer 0 4 10_000_000 (Just cborMemo)) :-> True)
                     :>>: (PLTQ (GetAccount (dummyAccountAddress 2)) :-> Just 16)
                     :>>: (PLTU (Transfer 0 16 50_000_000 (Just simpleMemo)) :-> False)
-                    :>>: (PLTQ (GetAccountBalance 0) :-> Just 5_000_000)
+                    :>>: (PLTQ (GetAccountBalance 0) :-> 5_000_000)
                     :>>: ( abortPLTError . encodeTokenHolderFailure $
                             TokenBalanceInsufficient
                                 { thfOperationIndex = 1,


### PR DESCRIPTION
## Purpose

Support getting the account token balance and account token state in the PLT Kernel.

## Changes

- Add `getAccountTokenBalance` and `getAccountTokenState` to `AccountOperations`, and implement these in the block state.
- Add `getAccountBalance` and `getAccountState` to `PLTKernelQuery`.
- Change the implementation representation of accounts in `KernelT` to use the account index. This is to ensure that if, for instance, you query an account balance, mint to that account, and query the account again, you will see the effect of the minting.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
