### PR TITLE
Plt fix authorization

### DIFF
--- a/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
@@ -119,7 +119,7 @@ deriving instance
     MonadCache (BS.AccountCache av) (PersistentBSM pv)
 
 instance MonadLogger (PersistentBSM pv) where
-    logEvent _ _ _ = return ()
+    logEvent src lvl msg = PersistentBSM (logEvent src lvl msg)
 
 instance TimeMonad (PersistentBSM pv) where
     currentTime = return $ read "1970-01-01 13:27:13.257285424 UTC"
@@ -357,6 +357,7 @@ runSchedulerTestAssertIntermediateStates config constructState transactionsAndAs
         BlockItemAndAssertion pv ->
         PersistentBSM pv (Assertion, BS.HashedPersistentBlockState pv, Types.Amount)
     transactionRunner (assertedSoFar, currentState, costsSoFar) step = do
+        logEvent Scheduler LLError "Transaction runner"
         transactions <- liftIO $ SchedTest.processUngroupedBlockItems [biaaTransaction step]
         (result, updatedState) <- runScheduler config currentState transactions
         let nextCostsSoFar = costsSoFar + srExecutionCosts result

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TokenCreation.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TokenCreation.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -9,14 +10,18 @@ module SchedulerTests.TokenCreation (tests) where
 
 import Data.Bool.Singletons
 import qualified Data.ByteString.Short as BSS
+import qualified Data.Set as Set
+import qualified Data.Vector as Vec
 import qualified SchedulerTests.Helpers as Helpers
 import Test.Hspec
 
+import qualified Concordium.Crypto.DummyData as DummyData
 import qualified Concordium.Crypto.SHA256 as Hash
 import Concordium.ID.Types as ID
 import qualified Concordium.Types.DummyData as DummyData
 import qualified Concordium.Types.ProtocolLevelTokens.CBOR as CBOR
 import Concordium.Types.Tokens
+import Concordium.Types.Updates
 
 import qualified Concordium.GlobalState.DummyData as DummyData
 import qualified Concordium.GlobalState.Persistent.Account as BS
@@ -51,6 +56,32 @@ initialBlockState =
         [ dummyAccount,
           dummyAccount2
         ]
+
+initialBlockStateWithCustomKeys ::
+    forall pv.
+    (IsProtocolVersion pv, PVSupportsPLT pv) =>
+    -- | Number of keys
+    Int ->
+    -- | Which key indices are authorized for CreatePLT
+    [UpdateKeyIndex] ->
+    -- | Threshold for CreatePLT
+    UpdateKeysThreshold ->
+    Helpers.PersistentBSM pv (BS.HashedPersistentBlockState pv)
+initialBlockStateWithCustomKeys numKeys authorizedKeys threshold = do
+    accounts <- sequence [dummyAccount, dummyAccount2]
+    let auths0 = DummyData.dummyAuthorizations @(AuthorizationsVersionFor pv)
+    let createPLT = AccessStructure (Set.fromList authorizedKeys) threshold
+    let keys =
+            UpdateKeysCollection
+                { rootKeys = DummyData.dummyHigherLevelKeys,
+                  level1Keys = DummyData.dummyHigherLevelKeys,
+                  level2Keys =
+                    auths0
+                        { asKeys = Vec.fromList (DummyData.deterministicVK <$> [1 .. numKeys]),
+                          asCreatePLT = createPLT <$ asCreatePLT auths0
+                        }
+                }
+    Helpers.createTestBlockStateWithAccountsAndKeys accounts keys
 
 testCreatePLT :: forall pv. (IsProtocolVersion pv, PVSupportsPLT pv) => SProtocolVersion pv -> String -> Spec
 testCreatePLT _ pvString = describe pvString $ do
@@ -106,16 +137,125 @@ testCreatePLT _ pvString = describe pvString $ do
             Helpers.defaultTestConfig
             initialBlockState
             transactionsAndAssertions
