### PR TITLE
Test for TokenHolderOperation and allow any transaction in Scheduler tests

### DIFF
--- a/concordium-consensus/tests/scheduler/SchedulerTests/Delegation.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/Delegation.hs
@@ -765,67 +765,71 @@ testReduceStakeWhileInCooldown ::
     Spec
 testReduceStakeWhileInCooldown spv pvString =
     specify (pvString ++ ": Reduce stake while in cooldown.") $ do
-        let transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+        let transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
             transactionsAndAssertions =
-                [ Helpers.TransactionAndAssertion
-                    { taaTransaction =
-                        Runner.TJSON
-                            { payload =
-                                Runner.ConfigureDelegation
-                                    { cdCapital = Just 999,
-                                      cdRestakeEarnings = Nothing,
-                                      cdDelegationTarget = Nothing
-                                    },
-                              metadata = makeDummyHeader delegator3Address 1 1_000,
-                              keys = [(0, [(0, delegator3KP)])]
-                            },
-                      taaAssertion = \result _ -> do
+                [ Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        Runner.AccountTx $
+                            Runner.TJSON
+                                { payload =
+                                    Runner.ConfigureDelegation
+                                        { cdCapital = Just 999,
+                                          cdRestakeEarnings = Nothing,
+                                          cdDelegationTarget = Nothing
+                                        },
+                                  metadata = makeDummyHeader delegator3Address 1 1_000,
+                                  keys = [(0, [(0, delegator3KP)])]
+                                },
+                      biaaAssertion = \result _ -> do
                         return $ do
                             Helpers.assertSuccessWithEvents
                                 [DelegationStakeDecreased 3 delegator3Address 999]
                                 result
                     },
-                  Helpers.TransactionAndAssertion
-                    { taaTransaction =
-                        Runner.TJSON
-                            { payload =
-                                Runner.ConfigureDelegation
-                                    { cdCapital = Just 995,
-                                      cdRestakeEarnings = Nothing,
-                                      cdDelegationTarget = Nothing
-                                    },
-                              metadata = makeDummyHeader delegator3Address 2 1_000,
-                              keys = [(0, [(0, delegator3KP)])]
-                            },
-                      taaAssertion = assertPrePreCooldown 5 (DelegationStakeDecreased 3 delegator3Address 995)
+                  Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        Runner.AccountTx $
+                            Runner.TJSON
+                                { payload =
+                                    Runner.ConfigureDelegation
+                                        { cdCapital = Just 995,
+                                          cdRestakeEarnings = Nothing,
+                                          cdDelegationTarget = Nothing
+                                        },
+                                  metadata = makeDummyHeader delegator3Address 2 1_000,
+                                  keys = [(0, [(0, delegator3KP)])]
+                                },
+                      biaaAssertion = assertPrePreCooldown 5 (DelegationStakeDecreased 3 delegator3Address 995)
                     },
-                  Helpers.TransactionAndAssertion
-                    { taaTransaction =
-                        Runner.TJSON
-                            { payload =
-                                Runner.ConfigureDelegation
-                                    { cdCapital = Just 998,
-                                      cdRestakeEarnings = Nothing,
-                                      cdDelegationTarget = Nothing
-                                    },
-                              metadata = makeDummyHeader delegator3Address 3 1_000,
-                              keys = [(0, [(0, delegator3KP)])]
-                            },
-                      taaAssertion = assertPrePreCooldown 2 (DelegationStakeIncreased 3 delegator3Address 998)
+                  Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        Runner.AccountTx $
+                            Runner.TJSON
+                                { payload =
+                                    Runner.ConfigureDelegation
+                                        { cdCapital = Just 998,
+                                          cdRestakeEarnings = Nothing,
+                                          cdDelegationTarget = Nothing
+                                        },
+                                  metadata = makeDummyHeader delegator3Address 3 1_000,
+                                  keys = [(0, [(0, delegator3KP)])]
+                                },
+                      biaaAssertion = assertPrePreCooldown 2 (DelegationStakeIncreased 3 delegator3Address 998)
                     },
-                  Helpers.TransactionAndAssertion
-                    { taaTransaction =
-                        Runner.TJSON
-                            { payload =
-                                Runner.ConfigureDelegation
-                                    { cdCapital = Just 1000,
-                                      cdRestakeEarnings = Nothing,
-                                      cdDelegationTarget = Nothing
-                                    },
-                              metadata = makeDummyHeader delegator3Address 4 1_000,
-                              keys = [(0, [(0, delegator3KP)])]
-                            },
-                      taaAssertion = assertNoCooldown (DelegationStakeIncreased 3 delegator3Address 1000)
+                  Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        Runner.AccountTx $
+                            Runner.TJSON
+                                { payload =
+                                    Runner.ConfigureDelegation
+                                        { cdCapital = Just 1000,
+                                          cdRestakeEarnings = Nothing,
+                                          cdDelegationTarget = Nothing
+                                        },
+                                  metadata = makeDummyHeader delegator3Address 4 1_000,
+                                  keys = [(0, [(0, delegator3KP)])]
+                                },
+                      biaaAssertion = assertNoCooldown (DelegationStakeIncreased 3 delegator3Address 1000)
                     }
                 ]
         Helpers.runSchedulerTestAssertIntermediateStates

--- a/concordium-consensus/tests/scheduler/SchedulerTests/EncryptedTransfersTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/EncryptedTransfersTest.hs
@@ -161,7 +161,7 @@ testCase0 _ pvString = specify
             initialBlockState
             transactionsAndAssertions
   where
-    makeTransactions :: IO [Helpers.TransactionAndAssertion pv]
+    makeTransactions :: IO [Helpers.BlockItemAndAssertion pv]
     makeTransactions = do
         -- Transaction 1. Pub to sec (1000)
         let encryptedAmount1000 :: EncryptedAmount
@@ -334,14 +334,15 @@ testCase0 _ pvString = specify
             incomingAmounts8account0 = Seq.empty
 
         return
-            [ Helpers.TransactionAndAssertion
-                { taaTransaction =
-                    Runner.TJSON
-                        { payload = Runner.TransferToEncrypted 1_000,
-                          metadata = makeDummyHeader accountAddress0 1 100_000,
-                          keys = [(0, [(0, keyPair0)])]
-                        },
-                  taaAssertion = \result state -> do
+            [ Helpers.BlockItemAndAssertion
+                { biaaTransaction =
+                    Runner.AccountTx $
+                        Runner.TJSON
+                            { payload = Runner.TransferToEncrypted 1_000,
+                              metadata = makeDummyHeader accountAddress0 1 100_000,
+                              keys = [(0, [(0, keyPair0)])]
+                            },
+                  biaaAssertion = \result state -> do
                     doEncryptedBalanceAssertions <-
                         assertEncryptedBalance
                             Types.initialAccountEncryptedAmount
@@ -360,17 +361,18 @@ testCase0 _ pvString = specify
                             result
                         doEncryptedBalanceAssertions
                 },
-              Helpers.TransactionAndAssertion
-                { taaTransaction =
-                    Runner.TJSON
-                        { payload =
-                            Runner.EncryptedAmountTransfer
-                                accountAddress1
-                                encryptedTransferData1,
-                          metadata = makeDummyHeader accountAddress0 2 100_000,
-                          keys = [(0, [(0, keyPair0)])]
-                        },
-                  taaAssertion = \result state -> do
+              Helpers.BlockItemAndAssertion
+                { biaaTransaction =
+                    Runner.AccountTx $
+                        Runner.TJSON
+                            { payload =
+                                Runner.EncryptedAmountTransfer
+                                    accountAddress1
+                                    encryptedTransferData1,
+                              metadata = makeDummyHeader accountAddress0 2 100_000,
+                              keys = [(0, [(0, keyPair0)])]
+                            },
+                  biaaAssertion = \result state -> do
                     doEncryptedBalanceAssertionSender <-
                         assertEncryptedBalance
                             Types.initialAccountEncryptedAmount
@@ -407,17 +409,18 @@ testCase0 _ pvString = specify
                         doEncryptedBalanceAssertionSender
                         doEncryptedBalanceAssertionReceiver
                 },
-              Helpers.TransactionAndAssertion
-                { taaTransaction =
-                    Runner.TJSON
-                        { payload =
-                            Runner.EncryptedAmountTransfer
-                                accountAddress1
-                                encryptedTransferData2,
-                          metadata = makeDummyHeader accountAddress0 3 100_000,
-                          keys = [(0, [(0, keyPair0)])]
-                        },
-                  taaAssertion = \result state -> do
+              Helpers.BlockItemAndAssertion
+                { biaaTransaction =
+                    Runner.AccountTx $
+                        Runner.TJSON
+                            { payload =
+                                Runner.EncryptedAmountTransfer
+                                    accountAddress1
+                                    encryptedTransferData2,
+                              metadata = makeDummyHeader accountAddress0 3 100_000,
+                              keys = [(0, [(0, keyPair0)])]
+                            },
+                  biaaAssertion = \result state -> do
                     doEncryptedBalanceAssertionSender <-
                         assertEncryptedBalance
                             Types.initialAccountEncryptedAmount
@@ -455,17 +458,18 @@ testCase0 _ pvString = specify
                         doEncryptedBalanceAssertionSender
                         doEncryptedBalanceAssertionReceiver
                 },
-              Helpers.TransactionAndAssertion
-                { taaTransaction =
-                    Runner.TJSON
-                        { payload =
-                            Runner.EncryptedAmountTransfer
-                                accountAddress1
-                                encryptedTransferData3,
-                          metadata = makeDummyHeader accountAddress0 4 100_000,
-                          keys = [(0, [(0, keyPair0)])]
-                        },
-                  taaAssertion = \result state -> do
+              Helpers.BlockItemAndAssertion
+                { biaaTransaction =
+                    Runner.AccountTx $
+                        Runner.TJSON
+                            { payload =
+                                Runner.EncryptedAmountTransfer
+                                    accountAddress1
+                                    encryptedTransferData3,
+                              metadata = makeDummyHeader accountAddress0 4 100_000,
+                              keys = [(0, [(0, keyPair0)])]
+                            },
+                  biaaAssertion = \result state -> do
                     doEncryptedBalanceAssertionSender <-
                         assertEncryptedBalance
                             Types.initialAccountEncryptedAmount
@@ -503,14 +507,15 @@ testCase0 _ pvString = specify
                         doEncryptedBalanceAssertionSender
                         doEncryptedBalanceAssertionReceiver
                 },
-              Helpers.TransactionAndAssertion
-                { taaTransaction =
-                    Runner.TJSON
-                        { payload = Runner.EncryptedAmountTransfer accountAddress0 encryptedTransferData4,
-                          metadata = makeDummyHeader accountAddress1 1 100_000,
-                          keys = [(0, [(0, keyPair1)])]
-                        },
-                  taaAssertion = \result state -> do
+              Helpers.BlockItemAndAssertion
+                { biaaTransaction =
+                    Runner.AccountTx $
+                        Runner.TJSON
+                            { payload = Runner.EncryptedAmountTransfer accountAddress0 encryptedTransferData4,
+                              metadata = makeDummyHeader accountAddress1 1 100_000,
+                              keys = [(0, [(0, keyPair1)])]
+                            },
+                  biaaAssertion = \result state -> do
                     doEncryptedBalanceAssertionSender <-
                         assertEncryptedBalance
                             Types.initialAccountEncryptedAmount
@@ -549,17 +554,18 @@ testCase0 _ pvString = specify
                         doEncryptedBalanceAssertionSender
                         doEncryptedBalanceAssertionReceiver
                 },
-              Helpers.TransactionAndAssertion
-                { taaTransaction =
-                    Runner.TJSON
-                        { payload =
-                            Runner.EncryptedAmountTransfer
-                                accountAddress0
-                                encryptedTransferData5,
-                          metadata = makeDummyHeader accountAddress1 2 100_000,
-                          keys = [(0, [(0, keyPair1)])]
-                        },
-                  taaAssertion = \result state -> do
+              Helpers.BlockItemAndAssertion
+                { biaaTransaction =
+                    Runner.AccountTx $
+                        Runner.TJSON
+                            { payload =
+                                Runner.EncryptedAmountTransfer
+                                    accountAddress0
+                                    encryptedTransferData5,
+                              metadata = makeDummyHeader accountAddress1 2 100_000,
+                              keys = [(0, [(0, keyPair1)])]
+                            },
+                  biaaAssertion = \result state -> do
                     doEncryptedBalanceAssertionSender <-
                         assertEncryptedBalance
                             Types.initialAccountEncryptedAmount
@@ -598,14 +604,15 @@ testCase0 _ pvString = specify
                         doEncryptedBalanceAssertionSender
                         doEncryptedBalanceAssertionReceiver
                 },
-              Helpers.TransactionAndAssertion
-                { taaTransaction =
-                    Runner.TJSON
-                        { payload = Runner.TransferToPublic secToPubTransferData1,
-                          metadata = makeDummyHeader accountAddress0 5 100_000,
-                          keys = [(0, [(0, keyPair0)])]
-                        },
-                  taaAssertion = \result state -> do
+              Helpers.BlockItemAndAssertion
+                { biaaTransaction =
+                    Runner.AccountTx $
+                        Runner.TJSON
+                            { payload = Runner.TransferToPublic secToPubTransferData1,
+                              metadata = makeDummyHeader accountAddress0 5 100_000,
+                              keys = [(0, [(0, keyPair0)])]
+                            },
+                  biaaAssertion = \result state -> do
                     doEncryptedBalanceAssertion <-
                         assertEncryptedBalance
                             Types.initialAccountEncryptedAmount
@@ -635,14 +642,15 @@ testCase0 _ pvString = specify
                             result
                         doEncryptedBalanceAssertion
                 },
-              Helpers.TransactionAndAssertion
-                { taaTransaction =
-                    Runner.TJSON
-                        { payload = Runner.TransferToPublic secToPubTransferData2,
-                          metadata = makeDummyHeader accountAddress0 6 100_000,
-                          keys = [(0, [(0, keyPair0)])]
-                        },
-                  taaAssertion = \result state -> do
+              Helpers.BlockItemAndAssertion
+                { biaaTransaction =
+                    Runner.AccountTx $
+                        Runner.TJSON
+                            { payload = Runner.TransferToPublic secToPubTransferData2,
+                              metadata = makeDummyHeader accountAddress0 6 100_000,
+                              keys = [(0, [(0, keyPair0)])]
+                            },
+                  biaaAssertion = \result state -> do
                     doEncryptedBalanceAssertion <-
                         assertEncryptedBalance
                             Types.initialAccountEncryptedAmount
@@ -670,14 +678,15 @@ testCase0 _ pvString = specify
                             result
                         doEncryptedBalanceAssertion
                 },
-              Helpers.TransactionAndAssertion
-                { taaTransaction =
-                    Runner.TJSON
-                        { payload = Runner.TransferToPublic secToPubTransferData3,
-                          metadata = makeDummyHeader accountAddress0 7 100_000,
-                          keys = [(0, [(0, keyPair0)])]
-                        },
-                  taaAssertion = \result state -> do
+              Helpers.BlockItemAndAssertion
+                { biaaTransaction =
+                    Runner.AccountTx $
+                        Runner.TJSON
+                            { payload = Runner.TransferToPublic secToPubTransferData3,
+                              metadata = makeDummyHeader accountAddress0 7 100_000,
+                              keys = [(0, [(0, keyPair0)])]
+                            },
+                  biaaAssertion = \result state -> do
                     doEncryptedBalanceAssertion <-
                         assertEncryptedBalance
                             Types.initialAccountEncryptedAmount
@@ -727,7 +736,7 @@ testCase1 spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    makeTransactions :: IO [Helpers.TransactionAndAssertion pv]
+    makeTransactions :: IO [Helpers.BlockItemAndAssertion pv]
     makeTransactions = do
         -- Transaction 1. Pub to sec (1000)
         let encryptedAmount1000 :: EncryptedAmount
@@ -748,14 +757,15 @@ testCase1 spv pvString =
         let memo = Types.Memo $ BSS.pack [0, 1, 2, 3]
 
         return
-            [ Helpers.TransactionAndAssertion
-                { taaTransaction =
-                    Runner.TJSON
-                        { payload = Runner.TransferToEncrypted 1_000,
-                          metadata = makeDummyHeader accountAddress0 1 100_000,
-                          keys = [(0, [(0, keyPair0)])]
-                        },
-                  taaAssertion = \result state -> do
+            [ Helpers.BlockItemAndAssertion
+                { biaaTransaction =
+                    Runner.AccountTx $
+                        Runner.TJSON
+                            { payload = Runner.TransferToEncrypted 1_000,
+                              metadata = makeDummyHeader accountAddress0 1 100_000,
+                              keys = [(0, [(0, keyPair0)])]
+                            },
+                  biaaAssertion = \result state -> do
                     doEncryptedBalanceAssertions <-
                         assertEncryptedBalance
                             Types.initialAccountEncryptedAmount
@@ -774,18 +784,19 @@ testCase1 spv pvString =
                             result
                         doEncryptedBalanceAssertions
                 },
-              Helpers.TransactionAndAssertion
-                { taaTransaction =
-                    Runner.TJSON
-                        { payload =
-                            Runner.EncryptedAmountTransferWithMemo
-                                accountAddress1
-                                memo
-                                encryptedTransferData1,
-                          metadata = makeDummyHeader accountAddress0 2 100_000,
-                          keys = [(0, [(0, keyPair0)])]
-                        },
-                  taaAssertion = \result state -> do
+              Helpers.BlockItemAndAssertion
+                { biaaTransaction =
+                    Runner.AccountTx $
+                        Runner.TJSON
+                            { payload =
+                                Runner.EncryptedAmountTransferWithMemo
+                                    accountAddress1
+                                    memo
+                                    encryptedTransferData1,
+                              metadata = makeDummyHeader accountAddress0 2 100_000,
+                              keys = [(0, [(0, keyPair0)])]
+                            },
+                  biaaAssertion = \result state -> do
                     doEncryptedBalanceAssertions <-
                         assertEncryptedBalance
                             Types.initialAccountEncryptedAmount
@@ -995,14 +1006,15 @@ testCase2 spv pvString =
         let memo = Types.Memo $ BSS.pack [0, 1, 2, 3]
 
         return
-            [ Helpers.TransactionAndAssertion
-                { taaTransaction =
-                    Runner.TJSON
-                        { payload = Runner.TransferToEncrypted 1_000,
-                          metadata = makeDummyHeader accountAddress0 1 100_000,
-                          keys = [(0, [(0, keyPair0)])]
-                        },
-                  taaAssertion = \result state -> do
+            [ Helpers.BlockItemAndAssertion
+                { biaaTransaction =
+                    Runner.AccountTx $
+                        Runner.TJSON
+                            { payload = Runner.TransferToEncrypted 1_000,
+                              metadata = makeDummyHeader accountAddress0 1 100_000,
+                              keys = [(0, [(0, keyPair0)])]
+                            },
+                  biaaAssertion = \result state -> do
                     doEncryptedBalanceAssertions <-
                         assertEncryptedBalance
                             Types.initialAccountEncryptedAmount
@@ -1021,18 +1033,19 @@ testCase2 spv pvString =
                             result
                         doEncryptedBalanceAssertions
                 },
-              Helpers.TransactionAndAssertion
-                { taaTransaction =
-                    Runner.TJSON
-                        { payload =
-                            Runner.EncryptedAmountTransferWithMemo
-                                accountAddress1
-                                memo
-                                encryptedTransferData1,
-                          metadata = makeDummyHeader accountAddress0 2 100_000,
-                          keys = [(0, [(0, keyPair0)])]
-                        },
-                  taaAssertion = \result state -> do
+              Helpers.BlockItemAndAssertion
+                { biaaTransaction =
+                    Runner.AccountTx $
+                        Runner.TJSON
+                            { payload =
+                                Runner.EncryptedAmountTransferWithMemo
+                                    accountAddress1
+                                    memo
+                                    encryptedTransferData1,
+                              metadata = makeDummyHeader accountAddress0 2 100_000,
+                              keys = [(0, [(0, keyPair0)])]
+                            },
+                  biaaAssertion = \result state -> do
                     doEncryptedBalanceAssertionSender <-
                         assertEncryptedBalance
                             Types.initialAccountEncryptedAmount
@@ -1070,18 +1083,19 @@ testCase2 spv pvString =
                         doEncryptedBalanceAssertionSender
                         doEncryptedBalanceAssertionReceiver
                 },
-              Helpers.TransactionAndAssertion
-                { taaTransaction =
-                    Runner.TJSON
-                        { payload =
-                            Runner.EncryptedAmountTransferWithMemo
-                                accountAddress1
-                                memo
-                                encryptedTransferData2,
-                          metadata = makeDummyHeader accountAddress0 3 100_000,
-                          keys = [(0, [(0, keyPair0)])]
-                        },
-                  taaAssertion = \result state -> do
+              Helpers.BlockItemAndAssertion
+                { biaaTransaction =
+                    Runner.AccountTx $
+                        Runner.TJSON
+                            { payload =
+                                Runner.EncryptedAmountTransferWithMemo
+                                    accountAddress1
+                                    memo
+                                    encryptedTransferData2,
+                              metadata = makeDummyHeader accountAddress0 3 100_000,
+                              keys = [(0, [(0, keyPair0)])]
+                            },
+                  biaaAssertion = \result state -> do
                     doEncryptedBalanceAssertionSender <-
                         assertEncryptedBalance
                             Types.initialAccountEncryptedAmount
@@ -1121,18 +1135,19 @@ testCase2 spv pvString =
                         doEncryptedBalanceAssertionSender
                         doEncryptedBalanceAssertionReceiver
                 },
-              Helpers.TransactionAndAssertion
-                { taaTransaction =
-                    Runner.TJSON
-                        { payload =
-                            Runner.EncryptedAmountTransferWithMemo
-                                accountAddress1
-                                memo
-                                encryptedTransferData3,
-                          metadata = makeDummyHeader accountAddress0 4 100_000,
-                          keys = [(0, [(0, keyPair0)])]
-                        },
-                  taaAssertion = \result state -> do
+              Helpers.BlockItemAndAssertion
+                { biaaTransaction =
+                    Runner.AccountTx $
+                        Runner.TJSON
+                            { payload =
+                                Runner.EncryptedAmountTransferWithMemo
+                                    accountAddress1
+                                    memo
+                                    encryptedTransferData3,
+                              metadata = makeDummyHeader accountAddress0 4 100_000,
+                              keys = [(0, [(0, keyPair0)])]
+                            },
+                  biaaAssertion = \result state -> do
                     doEncryptedBalanceAssertionSender <-
                         assertEncryptedBalance
                             Types.initialAccountEncryptedAmount
@@ -1171,18 +1186,19 @@ testCase2 spv pvString =
                         doEncryptedBalanceAssertionSender
                         doEncryptedBalanceAssertionReceiver
                 },
-              Helpers.TransactionAndAssertion
-                { taaTransaction =
-                    Runner.TJSON
-                        { payload =
-                            Runner.EncryptedAmountTransferWithMemo
-                                accountAddress0
-                                memo
-                                encryptedTransferData4,
-                          metadata = makeDummyHeader accountAddress1 1 100_000,
-                          keys = [(0, [(0, keyPair1)])]
-                        },
-                  taaAssertion = \result state -> do
+              Helpers.BlockItemAndAssertion
+                { biaaTransaction =
+                    Runner.AccountTx $
+                        Runner.TJSON
+                            { payload =
+                                Runner.EncryptedAmountTransferWithMemo
+                                    accountAddress0
+                                    memo
+                                    encryptedTransferData4,
+                              metadata = makeDummyHeader accountAddress1 1 100_000,
+                              keys = [(0, [(0, keyPair1)])]
+                            },
+                  biaaAssertion = \result state -> do
                     doEncryptedBalanceAssertionSender <-
                         assertEncryptedBalance
                             Types.initialAccountEncryptedAmount
@@ -1222,18 +1238,19 @@ testCase2 spv pvString =
                         doEncryptedBalanceAssertionSender
                         doEncryptedBalanceAssertionReceiver
                 },
-              Helpers.TransactionAndAssertion
-                { taaTransaction =
-                    Runner.TJSON
-                        { payload =
-                            Runner.EncryptedAmountTransferWithMemo
-                                accountAddress0
-                                memo
-                                encryptedTransferData5,
-                          metadata = makeDummyHeader accountAddress1 2 100_000,
-                          keys = [(0, [(0, keyPair1)])]
-                        },
-                  taaAssertion = \result state -> do
+              Helpers.BlockItemAndAssertion
+                { biaaTransaction =
+                    Runner.AccountTx $
+                        Runner.TJSON
+                            { payload =
+                                Runner.EncryptedAmountTransferWithMemo
+                                    accountAddress0
+                                    memo
+                                    encryptedTransferData5,
+                              metadata = makeDummyHeader accountAddress1 2 100_000,
+                              keys = [(0, [(0, keyPair1)])]
+                            },
+                  biaaAssertion = \result state -> do
                     doEncryptedBalanceAssertionSender <-
                         assertEncryptedBalance
                             Types.initialAccountEncryptedAmount
@@ -1273,14 +1290,15 @@ testCase2 spv pvString =
                         doEncryptedBalanceAssertionSender
                         doEncryptedBalanceAssertionReceiver
                 },
-              Helpers.TransactionAndAssertion
-                { taaTransaction =
-                    Runner.TJSON
-                        { payload = Runner.TransferToPublic secToPubTransferData1,
-                          metadata = makeDummyHeader accountAddress0 5 100_000,
-                          keys = [(0, [(0, keyPair0)])]
-                        },
-                  taaAssertion = \result state -> do
+              Helpers.BlockItemAndAssertion
+                { biaaTransaction =
+                    Runner.AccountTx $
+                        Runner.TJSON
+                            { payload = Runner.TransferToPublic secToPubTransferData1,
+                              metadata = makeDummyHeader accountAddress0 5 100_000,
+                              keys = [(0, [(0, keyPair0)])]
+                            },
+                  biaaAssertion = \result state -> do
                     doEncryptedBalanceAssertion <-
                         assertEncryptedBalance
                             Types.initialAccountEncryptedAmount
@@ -1311,14 +1329,15 @@ testCase2 spv pvString =
 
                         doEncryptedBalanceAssertion
                 },
-              Helpers.TransactionAndAssertion
-                { taaTransaction =
-                    Runner.TJSON
-                        { payload = Runner.TransferToPublic secToPubTransferData2,
-                          metadata = makeDummyHeader accountAddress0 6 100_000,
-                          keys = [(0, [(0, keyPair0)])]
-                        },
-                  taaAssertion = \result state -> do
+              Helpers.BlockItemAndAssertion
+                { biaaTransaction =
+                    Runner.AccountTx $
+                        Runner.TJSON
+                            { payload = Runner.TransferToPublic secToPubTransferData2,
+                              metadata = makeDummyHeader accountAddress0 6 100_000,
+                              keys = [(0, [(0, keyPair0)])]
+                            },
+                  biaaAssertion = \result state -> do
                     doEncryptedBalanceAssertion <-
                         assertEncryptedBalance
                             Types.initialAccountEncryptedAmount
@@ -1347,14 +1366,15 @@ testCase2 spv pvString =
 
                         doEncryptedBalanceAssertion
                 },
-              Helpers.TransactionAndAssertion
-                { taaTransaction =
-                    Runner.TJSON
-                        { payload = Runner.TransferToPublic secToPubTransferData3,
-                          metadata = makeDummyHeader accountAddress0 7 100_000,
-                          keys = [(0, [(0, keyPair0)])]
-                        },
-                  taaAssertion = \result state -> do
+              Helpers.BlockItemAndAssertion
+                { biaaTransaction =
+                    Runner.AccountTx $
+                        Runner.TJSON
+                            { payload = Runner.TransferToPublic secToPubTransferData3,
+                              metadata = makeDummyHeader accountAddress0 7 100_000,
+                              keys = [(0, [(0, keyPair0)])]
+                            },
+                  biaaAssertion = \result state -> do
                     doEncryptedBalanceAssertion <-
                         assertEncryptedBalance
                             Types.initialAccountEncryptedAmount

--- a/concordium-consensus/tests/scheduler/SchedulerTests/FibonacciSelfMessageTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/FibonacciSelfMessageTest.hs
@@ -66,26 +66,28 @@ testCase1 _ pvString =
             transactions
   where
     transactions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                Runner.TJSON
-                    { payload = Runner.DeployModule V0 fibSourceFile,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, Helpers.keyPairFromSeed 0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                Runner.AccountTx $
+                    Runner.TJSON
+                        { payload = Runner.DeployModule V0 fibSourceFile,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, Helpers.keyPairFromSeed 0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV0 fibSourceFile result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                Runner.TJSON
-                    { payload = Runner.InitContract 0 V0 fibSourceFile "init_fib" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, Helpers.keyPairFromSeed 0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                Runner.AccountTx $
+                    Runner.TJSON
+                        { payload = Runner.InitContract 0 V0 fibSourceFile "init_fib" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, Helpers.keyPairFromSeed 0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -97,14 +99,15 @@ testCase1 _ pvString =
                         result
             },
           -- compute F(10)
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                Runner.TJSON
-                    { payload = Runner.Update 0 (Types.ContractAddress 0 0) "fib.receive" (fibParamBytes 10),
-                      metadata = makeDummyHeader accountAddress0 3 700_000,
-                      keys = [(0, [(0, Helpers.keyPairFromSeed 0)])]
-                    },
-              taaAssertion = ensureAllUpdates
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                Runner.AccountTx $
+                    Runner.TJSON
+                        { payload = Runner.Update 0 (Types.ContractAddress 0 0) "fib.receive" (fibParamBytes 10),
+                          metadata = makeDummyHeader accountAddress0 3 700_000,
+                          keys = [(0, [(0, Helpers.keyPairFromSeed 0)])]
+                        },
+              biaaAssertion = ensureAllUpdates
             }
         ]
     ensureAllUpdates ::

--- a/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
@@ -321,7 +321,7 @@ data TransactionAndAssertion pv = TransactionAndAssertion
 
 data AnyTransactionAndAssertion pv = AnyTransactionAndAssertion
     { -- | A transaction to run in the scheduler.
-      ataaTransaction :: SchedTest.AnyTransaction,
+      ataaTransaction :: SchedTest.BlockItemDescription,
       -- | Assertions to make about the outcome from the scheduler and the resulting block state.
       ataaAssertion :: TransactionAssertion pv
     }

--- a/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
@@ -346,7 +346,7 @@ runSchedulerTestAssertIntermediateStates config constructState transactionsAndAs
         BlockItemAndAssertion pv ->
         PersistentBSM pv (Assertion, BS.HashedPersistentBlockState pv, Types.Amount)
     transactionRunner (assertedSoFar, currentState, costsSoFar) step = do
-        transactions <- liftIO $ SchedTest.processAnyUngroupedTransactions [biaaTransaction step]
+        transactions <- liftIO $ SchedTest.processUngroupedBlockItems [biaaTransaction step]
         (result, updatedState) <- runScheduler config currentState transactions
         let nextCostsSoFar = costsSoFar + srExecutionCosts result
         doStateAssertions <- assertBlockStateInvariantsH updatedState nextCostsSoFar

--- a/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
@@ -312,13 +312,6 @@ type TransactionAssertion pv =
     PersistentBSM pv Assertion
 
 -- | A test transaction paired with assertions to run on the scheduler result and block state.
-data TransactionAndAssertion pv = TransactionAndAssertion
-    { -- | A transaction to run in the scheduler.
-      taaTransaction :: SchedTest.TransactionJSON,
-      -- | Assertions to make about the outcome from the scheduler and the resulting block state.
-      taaAssertion :: TransactionAssertion pv
-    }
-
 data BlockItemAndAssertion pv = BlockItemAndAssertion
     { -- | A transaction to run in the scheduler.
       biaaTransaction :: SchedTest.BlockItemDescription,
@@ -326,36 +319,20 @@ data BlockItemAndAssertion pv = BlockItemAndAssertion
       biaaAssertion :: TransactionAssertion pv
     }
 
--- | This is a special case of `runSchedulerTestAssertIntermediateStatesAnyTransaction` below that
--- only support account transactions. Kept for compatibility with existing tests that only use
--- account transactions.
-runSchedulerTestAssertIntermediateStates ::
-    forall pv.
-    (Types.IsProtocolVersion pv) =>
-    TestConfig ->
-    PersistentBSM pv (BS.HashedPersistentBlockState pv) ->
-    [TransactionAndAssertion pv] ->
-    Assertion
-runSchedulerTestAssertIntermediateStates config constructState transactionsAndAssertions =
-    runSchedulerTestAssertIntermediateStatesBlockItem config constructState $ toAny <$> transactionsAndAssertions
-  where
-    toAny :: TransactionAndAssertion pv -> BlockItemAndAssertion pv
-    toAny (TransactionAndAssertion tx a) = BlockItemAndAssertion (SchedTest.AccountTx tx) a
-
 -- | Run the scheduler on transactions in a test environment. Each transaction in the list of
 --  transactions is paired with the assertions to run on the scheduler result and the resulting block
 --  state right after executing each transaction in the intermediate block state.
 --
 --  This will also run invariant assertions on each intermediate block state, see
 --  @assertBlockStateInvariantsH@ for more details.
-runSchedulerTestAssertIntermediateStatesBlockItem ::
+runSchedulerTestAssertIntermediateStates ::
     forall pv.
     (Types.IsProtocolVersion pv) =>
     TestConfig ->
     PersistentBSM pv (BS.HashedPersistentBlockState pv) ->
     [BlockItemAndAssertion pv] ->
     Assertion
-runSchedulerTestAssertIntermediateStatesBlockItem config constructState transactionsAndAssertions =
+runSchedulerTestAssertIntermediateStates config constructState transactionsAndAssertions =
     join $ runTestBlockState blockStateComputation
   where
     blockStateComputation :: PersistentBSM pv Assertion

--- a/concordium-consensus/tests/scheduler/SchedulerTests/MaxIncomingAmountsTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/MaxIncomingAmountsTest.hs
@@ -63,7 +63,7 @@ testCase0 spv pvString = when (supportsEncryptedTransfers spv)
             initialBlockState
             transactionsAndAssertions
   where
-    makeTransactionsAndAssertions :: IO [Helpers.TransactionAndAssertion pv]
+    makeTransactionsAndAssertions :: IO [Helpers.BlockItemAndAssertion pv]
     makeTransactionsAndAssertions = do
         -- Transaction 1. Pub to sec (1000)
         let encryptedAmount1000 :: EncryptedAmount
@@ -121,14 +121,15 @@ testCase0 spv pvString = when (supportsEncryptedTransfers spv)
                     (numberOfTransactions * 10)
 
         return $
-            [ Helpers.TransactionAndAssertion
-                { taaTransaction =
-                    Runner.TJSON
-                        { payload = Runner.TransferToEncrypted 1_000,
-                          metadata = makeDummyHeader accountAddress0 1 100_000,
-                          keys = [(0, [(0, keyPair0)])]
-                        },
-                  taaAssertion = \result state -> do
+            [ Helpers.BlockItemAndAssertion
+                { biaaTransaction =
+                    Runner.AccountTx $
+                        Runner.TJSON
+                            { payload = Runner.TransferToEncrypted 1_000,
+                              metadata = makeDummyHeader accountAddress0 1 100_000,
+                              keys = [(0, [(0, keyPair0)])]
+                            },
+                  biaaAssertion = \result state -> do
                     doEncryptedBalanceAssertions <-
                         assertEncryptedBalance
                             Types.initialAccountEncryptedAmount
@@ -151,14 +152,15 @@ testCase0 spv pvString = when (supportsEncryptedTransfers spv)
                 -- Now send 34 transactions of 10 tokens from account0 to account1
                 ++ generatedTransactions
                 -- Send the encrypted 340 tokens on account1 to public balance
-                ++ [ Helpers.TransactionAndAssertion
-                        { taaTransaction =
-                            Runner.TJSON
-                                { payload = Runner.TransferToPublic secToPubTransferData,
-                                  metadata = makeDummyHeader accountAddress1 1 100_000,
-                                  keys = [(0, [(0, keyPair1)])]
-                                },
-                          taaAssertion = \result state -> do
+                ++ [ Helpers.BlockItemAndAssertion
+                        { biaaTransaction =
+                            Runner.AccountTx $
+                                Runner.TJSON
+                                    { payload = Runner.TransferToPublic secToPubTransferData,
+                                      metadata = makeDummyHeader accountAddress1 1 100_000,
+                                      keys = [(0, [(0, keyPair1)])]
+                                    },
+                          biaaAssertion = \result state -> do
                             doEncryptedBalanceAssertions <-
                                 assertEncryptedBalance
                                     Types.initialAccountEncryptedAmount
@@ -369,16 +371,17 @@ makeTransaction ::
     Helpers.TransactionAssertion pv ->
     EncryptedAmountTransferData ->
     EncryptedAmountAggIndex ->
-    Helpers.TransactionAndAssertion pv
+    Helpers.BlockItemAndAssertion pv
 makeTransaction blockStateChecks transferData idx =
-    Helpers.TransactionAndAssertion
-        { taaTransaction =
-            Runner.TJSON
-                { payload = Runner.EncryptedAmountTransfer accountAddress1 transferData, -- create an encrypted transfer to account1
-                  metadata = makeDummyHeader accountAddress0 (fromIntegral idx + 1) 100_000, -- from account0 with nonce idx + 1
-                  keys = [(0, [(0, keyPair0)])]
-                },
-          taaAssertion = \result state -> do
+    Helpers.BlockItemAndAssertion
+        { biaaTransaction =
+            Runner.AccountTx $
+                Runner.TJSON
+                    { payload = Runner.EncryptedAmountTransfer accountAddress1 transferData, -- create an encrypted transfer to account1
+                      metadata = makeDummyHeader accountAddress0 (fromIntegral idx + 1) 100_000, -- from account0 with nonce idx + 1
+                      keys = [(0, [(0, keyPair0)])]
+                    },
+          biaaAssertion = \result state -> do
             doBlockStateChecks <- blockStateChecks result state
             return $ do
                 case Helpers.getResults $ Sch.ftAdded $ Helpers.srTransactions result of

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V0/RelaxedRestrictions.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V0/RelaxedRestrictions.hs
@@ -69,41 +69,44 @@ oldParameterLimitTest spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
         deployAndInitTransactions
             ++ [
                  -- Check that the max size parameter is allowed.
-                 Helpers.TransactionAndAssertion
-                    { taaTransaction =
-                        TJSON
-                            { payload = Update 0 (Types.ContractAddress 0 0) "relax.param" (callArgsParam 1_024 1_024),
-                              metadata = makeDummyHeader accountAddress0 3 700_000,
-                              keys = [(0, [(0, keyPair0)])]
-                            },
-                      taaAssertion = \result _ ->
+                 Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        AccountTx $
+                            TJSON
+                                { payload = Update 0 (Types.ContractAddress 0 0) "relax.param" (callArgsParam 1_024 1_024),
+                                  metadata = makeDummyHeader accountAddress0 3 700_000,
+                                  keys = [(0, [(0, keyPair0)])]
+                                },
+                      biaaAssertion = \result _ ->
                         return $ Helpers.assertSuccess result
                     },
                  -- Check that if the top-level parameter is too big, we get a serialization failure.
-                 Helpers.TransactionAndAssertion
-                    { taaTransaction =
-                        TJSON
-                            { payload = Update 0 (Types.ContractAddress 0 0) "relax.param" (callArgsParam 1_024 1_025),
-                              metadata = makeDummyHeader accountAddress0 4 700_000,
-                              keys = [(0, [(0, keyPair0)])]
-                            },
-                      taaAssertion = \result _ ->
+                 Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        AccountTx $
+                            TJSON
+                                { payload = Update 0 (Types.ContractAddress 0 0) "relax.param" (callArgsParam 1_024 1_025),
+                                  metadata = makeDummyHeader accountAddress0 4 700_000,
+                                  keys = [(0, [(0, keyPair0)])]
+                                },
+                      biaaAssertion = \result _ ->
                         return $ Helpers.assertRejectWithReason Types.SerializationFailure result
                     },
                  -- Check that if the inter-contract parameter is too big, we get a runtime failure.
-                 Helpers.TransactionAndAssertion
-                    { taaTransaction =
-                        TJSON
-                            { payload = Update 0 (Types.ContractAddress 0 0) "relax.param" (callArgsParam 1_025 1_024),
-                              metadata = makeDummyHeader accountAddress0 5 700_000,
-                              keys = [(0, [(0, keyPair0)])]
-                            },
-                      taaAssertion = \result _ ->
+                 Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        AccountTx $
+                            TJSON
+                                { payload = Update 0 (Types.ContractAddress 0 0) "relax.param" (callArgsParam 1_025 1_024),
+                                  metadata = makeDummyHeader accountAddress0 5 700_000,
+                                  keys = [(0, [(0, keyPair0)])]
+                                },
+                      biaaAssertion = \result _ ->
                         return $ Helpers.assertRejectWithReason Types.RuntimeFailure result
                     }
                ]
@@ -125,30 +128,32 @@ oldLogLimitTest spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
         deployAndInitTransactions
             ++ [
                  -- Check that the max number of logs is allowed.
-                 Helpers.TransactionAndAssertion
-                    { taaTransaction =
-                        TJSON
-                            { payload = Update 0 (Types.ContractAddress 0 0) "relax.logs" (callArgsWord32 64),
-                              metadata = makeDummyHeader accountAddress0 3 700_000,
-                              keys = [(0, [(0, keyPair0)])]
-                            },
-                      taaAssertion = \result _ ->
+                 Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        AccountTx $
+                            TJSON
+                                { payload = Update 0 (Types.ContractAddress 0 0) "relax.logs" (callArgsWord32 64),
+                                  metadata = makeDummyHeader accountAddress0 3 700_000,
+                                  keys = [(0, [(0, keyPair0)])]
+                                },
+                      biaaAssertion = \result _ ->
                         return $ Helpers.assertSuccess result
                     },
                  -- Check that one above the max number of logs is _not_ allowed.
-                 Helpers.TransactionAndAssertion
-                    { taaTransaction =
-                        TJSON
-                            { payload = Update 0 (Types.ContractAddress 0 0) "relax.logs" (callArgsWord32 65),
-                              metadata = makeDummyHeader accountAddress0 4 700_000,
-                              keys = [(0, [(0, keyPair0)])]
-                            },
-                      taaAssertion = \result _ ->
+                 Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        AccountTx $
+                            TJSON
+                                { payload = Update 0 (Types.ContractAddress 0 0) "relax.logs" (callArgsWord32 65),
+                                  metadata = makeDummyHeader accountAddress0 4 700_000,
+                                  keys = [(0, [(0, keyPair0)])]
+                                },
+                      biaaAssertion = \result _ ->
                         return $ Helpers.assertRejectWithReason Types.RuntimeFailure result
                     }
                ]
@@ -169,20 +174,21 @@ newParameterLimitTest spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
         deployAndInitTransactions
             ++ [
                  -- Check that the max size parameter is allowed. We cannot check above it easily,
                  -- because it is Word16::MAX.
-                 Helpers.TransactionAndAssertion
-                    { taaTransaction =
-                        TJSON
-                            { payload = Update 0 (Types.ContractAddress 0 0) "relax.param" (callArgsParam 65_535 65_535),
-                              metadata = makeDummyHeader accountAddress0 3 700_000,
-                              keys = [(0, [(0, keyPair0)])]
-                            },
-                      taaAssertion = \result _ ->
+                 Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        AccountTx $
+                            TJSON
+                                { payload = Update 0 (Types.ContractAddress 0 0) "relax.param" (callArgsParam 65_535 65_535),
+                                  metadata = makeDummyHeader accountAddress0 3 700_000,
+                                  keys = [(0, [(0, keyPair0)])]
+                                },
+                      biaaAssertion = \result _ ->
                         return $ Helpers.assertSuccess result
                     }
                ]
@@ -203,46 +209,49 @@ newLogLimitTest spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
         deployAndInitTransactions
             ++ [
                  -- Check that a large number of logs is allowed (more than allowed in P4).
-                 Helpers.TransactionAndAssertion
-                    { taaTransaction =
-                        TJSON
-                            { payload = Update 0 (Types.ContractAddress 0 0) "relax.logs" (callArgsWord32 64),
-                              metadata = makeDummyHeader accountAddress0 3 700_000,
-                              keys = [(0, [(0, keyPair0)])]
-                            },
-                      taaAssertion = \result _ ->
+                 Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        AccountTx $
+                            TJSON
+                                { payload = Update 0 (Types.ContractAddress 0 0) "relax.logs" (callArgsWord32 64),
+                                  metadata = makeDummyHeader accountAddress0 3 700_000,
+                                  keys = [(0, [(0, keyPair0)])]
+                                },
+                      biaaAssertion = \result _ ->
                         return $ Helpers.assertSuccess result
                     }
                ]
 
 -- | Transactions and assertions for deploying and initializing the "relax" contract.
-deployAndInitTransactions :: forall pv. (Types.IsProtocolVersion pv) => [Helpers.TransactionAndAssertion pv]
+deployAndInitTransactions :: forall pv. (Types.IsProtocolVersion pv) => [Helpers.BlockItemAndAssertion pv]
 deployAndInitTransactions =
-    [ Helpers.TransactionAndAssertion
-        { taaTransaction =
-            TJSON
-                { payload = DeployModule wasmModVersion sourceFile,
-                  metadata = makeDummyHeader accountAddress0 1 100_000,
-                  keys = [(0, [(0, keyPair0)])]
-                },
-          taaAssertion = \result _ ->
+    [ Helpers.BlockItemAndAssertion
+        { biaaTransaction =
+            AccountTx $
+                TJSON
+                    { payload = DeployModule wasmModVersion sourceFile,
+                      metadata = makeDummyHeader accountAddress0 1 100_000,
+                      keys = [(0, [(0, keyPair0)])]
+                    },
+          biaaAssertion = \result _ ->
             return $ do
                 Helpers.assertSuccess result
                 Helpers.assertUsedEnergyDeploymentV0 sourceFile result
         },
-      Helpers.TransactionAndAssertion
-        { taaTransaction =
-            TJSON
-                { payload = InitContract 0 wasmModVersion sourceFile "init_relax" "",
-                  metadata = makeDummyHeader accountAddress0 2 100_000,
-                  keys = [(0, [(0, keyPair0)])]
-                },
-          taaAssertion = \result _ ->
+      Helpers.BlockItemAndAssertion
+        { biaaTransaction =
+            AccountTx $
+                TJSON
+                    { payload = InitContract 0 wasmModVersion sourceFile "init_relax" "",
+                      metadata = makeDummyHeader accountAddress0 2 100_000,
+                      keys = [(0, [(0, keyPair0)])]
+                    },
+          biaaAssertion = \result _ ->
             return $ do
                 Helpers.assertSuccess result
                 Helpers.assertUsedEnergyInitialization

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V0/SmartContractTests.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V0/SmartContractTests.hs
@@ -39,7 +39,7 @@ import qualified Concordium.Crypto.SignatureScheme as SigScheme
 import qualified Concordium.GlobalState.Persistent.BlockState as BS
 import qualified Concordium.ID.Types as ID
 import Concordium.Scheduler.DummyData
-import Concordium.Scheduler.Runner (PayloadJSON (..), TransactionJSON (..))
+import Concordium.Scheduler.Runner (BlockItemDescription (..), PayloadJSON (..), TransactionJSON (..))
 import Concordium.Scheduler.Types (Amount, ContractAddress (..), Event, RejectReason (..))
 import qualified Concordium.Scheduler.Types as Types
 import Concordium.Wasm (InitName (..), Parameter (..), WasmVersion (..))
@@ -66,26 +66,28 @@ runInitTestsFromFile _ testCaseDescription testFile testCases =
                 @pv
                 Helpers.defaultTestConfig
                 initialBlockState
-                [ Helpers.TransactionAndAssertion
-                    { taaTransaction =
-                        TJSON
-                            { payload = DeployModule V0 testFile,
-                              metadata = makeDummyHeader accountAddress0 1 100_000,
-                              keys = [(0, [(0, keyPair0)])]
-                            },
-                      taaAssertion = \result _ ->
+                [ Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        AccountTx $
+                            TJSON
+                                { payload = DeployModule V0 testFile,
+                                  metadata = makeDummyHeader accountAddress0 1 100_000,
+                                  keys = [(0, [(0, keyPair0)])]
+                                },
+                      biaaAssertion = \result _ ->
                         return $ do
                             Helpers.assertSuccess result
                             Helpers.assertUsedEnergyDeploymentV0 testFile result
                     },
-                  Helpers.TransactionAndAssertion
-                    { taaTransaction =
-                        TJSON
-                            { payload = InitContract 0 V0 testFile testName initParam,
-                              metadata = makeDummyHeader accountAddress0 2 100_000,
-                              keys = [(0, [(0, keyPair0)])]
-                            },
-                      taaAssertion = \result _ ->
+                  Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        AccountTx $
+                            TJSON
+                                { payload = InitContract 0 V0 testFile testName initParam,
+                                  metadata = makeDummyHeader accountAddress0 2 100_000,
+                                  keys = [(0, [(0, keyPair0)])]
+                                },
+                      biaaAssertion = \result _ ->
                         return $ do
                             Helpers.assertUsedEnergyInitialization
                                 (Types.protocolVersion @pv)
@@ -120,26 +122,28 @@ runReceiveTestsFromFile _ testCaseDescription testFile testCases =
                 @pv
                 Helpers.defaultTestConfig
                 initialBlockState
-                [ Helpers.TransactionAndAssertion
-                    { taaTransaction =
-                        TJSON
-                            { payload = DeployModule V0 testFile,
-                              metadata = makeDummyHeader accountAddress0 1 100_000,
-                              keys = [(0, [(0, keyPair0)])]
-                            },
-                      taaAssertion = \result _ ->
+                [ Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        AccountTx $
+                            TJSON
+                                { payload = DeployModule V0 testFile,
+                                  metadata = makeDummyHeader accountAddress0 1 100_000,
+                                  keys = [(0, [(0, keyPair0)])]
+                                },
+                      biaaAssertion = \result _ ->
                         return $ do
                             Helpers.assertSuccess result
                             Helpers.assertUsedEnergyDeploymentV0 testFile result
                     },
-                  Helpers.TransactionAndAssertion
-                    { taaTransaction =
-                        TJSON
-                            { payload = InitContract 10_000 V0 testFile "init_test" "",
-                              metadata = makeDummyHeader accountAddress0 2 100_000,
-                              keys = [(0, [(0, keyPair0)])]
-                            },
-                      taaAssertion = \result _ ->
+                  Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        AccountTx $
+                            TJSON
+                                { payload = InitContract 10_000 V0 testFile "init_test" "",
+                                  metadata = makeDummyHeader accountAddress0 2 100_000,
+                                  keys = [(0, [(0, keyPair0)])]
+                                },
+                      biaaAssertion = \result _ ->
                         return $ do
                             Helpers.assertSuccess result
                             Helpers.assertUsedEnergyInitialization
@@ -150,14 +154,15 @@ runReceiveTestsFromFile _ testCaseDescription testFile testCases =
                                 Nothing
                                 result
                     },
-                  Helpers.TransactionAndAssertion
-                    { taaTransaction =
-                        TJSON
-                            { payload = Update 0 (ContractAddress 0 0) ("test." <> testName) rcvParam,
-                              metadata = makeDummyHeader accountAddress0 3 100_000,
-                              keys = [(0, [(0, keyPair0)])]
-                            },
-                      taaAssertion = \result _ ->
+                  Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        AccountTx $
+                            TJSON
+                                { payload = Update 0 (ContractAddress 0 0) ("test." <> testName) rcvParam,
+                                  metadata = makeDummyHeader accountAddress0 3 100_000,
+                                  keys = [(0, [(0, keyPair0)])]
+                                },
+                      biaaAssertion = \result _ ->
                         return $ resSpec result
                     }
                 ]

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Caller.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Caller.hs
@@ -58,28 +58,30 @@ test1 spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule wasmModVersion contractSourceFile,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule wasmModVersion contractSourceFile,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 contractSourceFile result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 wasmModVersion contractSourceFile "init_caller" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ -> do
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 wasmModVersion contractSourceFile "init_caller" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ -> do
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -90,14 +92,15 @@ test1 spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "caller.call" callArgs,
-                      metadata = makeDummyHeader accountAddress0 3 700_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ -> do
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "caller.call" callArgs,
+                          metadata = makeDummyHeader accountAddress0 3 700_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ -> do
                 return $ do
                     Helpers.assertSuccess result
             }

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Checkpointing.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Checkpointing.hs
@@ -79,28 +79,30 @@ checkpointingTest1 spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 checkpointingSourceFile,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 checkpointingSourceFile,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 checkpointingSourceFile result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V1 checkpointingSourceFile "init_a" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V1 checkpointingSourceFile "init_a" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -111,14 +113,15 @@ checkpointingTest1 spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V1 checkpointingSourceFile "init_b" "",
-                      metadata = makeDummyHeader accountAddress0 3 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V1 checkpointingSourceFile "init_b" "",
+                          metadata = makeDummyHeader accountAddress0 3 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -131,14 +134,15 @@ checkpointingTest1 spv pvString =
             },
           -- We supply one micro CCD as we expect a trap from a v1 contract.
           -- See the contract for details.
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 1 (Types.ContractAddress 0 0) "a.a_modify_proxy" parameters,
-                      metadata = makeDummyHeader accountAddress0 4 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 1 (Types.ContractAddress 0 0) "a.a_modify_proxy" parameters,
+                          metadata = makeDummyHeader accountAddress0 4 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertSuccessWhere (Helpers.assertNumberOfEvents 3) result
             }
         ]
@@ -185,28 +189,30 @@ checkpointingTest2 spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 checkpointingSourceFile,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 checkpointingSourceFile,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 checkpointingSourceFile result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V1 checkpointingSourceFile "init_a" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V1 checkpointingSourceFile "init_a" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -217,14 +223,15 @@ checkpointingTest2 spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V1 checkpointingSourceFile "init_b" "",
-                      metadata = makeDummyHeader accountAddress0 3 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V1 checkpointingSourceFile "init_b" "",
+                          metadata = makeDummyHeader accountAddress0 3 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -239,14 +246,15 @@ checkpointingTest2 spv pvString =
           -- does not expect errors i.e. a trap signal from underlying invocations.
           -- The 'inner' call to contract A does not modify the state.
           -- See the contract for details.
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "a.a_modify_proxy" parameters,
-                      metadata = makeDummyHeader accountAddress0 4 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "a.a_modify_proxy" parameters,
+                          metadata = makeDummyHeader accountAddress0 4 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertSuccessWhere (Helpers.assertNumberOfEvents 7) result
             }
         ]
@@ -289,28 +297,30 @@ checkpointingTest3 spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 checkpointingSourceFile,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 checkpointingSourceFile,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 checkpointingSourceFile result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V1 checkpointingSourceFile "init_a" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V1 checkpointingSourceFile "init_a" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -321,14 +331,15 @@ checkpointingTest3 spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V1 checkpointingSourceFile "init_b" "",
-                      metadata = makeDummyHeader accountAddress0 3 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V1 checkpointingSourceFile "init_b" "",
+                          metadata = makeDummyHeader accountAddress0 3 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -341,14 +352,15 @@ checkpointingTest3 spv pvString =
             },
           -- We supply three micro CCDs as we're instructing the contract to carry out a transfer instead of a call.
           -- See the contract for details.
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 3 (Types.ContractAddress 0 0) "a.a_modify_proxy" (BSS.toShort (encode accountAddress1)),
-                      metadata = makeDummyHeader accountAddress0 4 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 3 (Types.ContractAddress 0 0) "a.a_modify_proxy" (BSS.toShort (encode accountAddress1)),
+                          metadata = makeDummyHeader accountAddress0 4 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertSuccessWhere (Helpers.assertNumberOfEvents 4) result
             }
         ]
@@ -378,28 +390,30 @@ checkpointingTest4 spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 checkpointingSourceFile,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 checkpointingSourceFile,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 checkpointingSourceFile result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V1 checkpointingSourceFile "init_a" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V1 checkpointingSourceFile "init_a" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -410,14 +424,15 @@ checkpointingTest4 spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V1 checkpointingSourceFile "init_b" "",
-                      metadata = makeDummyHeader accountAddress0 3 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V1 checkpointingSourceFile "init_b" "",
+                          metadata = makeDummyHeader accountAddress0 3 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -431,14 +446,15 @@ checkpointingTest4 spv pvString =
           -- We supply four micro CCDs as we're instructing the contract to expect state modifications
           -- being made from the 'inner' contract A call to be in effect when returned to the caller (a.a_modify_proxy)
           -- See the contract for details.
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 4 (Types.ContractAddress 0 0) "a.a_modify_proxy" parameters,
-                      metadata = makeDummyHeader accountAddress0 4 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 4 (Types.ContractAddress 0 0) "a.a_modify_proxy" parameters,
+                          metadata = makeDummyHeader accountAddress0 4 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertSuccessWhere (Helpers.assertNumberOfEvents 7) result
             }
         ]
@@ -486,40 +502,43 @@ checkpointingTest5 spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 checkpointingSourceFile,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 checkpointingSourceFile,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 checkpointingSourceFile result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V0 v0ProxySourceFile,
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V0 v0ProxySourceFile,
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV0 v0ProxySourceFile result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V1 checkpointingSourceFile "init_a" "",
-                      metadata = makeDummyHeader accountAddress0 3 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V1 checkpointingSourceFile "init_a" "",
+                          metadata = makeDummyHeader accountAddress0 3 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -530,14 +549,15 @@ checkpointingTest5 spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V1 checkpointingSourceFile "init_b" "",
-                      metadata = makeDummyHeader accountAddress0 4 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V1 checkpointingSourceFile "init_b" "",
+                          metadata = makeDummyHeader accountAddress0 4 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -548,14 +568,15 @@ checkpointingTest5 spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V0 v0ProxySourceFile "init_proxy" "",
-                      metadata = makeDummyHeader accountAddress0 5 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V0 v0ProxySourceFile "init_proxy" "",
+                          metadata = makeDummyHeader accountAddress0 5 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -568,14 +589,15 @@ checkpointingTest5 spv pvString =
             },
           -- We supply two micro CCDs as we expect a trap from a v0 contract.
           -- See the contract for details.
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 2 (Types.ContractAddress 0 0) "a.a_modify_proxy" parameters,
-                      metadata = makeDummyHeader accountAddress0 6 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 2 (Types.ContractAddress 0 0) "a.a_modify_proxy" parameters,
+                          metadata = makeDummyHeader accountAddress0 6 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertSuccessWhere (Helpers.assertNumberOfEvents 3) result
             }
         ]
@@ -633,40 +655,43 @@ checkpointingTest6 spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 checkpointingSourceFile,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 checkpointingSourceFile,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 checkpointingSourceFile result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V0 v0ProxySourceFile,
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V0 v0ProxySourceFile,
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV0 v0ProxySourceFile result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V1 checkpointingSourceFile "init_a" "",
-                      metadata = makeDummyHeader accountAddress0 3 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V1 checkpointingSourceFile "init_a" "",
+                          metadata = makeDummyHeader accountAddress0 3 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -677,14 +702,15 @@ checkpointingTest6 spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V1 checkpointingSourceFile "init_b" "",
-                      metadata = makeDummyHeader accountAddress0 4 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V1 checkpointingSourceFile "init_b" "",
+                          metadata = makeDummyHeader accountAddress0 4 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -695,14 +721,15 @@ checkpointingTest6 spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V0 v0ProxySourceFile "init_proxy" "",
-                      metadata = makeDummyHeader accountAddress0 5 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V0 v0ProxySourceFile "init_proxy" "",
+                          metadata = makeDummyHeader accountAddress0 5 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -716,14 +743,15 @@ checkpointingTest6 spv pvString =
           -- We supply four micro CCDs as we're instructing the contract to expect state modifications
           -- being made from the 'inner' contract A call to be in effect when returned to the caller (a.a_modify_proxy)
           -- See the contract for details.
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 4 (Types.ContractAddress 0 0) "a.a_modify_proxy" parameters,
-                      metadata = makeDummyHeader accountAddress0 6 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 4 (Types.ContractAddress 0 0) "a.a_modify_proxy" parameters,
+                          metadata = makeDummyHeader accountAddress0 6 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertSuccessWhere (Helpers.assertNumberOfEvents 8) result
             }
         ]
@@ -783,28 +811,30 @@ checkpointingTest7 spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 checkpointing2SourceFile,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 checkpointing2SourceFile,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 checkpointing2SourceFile result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V1 checkpointing2SourceFile "init_test" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ -> do
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V1 checkpointing2SourceFile "init_test" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ -> do
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -815,14 +845,15 @@ checkpointingTest7 spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "test.a" callArgs,
-                      metadata = makeDummyHeader accountAddress0 3 700_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ -> do
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "test.a" callArgs,
+                          metadata = makeDummyHeader accountAddress0 3 700_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ -> do
                 return $ do
                     if Types.demoteProtocolVersion spv >= Types.P6
                         then Helpers.assertSuccess result
@@ -861,28 +892,30 @@ checkpointingTest8 spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 checkpointing2SourceFile,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 checkpointing2SourceFile,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 checkpointing2SourceFile result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V1 checkpointing2SourceFile "init_test" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ -> do
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V1 checkpointing2SourceFile "init_test" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ -> do
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -893,14 +926,15 @@ checkpointingTest8 spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "test.a" callArgs,
-                      metadata = makeDummyHeader accountAddress0 3 700_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ -> do
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "test.a" callArgs,
+                          metadata = makeDummyHeader accountAddress0 3 700_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ -> do
                 return $ do
                     if Types.demoteProtocolVersion spv >= Types.P6
                         then Helpers.assertSuccess result
@@ -936,28 +970,30 @@ checkpointingTest9 spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 checkpointing2SourceFile,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 checkpointing2SourceFile,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 checkpointing2SourceFile result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V1 checkpointing2SourceFile "init_test" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ -> do
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V1 checkpointing2SourceFile "init_test" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ -> do
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -968,14 +1004,15 @@ checkpointingTest9 spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "test.e" callArgs,
-                      metadata = makeDummyHeader accountAddress0 3 700_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ -> do
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "test.e" callArgs,
+                          metadata = makeDummyHeader accountAddress0 3 700_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ -> do
                 return $ do
                     if Types.demoteProtocolVersion spv >= Types.P6
                         then Helpers.assertSuccess result

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Counter.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Counter.hs
@@ -62,28 +62,30 @@ test1 spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule wasmModVersion counterSourceFile,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule wasmModVersion counterSourceFile,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 counterSourceFile result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 wasmModVersion counterSourceFile "init_counter" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result state -> do
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 wasmModVersion counterSourceFile "init_counter" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result state -> do
                 doAssertState <- assertCounterState 0 state
                 return $ do
                     Helpers.assertSuccess result
@@ -96,40 +98,43 @@ test1 spv pvString =
                         result
                     doAssertState
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "counter.inc" BSS.empty,
-                      metadata = makeDummyHeader accountAddress0 3 700_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result state -> do
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "counter.inc" BSS.empty,
+                          metadata = makeDummyHeader accountAddress0 3 700_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result state -> do
                 doAssertState <- assertCounterState 1 state
                 return $ do
                     Helpers.assertSuccess result
                     doAssertState
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "counter.inc" BSS.empty,
-                      metadata = makeDummyHeader accountAddress0 4 700_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result state -> do
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "counter.inc" BSS.empty,
+                          metadata = makeDummyHeader accountAddress0 4 700_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result state -> do
                 doAssertState <- assertCounterState 2 state
                 return $ do
                     Helpers.assertSuccess result
                     doAssertState
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "counter.inc10" callArgs,
-                      metadata = makeDummyHeader accountAddress0 5 700_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result state -> do
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "counter.inc10" callArgs,
+                          metadata = makeDummyHeader accountAddress0 5 700_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result state -> do
                 doAssertState <- assertCounterState 12 state
                 return $ do
                     Helpers.assertSuccess result

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/CrossMessaging.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/CrossMessaging.hs
@@ -72,40 +72,43 @@ test1 spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule version1 counterSourceFile,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule version1 counterSourceFile,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 counterSourceFile result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule version0 proxySourceFile,
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ -> do
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule version0 proxySourceFile,
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ -> do
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 proxySourceFile result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 version1 counterSourceFile "init_counter" "",
-                      metadata = makeDummyHeader accountAddress0 3 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result state -> do
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 version1 counterSourceFile "init_counter" "",
+                          metadata = makeDummyHeader accountAddress0 3 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result state -> do
                 doAssertState <- assertCounterState 0 state
                 return $ do
                     Helpers.assertSuccess result
@@ -118,14 +121,15 @@ test1 spv pvString =
                         result
                     doAssertState
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 version0 proxySourceFile "init_proxy" "",
-                      metadata = makeDummyHeader accountAddress0 4 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ -> do
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 version0 proxySourceFile "init_proxy" "",
+                          metadata = makeDummyHeader accountAddress0 4 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ -> do
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -136,14 +140,15 @@ test1 spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "counter.inc10nocheck" callArgs,
-                      metadata = makeDummyHeader accountAddress0 5 700_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result state -> do
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "counter.inc10nocheck" callArgs,
+                          metadata = makeDummyHeader accountAddress0 5 700_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result state -> do
                 doAssertState <- assertCounterState 10 state
                 return $ do
                     Helpers.assertSuccess result

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/InspectModuleReferenceAndContractName.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/InspectModuleReferenceAndContractName.hs
@@ -96,7 +96,7 @@ testModuleRefAndName spv pvString
                 transactionsAndAssertions
     | otherwise = return ()
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
         [ deployModHelper 1 srcQueriesContractInspection,
           deployModHelper 2 srcQueriesAccountBalance,
@@ -115,27 +115,29 @@ testModuleRefAndName spv pvString
           getNameHelper 15 (Types.ContractAddress 0 1) Nothing (ifLowerModuleCost spv 741 732)
         ]
     deployModHelper nce src =
-        Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 src,
-                      metadata = makeDummyHeader accountAddress0 nce 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 src,
+                          metadata = makeDummyHeader accountAddress0 nce 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 src result
             }
     initContractHelper nce src constructor =
-        Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V1 src constructor "",
-                      metadata = makeDummyHeader accountAddress0 nce 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V1 src constructor "",
+                          metadata = makeDummyHeader accountAddress0 nce 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -150,16 +152,17 @@ testModuleRefAndName spv pvString
         Types.Nonce ->
         Types.ContractAddress ->
         Maybe Types.ModuleRef ->
-        Helpers.TransactionAndAssertion pv
+        Helpers.BlockItemAndAssertion pv
     getModRefHelper nce scAddr mExpectModRef =
-        Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "contract.get_module_reference" params,
-                      metadata = makeDummyHeader accountAddress0 nce 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "contract.get_module_reference" params,
+                          metadata = makeDummyHeader accountAddress0 nce 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $
                     if Types.supportsContractInspectionQueries spv
                         then case mExpectModRef of
@@ -200,16 +203,17 @@ testModuleRefAndName spv pvString
         Types.ContractAddress ->
         Maybe BSS.ShortByteString ->
         Types.Energy ->
-        Helpers.TransactionAndAssertion pv
+        Helpers.BlockItemAndAssertion pv
     getNameHelper nce scAddr mExpectName expectEnergy =
-        Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 2 0) "contract2.get_contract_name" params,
-                      metadata = makeDummyHeader accountAddress0 nce 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 2 0) "contract2.get_contract_name" params,
+                          metadata = makeDummyHeader accountAddress0 nce 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     if Types.supportsContractInspectionQueries spv
                         then do
@@ -267,7 +271,7 @@ testUpgradeModuleRef spv pvString
     | otherwise = return ()
   where
     addr0 = Types.ContractAddress 0 0
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
         [ deployModHelper 1 srcUpgrade0,
           deployModHelper 2 srcUpgrade1,
@@ -279,27 +283,29 @@ testUpgradeModuleRef spv pvString
           checkModRefHelper 8 addr0 modUpgrade1 Nothing
         ]
     deployModHelper nce src =
-        Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 src,
-                      metadata = makeDummyHeader accountAddress0 nce 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 src,
+                          metadata = makeDummyHeader accountAddress0 nce 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 src result
             }
     initContractHelper nce src constructor =
-        Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V1 src constructor "",
-                      metadata = makeDummyHeader accountAddress0 nce 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V1 src constructor "",
+                          metadata = makeDummyHeader accountAddress0 nce 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -311,19 +317,20 @@ testUpgradeModuleRef spv pvString
                         result
             }
     checkModRefHelper nce scAddr expectModRef mreject =
-        Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload =
-                        Update
-                            0
-                            (Types.ContractAddress 0 0)
-                            "contract.check_module_reference"
-                            (params scAddr expectModRef),
-                      metadata = makeDummyHeader accountAddress0 nce 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload =
+                            Update
+                                0
+                                (Types.ContractAddress 0 0)
+                                "contract.check_module_reference"
+                                (params scAddr expectModRef),
+                          metadata = makeDummyHeader accountAddress0 nce 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $
                     if Types.supportsContractInspectionQueries spv
                         then case mreject of
@@ -344,14 +351,15 @@ testUpgradeModuleRef spv pvString
             putWord64le $ fromIntegral si
             put modRef
     upgradeHelper nce scAddr toModRef mreject =
-        Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 scAddr "contract.upgrade" (BSS.toShort $ encode toModRef),
-                      metadata = makeDummyHeader accountAddress0 nce 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 scAddr "contract.upgrade" (BSS.toShort $ encode toModRef),
+                          metadata = makeDummyHeader accountAddress0 nce 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $
                     if Types.supportsContractInspectionQueries spv
                         then case mreject of

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Iterator.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Iterator.hs
@@ -58,28 +58,30 @@ test1 spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule wasmModVersion iteratorSourceFile,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule wasmModVersion iteratorSourceFile,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 iteratorSourceFile result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 wasmModVersion iteratorSourceFile "init_iterator" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 wasmModVersion iteratorSourceFile "init_iterator" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -90,24 +92,26 @@ test1 spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "iterator.iteratetest" BSS.empty,
-                      metadata = makeDummyHeader accountAddress0 3 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "iterator.iteratetest" BSS.empty,
+                          metadata = makeDummyHeader accountAddress0 3 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertSuccess result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "iterator.lockingtest" BSS.empty,
-                      metadata = makeDummyHeader accountAddress0 4 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "iterator.lockingtest" BSS.empty,
+                          metadata = makeDummyHeader accountAddress0 4 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertSuccess result
             }
         ]

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/P6WasmFeatures.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/P6WasmFeatures.hs
@@ -71,7 +71,7 @@ testCase ::
     -- | Path to the module to attempt to deploy.
     FilePath ->
     Spec
-testCase spv taaAssertion pvString sourceFile =
+testCase spv biaaAssertion pvString sourceFile =
     -- we only check V1 contracts, which do not exist before P4.
     when (Types.demoteProtocolVersion spv >= Types.P4) $
         specify (pvString ++ ": Wasm features") $
@@ -81,15 +81,16 @@ testCase spv taaAssertion pvString sourceFile =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule wasmModVersion1 sourceFile,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule wasmModVersion1 sourceFile,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
               ..
             }
         ]

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Queries.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Queries.hs
@@ -101,28 +101,30 @@ accountBalanceTestCase spv pvString =
                         initialBlockStateWithStakeAndSchedule
                         transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 accountBalanceSourceFile,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 accountBalanceSourceFile,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 accountBalanceSourceFile result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V1 accountBalanceSourceFile "init_contract" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V1 accountBalanceSourceFile "init_contract" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -133,24 +135,26 @@ accountBalanceTestCase spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = TransferWithSchedule accountAddress1 [(Types.Timestamp maxBound, 123)],
-                      metadata = makeDummyHeader accountAddress0 3 10_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = TransferWithSchedule accountAddress1 [(Types.Timestamp maxBound, 123)],
+                          metadata = makeDummyHeader accountAddress0 3 10_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertSuccess result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "contract.query" parameters,
-                      metadata = makeDummyHeader accountAddress0 4 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "contract.query" parameters,
+                          metadata = makeDummyHeader accountAddress0 4 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccessWhere (Helpers.assertNumberOfEvents 1) result
             }
@@ -176,28 +180,30 @@ accountBalanceInvokerTestCase spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 accountBalanceSourceFile,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 accountBalanceSourceFile,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 accountBalanceSourceFile result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V1 accountBalanceSourceFile "init_contract" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V1 accountBalanceSourceFile "init_contract" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -208,14 +214,15 @@ accountBalanceInvokerTestCase spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update updateAmount (Types.ContractAddress 0 0) "contract.query" parameters,
-                      metadata = makeDummyHeader accountAddress1 1 energyLimit,
-                      keys = [(0, [(0, keyPair1)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update updateAmount (Types.ContractAddress 0 0) "contract.query" parameters,
+                          metadata = makeDummyHeader accountAddress1 1 energyLimit,
+                          keys = [(0, [(0, keyPair1)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertSuccessWhere (Helpers.assertNumberOfEvents 1) result
             }
         ]
@@ -246,28 +253,30 @@ accountBalanceTransferTestCase spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 accountBalanceTransferSourceFile,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 accountBalanceTransferSourceFile,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 accountBalanceTransferSourceFile result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 123 V1 accountBalanceTransferSourceFile "init_contract" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 123 V1 accountBalanceTransferSourceFile "init_contract" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -278,14 +287,15 @@ accountBalanceTransferTestCase spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "contract.query" parameters,
-                      metadata = makeDummyHeader accountAddress0 3 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "contract.query" parameters,
+                          metadata = makeDummyHeader accountAddress0 3 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 -- Check the number of events:
                 -- - 3 events for the transfer.
                 -- - 1 event for a succesful update to the contract.
@@ -317,28 +327,30 @@ accountBalanceMissingAccountTestCase spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 accountBalanceMissingAccountSourceFile,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 accountBalanceMissingAccountSourceFile,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 accountBalanceMissingAccountSourceFile result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 123 V1 accountBalanceMissingAccountSourceFile "init_contract" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 123 V1 accountBalanceMissingAccountSourceFile "init_contract" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -349,14 +361,15 @@ accountBalanceMissingAccountTestCase spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "contract.query" parameters,
-                      metadata = makeDummyHeader accountAddress0 3 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "contract.query" parameters,
+                          metadata = makeDummyHeader accountAddress0 3 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 -- Check the number of events:
                 -- - 1 event for a succesful update to the contract.
                 return $ Helpers.assertSuccessWhere (Helpers.assertNumberOfEvents 1) result
@@ -383,28 +396,30 @@ contractBalanceTestCase spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 contractBalanceSourceFile,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 contractBalanceSourceFile,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 contractBalanceSourceFile result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V1 contractBalanceSourceFile "init_contract" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V1 contractBalanceSourceFile "init_contract" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -415,24 +430,26 @@ contractBalanceTestCase spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract initAmount V1 contractBalanceSourceFile "init_contract" "",
-                      metadata = makeDummyHeader accountAddress0 3 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract initAmount V1 contractBalanceSourceFile "init_contract" "",
+                          metadata = makeDummyHeader accountAddress0 3 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertSuccess result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "contract.query" parameters,
-                      metadata = makeDummyHeader accountAddress0 4 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "contract.query" parameters,
+                          metadata = makeDummyHeader accountAddress0 4 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 -- Check the number of events:
                 -- - 1 event for a succesful update to the contract.
                 return $ Helpers.assertSuccessWhere (Helpers.assertNumberOfEvents 1) result
@@ -459,28 +476,30 @@ contractBalanceSelfTestCase spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 contractBalanceSourceFile,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 contractBalanceSourceFile,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 contractBalanceSourceFile result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract initAmount V1 contractBalanceSourceFile "init_contract" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract initAmount V1 contractBalanceSourceFile "init_contract" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -491,14 +510,15 @@ contractBalanceSelfTestCase spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update updateAmount (Types.ContractAddress 0 0) "contract.query" parameters,
-                      metadata = makeDummyHeader accountAddress0 3 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update updateAmount (Types.ContractAddress 0 0) "contract.query" parameters,
+                          metadata = makeDummyHeader accountAddress0 3 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 -- Check the number of events:
                 -- - 1 event for a succesful update to the contract.
                 return $ Helpers.assertSuccessWhere (Helpers.assertNumberOfEvents 1) result
@@ -529,28 +549,30 @@ contractBalanceTransferTestCase spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 contractBalanceTransferSourceFile,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 contractBalanceTransferSourceFile,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 contractBalanceTransferSourceFile result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract initAmount V1 contractBalanceTransferSourceFile "init_contract" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract initAmount V1 contractBalanceTransferSourceFile "init_contract" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -561,14 +583,15 @@ contractBalanceTransferTestCase spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update updateAmount (Types.ContractAddress 0 0) "contract.query" parameters,
-                      metadata = makeDummyHeader accountAddress0 3 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update updateAmount (Types.ContractAddress 0 0) "contract.query" parameters,
+                          metadata = makeDummyHeader accountAddress0 3 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 -- Check the number of events:
                 -- - 3 events for transfering
                 -- - 1 event for a succesful update to the contract.
@@ -604,28 +627,30 @@ contractBalanceMissingContractTestCase spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 contractBalanceMissingContractSourceFile,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 contractBalanceMissingContractSourceFile,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 contractBalanceMissingContractSourceFile result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 123 V1 contractBalanceMissingContractSourceFile "init_contract" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 123 V1 contractBalanceMissingContractSourceFile "init_contract" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -636,14 +661,15 @@ contractBalanceMissingContractTestCase spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "contract.query" parameters,
-                      metadata = makeDummyHeader accountAddress0 3 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "contract.query" parameters,
+                          metadata = makeDummyHeader accountAddress0 3 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 -- Check the number of events:
                 -- - 1 event for a succesful update to the contract.
                 return $ Helpers.assertSuccessWhere (Helpers.assertNumberOfEvents 1) result
@@ -671,28 +697,30 @@ exchangeRatesTestCase spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 exchangeRatesSourceFile,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 exchangeRatesSourceFile,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 exchangeRatesSourceFile result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V1 exchangeRatesSourceFile "init_contract" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V1 exchangeRatesSourceFile "init_contract" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -703,14 +731,15 @@ exchangeRatesTestCase spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "contract.query" parameters,
-                      metadata = makeDummyHeader accountAddress0 3 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "contract.query" parameters,
+                          metadata = makeDummyHeader accountAddress0 3 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 -- Check the number of events:
                 -- - 1 event for a succesful update to the contract.
                 return $ Helpers.assertSuccessWhere (Helpers.assertNumberOfEvents 1) result
@@ -742,28 +771,30 @@ allTestCase spv pvString =
                     initialBlockState
                     transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 allSourceFile,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 allSourceFile,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 allSourceFile result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V1 allSourceFile "init_contract" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V1 allSourceFile "init_contract" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -774,34 +805,37 @@ allTestCase spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "contract.account_balance" "",
-                      metadata = makeDummyHeader accountAddress0 3 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "contract.account_balance" "",
+                          metadata = makeDummyHeader accountAddress0 3 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertRejectWithReason Types.RuntimeFailure result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "contract.contract_balance" "",
-                      metadata = makeDummyHeader accountAddress0 4 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "contract.contract_balance" "",
+                          metadata = makeDummyHeader accountAddress0 4 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertRejectWithReason Types.RuntimeFailure result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "contract.exchange_rates" "",
-                      metadata = makeDummyHeader accountAddress0 5 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "contract.exchange_rates" "",
+                          metadata = makeDummyHeader accountAddress0 5 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertRejectWithReason Types.RuntimeFailure result
             }
         ]

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Recorder.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Recorder.hs
@@ -61,28 +61,30 @@ testCase spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule wasmModVersion recorderSourceFile,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule wasmModVersion recorderSourceFile,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 recorderSourceFile result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 wasmModVersion recorderSourceFile "init_recorder" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result state -> do
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 wasmModVersion recorderSourceFile "init_recorder" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result state -> do
                 doStateAssertion <- recorderSpec 0 state
                 return $ do
                     Helpers.assertSuccess result
@@ -95,37 +97,39 @@ testCase spv pvString =
                         result
                     doStateAssertion
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload =
-                        Update
-                            0
-                            (Types.ContractAddress 0 0)
-                            "recorder.record_u64"
-                            (BSS.toShort (runPut (putWord64le 20))),
-                      metadata = makeDummyHeader accountAddress0 3 700_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result state -> do
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload =
+                            Update
+                                0
+                                (Types.ContractAddress 0 0)
+                                "recorder.record_u64"
+                                (BSS.toShort (runPut (putWord64le 20))),
+                          metadata = makeDummyHeader accountAddress0 3 700_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result state -> do
                 doStateAssertion <- recorderSpec 20 state
                 return $ do
                     Helpers.assertSuccess result
                     doStateAssertion
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload =
-                        Update
-                            0
-                            (Types.ContractAddress 0 0)
-                            "recorder.record_u64"
-                            (BSS.toShort (runPut (putWord64le 40))),
-                      metadata = makeDummyHeader accountAddress0 4 700_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result state -> do
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload =
+                            Update
+                                0
+                                (Types.ContractAddress 0 0)
+                                "recorder.record_u64"
+                                (BSS.toShort (runPut (putWord64le 40))),
+                          metadata = makeDummyHeader accountAddress0 4 700_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result state -> do
                 doStateAssertion <- recorderSpec 60 state
                 return $ do
                     Helpers.assertSuccess result

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/RelaxedRestrictions.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/RelaxedRestrictions.hs
@@ -69,41 +69,44 @@ oldParameterLimitTest spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
         deployAndInitTransactions
             ++ [
                  -- Check that the max size parameter is allowed.
-                 Helpers.TransactionAndAssertion
-                    { taaTransaction =
-                        TJSON
-                            { payload = Update 0 (Types.ContractAddress 0 0) "relax.param" (callArgsParam 1_024 1_024),
-                              metadata = makeDummyHeader accountAddress0 3 700_000,
-                              keys = [(0, [(0, keyPair0)])]
-                            },
-                      taaAssertion = \result _ ->
+                 Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        AccountTx $
+                            TJSON
+                                { payload = Update 0 (Types.ContractAddress 0 0) "relax.param" (callArgsParam 1_024 1_024),
+                                  metadata = makeDummyHeader accountAddress0 3 700_000,
+                                  keys = [(0, [(0, keyPair0)])]
+                                },
+                      biaaAssertion = \result _ ->
                         return $ Helpers.assertSuccess result
                     },
                  -- Check that if the top-level parameter is too big, we get a serialization failure.
-                 Helpers.TransactionAndAssertion
-                    { taaTransaction =
-                        TJSON
-                            { payload = Update 0 (Types.ContractAddress 0 0) "relax.param" (callArgsParam 1_024 1_025),
-                              metadata = makeDummyHeader accountAddress0 4 700_000,
-                              keys = [(0, [(0, keyPair0)])]
-                            },
-                      taaAssertion = \result _ ->
+                 Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        AccountTx $
+                            TJSON
+                                { payload = Update 0 (Types.ContractAddress 0 0) "relax.param" (callArgsParam 1_024 1_025),
+                                  metadata = makeDummyHeader accountAddress0 4 700_000,
+                                  keys = [(0, [(0, keyPair0)])]
+                                },
+                      biaaAssertion = \result _ ->
                         return $ Helpers.assertRejectWithReason Types.SerializationFailure result
                     },
                  -- Check that if the inter-contract parameter is too big, we get a runtime failure.
-                 Helpers.TransactionAndAssertion
-                    { taaTransaction =
-                        TJSON
-                            { payload = Update 0 (Types.ContractAddress 0 0) "relax.param" (callArgsParam 1_025 1_024),
-                              metadata = makeDummyHeader accountAddress0 5 700_000,
-                              keys = [(0, [(0, keyPair0)])]
-                            },
-                      taaAssertion = \result _ ->
+                 Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        AccountTx $
+                            TJSON
+                                { payload = Update 0 (Types.ContractAddress 0 0) "relax.param" (callArgsParam 1_025 1_024),
+                                  metadata = makeDummyHeader accountAddress0 5 700_000,
+                                  keys = [(0, [(0, keyPair0)])]
+                                },
+                      biaaAssertion = \result _ ->
                         return $ Helpers.assertRejectWithReason Types.RuntimeFailure result
                     }
                ]
@@ -125,30 +128,32 @@ oldReturnValueLimitTest spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
         deployAndInitTransactions
             ++ [
                  -- Check that the max size return value is allowed.
-                 Helpers.TransactionAndAssertion
-                    { taaTransaction =
-                        TJSON
-                            { payload = Update 0 (Types.ContractAddress 0 0) "relax.return-value" (callArgsWord32 16_384),
-                              metadata = makeDummyHeader accountAddress0 3 700_000,
-                              keys = [(0, [(0, keyPair0)])]
-                            },
-                      taaAssertion = \result _ ->
+                 Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        AccountTx $
+                            TJSON
+                                { payload = Update 0 (Types.ContractAddress 0 0) "relax.return-value" (callArgsWord32 16_384),
+                                  metadata = makeDummyHeader accountAddress0 3 700_000,
+                                  keys = [(0, [(0, keyPair0)])]
+                                },
+                      biaaAssertion = \result _ ->
                         return $ Helpers.assertSuccess result
                     },
                  -- Check that one above the max size is truncated to the max. Which in turn makes the contract fail.
-                 Helpers.TransactionAndAssertion
-                    { taaTransaction =
-                        TJSON
-                            { payload = Update 0 (Types.ContractAddress 0 0) "relax.return-value" (callArgsWord32 16_385),
-                              metadata = makeDummyHeader accountAddress0 4 700_000,
-                              keys = [(0, [(0, keyPair0)])]
-                            },
-                      taaAssertion = \result _ ->
+                 Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        AccountTx $
+                            TJSON
+                                { payload = Update 0 (Types.ContractAddress 0 0) "relax.return-value" (callArgsWord32 16_385),
+                                  metadata = makeDummyHeader accountAddress0 4 700_000,
+                                  keys = [(0, [(0, keyPair0)])]
+                                },
+                      biaaAssertion = \result _ ->
                         return $ Helpers.assertRejectWithReason Types.RuntimeFailure result
                     }
                ]
@@ -170,30 +175,32 @@ oldLogLimitTest spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
         deployAndInitTransactions
             ++ [
                  -- Check that the max number of logs is allowed.
-                 Helpers.TransactionAndAssertion
-                    { taaTransaction =
-                        TJSON
-                            { payload = Update 0 (Types.ContractAddress 0 0) "relax.logs" (callArgsWord32 64),
-                              metadata = makeDummyHeader accountAddress0 3 700_000,
-                              keys = [(0, [(0, keyPair0)])]
-                            },
-                      taaAssertion = \result _ ->
+                 Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        AccountTx $
+                            TJSON
+                                { payload = Update 0 (Types.ContractAddress 0 0) "relax.logs" (callArgsWord32 64),
+                                  metadata = makeDummyHeader accountAddress0 3 700_000,
+                                  keys = [(0, [(0, keyPair0)])]
+                                },
+                      biaaAssertion = \result _ ->
                         return $ Helpers.assertSuccess result
                     },
                  -- Check that one above the max number of logs is _not_ allowed.
-                 Helpers.TransactionAndAssertion
-                    { taaTransaction =
-                        TJSON
-                            { payload = Update 0 (Types.ContractAddress 0 0) "relax.logs" (callArgsWord32 65),
-                              metadata = makeDummyHeader accountAddress0 4 700_000,
-                              keys = [(0, [(0, keyPair0)])]
-                            },
-                      taaAssertion = \result _ ->
+                 Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        AccountTx $
+                            TJSON
+                                { payload = Update 0 (Types.ContractAddress 0 0) "relax.logs" (callArgsWord32 65),
+                                  metadata = makeDummyHeader accountAddress0 4 700_000,
+                                  keys = [(0, [(0, keyPair0)])]
+                                },
+                      biaaAssertion = \result _ ->
                         return $ Helpers.assertRejectWithReason Types.RuntimeFailure result
                     }
                ]
@@ -215,20 +222,21 @@ newParameterLimitTest spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
         deployAndInitTransactions
             ++ [
                  -- Check that the max size parameter is allowed. We cannot check above it easily,
                  -- because it is Word16::MAX.
-                 Helpers.TransactionAndAssertion
-                    { taaTransaction =
-                        TJSON
-                            { payload = Update 0 (Types.ContractAddress 0 0) "relax.param" (callArgsParam 65_535 65_535),
-                              metadata = makeDummyHeader accountAddress0 3 700_000,
-                              keys = [(0, [(0, keyPair0)])]
-                            },
-                      taaAssertion = \result _ ->
+                 Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        AccountTx $
+                            TJSON
+                                { payload = Update 0 (Types.ContractAddress 0 0) "relax.param" (callArgsParam 65_535 65_535),
+                                  metadata = makeDummyHeader accountAddress0 3 700_000,
+                                  keys = [(0, [(0, keyPair0)])]
+                                },
+                      biaaAssertion = \result _ ->
                         return $ Helpers.assertSuccess result
                     }
                ]
@@ -250,19 +258,20 @@ newReturnValueLimitTest spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
         deployAndInitTransactions
             ++ [
                  -- -- Check that a large return value can be returned (larger than what is allowed in P4).
-                 Helpers.TransactionAndAssertion
-                    { taaTransaction =
-                        TJSON
-                            { payload = Update 0 (Types.ContractAddress 0 0) "relax.return-value" (callArgsWord32 100_000),
-                              metadata = makeDummyHeader accountAddress0 3 700_000,
-                              keys = [(0, [(0, keyPair0)])]
-                            },
-                      taaAssertion = \result _ ->
+                 Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        AccountTx $
+                            TJSON
+                                { payload = Update 0 (Types.ContractAddress 0 0) "relax.return-value" (callArgsWord32 100_000),
+                                  metadata = makeDummyHeader accountAddress0 3 700_000,
+                                  keys = [(0, [(0, keyPair0)])]
+                                },
+                      biaaAssertion = \result _ ->
                         return $ Helpers.assertSuccess result
                     }
                ]
@@ -283,46 +292,49 @@ newLogLimitTest spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
         deployAndInitTransactions
             ++ [
                  -- Check that a large number of logs is allowed (more than allowed in P4).
-                 Helpers.TransactionAndAssertion
-                    { taaTransaction =
-                        TJSON
-                            { payload = Update 0 (Types.ContractAddress 0 0) "relax.logs" (callArgsWord32 64),
-                              metadata = makeDummyHeader accountAddress0 3 700_000,
-                              keys = [(0, [(0, keyPair0)])]
-                            },
-                      taaAssertion = \result _ ->
+                 Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        AccountTx $
+                            TJSON
+                                { payload = Update 0 (Types.ContractAddress 0 0) "relax.logs" (callArgsWord32 64),
+                                  metadata = makeDummyHeader accountAddress0 3 700_000,
+                                  keys = [(0, [(0, keyPair0)])]
+                                },
+                      biaaAssertion = \result _ ->
                         return $ Helpers.assertSuccess result
                     }
                ]
 
 -- | Transactions and assertions for deploying and initializing the "relax" contract.
-deployAndInitTransactions :: forall pv. (Types.IsProtocolVersion pv) => [Helpers.TransactionAndAssertion pv]
+deployAndInitTransactions :: forall pv. (Types.IsProtocolVersion pv) => [Helpers.BlockItemAndAssertion pv]
 deployAndInitTransactions =
-    [ Helpers.TransactionAndAssertion
-        { taaTransaction =
-            TJSON
-                { payload = DeployModule wasmModVersion sourceFile,
-                  metadata = makeDummyHeader accountAddress0 1 100_000,
-                  keys = [(0, [(0, keyPair0)])]
-                },
-          taaAssertion = \result _ ->
+    [ Helpers.BlockItemAndAssertion
+        { biaaTransaction =
+            AccountTx $
+                TJSON
+                    { payload = DeployModule wasmModVersion sourceFile,
+                      metadata = makeDummyHeader accountAddress0 1 100_000,
+                      keys = [(0, [(0, keyPair0)])]
+                    },
+          biaaAssertion = \result _ ->
             return $ do
                 Helpers.assertSuccess result
                 Helpers.assertUsedEnergyDeploymentV1 sourceFile result
         },
-      Helpers.TransactionAndAssertion
-        { taaTransaction =
-            TJSON
-                { payload = InitContract 0 wasmModVersion sourceFile "init_relax" "",
-                  metadata = makeDummyHeader accountAddress0 2 100_000,
-                  keys = [(0, [(0, keyPair0)])]
-                },
-          taaAssertion = \result _ ->
+      Helpers.BlockItemAndAssertion
+        { biaaTransaction =
+            AccountTx $
+                TJSON
+                    { payload = InitContract 0 wasmModVersion sourceFile "init_relax" "",
+                      metadata = makeDummyHeader accountAddress0 2 100_000,
+                      keys = [(0, [(0, keyPair0)])]
+                    },
+          biaaAssertion = \result _ ->
             return $ do
                 Helpers.assertSuccess result
                 Helpers.assertUsedEnergyInitialization

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Transfer.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Transfer.hs
@@ -58,28 +58,30 @@ testCase spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule wasmModVersion transferSourceFile,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule wasmModVersion transferSourceFile,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 transferSourceFile result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 wasmModVersion transferSourceFile "init_transfer" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result state -> do
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 wasmModVersion transferSourceFile "init_transfer" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result state -> do
                 doStateAssertion <- transferSpec state
                 return $ do
                     Helpers.assertSuccess result
@@ -92,37 +94,40 @@ testCase spv pvString =
                         result
                     doStateAssertion
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 123 (Types.ContractAddress 0 0) "transfer.forward" (BSS.toShort (encode accountAddress0)),
-                      metadata = makeDummyHeader accountAddress0 3 700_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result state -> do
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 123 (Types.ContractAddress 0 0) "transfer.forward" (BSS.toShort (encode accountAddress0)),
+                          metadata = makeDummyHeader accountAddress0 3 700_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result state -> do
                 doStateAssertion <- transferSpec state
                 return $ do
                     Helpers.assertSuccess result
                     doStateAssertion
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 1_000 (Types.ContractAddress 0 0) "transfer.deposit" "",
-                      metadata = makeDummyHeader accountAddress0 4 700_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ -> do
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 1_000 (Types.ContractAddress 0 0) "transfer.deposit" "",
+                          metadata = makeDummyHeader accountAddress0 4 700_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ -> do
                 return $ Helpers.assertSuccess result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "transfer.send" sendParameter,
-                      metadata = makeDummyHeader accountAddress0 5 700_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result state -> do
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "transfer.send" sendParameter,
+                          metadata = makeDummyHeader accountAddress0 5 700_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result state -> do
                 doStateAssertion <- sendSpec state
                 return $ do
                     Helpers.assertSuccessWithEvents

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Upgrading.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Upgrading.hs
@@ -76,43 +76,46 @@ upgradingTestCase spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
         [ -- Deploy `upgrading_0.wasm
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule wasmModVersion1 upgrading0SourceFile,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule wasmModVersion1 upgrading0SourceFile,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 upgrading0SourceFile result
             },
           -- Deploy upgrading_1.wasm
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule wasmModVersion1 upgrading1SourceFile,
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule wasmModVersion1 upgrading1SourceFile,
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 upgrading1SourceFile result
             },
           -- Initialize upgrading_0.wasm
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 wasmModVersion1 upgrading0SourceFile "init_a" "",
-                      metadata = makeDummyHeader accountAddress0 3 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 wasmModVersion1 upgrading0SourceFile "init_a" "",
+                          metadata = makeDummyHeader accountAddress0 3 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -125,28 +128,30 @@ upgradingTestCase spv pvString =
             },
           -- Invoke the `upgrade` by calling 'a.upgrade' with the resulting 'ModuleRef' of
           -- deploying upgrade_1.wasm.
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 instanceAddr "a.bump" parameters,
-                      metadata = makeDummyHeader accountAddress0 4 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 instanceAddr "a.bump" parameters,
+                          metadata = makeDummyHeader accountAddress0 4 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 -- Check the number of events:
                 -- - 3 events from upgrading.
                 -- - 1 event for a succesful update to the contract.
                 return $ Helpers.assertSuccessWhere (Helpers.assertNumberOfEvents 4) result
             },
           -- Invoke `new` which is only accessible after the module upgrade
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 instanceAddr "a.newfun" BSS.empty,
-                      metadata = makeDummyHeader accountAddress0 5 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result state -> do
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 instanceAddr "a.newfun" BSS.empty,
+                          metadata = makeDummyHeader accountAddress0 5 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result state -> do
                 doAssertState <- Helpers.checkReloadCheck (const assertFinalState) result state
                 -- Check the number of events:
                 -- - 1 event for a succesful update to the contract.
@@ -210,28 +215,30 @@ selfInvokeTestCase spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 selfInvokeSourceFile0,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 selfInvokeSourceFile0,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 selfInvokeSourceFile0 result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V1 selfInvokeSourceFile0 "init_contract" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V1 selfInvokeSourceFile0 "init_contract" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -242,31 +249,33 @@ selfInvokeTestCase spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 selfInvokeSourceFile1,
-                      metadata = makeDummyHeader accountAddress0 3 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 selfInvokeSourceFile1,
+                          metadata = makeDummyHeader accountAddress0 3 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 selfInvokeSourceFile1 result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload =
-                        Update
-                            0
-                            (Types.ContractAddress 0 0)
-                            "contract.upgrade"
-                            upgradeParameters,
-                      metadata = makeDummyHeader accountAddress0 4 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload =
+                            Update
+                                0
+                                (Types.ContractAddress 0 0)
+                                "contract.upgrade"
+                                upgradeParameters,
+                          metadata = makeDummyHeader accountAddress0 4 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertSuccessWhere eventsCheck result
             }
         ]
@@ -308,28 +317,30 @@ missingModuleTestCase spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 missingModuleSourceFile,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 missingModuleSourceFile,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 missingModuleSourceFile result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V1 missingModuleSourceFile "init_contract" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V1 missingModuleSourceFile "init_contract" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -340,14 +351,15 @@ missingModuleTestCase spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "contract.upgrade" "",
-                      metadata = makeDummyHeader accountAddress0 3 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "contract.upgrade" "",
+                          metadata = makeDummyHeader accountAddress0 3 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertSuccessWhere eventsCheck result
             }
         ]
@@ -382,28 +394,30 @@ missingContractTestCase spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 missingContractSourceFile0,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 missingContractSourceFile0,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 missingContractSourceFile0 result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V1 missingContractSourceFile0 "init_contract" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V1 missingContractSourceFile0 "init_contract" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -414,26 +428,28 @@ missingContractTestCase spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 missingContractSourceFile1,
-                      metadata = makeDummyHeader accountAddress0 3 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 missingContractSourceFile1,
+                          metadata = makeDummyHeader accountAddress0 3 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 missingContractSourceFile1 result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "contract.upgrade" upgradeParameters,
-                      metadata = makeDummyHeader accountAddress0 4 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "contract.upgrade" upgradeParameters,
+                          metadata = makeDummyHeader accountAddress0 4 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertSuccessWhere eventsCheck result
             }
         ]
@@ -469,28 +485,30 @@ unsupportedVersionTestCase spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 unsupportedVersionSourceFile0,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 unsupportedVersionSourceFile0,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 unsupportedVersionSourceFile0 result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V1 unsupportedVersionSourceFile0 "init_contract" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V1 unsupportedVersionSourceFile0 "init_contract" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -501,24 +519,26 @@ unsupportedVersionTestCase spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V0 unsupportedVersionSourceFile1,
-                      metadata = makeDummyHeader accountAddress0 3 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V0 unsupportedVersionSourceFile1,
+                          metadata = makeDummyHeader accountAddress0 3 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertSuccess result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "contract.upgrade" upgradeParameters,
-                      metadata = makeDummyHeader accountAddress0 4 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "contract.upgrade" upgradeParameters,
+                          metadata = makeDummyHeader accountAddress0 4 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertSuccessWhere eventsCheck result
             }
         ]
@@ -558,28 +578,30 @@ twiceTestCase spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 twiceSourceFile0,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 twiceSourceFile0,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 twiceSourceFile0 result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V1 twiceSourceFile0 "init_contract" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V1 twiceSourceFile0 "init_contract" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -590,38 +612,41 @@ twiceTestCase spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 twiceSourceFile1,
-                      metadata = makeDummyHeader accountAddress0 3 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 twiceSourceFile1,
+                          metadata = makeDummyHeader accountAddress0 3 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 twiceSourceFile1 result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 twiceSourceFile2,
-                      metadata = makeDummyHeader accountAddress0 4 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 twiceSourceFile2,
+                          metadata = makeDummyHeader accountAddress0 4 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 twiceSourceFile2 result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 instanceAddr "contract.upgrade" upgradeParameters,
-                      metadata = makeDummyHeader accountAddress0 5 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 instanceAddr "contract.upgrade" upgradeParameters,
+                          metadata = makeDummyHeader accountAddress0 5 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertSuccessWhere eventsCheck result
             }
         ]
@@ -664,28 +689,30 @@ chainedTestCase spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 chainedSourceFile0,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 chainedSourceFile0,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 chainedSourceFile0 result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V1 chainedSourceFile0 "init_contract" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V1 chainedSourceFile0 "init_contract" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -696,14 +723,15 @@ chainedTestCase spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "contract.upgrade" upgradeParameters,
-                      metadata = makeDummyHeader accountAddress0 3 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "contract.upgrade" upgradeParameters,
+                          metadata = makeDummyHeader accountAddress0 3 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertSuccessWhere eventsCheck result
             }
         ]
@@ -748,28 +776,30 @@ rejectTestCase spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 rejectSourceFile0,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 rejectSourceFile0,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 rejectSourceFile0 result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V1 rejectSourceFile0 "init_contract" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V1 rejectSourceFile0 "init_contract" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -780,36 +810,39 @@ rejectTestCase spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 rejectSourceFile1,
-                      metadata = makeDummyHeader accountAddress0 3 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 rejectSourceFile1,
+                          metadata = makeDummyHeader accountAddress0 3 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 rejectSourceFile1 result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "contract.upgrade" upgradeParameters,
-                      metadata = makeDummyHeader accountAddress0 4 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "contract.upgrade" upgradeParameters,
+                          metadata = makeDummyHeader accountAddress0 4 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertRejectWhere rejectReasonCheck result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "contract.new_feature" "",
-                      metadata = makeDummyHeader accountAddress0 5 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "contract.new_feature" "",
+                          metadata = makeDummyHeader accountAddress0 5 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertRejectWhere assertInvalidReceiveMethod result
             }
         ]
@@ -845,28 +878,30 @@ changingEntrypointsTestCase spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 changingEntrypointsSourceFile0,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 changingEntrypointsSourceFile0,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 changingEntrypointsSourceFile0 result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V1 changingEntrypointsSourceFile0 "init_contract" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V1 changingEntrypointsSourceFile0 "init_contract" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -877,66 +912,72 @@ changingEntrypointsTestCase spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 changingEntrypointsSourceFile1,
-                      metadata = makeDummyHeader accountAddress0 3 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 changingEntrypointsSourceFile1,
+                          metadata = makeDummyHeader accountAddress0 3 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 changingEntrypointsSourceFile1 result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "contract.old_feature" "",
-                      metadata = makeDummyHeader accountAddress0 4 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "contract.old_feature" "",
+                          metadata = makeDummyHeader accountAddress0 4 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertSuccessWhere contractOldFeatureEventsCheck result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "contract.new_feature" "",
-                      metadata = makeDummyHeader accountAddress0 5 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "contract.new_feature" "",
+                          metadata = makeDummyHeader accountAddress0 5 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertRejectWhere assertInvalidReceiveMethod result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "contract.upgrade" upgradeParameters,
-                      metadata = makeDummyHeader accountAddress0 6 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "contract.upgrade" upgradeParameters,
+                          metadata = makeDummyHeader accountAddress0 6 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertSuccessWhere contractUpgradeEventsCheck result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "contract.new_feature" "",
-                      metadata = makeDummyHeader accountAddress0 7 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "contract.new_feature" "",
+                          metadata = makeDummyHeader accountAddress0 7 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertSuccessWhere contractNewFeatureEventsCheck result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "contract.old_feature" "",
-                      metadata = makeDummyHeader accountAddress0 8 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "contract.old_feature" "",
+                          metadata = makeDummyHeader accountAddress0 8 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertRejectWhere assertInvalidReceiveMethod result
             }
         ]
@@ -987,28 +1028,30 @@ persistingStateTestCase spv pvString =
                 initialBlockState
                 transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 persistingStateSourceFile0,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 persistingStateSourceFile0,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 persistingStateSourceFile0 result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V1 persistingStateSourceFile0 "init_contract" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V1 persistingStateSourceFile0 "init_contract" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -1019,36 +1062,39 @@ persistingStateTestCase spv pvString =
                         Nothing
                         result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V1 persistingStateSourceFile1,
-                      metadata = makeDummyHeader accountAddress0 3 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V1 persistingStateSourceFile1,
+                          metadata = makeDummyHeader accountAddress0 3 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV1 persistingStateSourceFile1 result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "contract.upgrade" upgradeParameters,
-                      metadata = makeDummyHeader accountAddress0 4 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "contract.upgrade" upgradeParameters,
+                          metadata = makeDummyHeader accountAddress0 4 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertSuccessWhere contractUpgradeEventsCheck result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 0 (Types.ContractAddress 0 0) "contract.check" "",
-                      metadata = makeDummyHeader accountAddress0 5 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 0 (Types.ContractAddress 0 0) "contract.check" "",
+                          metadata = makeDummyHeader accountAddress0 5 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertSuccessWhere contractCheckEventsCheck result
             }
         ]

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TokenHolderTransactions.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TokenHolderTransactions.hs
@@ -69,10 +69,10 @@ testTokenHolder ::
     Spec
 testTokenHolder _ pvString =
     specify (pvString ++ ": Token holder operations") $ do
-        let transactionsAndAssertions :: [Helpers.AnyTransactionAndAssertion pv]
+        let transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
             transactionsAndAssertions =
-                [ Helpers.AnyTransactionAndAssertion
-                    { ataaTransaction =
+                [ Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
                         Runner.AccountTx $
                             Runner.TJSON
                                 { payload =
@@ -83,11 +83,11 @@ testTokenHolder _ pvString =
                                   metadata = makeDummyHeader dummyAddress 1 1_000,
                                   keys = [(0, [(0, dummyKP)])]
                                 },
-                      ataaAssertion = \result _ -> do
+                      biaaAssertion = \result _ -> do
                         return $ Helpers.assertRejectWithReason (NonExistentTokenId gtu) result
                     },
-                  Helpers.AnyTransactionAndAssertion
-                    { ataaTransaction =
+                  Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
                         Runner.ChainUpdateTx $
                             Runner.ChainUpdateTransaction
                                 { ctSeqNumber = 1,
@@ -96,11 +96,11 @@ testTokenHolder _ pvString =
                                   ctPayload = plt,
                                   ctKeys = [(0, DummyData.dummyAuthorizationKeyPair)]
                                 },
-                      ataaAssertion = \result _ -> do
+                      biaaAssertion = \result _ -> do
                         return $ Helpers.assertSuccessWithEvents [gtuEvent] result
                     },
-                  Helpers.AnyTransactionAndAssertion
-                    { ataaTransaction =
+                  Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
                         Runner.AccountTx $
                             Runner.TJSON
                                 { payload =
@@ -111,7 +111,7 @@ testTokenHolder _ pvString =
                                   metadata = makeDummyHeader dummyAddress 2 1_000,
                                   keys = [(0, [(0, dummyKP)])]
                                 },
-                      ataaAssertion = \result _ -> do
+                      biaaAssertion = \result _ -> do
                         return $
                             Helpers.assertRejectWithReason
                                 ( TokenHolderTransactionFailed
@@ -120,7 +120,7 @@ testTokenHolder _ pvString =
                                 result
                     }
                 ]
-        Helpers.runSchedulerTestAssertIntermediateStatesAnyTransaction
+        Helpers.runSchedulerTestAssertIntermediateStatesBlockItem
             @pv
             Helpers.defaultTestConfig
             initialBlockState

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TokenHolderTransactions.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TokenHolderTransactions.hs
@@ -120,7 +120,7 @@ testTokenHolder _ pvString =
                                 result
                     }
                 ]
-        Helpers.runSchedulerTestAssertIntermediateStatesBlockItem
+        Helpers.runSchedulerTestAssertIntermediateStates
             @pv
             Helpers.defaultTestConfig
             initialBlockState

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TokenHolderTransactions.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TokenHolderTransactions.hs
@@ -147,7 +147,7 @@ testTokenHolder _ pvString =
 
 tests :: Spec
 tests =
-    describe "Delegate in different scenarios" $
+    describe "Token holder transactions" $
         sequence_ $
             Helpers.forEveryProtocolVersion testCases
   where

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TokenHolderTransactions.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TokenHolderTransactions.hs
@@ -88,8 +88,8 @@ testTokenHolder _ pvString =
                     },
                   Helpers.AnyTransactionAndAssertion
                     { ataaTransaction =
-                        Runner.ChainTx $
-                            Runner.ChainTransaction
+                        Runner.ChainUpdateTx $
+                            Runner.ChainUpdateTransaction
                                 { ctSeqNumber = 1,
                                   ctEffectiveTime = 0,
                                   ctTimeout = DummyData.dummyMaxTransactionExpiryTime,

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TokenHolderTransactions.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TokenHolderTransactions.hs
@@ -109,10 +109,9 @@ testTokenHolder _ pvString =
                                   ctEffectiveTime = 0,
                                   ctTimeout = DummyData.dummyMaxTransactionExpiryTime,
                                   ctPayload = plt,
-                                  ctKeys = [(0, DummyData.dummyAuthorizationKeyPair)] -- dummyKP)]
+                                  ctKeys = [(0, DummyData.dummyAuthorizationKeyPair)]
                                 },
                       ataaAssertion = \result _ -> do
-                        -- error $ show (dummyKP, DummyData.dummyAuthorizationKeyPair)
                         return $ Helpers.assertSuccessWithEvents [gtuEvent] result
                     },
                   Helpers.AnyTransactionAndAssertion

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TokenHolderTransactions.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TokenHolderTransactions.hs
@@ -9,41 +9,26 @@
 -- | Test of token holder transactions
 module SchedulerTests.TokenHolderTransactions (tests) where
 
-import Lens.Micro.Platform
-
-import qualified Concordium.Cost as Cost
 import qualified Concordium.Crypto.SignatureScheme as SigScheme
 import Concordium.ID.Types as ID
-import Concordium.Types.Accounts
-import Concordium.Types.Conditionally
 import qualified Concordium.Types.ProtocolLevelTokens.CBOR as CBOR
 
 import qualified Concordium.Crypto.SHA256 as Hash
-import Concordium.GlobalState.BakerInfo
-import qualified Concordium.GlobalState.Basic.BlockState.Account as Transient
-import qualified Concordium.GlobalState.BlockState as BS
 import qualified Concordium.GlobalState.DummyData as DummyData
 import qualified Concordium.GlobalState.Persistent.Account as BS
 import qualified Concordium.GlobalState.Persistent.BlobStore as Blob
 import qualified Concordium.GlobalState.Persistent.BlockState as BS
-import qualified Concordium.Scheduler as Sch
 import qualified Concordium.Scheduler.Runner as Runner
 import Concordium.Scheduler.Types
 import qualified Concordium.Scheduler.Types as Types
 import qualified Concordium.Types.DummyData as DummyData
 
-import Concordium.GlobalState.CooldownQueue
-import Concordium.GlobalState.DummyData
 import Concordium.Scheduler.DummyData
-import Concordium.Types.Option
 
-import Control.Monad
 import Data.Bool.Singletons
 import qualified Data.ByteString.Short as BSS
-import Data.Maybe
 import Data.String
 import qualified SchedulerTests.Helpers as Helpers
-import Test.HUnit
 import Test.Hspec
 
 dummyKP :: SigScheme.KeyPair

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TokenHolderTransactions.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TokenHolderTransactions.hs
@@ -1,0 +1,174 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Test of token holder transactions
+module SchedulerTests.TokenHolderTransactions (tests) where
+
+import Lens.Micro.Platform
+
+import qualified Concordium.Cost as Cost
+import qualified Concordium.Crypto.SignatureScheme as SigScheme
+import Concordium.ID.Types as ID
+import Concordium.Types.Accounts
+import Concordium.Types.Conditionally
+import qualified Concordium.Types.ProtocolLevelTokens.CBOR as CBOR
+
+import qualified Concordium.Crypto.SHA256 as Hash
+import Concordium.GlobalState.BakerInfo
+import qualified Concordium.GlobalState.Basic.BlockState.Account as Transient
+import qualified Concordium.GlobalState.BlockState as BS
+import qualified Concordium.GlobalState.DummyData as DummyData
+import qualified Concordium.GlobalState.Persistent.Account as BS
+import qualified Concordium.GlobalState.Persistent.BlobStore as Blob
+import qualified Concordium.GlobalState.Persistent.BlockState as BS
+import qualified Concordium.Scheduler as Sch
+import qualified Concordium.Scheduler.Runner as Runner
+import Concordium.Scheduler.Types
+import qualified Concordium.Scheduler.Types as Types
+import qualified Concordium.Types.DummyData as DummyData
+
+import Concordium.GlobalState.CooldownQueue
+import Concordium.GlobalState.DummyData
+import Concordium.Scheduler.DummyData
+import Concordium.Types.Option
+
+import Control.Monad
+import Data.Bool.Singletons
+import qualified Data.ByteString.Short as BSS
+import Data.Maybe
+import Data.String
+import qualified SchedulerTests.Helpers as Helpers
+import Test.HUnit
+import Test.Hspec
+
+dummyKP :: SigScheme.KeyPair
+dummyKP = Helpers.keyPairFromSeed 1
+
+dummyAddress :: AccountAddress
+dummyAddress = Helpers.accountAddressFromSeed 1
+
+dummyAddress2 :: AccountAddress
+dummyAddress2 = Helpers.accountAddressFromSeed 2
+
+dummyAccount ::
+    (IsAccountVersion av, Blob.MonadBlobStore m) =>
+    m (BS.PersistentAccount av)
+dummyAccount = Helpers.makeTestAccountFromSeed 20_000_000 1
+
+dummyAccount2 ::
+    (IsAccountVersion av, Blob.MonadBlobStore m) =>
+    m (BS.PersistentAccount av)
+dummyAccount2 = Helpers.makeTestAccountFromSeed 20_000_000 2
+
+-- | Create initial block state
+initialBlockState ::
+    (IsProtocolVersion pv) =>
+    Helpers.PersistentBSM pv (BS.HashedPersistentBlockState pv)
+initialBlockState =
+    Helpers.createTestBlockStateWithAccountsM
+        [ dummyAccount,
+          dummyAccount2
+        ]
+
+-- | Test removing a delegator even if the stake is over the threshold.
+testTokenHolder ::
+    forall pv.
+    (IsProtocolVersion pv, PVSupportsPLT pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Spec
+testTokenHolder _ pvString =
+    specify (pvString ++ ": Token holder operations") $ do
+        let transactionsAndAssertions :: [Helpers.AnyTransactionAndAssertion pv]
+            transactionsAndAssertions =
+                [ Helpers.AnyTransactionAndAssertion
+                    { ataaTransaction =
+                        Runner.AccountTx $
+                            Runner.TJSON
+                                { payload =
+                                    Runner.TokenHolder
+                                        { thTokenSymbol = gtu,
+                                          thOperations = Types.TokenParameter BSS.empty
+                                        },
+                                  metadata = makeDummyHeader dummyAddress 1 1_000,
+                                  keys = [(0, [(0, dummyKP)])]
+                                },
+                      ataaAssertion = \result _ -> do
+                        return $ Helpers.assertRejectWithReason (NonExistentTokenId gtu) result
+                    },
+                  Helpers.AnyTransactionAndAssertion
+                    { ataaTransaction =
+                        Runner.ChainTx $
+                            Runner.ChainTransaction
+                                { ctSeqNumber = 1,
+                                  ctEffectiveTime = 0,
+                                  ctTimeout = DummyData.dummyMaxTransactionExpiryTime,
+                                  ctPayload = plt,
+                                  ctKeys = [(0, DummyData.dummyAuthorizationKeyPair)] -- dummyKP)]
+                                },
+                      ataaAssertion = \result _ -> do
+                        -- error $ show (dummyKP, DummyData.dummyAuthorizationKeyPair)
+                        return $ Helpers.assertSuccessWithEvents [gtuEvent] result
+                    },
+                  Helpers.AnyTransactionAndAssertion
+                    { ataaTransaction =
+                        Runner.AccountTx $
+                            Runner.TJSON
+                                { payload =
+                                    Runner.TokenHolder
+                                        { thTokenSymbol = gtu,
+                                          thOperations = Types.TokenParameter BSS.empty
+                                        },
+                                  metadata = makeDummyHeader dummyAddress 2 1_000,
+                                  keys = [(0, [(0, dummyKP)])]
+                                },
+                      ataaAssertion = \result _ -> do
+                        return $
+                            Helpers.assertRejectWithReason
+                                ( TokenHolderTransactionFailed
+                                    (TokenModuleRejectReason{tmrrTokenSymbol = gtu, tmrrType = errType, tmrrDetails = Just cborFail})
+                                )
+                                result
+                    }
+                ]
+        Helpers.runSchedulerTestAssertIntermediateStatesAnyTransaction
+            @pv
+            Helpers.defaultTestConfig
+            initialBlockState
+            transactionsAndAssertions
+  where
+    dummyHash = Hash.hashShort BSS.empty
+    gtu = Types.TokenId $ fromString "GTU"
+    params =
+        CBOR.TokenInitializationParameters
+            { tipName = "Protocol-level token",
+              tipMetadata = "https://plt.token",
+              tipAllowList = True,
+              tipDenyList = False,
+              tipInitialSupply = Nothing,
+              tipMintable = True,
+              tipBurnable = True
+            }
+    tp = Types.TokenParameter $ BSS.toShort $ CBOR.tokenInitializationParametersToBytes params
+    plt = Types.CreatePLTUpdatePayload $ Types.CreatePLT gtu (TokenModuleRef dummyHash) dummyAddress2 0 tp
+    gtuEvent = UpdateEnqueued{ueEffectiveTime = 0, uePayload = plt}
+    -- This is CBOR-encoding of {"cause": "DeserialiseFailure 0 \"end of input\""}
+    cborFail = Types.TokenEventDetails $ BSS.pack [161, 101, 99, 97, 117, 115, 101, 120, 35, 68, 101, 115, 101, 114, 105, 97, 108, 105, 115, 101, 70, 97, 105, 108, 117, 114, 101, 32, 48, 32, 34, 101, 110, 100, 32, 111, 102, 32, 105, 110, 112, 117, 116, 34]
+    errType = Types.TokenEventType $ fromString "deserializationFailure"
+
+tests :: Spec
+tests =
+    describe "Delegate in different scenarios" $
+        sequence_ $
+            Helpers.forEveryProtocolVersion testCases
+  where
+    testCases :: forall pv. (IsProtocolVersion pv) => SProtocolVersion pv -> String -> Spec
+    testCases spv pvString =
+        case sSupportsPLT (sAccountVersionFor spv) of
+            STrue -> testTokenHolder spv pvString
+            SFalse -> return ()

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TransfersWithScheduleTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TransfersWithScheduleTest.hs
@@ -105,17 +105,18 @@ scheduledTransferTest _ pvString =
   where
     transactionsAndAssertions =
         [ -- make a scheduled transfer
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                Runner.TJSON
-                    { payload =
-                        Runner.TransferWithSchedule
-                            accountAddress1
-                            [(101, 10), (102, 11), (103, 12)],
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                Runner.AccountTx $
+                    Runner.TJSON
+                        { payload =
+                            Runner.TransferWithSchedule
+                                accountAddress1
+                                [(101, 10), (102, 11), (103, 12)],
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $
                     Helpers.assertSuccessWithEvents
                         [ TransferredWithSchedule
@@ -126,59 +127,63 @@ scheduledTransferTest _ pvString =
                         result
             },
           -- should get rejected since timestamps are not increasing
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                Runner.TJSON
-                    { payload =
-                        Runner.TransferWithSchedule
-                            accountAddress1
-                            [(101, 10), (103, 11), (102, 12)],
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                Runner.AccountTx $
+                    Runner.TJSON
+                        { payload =
+                            Runner.TransferWithSchedule
+                                accountAddress1
+                                [(101, 10), (103, 11), (102, 12)],
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertRejectWithReason NonIncreasingSchedule result
             },
           -- should get rejected since first timestamp has expired
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                Runner.TJSON
-                    { payload =
-                        Runner.TransferWithSchedule
-                            accountAddress1
-                            [(99, 10), (102, 11), (103, 12)],
-                      metadata = makeDummyHeader accountAddress0 3 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                Runner.AccountTx $
+                    Runner.TJSON
+                        { payload =
+                            Runner.TransferWithSchedule
+                                accountAddress1
+                                [(99, 10), (102, 11), (103, 12)],
+                          metadata = makeDummyHeader accountAddress0 3 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertRejectWithReason FirstScheduledReleaseExpired result
             },
           -- should get rejected since sender = receiver
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                Runner.TJSON
-                    { payload =
-                        Runner.TransferWithSchedule
-                            accountAddress0
-                            [(101, 10), (102, 11), (103, 12)],
-                      metadata = makeDummyHeader accountAddress0 4 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                Runner.AccountTx $
+                    Runner.TJSON
+                        { payload =
+                            Runner.TransferWithSchedule
+                                accountAddress0
+                                [(101, 10), (102, 11), (103, 12)],
+                          metadata = makeDummyHeader accountAddress0 4 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertRejectWithReason (ScheduledSelfTransfer accountAddress0) result
             },
           -- should get rejected since one of the amounts is 0
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                Runner.TJSON
-                    { payload =
-                        Runner.TransferWithSchedule
-                            accountAddress1
-                            [(101, 10), (102, 0), (103, 12)],
-                      metadata = makeDummyHeader accountAddress0 5 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                Runner.AccountTx $
+                    Runner.TJSON
+                        { payload =
+                            Runner.TransferWithSchedule
+                                accountAddress1
+                                [(101, 10), (102, 0), (103, 12)],
+                          metadata = makeDummyHeader accountAddress0 5 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertRejectWithReason ZeroScheduledAmount result
             }
         ]
@@ -209,18 +214,19 @@ scheduledTransferWithMemoTest _ pvString =
   where
     transactionsAndAssertions =
         [ -- make a scheduled transfer
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                Runner.TJSON
-                    { payload =
-                        Runner.TransferWithScheduleAndMemo
-                            accountAddress1
-                            (Memo $ BSS.pack [0, 1, 2, 3])
-                            [(101, 10), (102, 11), (103, 12)],
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                Runner.AccountTx $
+                    Runner.TJSON
+                        { payload =
+                            Runner.TransferWithScheduleAndMemo
+                                accountAddress1
+                                (Memo $ BSS.pack [0, 1, 2, 3])
+                                [(101, 10), (102, 11), (103, 12)],
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $
                     Helpers.assertSuccessWithEvents
                         [ TransferredWithSchedule
@@ -232,63 +238,67 @@ scheduledTransferWithMemoTest _ pvString =
                         result
             },
           -- should get rejected since timestamps are not increasing
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                Runner.TJSON
-                    { payload =
-                        Runner.TransferWithScheduleAndMemo
-                            accountAddress1
-                            (Memo $ BSS.pack [0, 1, 2, 3])
-                            [(101, 10), (103, 11), (102, 12)],
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                Runner.AccountTx $
+                    Runner.TJSON
+                        { payload =
+                            Runner.TransferWithScheduleAndMemo
+                                accountAddress1
+                                (Memo $ BSS.pack [0, 1, 2, 3])
+                                [(101, 10), (103, 11), (102, 12)],
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertRejectWithReason NonIncreasingSchedule result
             },
           -- should get rejected since first timestamp has expired
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                Runner.TJSON
-                    { payload =
-                        Runner.TransferWithScheduleAndMemo
-                            accountAddress1
-                            (Memo $ BSS.pack [0, 1, 2, 3])
-                            [(99, 10), (102, 11), (103, 12)],
-                      metadata = makeDummyHeader accountAddress0 3 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                Runner.AccountTx $
+                    Runner.TJSON
+                        { payload =
+                            Runner.TransferWithScheduleAndMemo
+                                accountAddress1
+                                (Memo $ BSS.pack [0, 1, 2, 3])
+                                [(99, 10), (102, 11), (103, 12)],
+                          metadata = makeDummyHeader accountAddress0 3 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertRejectWithReason FirstScheduledReleaseExpired result
             },
           -- should get rejected since sender = receiver
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                Runner.TJSON
-                    { payload =
-                        Runner.TransferWithScheduleAndMemo
-                            accountAddress0
-                            (Memo $ BSS.pack [0, 1, 2, 3])
-                            [(101, 10), (102, 11), (103, 12)],
-                      metadata = makeDummyHeader accountAddress0 4 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                Runner.AccountTx $
+                    Runner.TJSON
+                        { payload =
+                            Runner.TransferWithScheduleAndMemo
+                                accountAddress0
+                                (Memo $ BSS.pack [0, 1, 2, 3])
+                                [(101, 10), (102, 11), (103, 12)],
+                          metadata = makeDummyHeader accountAddress0 4 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertRejectWithReason (ScheduledSelfTransfer accountAddress0) result
             },
           -- should get rejected since one of the amounts is 0
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                Runner.TJSON
-                    { payload =
-                        Runner.TransferWithScheduleAndMemo
-                            accountAddress1
-                            (Memo $ BSS.pack [0, 1, 2, 3])
-                            [(101, 10), (102, 0), (103, 12)],
-                      metadata = makeDummyHeader accountAddress0 5 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                Runner.AccountTx $
+                    Runner.TJSON
+                        { payload =
+                            Runner.TransferWithScheduleAndMemo
+                                accountAddress1
+                                (Memo $ BSS.pack [0, 1, 2, 3])
+                                [(101, 10), (102, 0), (103, 12)],
+                          metadata = makeDummyHeader accountAddress0 5 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ Helpers.assertRejectWithReason ZeroScheduledAmount result
             }
         ]

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TrySendTest.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TrySendTest.hs
@@ -63,26 +63,28 @@ errorHandlingTest _ pvString =
     -- NOTE: Could also check resulting balances on each affected account or contract, but
     -- the block state invariant at least tests that the total amount is preserved.
     transactionsAndAssertions =
-        [ Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = DeployModule V0 contractSourceFile,
-                      metadata = makeDummyHeader accountAddress0 1 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+        [ Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = DeployModule V0 contractSourceFile,
+                          metadata = makeDummyHeader accountAddress0 1 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyDeploymentV0 contractSourceFile result
             },
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = InitContract 0 V0 contractSourceFile "init_try" "",
-                      metadata = makeDummyHeader accountAddress0 2 100_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = InitContract 0 V0 contractSourceFile "init_try" "",
+                          metadata = makeDummyHeader accountAddress0 2 100_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $ do
                     Helpers.assertSuccess result
                     Helpers.assertUsedEnergyInitialization
@@ -94,14 +96,15 @@ errorHandlingTest _ pvString =
                         result
             },
           -- valid account, should succeed in transferring
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 11 (Types.ContractAddress 0 0) "try.receive" toAddr,
-                      metadata = makeDummyHeader accountAddress0 3 70_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 11 (Types.ContractAddress 0 0) "try.receive" toAddr,
+                          metadata = makeDummyHeader accountAddress0 3 70_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $
                     Helpers.assertSuccessWithEvents
                         [ Types.Updated
@@ -122,14 +125,15 @@ errorHandlingTest _ pvString =
                         result
             },
           -- transfer did not happen
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                TJSON
-                    { payload = Update 11 (Types.ContractAddress 0 0) "try.receive" (BSS.pack (replicate 32 0)),
-                      metadata = makeDummyHeader accountAddress0 4 70_000,
-                      keys = [(0, [(0, keyPair0)])]
-                    },
-              taaAssertion = \result _ ->
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                AccountTx $
+                    TJSON
+                        { payload = Update 11 (Types.ContractAddress 0 0) "try.receive" (BSS.pack (replicate 32 0)),
+                          metadata = makeDummyHeader accountAddress0 4 70_000,
+                          keys = [(0, [(0, keyPair0)])]
+                        },
+              biaaAssertion = \result _ ->
                 return $
                     Helpers.assertSuccessWithEvents
                         [ Types.Updated

--- a/concordium-consensus/tests/scheduler/SchedulerTests/UpdateAccountKeys.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/UpdateAccountKeys.hs
@@ -75,22 +75,23 @@ credentialKeyUpdateTest _ pvString =
             initialBlockState
             transactionsAndAssertions
   where
-    transactionsAndAssertions :: [Helpers.TransactionAndAssertion pv]
+    transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
     transactionsAndAssertions =
         [ -- correctly update a keypair
-          Helpers.TransactionAndAssertion
-            { taaTransaction =
-                Runner.TJSON
-                    { payload =
-                        Runner.UpdateCredentialKeys
-                            credentialRegistrationId0
-                            $ makeCredentialPublicKeys
-                                [verifyKey keyPair2, verifyKey keyPair1]
-                                2,
-                      metadata = makeDummyHeader accountAddress0 1 10_000,
-                      keys = [(0, [(0, keyPair0), (1, keyPair1)])]
-                    },
-              taaAssertion = \result state -> do
+          Helpers.BlockItemAndAssertion
+            { biaaTransaction =
+                Runner.AccountTx $
+                    Runner.TJSON
+                        { payload =
+                            Runner.UpdateCredentialKeys
+                                credentialRegistrationId0
+                                $ makeCredentialPublicKeys
+                                    [verifyKey keyPair2, verifyKey keyPair1]
+                                    2,
+                          metadata = makeDummyHeader accountAddress0 1 10_000,
+                          keys = [(0, [(0, keyPair0), (1, keyPair1)])]
+                        },
+              biaaAssertion = \result state -> do
                 doCheckKeys <- checkKeys state [(0, verifyKey keyPair2), (1, verifyKey keyPair1)] 2
                 return $ do
                     Helpers.assertSuccessWithEvents [CredentialKeysUpdated credentialRegistrationId0] result

--- a/concordium-consensus/tests/scheduler/Spec.hs
+++ b/concordium-consensus/tests/scheduler/Spec.hs
@@ -20,6 +20,7 @@ import qualified SchedulerTests.RejectReasonsRustContract (tests)
 import qualified SchedulerTests.SimpleTransferSpec (tests)
 import qualified SchedulerTests.SimpleTransfersTest (tests)
 import qualified SchedulerTests.StakedAmountLocked (tests)
+import qualified SchedulerTests.TokenHolderTransactions (tests)
 import qualified SchedulerTests.TokenModule (tests)
 import qualified SchedulerTests.TransactionExpirySpec (tests)
 import qualified SchedulerTests.TransactionGroupingSpec2 (tests)
@@ -114,3 +115,4 @@ main = hspec $ do
     SchedulerTests.SmartContracts.V1.Caller.tests
     SchedulerTests.KonsensusV1.EpochTransition.tests
     SchedulerTests.TokenModule.tests
+    SchedulerTests.TokenHolderTransactions.tests


### PR DESCRIPTION
## Purpose

- Add some test cases for the `TokenHolder`, namely:
  - Test that a token holder transaction fails with reject reason `NonExistentTokenId` when the token does not exist
  - Test that token holder transaction does not fail with reject reason `NonExistentTokenId` when the token does actually exist
- Add support for testing any kind of transaction (i.e. account transaction, account creation or chain update) in the scheduler tests.

## Changes

- Tests testing the above have been added
- The `TransactionAndAssertion` type have been generalized with a new type `BlockItemAndAssertion` to have any BlockItem (account transaction, account creation or chain update) together with an assertion. Accordingly a `runSchedulerTestAssertIntermediateStatesBlockItem` have been intruced so that one can combine different kinds of transactions (with assertions) in a test, e.g. in something like

```haskell
...
do
        let transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
            transactionsAndAssertions =
                [ Helpers.BlockItemAndAssertion
                    { biaaTransaction =
                        Runner.AccountTx ... -- a normal account transaction
                      ataaAssertion = \result _ -> do
                        return $ Helpers.assertSuccess result
                    },
                  Helpers.BlockItemAndAssertion
                    { biaaTransaction =
                        Runner.ChainUpdateTx ... -- a chain update transaction
                      biaaAssertion = \result _ -> do
                        return $ Helpers.assertSuccess result
                    }
                ]
        Helpers.runSchedulerTestAssertIntermediateStatesBlockItem
            @pv
            Helpers.defaultTestConfig
            initialBlockState
            transactionsAndAssertions
```


## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

