### PR TITLE
feat: add Mac code signing to the release pipeline

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -38,11 +38,11 @@ on:
     branches: main
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
-    # - '.github/workflows/build-test.yaml'  # temporarily cancel this, we don't want to run the full test build.
+    - '.github/workflows/build-test.yaml'
     - '**/Cargo.toml'
     - '**/Cargo.lock'
     - '**.rs'
-    # - '**.yaml' # temporarily cancel this, we don't want to run the full test build.
+    - '**.yaml'
     - '**.hs'
     - 'concordium-base'
     - 'concordium-consensus/smart-contracts'


### PR DESCRIPTION
## Purpose

Adds code signing for MacOS into Github Actions

* Adds builder and installer certificate to Mac keychain
* Uses the code signing option in the mac build.sh with the Concordium signing user and app-specific password 
* Removes the '-unsigned' from the package name of the resulting artefact

I have added the relevant credentials to the release environment in the repo settings, and in order to access these credentials the Mac build step will now be executed within the release environment context.

This does not currently make any change to how the artefact is published, the Mac build will continue to be uploaded to `s3://distribution.concordium.software/macos/concordium-node-<version>.pkg`.

Here is a signed artefact: https://github.com/Concordium/concordium-node/actions/runs/16002561785 