### PR TITLE
Use a EagerlyHashedBufferedReference instead of a HashedBufferedReference

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
@@ -1023,7 +1023,7 @@ data PersistentAccount av = PersistentAccount
       --  INVARIANT: This is 0 if the account is not a baker or delegator.
       accountStakedAmount :: !Amount,
       -- | The state table of the protocol level tokens of the account in ascending order of the TokenIndex.
-      accountTokenStateTable :: !(Conditionally (SupportsPLT av) (Nullable (HashedBufferedRef' TokenStateTableHash TokenAccountStateTable))),
+      accountTokenStateTable :: !(Conditionally (SupportsPLT av) (Nullable (EagerlyHashedBufferedRef' TokenStateTableHash TokenAccountStateTable))),
       -- | The enduring account data.
       accountEnduringData :: !(EagerBufferedRef (PersistentAccountEnduringData av))
     }
@@ -1988,7 +1988,7 @@ makePersistentAccount Transient.Account{..} = do
                     traverse makeHashedBufferedRef $
                         Transient.inMemoryTokenStateTable $
                             _unhashed inMemoryTast
-                Some <$> makeHashedBufferedRef TokenAccountStateTable{tokenAccountStateTable = tast}
+                Some <$> refMake TokenAccountStateTable{tokenAccountStateTable = tast}
     return $!
         PersistentAccount
             { accountNonce = _accountNonce,

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -4415,7 +4415,7 @@ doUpdateTokenAccountModuleState pbs tokIx accIx delta = do
     upd (PAV5 acc) = case StructureV1.accountTokenStateTable acc of
         CTrue (Some ref) -> doUpdate ref
         CTrue Null -> do
-            ref <- makeHashedBufferedRef emptyTokenAccountStateTable
+            ref <- refMake emptyTokenAccountStateTable
             doUpdate ref
       where
         doUpdate ref = do
@@ -4455,7 +4455,7 @@ doUpdateTokenAccountBalance pbs tokIx accIx (TokenAmountDelta delta) = runMaybeT
     upd (PAV5 acc) = case StructureV1.accountTokenStateTable acc of
         CTrue (Some ref) -> doUpdate ref
         CTrue Null -> do
-            ref <- makeHashedBufferedRef emptyTokenAccountStateTable
+            ref <- refMake emptyTokenAccountStateTable
             doUpdate ref
       where
         doUpdate ref = do


### PR DESCRIPTION
Store the token account state table under an `EagerlyHashedBufferedReference` to optimize for many PLT read/write operations.

Closes #1374 .

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
