### PR TITLE
PLT Event Generation

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/BlockState.hs
@@ -83,6 +83,7 @@ import Concordium.Types.AnonymityRevokers
 import Concordium.Types.IdentityProviders
 import Concordium.Types.Queries (BakerPoolStatus, PassiveDelegationStatus, RewardStatus')
 import Concordium.Types.SeedState (SeedState, SeedStateVersion (..), SeedStateVersionFor)
+import Concordium.Types.Tokens (TokenRawAmount)
 import Concordium.Types.Transactions hiding (BareBlockItem (..))
 import qualified Concordium.Types.UpdateQueues as UQ
 
@@ -96,7 +97,6 @@ import Concordium.GlobalState.Persistent.BlockState.ProtocolLevelTokens (
     PLTConfiguration,
     ProtocolLevelTokensHash (..),
     TokenIndex,
-    TokenRawAmount,
     TokenStateKey,
     TokenStateValue,
  )

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
@@ -23,6 +23,7 @@ import Concordium.Types.Accounts.Releases
 import Concordium.Types.Execution
 import Concordium.Types.HashableTo
 import Concordium.Types.Parameters
+import Concordium.Types.Tokens (TokenRawAmount)
 
 import qualified Concordium.Crypto.SHA256 as Hash
 import Concordium.Genesis.Data
@@ -383,7 +384,7 @@ accountTokenBalance ::
     (MonadBlobStore m, AVSupportsPLT av) =>
     PersistentAccount av ->
     BlockState.TokenIndex ->
-    m BlockState.TokenRawAmount
+    m TokenRawAmount
 accountTokenBalance (PAV5 acc) = V1.getTokenBalance acc
 
 -- | Look up the 'TokenStateValue' associated with a particular token and key on an account.

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/ProtocolLevelTokens.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/ProtocolLevelTokens.hs
@@ -7,16 +7,19 @@
 
 module Concordium.GlobalState.Persistent.Account.ProtocolLevelTokens where
 
+import Control.Monad
+import qualified Data.Map.Strict as Map
+import Data.Serialize
+
 import qualified Concordium.Crypto.SHA256 as Hash
+import Concordium.Types.HashableTo
+import Concordium.Types.Tokens
+import Concordium.Utils.Serialization
+
 import Concordium.GlobalState.Account
 import Concordium.GlobalState.Basic.BlockState.LFMBTree (hashAsLFMBTV1)
 import Concordium.GlobalState.Persistent.BlobStore
 import Concordium.GlobalState.Persistent.BlockState.ProtocolLevelTokens
-import Concordium.Types.HashableTo
-import Concordium.Utils.Serialization
-import Control.Monad
-import qualified Data.Map.Strict as Map
-import Data.Serialize
 
 -- | The table of PLT account states. The table is indexed by the token index
 --  into the global token table.

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
@@ -42,6 +42,7 @@ import Concordium.Types.Conditionally
 import Concordium.Types.Execution
 import Concordium.Types.HashableTo
 import Concordium.Types.Parameters
+import Concordium.Types.Tokens
 import Concordium.Utils
 
 import Concordium.GlobalState.Account hiding (addIncomingEncryptedAmount, addToSelfEncryptedAmount, replaceUpTo)

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
@@ -168,6 +168,7 @@ import Concordium.Types.Accounts
 import qualified Concordium.Types.AnonymityRevokers as ARS
 import qualified Concordium.Types.IdentityProviders as IPS
 import Concordium.Types.Parameters
+import Concordium.Types.Tokens (TokenRawAmount (..))
 import Concordium.Types.Transactions
 import Concordium.Types.Updates
 import Concordium.Wasm
@@ -1576,6 +1577,7 @@ instance (MonadBlobStore m) => BlobStorable m ()
 instance (MonadBlobStore m) => BlobStorable m Word8
 instance (MonadBlobStore m) => BlobStorable m Word32
 instance (MonadBlobStore m) => BlobStorable m Word64
+instance (MonadBlobStore m) => BlobStorable m TokenRawAmount
 
 instance (MonadBlobStore m) => BlobStorable m AccountEncryptedAmount
 instance (MonadBlobStore m) => BlobStorable m PersistingAccountData

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -104,6 +104,7 @@ import Concordium.Types.Queries (
     makePoolPendingChange,
  )
 import Concordium.Types.SeedState
+import qualified Concordium.Types.Tokens as PLT
 import qualified Concordium.Types.TransactionOutcomes as TransactionOutcomes
 import qualified Concordium.Types.Transactions as Transactions
 import qualified Concordium.Types.UpdateQueues as UQ

--- a/concordium-consensus/src/Concordium/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler.hs
@@ -2709,7 +2709,7 @@ handleTokenHolder depositContext tokenId tokenOperations =
                 Left encodedRejectReason ->
                     TxReject . TokenHolderTransactionFailed $
                         makeTokenModuleRejectReason tokenId encodedRejectReason
-                Right events -> TxSuccess (TokenModuleEvent . uncurry (TokenEvent tokenId) <$> events)
+                Right events -> TxSuccess events
         return (result, energyCost, usedEnergy)
     -- Call the module of the token with the operations and return the events emitted from the token module.
     invokeTokenHolderOperations ::
@@ -2717,7 +2717,7 @@ handleTokenHolder depositContext tokenId tokenOperations =
         Token.TokenIndex ->
         IndexedAccount m ->
         TokenParameter ->
-        m (Either PLTTypes.EncodedTokenRejectReason [(TokenEventType, TokenEventDetails)])
+        m (Either PLTTypes.EncodedTokenRejectReason [Event])
     invokeTokenHolderOperations _ tokenIndex sender parameter = do
         result <- withBlockStateRollback $ do
             let tc =
@@ -2774,7 +2774,7 @@ handleTokenGovernance depositContext tokenId tokenOperations =
                 Left encodedRejectReason ->
                     TxReject . TokenGovernanceTransactionFailed $
                         makeTokenModuleRejectReason tokenId encodedRejectReason
-                Right events -> TxSuccess (TokenModuleEvent . uncurry (TokenEvent tokenId) <$> events)
+                Right events -> TxSuccess (events)
         return (result, energyCost, usedEnergy)
     -- Call the module of the token with the operations and return the events emitted from the token module.
     invokeTokenGovernanceOperations ::
@@ -2782,7 +2782,7 @@ handleTokenGovernance depositContext tokenId tokenOperations =
         Token.TokenIndex ->
         IndexedAccount m ->
         TokenParameter ->
-        m (Either PLTTypes.EncodedTokenRejectReason [(TokenEventType, TokenEventDetails)])
+        m (Either PLTTypes.EncodedTokenRejectReason [Event])
     invokeTokenGovernanceOperations _ tokenIndex sender parameter = do
         result <- withBlockStateRollback $ do
             let tc =

--- a/concordium-consensus/src/Concordium/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler.hs
@@ -384,10 +384,10 @@ dispatchTransactionBody msg senderAccount checkHeaderCost = do
                                 handleConfigureDelegation (mkWTC TTConfigureDelegation) cdCapital cdRestakeEarnings cdDelegationTarget
                         TokenHolder{..} ->
                             onlyWithPLT $
-                                handleTokenHolder (mkWTC TTTokenHolder) thTokenSymbol thOperations
+                                handleTokenHolder (mkWTC TTTokenHolder) thTokenId thOperations
                         TokenGovernance{..} ->
                             onlyWithPLT $
-                                handleTokenGovernance (mkWTC TTTokenGovernance) tgTokenSymbol tgOperations
+                                handleTokenGovernance (mkWTC TTTokenGovernance) tgTokenId tgOperations
   where
     -- Function @onlyWithoutDelegation k@ fails if the protocol version @MPV m@ supports
     -- delegation. Otherwise, it continues with @k@, which may assume the chain parameters version
@@ -2953,13 +2953,13 @@ handleCreatePLT updateHeader payload = runExceptT $ do
         lift (getStateAccount governanceAccountAddress) >>= \case
             Nothing -> throwError $ UnknownAccount governanceAccountAddress
             Just govAcct -> return govAcct
-    let tokenSymbol = payload ^. cpltTokenSymbol
-    maybeExistingToken <- lift $ getTokenIndex tokenSymbol
-    when (isJust maybeExistingToken) $ throwError $ DuplicateTokenId tokenSymbol
+    let tokenId = payload ^. cpltTokenId
+    maybeExistingToken <- lift $ getTokenIndex tokenId
+    when (isJust maybeExistingToken) $ throwError $ DuplicateTokenId tokenId
     createResult <- lift . withBlockStateRollback $ do
         let config =
                 PLTConfiguration
-                    { _pltTokenId = tokenSymbol,
+                    { _pltTokenId = tokenId,
                       _pltModule = payload ^. cpltTokenModule,
                       _pltDecimals = payload ^. cpltDecimals,
                       _pltGovernanceAccountIndex = governanceAccountIndex

--- a/concordium-consensus/src/Concordium/Scheduler/Environment.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/Environment.hs
@@ -385,8 +385,8 @@ class
     runPLT ::
         (PVSupportsPLT (MPV m)) =>
         Token.TokenIndex ->
-        (forall m1. (Monad m1, PLTKernelPrivilegedUpdate m1, PLTKernelFail e m1, PLTAccount m1 ~ AccountIndex) => m1 a) ->
-        m (Either e a)
+        (forall m1. (Monad m1, PLTKernelPrivilegedUpdate m1, PLTKernelFail e m1, PLTAccount m1 ~ (AccountIndex, AccountAddress)) => m1 a) ->
+        m (Either e a, [Event])
 
     -- | Create a new protocol-layer token with the given 'PLTConfiguration'.
     --

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Kernel.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Kernel.hs
@@ -44,6 +44,9 @@ class (PLTKernelQuery m) => PLTKernelUpdate m where
         -- | Returns 'True' if successful, 'False' if the sender had insufficient balance.
         m Bool
 
+    -- | Log a token module event with the specified type and details.
+    logTokenEvent :: TokenEventType -> TokenEventDetails -> m ()
+
 class (PLTKernelUpdate m) => PLTKernelPrivilegedUpdate m where
     -- | Mint a specified amount and deposit it in the specified account.
     --  The return value indicates if this was successful.

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Kernel.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Kernel.hs
@@ -10,6 +10,7 @@ module Concordium.Scheduler.ProtocolLevelTokens.Kernel (
 import Data.Word
 
 import Concordium.Types
+import Concordium.Types.Tokens
 
 import Concordium.GlobalState.Persistent.BlockState.ProtocolLevelTokens
 

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Module.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Module.hs
@@ -54,7 +54,7 @@ toTokenRawAmount ::
     TokenAmount ->
     Either String TokenRawAmount
 toTokenRawAmount actualDecimals TokenAmount{..}
-    | actualDecimals == decimals = Right value
+    | actualDecimals == taDecimals = Right taValue
     | otherwise = Left "Token amount precision mismatch"
 
 -- | Convert a 'TokenRawAmount' to a 'TokenAmount' given the number of decimals in the
@@ -68,8 +68,8 @@ toTokenAmount ::
     TokenAmount
 toTokenAmount decimals rawAmount =
     TokenAmount
-        { value = rawAmount,
-          decimals = decimals
+        { taValue = rawAmount,
+          taDecimals = decimals
         }
 
 -- | Initialize a PLT by recording the relevant configuration parameters in the state and

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Module.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Module.hs
@@ -53,17 +53,9 @@ toTokenRawAmount ::
     Word8 ->
     TokenAmount ->
     Either String TokenRawAmount
-toTokenRawAmount actualDecimals TokenAmount{..} =
-    case compare nrDecimals (fromIntegral actualDecimals) of
-        EQ -> Right (TokenRawAmount digits)
-        GT -> Left "Token amount precision exceeds representable precision"
-        LT
-            | rawAmountInteger > fromIntegral (maxBound :: TokenRawAmount) ->
-                Left "Token amount exceeds maximum representable amount"
-            | otherwise -> Right (fromIntegral rawAmountInteger)
-          where
-            factor = 10 ^ (fromIntegral actualDecimals - nrDecimals)
-            rawAmountInteger = factor * toInteger digits
+toTokenRawAmount actualDecimals TokenAmount{..}
+    | actualDecimals == decimals = Right value
+    | otherwise = Left "Token amount precision mismatch"
 
 -- | Convert a 'TokenRawAmount' to a 'TokenAmount' given the number of decimals in the
 --  representation.
@@ -74,10 +66,10 @@ toTokenAmount ::
     TokenRawAmount ->
     -- | Converted amount
     TokenAmount
-toTokenAmount decimals (TokenRawAmount rawAmount) =
+toTokenAmount decimals rawAmount =
     TokenAmount
-        { digits = rawAmount,
-          nrDecimals = fromIntegral decimals
+        { value = rawAmount,
+          decimals = decimals
         }
 
 -- | Initialize a PLT by recording the relevant configuration parameters in the state and

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Queries.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Queries.hs
@@ -140,8 +140,8 @@ queryAccountTokens acc bs = do
         pltConfiguration <- BS.getTokenConfiguration @_ @m bs tokenIndex
         let accountBalance =
                 TokenAmount
-                    { digits = fromIntegral $ tasBalance tokenState,
-                      nrDecimals = fromIntegral $ _pltDecimals pltConfiguration
+                    { value = tasBalance tokenState,
+                      decimals = _pltDecimals pltConfiguration
                     }
         let ctx = QueryContext{qcTokenIndex = tokenIndex, qcBlockState = bs}
         (isAllow, isDeny) <-

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Queries.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Queries.hs
@@ -140,8 +140,8 @@ queryAccountTokens acc bs = do
         pltConfiguration <- BS.getTokenConfiguration @_ @m bs tokenIndex
         let accountBalance =
                 TokenAmount
-                    { value = tasBalance tokenState,
-                      decimals = _pltDecimals pltConfiguration
+                    { taValue = tasBalance tokenState,
+                      taDecimals = _pltDecimals pltConfiguration
                     }
         let ctx = QueryContext{qcTokenIndex = tokenIndex, qcBlockState = bs}
         (isAllow, isDeny) <-

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/Account.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/Account.hs
@@ -9,6 +9,7 @@ import Concordium.GlobalState.Persistent.Account.ProtocolLevelTokens
 import Concordium.GlobalState.Persistent.BlobStore
 import Concordium.GlobalState.Persistent.BlockState.ProtocolLevelTokens
 import Concordium.Types.HashableTo
+import Concordium.Types.Tokens
 import Control.Monad.IO.Class
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Short as SBS

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TokenModule.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TokenModule.hs
@@ -69,6 +69,7 @@ data PLTKernelUpdateCall acct ret where
     SetTokenState :: TokenStateKey -> Maybe TokenStateValue -> PLTKernelUpdateCall acct ()
     SetAccountState :: acct -> TokenStateKey -> Maybe TokenStateValue -> PLTKernelUpdateCall acct ()
     Transfer :: acct -> acct -> TokenRawAmount -> Maybe Memo -> PLTKernelUpdateCall acct Bool
+    LogTokenEvent :: TokenEventType -> TokenEventDetails -> PLTKernelUpdateCall acct ()
 
 deriving instance (Show acct) => Show (PLTKernelUpdateCall acct ret)
 deriving instance (Eq acct) => Eq (PLTKernelUpdateCall acct ret)
@@ -243,6 +244,7 @@ instance
     setTokenState key mValue = handleEvent $ PLTU $ SetTokenState key mValue
     setAccountState acct key mValue = handleEvent $ PLTU $ SetAccountState acct key mValue
     transfer sender receiver amount mMemo = handleEvent $ PLTU $ Transfer sender receiver amount mMemo
+    logTokenEvent eventType details = handleEvent $ PLTU $ LogTokenEvent eventType details
 
 instance
     (Eq e, Eq acct, Show e, Show acct, Show ret, Typeable e, Typeable acct, Typeable ret) =>

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TokenModule.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TokenModule.hs
@@ -319,7 +319,7 @@ testInitializeToken = describe "initializeToken" $ do
                       tipMetadata = "https://plt2.token",
                       tipAllowList = False,
                       tipDenyList = True,
-                      tipInitialSupply = Just TokenAmount{value = 500000, decimals = 2},
+                      tipInitialSupply = Just TokenAmount{taValue = 500000, taDecimals = 2},
                       tipMintable = False,
                       tipBurnable = False
                     }
@@ -343,7 +343,7 @@ testInitializeToken = describe "initializeToken" $ do
                       tipMetadata = "https://plt2.token",
                       tipAllowList = False,
                       tipDenyList = False,
-                      tipInitialSupply = Just TokenAmount{value = 500000, decimals = 2},
+                      tipInitialSupply = Just TokenAmount{taValue = 500000, taDecimals = 2},
                       tipMintable = False,
                       tipBurnable = False
                     }
@@ -363,7 +363,7 @@ testInitializeToken = describe "initializeToken" $ do
                       tipMetadata = "https://plt2.token",
                       tipAllowList = False,
                       tipDenyList = False,
-                      tipInitialSupply = Just TokenAmount{value = 500000, decimals = 2},
+                      tipInitialSupply = Just TokenAmount{taValue = 500000, taDecimals = 2},
                       tipMintable = False,
                       tipBurnable = False
                     }
@@ -386,7 +386,7 @@ testInitializeToken = describe "initializeToken" $ do
                       tipMetadata = "https://plt2.token",
                       tipAllowList = False,
                       tipDenyList = False,
-                      tipInitialSupply = Just TokenAmount{value = 500000, decimals = 6},
+                      tipInitialSupply = Just TokenAmount{taValue = 500000, taDecimals = 6},
                       tipMintable = False,
                       tipBurnable = False
                     }

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TokenModule.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TokenModule.hs
@@ -319,7 +319,7 @@ testInitializeToken = describe "initializeToken" $ do
                       tipMetadata = "https://plt2.token",
                       tipAllowList = False,
                       tipDenyList = True,
-                      tipInitialSupply = Just TokenAmount{digits = 500000, nrDecimals = 2},
+                      tipInitialSupply = Just TokenAmount{value = 500000, decimals = 2},
                       tipMintable = False,
                       tipBurnable = False
                     }
@@ -343,7 +343,7 @@ testInitializeToken = describe "initializeToken" $ do
                       tipMetadata = "https://plt2.token",
                       tipAllowList = False,
                       tipDenyList = False,
-                      tipInitialSupply = Just TokenAmount{digits = 500000, nrDecimals = 2},
+                      tipInitialSupply = Just TokenAmount{value = 500000, decimals = 2},
                       tipMintable = False,
                       tipBurnable = False
                     }
@@ -363,7 +363,7 @@ testInitializeToken = describe "initializeToken" $ do
                       tipMetadata = "https://plt2.token",
                       tipAllowList = False,
                       tipDenyList = False,
-                      tipInitialSupply = Just TokenAmount{digits = 500000, nrDecimals = 2},
+                      tipInitialSupply = Just TokenAmount{value = 500000, decimals = 2},
                       tipMintable = False,
                       tipBurnable = False
                     }
@@ -378,7 +378,7 @@ testInitializeToken = describe "initializeToken" $ do
                     :>>: abortPLTError (ITEInvalidMintAmount "Kernel failed to mint")
         assertTrace (initializeToken tokenParam) trace
     -- In this example, the parameters specify an initial supply with higher precision than the
-    -- token allows. (nrDecimals is 6, but GetDecimals returns 2.)
+    -- token allows. (decimals is 6, but GetDecimals returns 2.)
     it "too many decimals specified" $ do
         let params =
                 TokenInitializationParameters
@@ -386,7 +386,7 @@ testInitializeToken = describe "initializeToken" $ do
                       tipMetadata = "https://plt2.token",
                       tipAllowList = False,
                       tipDenyList = False,
-                      tipInitialSupply = Just TokenAmount{digits = 500000, nrDecimals = 6},
+                      tipInitialSupply = Just TokenAmount{value = 500000, decimals = 6},
                       tipMintable = False,
                       tipBurnable = False
                     }

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -694,7 +694,7 @@ dependencies = [
  "rust_decimal",
  "serde 1.0.214",
  "serde_json 1.0.132",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -724,7 +724,7 @@ dependencies = [
  "sha2",
  "sha3",
  "slab",
- "thiserror",
+ "thiserror 1.0.68",
  "tinyvec",
 ]
 
@@ -750,7 +750,7 @@ dependencies = [
  "ark-ff",
  "ark-serialize",
  "ark-std",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bs58",
  "byteorder",
  "cbc",
@@ -764,7 +764,7 @@ dependencies = [
  "ff",
  "hex",
  "hmac",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "leb128",
  "libc",
  "nom",
@@ -781,7 +781,7 @@ dependencies = [
  "sha2",
  "sha3",
  "subtle",
- "thiserror",
+ "thiserror 2.0.12",
  "zeroize",
 ]
 
@@ -849,7 +849,7 @@ dependencies = [
  "sha2",
  "structopt",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -1567,7 +1567,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "regex",
  "serde 1.0.214",
- "thiserror",
+ "thiserror 1.0.68",
  "time 0.3.36",
  "tokio",
  "uuid 1.11.0",
@@ -2187,6 +2187,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2209,7 +2218,7 @@ dependencies = [
  "combine",
  "jni-sys",
  "log",
- "thiserror",
+ "thiserror 1.0.68",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -2345,7 +2354,7 @@ dependencies = [
  "serde-value",
  "serde_json 1.0.132",
  "serde_yaml",
- "thiserror",
+ "thiserror 1.0.68",
  "thread-id",
  "toml 0.8.19",
  "typemap-ors",
@@ -2964,7 +2973,7 @@ dependencies = [
  "parking_lot",
  "protobuf",
  "reqwest 0.12.9",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -3403,7 +3412,7 @@ dependencies = [
  "paste",
  "serde 1.0.214",
  "serde_derive",
- "thiserror",
+ "thiserror 1.0.68",
  "url",
  "uuid 0.8.2",
 ]
@@ -4206,7 +4215,16 @@ version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.68",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -4214,6 +4232,17 @@ name = "thiserror-impl"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/concordium-node/src/consensus_ffi/ffi.rs
+++ b/concordium-node/src/consensus_ffi/ffi.rs
@@ -2340,14 +2340,14 @@ impl ConsensusContainer {
         use crate::grpc2::Require;
         let bhi = crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
         let (block_id_type, block_hash) = bhi.to_ptr();
-        let token_id_len = token_id.symbol.as_bytes().len();
+        let token_id_len = token_id.value.as_bytes().len();
         if token_id_len > 255 {
             return Err(tonic::Status::invalid_argument(
-                "TokenId: symbol length must be at most 255 bytes",
+                "TokenId: length must be at most 255 bytes",
             ));
         }
         let token_id_len = token_id_len as u8;
-        let token_id_ptr = token_id.symbol.as_ptr();
+        let token_id_ptr = token_id.value.as_ptr();
         let consensus = self.consensus.load(Ordering::SeqCst);
         let mut out_data: Vec<u8> = Vec::new();
         let mut out_hash = [0u8; 32];


### PR DESCRIPTION
## Purpose

Closes [COR-1363](https://linear.app/concordium/issue/COR-1363/generate-events-in-token-module-scheduler-token-kernel)

This introduces event generation for PLT transactions.

## Changes

- Refactoring:
  - `TokenRawAmount` moved into base
  - `TokenAmount` fields renamed
- Add `logTokenEvent` to `PLTKernelUpdate`.
- `KernelT` implementation:
  - `transfer`, `mint` and `burn` log relevant events
  - `PLTAccount` implementation is changed to include the account address. This facilitates logging, as it ensures the appropriate account alias is used.
  - Events are accumulated during execution.
  - Base is changed to `StateT (PLTExecutionState m) m` (following https://github.com/Concordium/concordium-node/pull/1394) where the `PLTExecutionState` includes the event accumulator.
- `runPLT` now returns the event list
- `handleTokenHolder`, `handleTokenGovernance` and `handleCreatePLT` propagate events.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
