### PR TITLE
Use rust trie state for token state and remove the account state.

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/ContractStateV1.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/ContractStateV1.hs
@@ -9,7 +9,11 @@ module Concordium.GlobalState.ContractStateV1 (
     InMemoryPersistentState (..),
     MutableState (..),
     MutableStateInner,
+    emptyPersistentState,
     newMutableState,
+    lookupMutableState,
+    insertMutableState,
+    deleteEntryMutableState,
     makePersistent,
     withMutableState,
     withPersistentState,
@@ -70,6 +74,130 @@ newMutableState msContext ptr = do
 withMutableState :: MutableState -> (Ptr MutableStateInner -> IO a) -> IO a
 withMutableState MutableState{msInner = MutableStateInner fp} = withForeignPtr fp
 
+-- | Look up entry using key and read the value in a mutable state.
+foreign import ccall "lookup_entry_value_mutable_state"
+    lookup_entry_value_mutable_state ::
+        -- | Callback for loading persistent nodes into memory.
+        LoadCallback ->
+        -- | Location of the key.
+        Ptr Word8 ->
+        -- | Length of the key.
+        CSize ->
+        -- | Reference to the mutable state.
+        Ptr MutableStateInner ->
+        -- | Location for returning the length of the output.
+        Ptr CSize ->
+        -- | Returns pointer to the value, null pointer if no entry was found.
+        IO (Ptr Word8)
+
+-- | Look up entry using key and read the value in a mutable state.
+lookupMutableState :: BS.ByteString -> MutableState -> IO (Maybe BS.ByteString)
+lookupMutableState key state = BSU.unsafeUseAsCStringLen key $ \(keyPtr, keyLen) ->
+    alloca $ \outPtr -> do
+        response <- withMutableState state $ \inner ->
+            lookup_entry_value_mutable_state
+                (msContext state)
+                (castPtr keyPtr)
+                (fromIntegral keyLen)
+                inner
+                outPtr
+        if response == nullPtr
+            then return Nothing
+            else do
+                len <- peek outPtr
+                Just
+                    <$> BSU.unsafePackCStringFinalizer
+                        (castPtr response)
+                        (fromIntegral len)
+                        (rs_free_array_len response (fromIntegral len))
+
+-- | Insert value into entry of the provided key.
+--
+-- The entry will be inserted into the tree if not already present.
+-- If a value is already present, this will be overwritten.
+--
+-- Returns:
+-- * 0 success and no entry was already present.
+-- * 1 success and entry got overwritten.
+-- * 2 failed due to the entry being locked.
+foreign import ccall "insert_entry_value_mutable_state"
+    insert_entry_value_mutable_state ::
+        -- | Callback for loading persistent nodes into memory.
+        LoadCallback ->
+        -- | Location of the key.
+        Ptr Word8 ->
+        -- | Length of the key.
+        CSize ->
+        -- | Location of the value.
+        Ptr Word8 ->
+        -- | Length of the value.
+        CSize ->
+        -- | Reference to the mutable state.
+        Ptr MutableStateInner ->
+        IO Word8
+
+-- | Insert value into entry at key.
+--
+-- Returns
+-- * @Just True@ if an entry had a value which got replaced.
+-- * @Just False@ if no entry was overwritten.
+-- * @Nothing@ signals error due to the entry being locked.
+insertMutableState :: BS.ByteString -> BS.ByteString -> MutableState -> IO (Maybe Bool)
+insertMutableState key value state = BSU.unsafeUseAsCStringLen key $ \(keyPtr, keyLen) ->
+    BSU.unsafeUseAsCStringLen value $ \(valuePtr, valueLen) ->
+        withMutableState state $ \inner -> do
+            out <-
+                insert_entry_value_mutable_state
+                    (msContext state)
+                    (castPtr keyPtr)
+                    (fromIntegral keyLen)
+                    (castPtr valuePtr)
+                    (fromIntegral valueLen)
+                    inner
+            return $ case out of
+                0 -> Just False
+                1 -> Just True
+                2 -> Nothing
+                _ -> error "Unexpected FFI status code"
+
+-- | Delete entry at key.
+--
+-- Returns:
+-- * 0 if no entry found to be deleted.
+-- * 1 if an entry got deleted.
+-- * 2 if it failed due to the entry being locked.
+foreign import ccall "delete_entry_mutable_state"
+    delete_entry_mutable_state ::
+        -- | Callback for loading persistent nodes into memory.
+        LoadCallback ->
+        -- | Location of the key.
+        Ptr Word8 ->
+        -- | Length of the key.
+        CSize ->
+        -- | Reference to the mutable state.
+        Ptr MutableStateInner ->
+        IO Word8
+
+-- | Delete entry at key.
+--
+-- Returns @Just True@ if an entry was deleted, @Just False@ if no entry found to be deleted.
+-- @Nothing@ signals error due to the entry being locked.
+deleteEntryMutableState :: BS.ByteString -> MutableState -> IO (Maybe Bool)
+deleteEntryMutableState key mutableState =
+    BSU.unsafeUseAsCStringLen key $ \(keyPtr, keyLen) ->
+        withMutableState mutableState $ \inner -> do
+            out <-
+                delete_entry_mutable_state
+                    (msContext mutableState)
+                    (castPtr keyPtr)
+                    (fromIntegral keyLen)
+                    inner
+            return $ case out of
+                0 -> Just False
+                1 -> Just True
+                2 -> Nothing
+                _ -> error "Unexpected FFI status code"
+
 -- | An opaque pointer to a contract instance's state. "Persistent" here is in
 --  the sense of "persistent data structures", meaning that the state is not
 --  updated in place, but that modifications create a copy of the relevant part
@@ -82,6 +210,15 @@ newtype PersistentState = PersistentState (ForeignPtr PersistentState)
 --  part of the state to disk, and thus the entirety of this state is always
 --  in-memory.
 newtype InMemoryPersistentState = InMemoryPersistentState PersistentState
+
+-- | Allocate empty persistent state.
+foreign import ccall "empty_persistent_state" empty_persistent_state :: IO (Ptr PersistentState)
+
+-- | Allocate empty persistent state.
+emptyPersistentState :: IO PersistentState
+emptyPersistentState = do
+    state <- empty_persistent_state
+    PersistentState <$> newForeignPtr freePersistentState state
 
 -- | Migrate the provided persistent state from the existing backing store (which
 --  can be accessed using the provided 'LoadCallback'), to the new backing store

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account.hs
@@ -387,16 +387,6 @@ accountTokenBalance ::
     m TokenRawAmount
 accountTokenBalance (PAV5 acc) = V1.getTokenBalance acc
 
--- | Look up the 'TokenStateValue' associated with a particular token and key on an account.
---  This is only available at account versions that support protocol-level tokens.
-accountTokenState ::
-    (MonadBlobStore m, AVSupportsPLT av) =>
-    PersistentAccount av ->
-    BlockState.TokenIndex ->
-    BlockState.TokenStateKey ->
-    m (Maybe BlockState.TokenStateValue)
-accountTokenState (PAV5 acc) = V1.getTokenState acc
-
 -- ** 'PersistentBakerInfoRef' queries
 
 -- | Load 'BakerInfo' from a 'PersistentBakerInfoRef'.

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/ProtocolLevelTokens.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/ProtocolLevelTokens.hs
@@ -63,26 +63,21 @@ emptyTokenAccountStateTable = TokenAccountStateTable{tokenAccountStateTable = Ma
 emptyTokenAccountState :: TokenAccountState
 emptyTokenAccountState =
     TokenAccountState
-        { tasBalance = TokenRawAmount 0,
-          tasModuleState = Map.empty
+        { tasBalance = TokenRawAmount 0
         }
 
 -- | Token state at the account level
 data TokenAccountState = TokenAccountState
     { -- | The available balance for the account.
-      tasBalance :: !TokenRawAmount,
-      -- | The token module state for the account, represented as a key-value map.
-      tasModuleState :: !(Map.Map TokenStateKey TokenStateValue)
+      tasBalance :: !TokenRawAmount
     }
     deriving (Eq, Show, Ord)
 
 instance Serialize TokenAccountState where
     put TokenAccountState{..} = do
         put tasBalance
-        put tasModuleState
     get = do
         tasBalance <- get
-        tasModuleState <- get
         return TokenAccountState{..}
 
 instance HashableTo Hash.Hash TokenAccountState where
@@ -95,9 +90,7 @@ instance (MonadBlobStore m) => BlobStorable m TokenAccountState
 -- | An update to the token account state.
 data TokenAccountStateDelta = TokenAccountStateDelta
     { -- | A change to the token balance.
-      tasBalanceDelta :: !(Maybe TokenAmountDelta),
-      -- | A change to the token module state.
-      tasModuleStateDelta :: ![(TokenStateKey, TokenAccountStateValueDelta)]
+      tasBalanceDelta :: !(Maybe TokenAmountDelta)
     }
     deriving (Eq, Show)
 
@@ -112,11 +105,3 @@ toTokenAmountDelta = TokenAmountDelta . fromIntegral
 --  of the given amount.
 negativeTokenAmountDelta :: TokenRawAmount -> TokenAmountDelta
 negativeTokenAmountDelta = TokenAmountDelta . negate . fromIntegral
-
--- | The possible update actions of a token module state.
-data TokenAccountStateValueDelta
-    = -- | Delete the state.
-      TASVDelete
-    | -- | Update the state to a new value or create it if it doesn't already exist.
-      TASVUpdate TokenStateValue
-    deriving (Eq, Show)

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Account/StructureV1.hs
@@ -1405,25 +1405,6 @@ getTokenBalance acc tokenIx = do
                     tokenState <- refLoad tokenStateRef
                     return $ tasBalance tokenState
 
--- | Look up the 'TokenStateValue' associated with a particular token and key on an account.
---  This is only available at account versions that support protocol-level tokens.
-getTokenState ::
-    (MonadBlobStore m, AVSupportsPLT av) =>
-    PersistentAccount av ->
-    TokenIndex ->
-    TokenStateKey ->
-    m (Maybe TokenStateValue)
-getTokenState acc tokenIx key = do
-    case uncond (accountTokenStateTable acc) of
-        Null -> return Nothing
-        Some ref -> do
-            table <- refLoad ref
-            case Map.lookup tokenIx (tokenAccountStateTable table) of
-                Nothing -> return Nothing
-                Just tokenStateRef -> do
-                    tokenState <- refLoad tokenStateRef
-                    return $ Map.lookup key (tasModuleState tokenState)
-
 -- ** Updates
 
 -- | Apply account updates to an account. It is assumed that the address in

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/ProtocolLevelTokens.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/ProtocolLevelTokens.hs
@@ -12,7 +12,6 @@ import Control.Monad.Trans.Class
 import Data.Bits
 import Data.Bool.Singletons
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Short as SBS
 import qualified Data.Map.Strict as Map
 import Data.Serialize
 import Data.Word
@@ -24,11 +23,12 @@ import Concordium.Types.Conditionally
 import Concordium.Types.HashableTo
 import Concordium.Types.Tokens
 import Concordium.Utils
-import Concordium.Utils.Serialization
 
 import Concordium.GlobalState.Basic.BlockState.LFMBTree (LFMBTreeHash' (..))
+import qualified Concordium.GlobalState.ContractStateV1 as StateV1
 import Concordium.GlobalState.Persistent.BlobStore
 import qualified Concordium.GlobalState.Persistent.LFMBTree as LFMBTree
+import Control.Monad.IO.Class (liftIO)
 
 -- | A token index is the index of a token in the 'ProtocolLevelTokens' table.
 newtype TokenIndex = TokenIndex {theTokenIndex :: Word64}
@@ -79,7 +79,7 @@ instance HashableTo PLTConfigurationHash PLTConfiguration where
 instance (Monad m) => MHashableTo m PLTConfigurationHash PLTConfiguration
 
 -- | The type of keys in the token state key-value map.
-type TokenStateKey = SBS.ShortByteString
+type TokenStateKey = BS.ByteString
 
 -- | The type of values in the token state key-value map.
 type TokenStateValue = BS.ByteString
@@ -89,8 +89,7 @@ data PLT = PLT
     { -- | The token configuration.
       _pltConfiguration :: !(HashedBufferedRef' PLTConfigurationHash PLTConfiguration),
       -- | The token-level state of the PLT.
-      -- TODO: Replace with trie-based state. https://linear.app/concordium/issue/NOD-700/switch-plt-key-value-maps-to-trie-implementation
-      _pltState :: !(Map.Map TokenStateKey TokenStateValue),
+      _pltState :: !StateV1.PersistentState,
       -- | The total amount of the token that exists in circulation.
       _pltCirculatingSupply :: !TokenRawAmount
     }
@@ -98,18 +97,20 @@ data PLT = PLT
 instance (MonadBlobStore m) => BlobStorable m PLT where
     load = do
         configRef <- load
-        _pltState <- getSafeMapOf get get
+        stateRef <- load
         _pltCirculatingSupply <- get
         return $ do
             _pltConfiguration <- configRef
+            _pltState <- stateRef
             return PLT{..}
     storeUpdate plt = do
         (putConfig, newConfig) <- storeUpdate (_pltConfiguration plt)
+        (putState, newState) <- storeUpdate (_pltState plt)
         let thePutter = do
                 putConfig
-                putSafeMapOf put put (_pltState plt)
+                putState
                 put (_pltCirculatingSupply plt)
-        return $!! (thePutter, plt{_pltConfiguration = newConfig})
+        return $!! (thePutter, plt{_pltConfiguration = newConfig, _pltState = newState})
 
 instance (MonadBlobStore m) => Cacheable m PLT where
     cache plt = do
@@ -119,11 +120,10 @@ instance (MonadBlobStore m) => Cacheable m PLT where
 instance (MonadBlobStore m) => MHashableTo m SHA256.Hash PLT where
     getHashM PLT{..} = do
         (PLTConfigurationHash configHash) <- getHashM _pltConfiguration
-
+        tokenStateHash :: SHA256.Hash <- getHashM _pltState
         let stateHash = SHA256.hashLazy $ runPutLazy $ do
-                putSafeMapOf put put _pltState
+                put tokenStateHash
                 put _pltCirculatingSupply
-
         return $! SHA256.hashOfHashes configHash stateHash
 
 type TokenRef = HashedBufferedRef PLT
@@ -276,33 +276,30 @@ lookupPLT index pvPLTs = do
         Nothing ->
             error $ "lookupPLT: TokenIndex (" ++ show index ++ ") not found in ProtocolLevelTokens"
 
--- | Get the state of a token for a given 'TokenStateKey'. Returns @Nothing@ if the token does not
---  have a state for the given key.
+-- | Create a mutable state from a persistent one. This is generative, it creates independent
+-- mutable states in different calls.
 --
 --  PRECONDITION: The 'TokenIndex' MUST exist in the given 'ProtocolLevelTokensForPV'.
-getTokenState ::
+thawTokenState ::
     (PVSupportsPLT pv, MonadBlobStore m) =>
     TokenIndex ->
-    TokenStateKey ->
     ProtocolLevelTokensForPV pv ->
-    m (Maybe TokenStateValue)
-getTokenState index key pvPLTs = do
+    m StateV1.MutableState
+thawTokenState index pvPLTs = do
     plt <- lookupPLT index pvPLTs
-    return $ Map.lookup key (_pltState plt)
+    loadCallback <- fst <$> getCallbacks
+    liftIO $ StateV1.thaw loadCallback (_pltState plt)
 
--- | Set the state of a token for a given 'TokenStateKey'. If the value is @Nothing@, the key is
---  removed from the token state. Otherwise, the key is set to the given value.
---  Returns the updated 'ProtocolLevelTokensForPV'.
+-- | Convert the mutable state to a persistent one.
 --
--- PRECONDITION: The 'TokenIndex' MUST exist in the given 'ProtocolLevelTokensForPV'.
-setTokenState ::
+--  PRECONDITION: The 'TokenIndex' MUST exist in the given 'ProtocolLevelTokensForPV'.
+freezeTokenState ::
     (PVSupportsPLT pv, MonadBlobStore m) =>
     TokenIndex ->
-    TokenStateKey ->
-    Maybe TokenStateValue ->
+    StateV1.MutableState ->
     ProtocolLevelTokensForPV pv ->
     m (ProtocolLevelTokensForPV pv)
-setTokenState index key mValue pvPLTs = do
+freezeTokenState index mutableState pvPLTs = do
     plts <- loadPLTs pvPLTs
     LFMBTree.update upd index (_pltTable plts) >>= \case
         Nothing ->
@@ -311,10 +308,36 @@ setTokenState index key mValue pvPLTs = do
         Just (_, newTable) -> storePLTs plts{_pltTable = newTable}
   where
     upd plt = do
-        let !newState = case mValue of
-                Nothing -> Map.delete key (_pltState plt)
-                Just v -> Map.insert key v (_pltState plt)
-        return ((), plt{_pltState = newState})
+        loadCallback <- fst <$> getCallbacks
+        (_hash, persistentState) <- liftIO $ StateV1.freeze loadCallback mutableState
+        return ((), plt{_pltState = persistentState})
+
+-- | Get the state of a token for a given 'TokenStateKey'. Returns @Nothing@ if the token does not
+--  have a state for the given key.
+getTokenState ::
+    (MonadBlobStore m) =>
+    TokenStateKey ->
+    StateV1.MutableState ->
+    m (Maybe TokenStateValue)
+getTokenState key mutableState = liftIO $ StateV1.lookupMutableState key mutableState
+
+-- | Insert entry into the mutable state, overwriting the value if already present.
+-- If the provided value is @Nothing@ the entry gets deleted.
+--
+-- Returns
+-- * @Just True@ signals an entry was present in the state.
+-- * @Just False@ if no entry was present.
+-- * @Nothing@ signals error due to the entry being locked.
+setTokenState ::
+    (MonadBlobStore m) =>
+    TokenStateKey ->
+    Maybe TokenStateValue ->
+    StateV1.MutableState ->
+    m (Maybe Bool)
+setTokenState key maybeValue mutableState =
+    liftIO $ case maybeValue of
+        Just value -> StateV1.insertMutableState key value mutableState
+        Nothing -> StateV1.deleteEntryMutableState key mutableState
 
 -- | Get the configuration data of a token for a given 'TokenIndex'.
 --
@@ -375,10 +398,11 @@ createToken ::
 createToken config pvPLTs = do
     plts <- loadPLTs pvPLTs
     newConfigRef <- refMake config
+    state <- liftIO StateV1.emptyPersistentState
     let plt =
             PLT
                 { _pltConfiguration = newConfigRef,
-                  _pltState = Map.empty,
+                  _pltState = state,
                   _pltCirculatingSupply = TokenRawAmount 0
                 }
     (tokIndex, newTable) <- LFMBTree.append plt (_pltTable plts)

--- a/concordium-consensus/src/Concordium/Scheduler/EnvironmentImplementation.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/EnvironmentImplementation.hs
@@ -24,6 +24,7 @@ import Concordium.Types.Tokens
 import Concordium.GlobalState.Account
 import qualified Concordium.GlobalState.BakerInfo as BI
 import qualified Concordium.GlobalState.BlockState as BS
+import qualified Concordium.GlobalState.ContractStateV1 as StateV1
 import Concordium.GlobalState.Persistent.Account.ProtocolLevelTokens
 import Concordium.GlobalState.Persistent.BlockState.ProtocolLevelTokens (PLTConfiguration (..), TokenIndex)
 import Concordium.GlobalState.TreeState
@@ -33,6 +34,7 @@ import Concordium.Scheduler.ProtocolLevelTokens.Kernel
 import Concordium.Scheduler.Types
 import Concordium.TimeMonad
 import qualified Concordium.TransactionVerification as TVer
+import Data.Either (isRight)
 
 -- | Context for executing a scheduler computation.
 data ContextState = ContextState
@@ -86,8 +88,10 @@ data PLTExecutionContext = PLTExecutionContext
       _pltecTokenIndex :: !TokenIndex,
       -- | The PLT configuration.
       _pltecConfiguration :: !PLTConfiguration,
-      -- | The available energy
-      _pltecEnergy :: !(Maybe Energy)
+      -- | The available energy.
+      _pltecEnergy :: !(Maybe Energy),
+      -- | The mutable token state.
+      _pltecMutableState :: !StateV1.MutableState
     }
 
 -- | Alias for the internal type used in @SchedulerT@.
@@ -475,43 +479,53 @@ instance
         return res
 
     runPLT tokenIx op = do
-        s <- use ssBlockState
+        s :: UpdatableBlockState m <- use ssBlockState
         let initialExecutionState =
                 PLTExecutionState
                     { _plteBlockState = s,
                       _plteEvents = [],
                       _plteEnergyUsed = 0
                     }
-
+        mutState <- lift $ BS.thawTokenState s tokenIx
         (res, finalExecutionState) <- lift $ do
             config <- BS.getTokenConfiguration s tokenIx
             let context =
                     PLTExecutionContext
                         { _pltecTokenIndex = tokenIx,
                           _pltecConfiguration = config,
-                          _pltecEnergy = Nothing
+                          _pltecEnergy = Nothing,
+                          _pltecMutableState = mutState
                         }
             runKernelT op context initialExecutionState
+        when (isRight res) $ do
+            let outBlockState = finalExecutionState ^. plteBlockState
+            newBlockState <- lift $ BS.bsoFreezeTokenState outBlockState tokenIx mutState
+            ssBlockState .= newBlockState
         return (res, reverse $ finalExecutionState ^. plteEvents)
 
     runPLTWithEnergy tokenIx energy op = do
-        s <- use ssBlockState
+        s :: UpdatableBlockState m <- use ssBlockState
         let initialExecutionState =
                 PLTExecutionState
                     { _plteBlockState = s,
                       _plteEvents = [],
                       _plteEnergyUsed = 0
                     }
-
+        mutState <- lift $ BS.thawTokenState s tokenIx
         (res, finalExecutionState) <- lift $ do
             config <- BS.getTokenConfiguration s tokenIx
             let context =
                     PLTExecutionContext
                         { _pltecTokenIndex = tokenIx,
                           _pltecConfiguration = config,
-                          _pltecEnergy = Just energy
+                          _pltecEnergy = Just energy,
+                          _pltecMutableState = mutState
                         }
             runKernelT op context initialExecutionState
+        when (isRight res) $ do
+            let outBlockState = finalExecutionState ^. plteBlockState
+            newBlockState <- lift $ BS.bsoFreezeTokenState outBlockState tokenIx mutState
+            ssBlockState .= newBlockState
         return (res, reverse $ finalExecutionState ^. plteEvents, finalExecutionState ^. plteEnergyUsed)
 
     createToken pltConfig = do
@@ -553,12 +567,13 @@ deriving via (MGSTrans (KernelT fail ret) m) instance BlockStateTypes (KernelT f
 instance (BS.BlockStateOperations m, PVSupportsPLT (MPV m)) => PLTKernelQuery (KernelT fail ret m) where
     type PLTAccount (KernelT fail ret m) = (AccountIndex, AccountAddress)
     getTokenState key = do
-        tokenIx <- asks _pltecTokenIndex
         bs <- use plteBlockState
-        lift $ BS.getTokenState bs tokenIx key
+        mutableState <- asks _pltecMutableState
+        lift $ BS.getTokenState bs key mutableState
     getAccount addr = do
         bs <- use plteBlockState
         lift $ fmap ((,addr) . fst) <$> BS.bsoGetAccount bs addr
+    getAccountIndex (acctIndex, _) = return acctIndex
     getAccountBalance (acctIndex, _) = do
         tokenIx <- asks _pltecTokenIndex
         bs <- use plteBlockState
@@ -566,13 +581,6 @@ instance (BS.BlockStateOperations m, PVSupportsPLT (MPV m)) => PLTKernelQuery (K
             BS.bsoGetAccountByIndex bs acctIndex >>= \case
                 Nothing -> error "getAccountBalance: Account does not exist"
                 Just acct -> BS.getAccountTokenBalance acct tokenIx
-    getAccountState (acctIndex, _) key = do
-        tokenIx <- asks _pltecTokenIndex
-        bs <- use plteBlockState
-        lift $
-            BS.bsoGetAccountByIndex bs acctIndex >>= \case
-                Nothing -> error "getAccountState: Account does not exist"
-                Just acct -> BS.getAccountTokenState acct tokenIx key
     getAccountCanonicalAddress (acctIndex, _) = do
         bs <- use plteBlockState
         lift $
@@ -597,19 +605,9 @@ instance (BS.BlockStateOperations m, PVSupportsPLT (MPV m)) => PLTKernelQuery (K
 
 instance (BS.BlockStateOperations m, PVSupportsPLT (MPV m)) => PLTKernelUpdate (KernelT fail ret m) where
     setTokenState key mValue = do
-        tokenIx <- asks _pltecTokenIndex
-        bs <- use plteBlockState
-        newBS <- lift $ BS.bsoSetTokenState bs tokenIx key mValue
-        plteBlockState .= newBS
-    setAccountState (account, _) key mValue = do
-        let updates = case mValue of
-                Nothing -> [(key, TASVDelete)]
-                Just value -> [(key, TASVUpdate value)]
-        tokenIx <- asks _pltecTokenIndex
-        bs <- use plteBlockState
-        newBS <- lift $ BS.bsoUpdateTokenAccountModuleState bs tokenIx account updates
-        plteBlockState .= newBS
-        return ()
+        mutableState <- asks _pltecMutableState
+        lift $ BS.bsoSetTokenState key mValue mutableState
+
     transfer (accIxFrom, accAddrFrom) (accIxTo, accAddrTo) amount mbMemo = do
         context <- ask
         let tokenIx = _pltecTokenIndex context

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Kernel.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Kernel.hs
@@ -18,16 +18,15 @@ class PLTKernelQuery m where
     type PLTAccount m
     getTokenState :: TokenStateKey -> m (Maybe TokenStateValue)
     getAccount :: AccountAddress -> m (Maybe (PLTAccount m))
+    getAccountIndex :: PLTAccount m -> m AccountIndex
     getAccountBalance :: PLTAccount m -> m TokenRawAmount
-    getAccountState :: PLTAccount m -> TokenStateKey -> m (Maybe TokenStateValue)
     getAccountCanonicalAddress :: PLTAccount m -> m AccountAddress
     getGovernanceAccount :: m (PLTAccount m)
     getCirculatingSupply :: m TokenRawAmount
     getDecimals :: m Word8
 
 class (PLTKernelQuery m) => PLTKernelUpdate m where
-    setTokenState :: TokenStateKey -> Maybe TokenStateValue -> m ()
-    setAccountState :: PLTAccount m -> TokenStateKey -> Maybe TokenStateValue -> m ()
+    setTokenState :: TokenStateKey -> Maybe TokenStateValue -> m (Maybe Bool)
 
     -- | Transfer a token amount from one account to another, with an optional memo.
     --  The return value indicates if the transfer was successful.

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/Account.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/Account.hs
@@ -45,17 +45,10 @@ instance Arbitrary SBS.ShortByteString where
     arbitrary = SBS.toShort <$> arbitrary
     shrink sbs = SBS.toShort <$> shrink (SBS.fromShort sbs)
 
-arbitraryTokenModuleState :: Gen (Map.Map TokenStateKey TokenStateValue)
-arbitraryTokenModuleState = sized $ \n -> do
-    k <- choose (0, n)
-    kvs <- vectorOf k $ (,) <$> arbitrary <*> arbitrary
-    return $ Map.fromList kvs
-
 arbitraryTokenAccountState :: Gen TokenAccountState
 arbitraryTokenAccountState = do
     balance <- TokenRawAmount <$> arbitrary
-    state <- arbitraryTokenModuleState
-    return $ TokenAccountState{tasBalance = balance, tasModuleState = state}
+    return $ TokenAccountState{tasBalance = balance}
 
 arbitraryInMemoryTokenStateTable :: Gen InMemoryTokenStateTable
 arbitraryInMemoryTokenStateTable = sized $ \n -> do


### PR DESCRIPTION
## Purpose

Use rust-implemented state trie for token modules.

Related PR in base: TBA

## Changes

- Change the token module, so it no longer have a separate account state, instead it uses the token state and prefixes the account related state with magic value + account index.


