### PR TITLE
fix: update terminology baker to validator in macos install doc

### DIFF
--- a/scripts/distribution/macOS-package/README.md
+++ b/scripts/distribution/macOS-package/README.md
@@ -158,16 +158,16 @@ The build script goes through the following major steps:
      - Optionally signing the code inside it first.
   6. Optionally notarizing the installer.
 
-## How to become a baker
+## How to become a validator
 
-1. Add a path to the baker credentials in the appropriate service file (mainnet
+1. Add a path to the validator credentials in the appropriate service file (mainnet
    or testnet)
    - For example in
      `/Library/Concordium
      Node/LaunchDaemons/software.concordium.mainnet.node.plist` in the
      EnviromentVariables section:
      ```
-     <!-- Path to the baker credentials file. -->
+     <!-- Path to the validator credentials file. -->
      <key>CONCORDIUM_NODE_VALIDATOR_CREDENTIALS_FILE</key>
      <string>/Library/Application Support/Concordium Node/Mainnet/Config/validator-credentials.json</string>
      ```


### PR DESCRIPTION
## Purpose

Trivial change - update the term 'baker' to 'validator' in the doc, the relevant config key had already been updated 

## Changes

Readme update

## Checklist

- [-] My code follows the style of this project.
- [-] The code compiles without warnings.
- [-] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [-] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