+    it "CreatePLT - multiple keys" $ do
+        let numKeys = 3
+            authorizedKeys = [1, 2]
+            threshold = 2
+        let transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
+            transactionsAndAssertions =
+                [ Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        txCreatePLTWithKeys
+                            1
+                            createPLT1
+                            [(1, DummyData.deterministicKP 1), (2, DummyData.deterministicKP 2)],
+                      biaaAssertion = \result _ -> do
+                        return $ Helpers.assertSuccessWithEvents [TokenCreated{etcPayload = createPLT1}] result
+                    }
+                ]
+        Helpers.runSchedulerTestAssertIntermediateStates
+            @pv
+            Helpers.defaultTestConfig
+            (initialBlockStateWithCustomKeys numKeys authorizedKeys threshold)
+            transactionsAndAssertions
+    it "CreatePLT - multiple keys - additional authorized" $ do
+        let numKeys = 3
+            authorizedKeys = [1, 2]
+            threshold = 1
+        let transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
+            transactionsAndAssertions =
+                [ Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        txCreatePLTWithKeys
+                            1
+                            createPLT1
+                            [(1, DummyData.deterministicKP 1), (2, DummyData.deterministicKP 2)],
+                      biaaAssertion = \result _ -> do
+                        return $ Helpers.assertSuccessWithEvents [TokenCreated{etcPayload = createPLT1}] result
+                    }
+                ]
+        Helpers.runSchedulerTestAssertIntermediateStates
+            @pv
+            Helpers.defaultTestConfig
+            (initialBlockStateWithCustomKeys numKeys authorizedKeys threshold)
+            transactionsAndAssertions
+    it "CreatePLT - multiple keys - incorrect signature" $ do
+        let numKeys = 3
+            authorizedKeys = [1, 2]
+            threshold = 2
+        let transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
+            transactionsAndAssertions =
+                [ Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        txCreatePLTWithKeys
+                            1
+                            createPLT1
+                            [(1, DummyData.deterministicKP 1), (2, DummyData.deterministicKP 23)],
+                      biaaAssertion = \result _ -> do
+                        return $ Helpers.assertUpdateFailureWithReason IncorrectSignature result
+                    }
+                ]
+        Helpers.runSchedulerTestAssertIntermediateStates
+            @pv
+            Helpers.defaultTestConfig
+            (initialBlockStateWithCustomKeys numKeys authorizedKeys threshold)
+            transactionsAndAssertions
+    it "CreatePLT - multiple keys - incorrect key" $ do
+        let numKeys = 3
+            authorizedKeys = [1, 2]
+            threshold = 1
+        let transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
+            transactionsAndAssertions =
+                [ Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        txCreatePLTWithKeys
+                            1
+                            createPLT1
+                            [(0, DummyData.deterministicKP 0)],
+                      biaaAssertion = \result _ -> do
+                        return $ Helpers.assertUpdateFailureWithReason IncorrectSignature result
+                    }
+                ]
+        Helpers.runSchedulerTestAssertIntermediateStates
+            @pv
+            Helpers.defaultTestConfig
+            (initialBlockStateWithCustomKeys numKeys authorizedKeys threshold)
+            transactionsAndAssertions
+    it "CreatePLT - multiple keys - additional unauthorized" $ do
+        let numKeys = 3
+            authorizedKeys = [0, 1]
+            threshold = 1
+        let transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
+            transactionsAndAssertions =
+                [ Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        txCreatePLTWithKeys
+                            1
+                            createPLT1
+                            [(1, DummyData.deterministicKP 1), (2, DummyData.deterministicKP 2)],
+                      biaaAssertion = \result _ -> do
+                        return $ Helpers.assertUpdateFailureWithReason IncorrectSignature result
+                    }
+                ]
+        Helpers.runSchedulerTestAssertIntermediateStates
+            @pv
+            Helpers.defaultTestConfig
+            (initialBlockStateWithCustomKeys numKeys authorizedKeys threshold)
+            transactionsAndAssertions
   where
-    txCreatePLT ctSeqNumber createPLT =
+    txCreatePLTWithKeys ctSeqNumber createPLT ctKeys =
         Runner.ChainUpdateTx
             Runner.ChainUpdateTransaction
                 { ctEffectiveTime = 0,
                   ctTimeout = DummyData.dummyMaxTransactionExpiryTime,
-                  ctKeys = [(0, DummyData.dummyAuthorizationKeyPair)],
                   ctPayload = Types.CreatePLTUpdatePayload createPLT,
                   ..
                 }
+    txCreatePLT ctSeqNumber createPLT =
+        txCreatePLTWithKeys
+            ctSeqNumber
+            createPLT
+            [(0, DummyData.dummyAuthorizationKeyPair)]
     dummyHash = Hash.hashShort BSS.empty
     plt1 = Types.TokenId "PLT1"
     plt2 = Types.TokenId "PLT2"

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TokenCreation.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TokenCreation.hs
@@ -77,7 +77,7 @@ initialBlockStateWithCustomKeys numKeys authorizedKeys threshold = do
                   level1Keys = DummyData.dummyHigherLevelKeys,
                   level2Keys =
                     auths0
-                        { asKeys = Vec.fromList (DummyData.deterministicVK <$> [1 .. numKeys]),
+                        { asKeys = Vec.fromList (DummyData.deterministicVK <$> [0 .. numKeys - 1]),
                           asCreatePLT = createPLT <$ asCreatePLT auths0
                         }
                 }
