### PR TITLE
Make token state table nullable

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/Account.hs
@@ -273,7 +273,7 @@ newAccountMultiCredential cryptoParams threshold _accountAddress cs =
           _accountTokenStateTable =
             conditionally
                 (sSupportsPLT (accountVersion @av))
-                (makeHashed $ InMemoryTokenStateTable Map.empty)
+                (makeHashed (InMemoryTokenStateTable{inMemoryTokenStateTable = Map.empty}))
         }
 
 -- | Create an empty account with the given public key, address and credential.

--- a/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Basic/BlockState/Account.hs
@@ -207,7 +207,7 @@ accountHashInputsV5 Account{..} =
           ahi3AccountBalance = _accountAmount,
           ahi3StakedBalance = stakedBalance,
           ahi3MerkleHash = getHash merkleInputs,
-          ahi3TokenStateTableHash = getHash $ uncond $ _accountTokenStateTable
+          ahi3TokenStateTableHash = getHash $ uncond _accountTokenStateTable
         }
   where
     stakedBalance = case _accountStaking of
@@ -273,7 +273,7 @@ newAccountMultiCredential cryptoParams threshold _accountAddress cs =
           _accountTokenStateTable =
             conditionally
                 (sSupportsPLT (accountVersion @av))
-                (makeHashed (InMemoryTokenStateTable{inMemoryTokenStateTable = Map.empty}))
+                (makeHashed $ InMemoryTokenStateTable Map.empty)
         }
 
 -- | Create an empty account with the given public key, address and credential.

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
@@ -375,7 +375,11 @@ accountTokens ::
     (MonadBlobStore m, AVSupportsPLT av) =>
     PersistentAccount av ->
     m (Map.Map BlockState.TokenIndex BlockState.TokenAccountState)
-accountTokens (PAV5 acc) = uncond <$> V1.getTokenStateTable acc
+accountTokens (PAV5 acc) = do
+    tast <- V1.getTokenStateTable acc
+    case uncond tast of
+        Null -> return Map.empty
+        Some tst -> return tst
 
 -- | Get the balance of a protocol-level token held by an account.
 --  This is only available at account versions that support protocol-level tokens.

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
@@ -375,11 +375,7 @@ accountTokens ::
     (MonadBlobStore m, AVSupportsPLT av) =>
     PersistentAccount av ->
     m (Map.Map BlockState.TokenIndex BlockState.TokenAccountState)
-accountTokens (PAV5 acc) = do
-    tast <- V1.getTokenStateTable acc
-    case uncond tast of
-        Null -> return Map.empty
-        Some tst -> return tst
+accountTokens (PAV5 acc) = uncond <$> V1.getTokenStateTable acc
 
 -- | Get the balance of a protocol-level token held by an account.
 --  This is only available at account versions that support protocol-level tokens.

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/AccountsMigrationP6ToP7.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/AccountsMigrationP6ToP7.hs
@@ -125,7 +125,10 @@ testAccount persisting stake =
           _accountReleaseSchedule = Transient.emptyAccountReleaseSchedule,
           _accountStaking = stake,
           _accountStakeCooldown = Transient.emptyCooldownQueue (accountVersion @av),
-          _accountTokenStateTable = conditionally (sSupportsPLT (accountVersion @av)) dummyTokenAccountStateTable
+          _accountTokenStateTable =
+            conditionally
+                (sSupportsPLT (accountVersion @av))
+                dummyTokenAccountStateTable
         }
 
 -- | Initial stake for a test account, set to 500 million CCD plus @2^accountIndex@ uCCD.


### PR DESCRIPTION
We change the reference to the account token state table to be `Nullable`. This should save some disk space, since many accounts won't have any token state.

Closes #1373 .

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