@@ -137,7 +137,7 @@ testCreatePLT _ pvString = describe pvString $ do
             Helpers.defaultTestConfig
             initialBlockState
             transactionsAndAssertions
-    it "CreatePLT - multiple keys" $ do
+    it "Create PLT - multiple keys" $ do
         let numKeys = 3
             authorizedKeys = [1, 2]
             threshold = 2
@@ -158,7 +158,7 @@ testCreatePLT _ pvString = describe pvString $ do
             Helpers.defaultTestConfig
             (initialBlockStateWithCustomKeys numKeys authorizedKeys threshold)
             transactionsAndAssertions
-    it "CreatePLT - multiple keys - additional authorized" $ do
+    it "Create PLT - multiple keys - additional authorized" $ do
         let numKeys = 3
             authorizedKeys = [1, 2]
             threshold = 1
@@ -179,7 +179,7 @@ testCreatePLT _ pvString = describe pvString $ do
             Helpers.defaultTestConfig
             (initialBlockStateWithCustomKeys numKeys authorizedKeys threshold)
             transactionsAndAssertions
-    it "CreatePLT - multiple keys - incorrect signature" $ do
+    it "Create PLT - multiple keys - incorrect signature" $ do
         let numKeys = 3
             authorizedKeys = [1, 2]
             threshold = 2
@@ -200,7 +200,7 @@ testCreatePLT _ pvString = describe pvString $ do
             Helpers.defaultTestConfig
             (initialBlockStateWithCustomKeys numKeys authorizedKeys threshold)
             transactionsAndAssertions
-    it "CreatePLT - multiple keys - incorrect key" $ do
+    it "Create PLT - multiple keys - incorrect key" $ do
         let numKeys = 3
             authorizedKeys = [1, 2]
             threshold = 1
@@ -221,7 +221,7 @@ testCreatePLT _ pvString = describe pvString $ do
             Helpers.defaultTestConfig
             (initialBlockStateWithCustomKeys numKeys authorizedKeys threshold)
             transactionsAndAssertions
-    it "CreatePLT - multiple keys - additional unauthorized" $ do
+    it "Create PLT - multiple keys - additional unauthorized" $ do
         let numKeys = 3
             authorizedKeys = [0, 1]
             threshold = 1
@@ -233,6 +233,48 @@ testCreatePLT _ pvString = describe pvString $ do
                             1
                             createPLT1
                             [(1, DummyData.deterministicKP 1), (2, DummyData.deterministicKP 2)],
+                      biaaAssertion = \result _ -> do
+                        return $ Helpers.assertUpdateFailureWithReason IncorrectSignature result
+                    }
+                ]
+        Helpers.runSchedulerTestAssertIntermediateStates
+            @pv
+            Helpers.defaultTestConfig
+            (initialBlockStateWithCustomKeys numKeys authorizedKeys threshold)
+            transactionsAndAssertions
+    it "Create PLT - multiple keys - first unauthorized" $ do
+        let numKeys = 3
+            authorizedKeys = [1, 2]
+            threshold = 1
+        let transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
+            transactionsAndAssertions =
+                [ Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        txCreatePLTWithKeys
+                            1
+                            createPLT1
+                            [(0, DummyData.deterministicKP 0)],
+                      biaaAssertion = \result _ -> do
+                        return $ Helpers.assertUpdateFailureWithReason IncorrectSignature result
+                    }
+                ]
+        Helpers.runSchedulerTestAssertIntermediateStates
+            @pv
+            Helpers.defaultTestConfig
+            (initialBlockStateWithCustomKeys numKeys authorizedKeys threshold)
+            transactionsAndAssertions
+    it "Create PLT - multiple keys - first incorrect key" $ do
+        let numKeys = 3
+            authorizedKeys = [0, 1, 2]
+            threshold = 1
+        let transactionsAndAssertions :: [Helpers.BlockItemAndAssertion pv]
+            transactionsAndAssertions =
+                [ Helpers.BlockItemAndAssertion
+                    { biaaTransaction =
+                        txCreatePLTWithKeys
+                            1
+                            createPLT1
+                            [(0, DummyData.deterministicKP 1)],
                       biaaAssertion = \result _ -> do
                         return $ Helpers.assertUpdateFailureWithReason IncorrectSignature result
                     }


### PR DESCRIPTION
## Purpose

Closes: https://linear.app/concordium/issue/COR-1557/bug-createplt-authorization-is-not-checked
Depends on: https://github.com/Concordium/concordium-base/pull/687

This checks that CreatePLT updates are correctly signed when executing the transaction.

## Changes

- Base updated to use the actual authorized key set.
- Check the signature(s) are correct before executing `handleCreatePLT`.
- Tests.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
