### PR TITLE
Plt token pause scheduler implementation

### DIFF
--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Module.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Module.hs
@@ -359,7 +359,7 @@ executeTokenUpdateTransaction TransactionContext{..} tokenParam = do
             failTH
                 OperationNotPermitted
                     { trrOperationIndex = opIndex,
-                      trrAddressNotPermitted = Just (accountTokenHolder tcSenderAddress),
+                      trrAddressNotPermitted = Nothing,
                       trrReason = Just $ Text.pack $ "token operation " ++ op ++ " is paused"
                     }
 

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Module.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Module.hs
@@ -219,6 +219,7 @@ executeTokenUpdateTransaction TransactionContext{..} tokenParam = do
     let handleOperation !opIndex op = do
             case op of
                 PTOTransfer{..} -> do
+                    checkPaused opIndex "transfer"
                     recipientAccount <- requireAccount opIndex pthoRecipient
                     -- If the allow list is enabled, check that the sender and recipient are
                     -- both on the allow list.
@@ -295,6 +296,7 @@ executeTokenUpdateTransaction TransactionContext{..} tokenParam = do
                                 }
                     case tokenGovernanceOp of
                         PTOTokenMint{..} -> do
+                            checkPaused opIndex "mint"
                             requireFeature opIndex "mint" "mintable"
                             pltTickEnergy tokenMintCost
                             mintOK <- mint tcSender ptgoAmount
@@ -309,6 +311,7 @@ executeTokenUpdateTransaction TransactionContext{..} tokenParam = do
                                             toTokenAmount decimals (maxBound :: TokenRawAmount)
                                         }
                         PTOTokenBurn{..} -> do
+                            checkPaused opIndex "burn"
                             requireFeature opIndex "burn" "burnable"
                             pltTickEnergy tokenBurnCost
                             burnOK <- burn tcSender ptgoAmount
@@ -350,6 +353,15 @@ executeTokenUpdateTransaction TransactionContext{..} tokenParam = do
     tokenParamLBS =
         BS.Builder.toLazyByteString $ BS.Builder.shortByteString $ parameterBytes tokenParam
     failTH = pltError . encodeTokenRejectReason
+    checkPaused opIndex op = do
+        paused <- isJust <$> getTokenState "paused"
+        when paused $
+            failTH
+                OperationNotPermitted
+                    { trrOperationIndex = opIndex,
+                      trrAddressNotPermitted = Just (accountTokenHolder tcSenderAddress),
+                      trrReason = Just $ Text.pack $ "token operation " ++ op ++ " is paused"
+                    }
 
 -- | Check that a particular feature is enabled for the token, and otherwise fail with
 --  'UnsupportedOperation'.

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Module.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Module.hs
@@ -416,6 +416,7 @@ queryTokenModuleState = do
                 Nothing -> pltError $ QTEInvariantViolation "Governance account does not exist"
                 Just account -> return account
         accountTokenHolderShort <$> getAccountCanonicalAddress account
+    tmsPaused <- isJust <$> getTokenState "paused" 
     tmsAllowList <- Just . isJust <$> getTokenState "allowList"
     tmsDenyList <- Just . isJust <$> getTokenState "denyList"
     tmsMintable <- Just . isJust <$> getTokenState "mintable"

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Module.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Module.hs
@@ -428,7 +428,7 @@ queryTokenModuleState = do
                 Nothing -> pltError $ QTEInvariantViolation "Governance account does not exist"
                 Just account -> return account
         accountTokenHolderShort <$> getAccountCanonicalAddress account
-    tmsPaused <- isJust <$> getTokenState "paused" 
+    tmsPaused <- isJust <$> getTokenState "paused"
     tmsAllowList <- Just . isJust <$> getTokenState "allowList"
     tmsDenyList <- Just . isJust <$> getTokenState "denyList"
     tmsMintable <- Just . isJust <$> getTokenState "mintable"

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TokenModule.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TokenModule.hs
@@ -507,6 +507,7 @@ testExecuteTokenUpdateTransactionTransfer = describe "executeTokenUpdateTransact
         let trace :: Trace (PLTCall EncodedTokenRejectReason AccountIndex) ()
             trace =
                 (PLTQ GetDecimals :-> 3)
+                    :>>: (PLTQ (GetTokenState "paused") :-> Nothing)
                     :>>: (PLTQ (GetAccount (dummyAccountAddress 1)) :-> Just 4)
                     :>>: (PLTQ (GetTokenState "allowList") :-> Nothing)
                     :>>: (PLTQ (GetTokenState "denyList") :-> Nothing)
@@ -521,6 +522,7 @@ testExecuteTokenUpdateTransactionTransfer = describe "executeTokenUpdateTransact
         let trace :: Trace (PLTCall EncodedTokenRejectReason AccountIndex) ()
             trace =
                 (PLTQ GetDecimals :-> 0)
+                    :>>: (PLTQ (GetTokenState "paused") :-> Nothing)
                     :>>: (PLTQ (GetAccount (dummyAccountAddress 2)) :-> Just 4)
                     :>>: (PLTQ (GetTokenState "allowList") :-> Nothing)
                     :>>: (PLTQ (GetTokenState "denyList") :-> Nothing)
@@ -559,11 +561,13 @@ testExecuteTokenUpdateTransactionTransfer = describe "executeTokenUpdateTransact
         let trace :: Trace (PLTCall EncodedTokenRejectReason AccountIndex) ()
             trace =
                 (PLTQ GetDecimals :-> 6)
+                    :>>: (PLTQ (GetTokenState "paused") :-> Nothing)
                     :>>: (PLTQ (GetAccount (dummyAccountAddress 1)) :-> Just 4)
                     :>>: (PLTQ (GetTokenState "allowList") :-> Nothing)
                     :>>: (PLTQ (GetTokenState "denyList") :-> Nothing)
                     :>>: (PLTE (PLTChargeEnergy tokenTransferCost) :-> ())
                     :>>: (PLTU (Transfer 0 4 10_000_000 (Just cborMemo)) :-> True)
+                    :>>: (PLTQ (GetTokenState "paused") :-> Nothing)
                     :>>: (PLTQ (GetAccount (dummyAccountAddress 2)) :-> Just 121)
                     :>>: (PLTQ (GetTokenState "allowList") :-> Nothing)
                     :>>: (PLTQ (GetTokenState "denyList") :-> Nothing)
@@ -580,6 +584,7 @@ testExecuteTokenUpdateTransactionTransfer = describe "executeTokenUpdateTransact
         let trace :: Trace (PLTCall EncodedTokenRejectReason AccountIndex) ()
             trace =
                 (PLTQ GetDecimals :-> 6)
+                    :>>: (PLTQ (GetTokenState "paused") :-> Nothing)
                     :>>: (PLTQ (GetAccount (dummyAccountAddress 1)) :-> Just 4)
                     :>>: (PLTQ (GetTokenState "allowList") :-> Nothing)
                     :>>: (PLTQ (GetTokenState "denyList") :-> Nothing)
@@ -603,11 +608,13 @@ testExecuteTokenUpdateTransactionTransfer = describe "executeTokenUpdateTransact
         let trace :: Trace (PLTCall EncodedTokenRejectReason AccountIndex) ()
             trace =
                 (PLTQ GetDecimals :-> 6)
+                    :>>: (PLTQ (GetTokenState "paused") :-> Nothing)
                     :>>: (PLTQ (GetAccount (dummyAccountAddress 1)) :-> Just 4)
                     :>>: (PLTQ (GetTokenState "allowList") :-> Nothing)
                     :>>: (PLTQ (GetTokenState "denyList") :-> Nothing)
                     :>>: (PLTE (PLTChargeEnergy tokenTransferCost) :-> ())
                     :>>: (PLTU (Transfer 0 4 10_000_000 (Just cborMemo)) :-> True)
+                    :>>: (PLTQ (GetTokenState "paused") :-> Nothing)
                     :>>: (PLTQ (GetAccount (dummyAccountAddress 2)) :-> Just 16)
                     :>>: (PLTQ (GetTokenState "allowList") :-> Nothing)
                     :>>: (PLTQ (GetTokenState "denyList") :-> Nothing)
@@ -631,11 +638,13 @@ testExecuteTokenUpdateTransactionTransfer = describe "executeTokenUpdateTransact
         let trace :: Trace (PLTCall EncodedTokenRejectReason AccountIndex) ()
             trace =
                 (PLTQ GetDecimals :-> 6)
+                    :>>: (PLTQ (GetTokenState "paused") :-> Nothing)
                     :>>: (PLTQ (GetAccount (dummyAccountAddress 1)) :-> Just 4)
                     :>>: (PLTQ (GetTokenState "allowList") :-> Nothing)
                     :>>: (PLTQ (GetTokenState "denyList") :-> Nothing)
                     :>>: (PLTE (PLTChargeEnergy tokenTransferCost) :-> ())
                     :>>: (PLTU (Transfer 0 4 10_000_000 (Just cborMemo)) :-> True)
+                    :>>: (PLTQ (GetTokenState "paused") :-> Nothing)
                     :>>: (PLTQ (GetAccount (dummyAccountAddress 2)) :-> Nothing)
                     :>>: ( abortPLTError . encodeTokenRejectReason $
                             AddressNotFound
@@ -651,6 +660,7 @@ testExecuteTokenUpdateTransactionTransfer = describe "executeTokenUpdateTransact
         let trace :: Trace (PLTCall EncodedTokenRejectReason AccountIndex) ()
             trace =
                 (PLTQ GetDecimals :-> 6)
+                    :>>: (PLTQ (GetTokenState "paused") :-> Nothing)
                     :>>: (PLTQ (GetAccount (dummyAccountAddress 1)) :-> Just 4)
                     :>>: (PLTQ (GetTokenState "allowList") :-> Just "")
                     :>>: (PLTQ (GetAccountState 0 "allowList") :-> Just "")
@@ -667,6 +677,7 @@ testExecuteTokenUpdateTransactionTransfer = describe "executeTokenUpdateTransact
         let trace :: Trace (PLTCall EncodedTokenRejectReason AccountIndex) ()
             trace =
                 (PLTQ GetDecimals :-> 6)
+                    :>>: (PLTQ (GetTokenState "paused") :-> Nothing)
                     :>>: (PLTQ (GetAccount (dummyAccountAddress 1)) :-> Just 4)
                     :>>: (PLTQ (GetTokenState "allowList") :-> Just "")
                     :>>: (PLTQ (GetAccountState 0 "allowList") :-> Nothing)
@@ -686,6 +697,7 @@ testExecuteTokenUpdateTransactionTransfer = describe "executeTokenUpdateTransact
         let trace :: Trace (PLTCall EncodedTokenRejectReason AccountIndex) ()
             trace =
                 (PLTQ GetDecimals :-> 6)
+                    :>>: (PLTQ (GetTokenState "paused") :-> Nothing)
                     :>>: (PLTQ (GetAccount (dummyAccountAddress 1)) :-> Just 9)
                     :>>: (PLTQ (GetTokenState "allowList") :-> Just "")
                     :>>: (PLTQ (GetAccountState 23 "allowList") :-> Just "")
@@ -705,6 +717,7 @@ testExecuteTokenUpdateTransactionTransfer = describe "executeTokenUpdateTransact
         let trace :: Trace (PLTCall EncodedTokenRejectReason AccountIndex) ()
             trace =
                 (PLTQ GetDecimals :-> 6)
+                    :>>: (PLTQ (GetTokenState "paused") :-> Nothing)
                     :>>: (PLTQ (GetAccount (dummyAccountAddress 1)) :-> Just 4)
                     :>>: (PLTQ (GetTokenState "allowList") :-> Nothing)
                     :>>: (PLTQ (GetTokenState "denyList") :-> Just "")
@@ -721,6 +734,7 @@ testExecuteTokenUpdateTransactionTransfer = describe "executeTokenUpdateTransact
         let trace :: Trace (PLTCall EncodedTokenRejectReason AccountIndex) ()
             trace =
                 (PLTQ GetDecimals :-> 6)
+                    :>>: (PLTQ (GetTokenState "paused") :-> Nothing)
                     :>>: (PLTQ (GetAccount (dummyAccountAddress 1)) :-> Just 4)
                     :>>: (PLTQ (GetTokenState "allowList") :-> Nothing)
                     :>>: (PLTQ (GetTokenState "denyList") :-> Just "")
@@ -741,6 +755,7 @@ testExecuteTokenUpdateTransactionTransfer = describe "executeTokenUpdateTransact
         let trace :: Trace (PLTCall EncodedTokenRejectReason AccountIndex) ()
             trace =
                 (PLTQ GetDecimals :-> 6)
+                    :>>: (PLTQ (GetTokenState "paused") :-> Nothing)
                     :>>: (PLTQ (GetAccount (dummyAccountAddress 1)) :-> Just 4)
                     :>>: (PLTQ (GetTokenState "allowList") :-> Nothing)
                     :>>: (PLTQ (GetTokenState "denyList") :-> Just "")
@@ -761,6 +776,7 @@ testExecuteTokenUpdateTransactionTransfer = describe "executeTokenUpdateTransact
         let trace :: Trace (PLTCall EncodedTokenRejectReason AccountIndex) ()
             trace =
                 (PLTQ GetDecimals :-> 6)
+                    :>>: (PLTQ (GetTokenState "paused") :-> Nothing)
                     :>>: (PLTQ (GetAccount (dummyAccountAddress 1)) :-> Just 4)
                     :>>: (PLTQ (GetTokenState "allowList") :-> Just "")
                     :>>: (PLTQ (GetAccountState 0 "allowList") :-> Just "")
@@ -786,7 +802,8 @@ testExecuteTokenUpdateTransactionTransfer = describe "executeTokenUpdateTransact
             traceLoop n
                 | n > 5000 = Done ()
                 | otherwise =
-                    (PLTQ (GetAccount (dummyAccountAddress (fromIntegral n))) :-> Just n)
+                        (PLTQ (GetTokenState "paused") :-> Nothing)
+                        :>>: (PLTQ (GetAccount (dummyAccountAddress (fromIntegral n))) :-> Just n)
                         :>>: (PLTQ (GetTokenState "allowList") :-> Nothing)
                         :>>: (PLTQ (GetTokenState "denyList") :-> Nothing)
                         :>>: (PLTE (PLTChargeEnergy tokenTransferCost) :-> ())
@@ -847,6 +864,29 @@ testExecuteTokenUpdateTransactionMintBurn = describe "executeTokenUpdateTransact
                                 }
                          )
         assertTrace (executeTokenUpdateTransaction (sender 1) (encodeTransaction transaction)) trace
+    it "paused operation" $ do
+        let transaction =
+                TokenUpdateTransaction . Seq.fromList $
+                    [TokenMint (TokenAmount 10_000_000 6)]
+        let trace :: Trace (PLTCall EncodedTokenRejectReason AccountIndex) ()
+            trace =
+                (PLTQ GetDecimals :-> 6)
+                    :>>: (PLTQ (GetTokenState "governanceAccount") :-> Just (encode (AccountIndex 0)))
+                    :>>: (PLTQ (GetAccountIndex 0) :-> AccountIndex 0)
+                    :>>: (PLTQ (GetTokenState "paused") :-> Just "")
+                    :>>: ( abortPLTError . encodeTokenRejectReason $
+                            OperationNotPermitted
+                                { trrOperationIndex = 0,
+                                  trrAddressNotPermitted =
+                                    Just $
+                                        CborHolderAccount
+                                            { chaAccount = dummyAccountAddress 0,
+                                              chaCoinInfo = Just CoinInfoConcordium
+                                            },
+                                  trrReason = Just "token operation mint is paused"
+                                }
+                         )
+        assertTrace (executeTokenUpdateTransaction (sender 0) (encodeTransaction transaction)) trace
     it "mint: OK" $ do
         let transaction =
                 TokenUpdateTransaction . Seq.fromList $
@@ -856,6 +896,7 @@ testExecuteTokenUpdateTransactionMintBurn = describe "executeTokenUpdateTransact
                 (PLTQ GetDecimals :-> 6)
                     :>>: (PLTQ (GetTokenState "governanceAccount") :-> Just (encode (AccountIndex 0)))
                     :>>: (PLTQ (GetAccountIndex 0) :-> AccountIndex 0)
+                    :>>: (PLTQ (GetTokenState "paused") :-> Nothing)
                     :>>: (PLTQ (GetTokenState "mintable") :-> Just "")
                     :>>: (PLTE (PLTChargeEnergy tokenMintCost) :-> ())
                     :>>: (PLTPU (Mint 0 10_000_000) :-> True)
@@ -870,6 +911,7 @@ testExecuteTokenUpdateTransactionMintBurn = describe "executeTokenUpdateTransact
                 (PLTQ GetDecimals :-> 6)
                     :>>: (PLTQ (GetTokenState "governanceAccount") :-> Just (encode (AccountIndex 0)))
                     :>>: (PLTQ (GetAccountIndex 0) :-> AccountIndex 0)
+                    :>>: (PLTQ (GetTokenState "paused") :-> Nothing)
                     :>>: (PLTQ (GetTokenState "mintable") :-> Nothing)
                     :>>: ( abortPLTError . encodeTokenRejectReason $
                             UnsupportedOperation
@@ -888,6 +930,7 @@ testExecuteTokenUpdateTransactionMintBurn = describe "executeTokenUpdateTransact
                 (PLTQ GetDecimals :-> 6)
                     :>>: (PLTQ (GetTokenState "governanceAccount") :-> Just (encode (AccountIndex 0)))
                     :>>: (PLTQ (GetAccountIndex 0) :-> AccountIndex 0)
+                    :>>: (PLTQ (GetTokenState "paused") :-> Nothing)
                     :>>: (PLTQ (GetTokenState "mintable") :-> Just "")
                     :>>: (PLTE (PLTChargeEnergy tokenMintCost) :-> ())
                     :>>: (PLTPU (Mint 0 10_000_000) :-> False)
@@ -910,6 +953,7 @@ testExecuteTokenUpdateTransactionMintBurn = describe "executeTokenUpdateTransact
                 (PLTQ GetDecimals :-> 6)
                     :>>: (PLTQ (GetTokenState "governanceAccount") :-> Just (encode (AccountIndex 0)))
                     :>>: (PLTQ (GetAccountIndex 0) :-> AccountIndex 0)
+                    :>>: (PLTQ (GetTokenState "paused") :-> Nothing)
                     :>>: (PLTQ (GetTokenState "burnable") :-> Just "")
                     :>>: (PLTE (PLTChargeEnergy tokenBurnCost) :-> ())
                     :>>: (PLTPU (Burn 0 10_000_000) :-> True)
@@ -924,6 +968,7 @@ testExecuteTokenUpdateTransactionMintBurn = describe "executeTokenUpdateTransact
                 (PLTQ GetDecimals :-> 6)
                     :>>: (PLTQ (GetTokenState "governanceAccount") :-> Just (encode (AccountIndex 0)))
                     :>>: (PLTQ (GetAccountIndex 0) :-> AccountIndex 0)
+                    :>>: (PLTQ (GetTokenState "paused") :-> Nothing)
                     :>>: (PLTQ (GetTokenState "burnable") :-> Nothing)
                     :>>: ( abortPLTError . encodeTokenRejectReason $
                             UnsupportedOperation
@@ -942,6 +987,7 @@ testExecuteTokenUpdateTransactionMintBurn = describe "executeTokenUpdateTransact
                 (PLTQ GetDecimals :-> 6)
                     :>>: (PLTQ (GetTokenState "governanceAccount") :-> Just (encode (AccountIndex 0)))
                     :>>: (PLTQ (GetAccountIndex 0) :-> AccountIndex 0)
+                    :>>: (PLTQ (GetTokenState "paused") :-> Nothing)
                     :>>: (PLTQ (GetTokenState "burnable") :-> Just "")
                     :>>: (PLTE (PLTChargeEnergy tokenBurnCost) :-> ())
                     :>>: (PLTPU (Burn 0 10_000_000) :-> False)
@@ -965,11 +1011,13 @@ testExecuteTokenUpdateTransactionMintBurn = describe "executeTokenUpdateTransact
                 (PLTQ GetDecimals :-> 6)
                     :>>: (PLTQ (GetTokenState "governanceAccount") :-> Just (encode (AccountIndex 0)))
                     :>>: (PLTQ (GetAccountIndex 0) :-> AccountIndex 0)
+                    :>>: (PLTQ (GetTokenState "paused") :-> Nothing)
                     :>>: (PLTQ (GetTokenState "mintable") :-> Just "")
                     :>>: (PLTE (PLTChargeEnergy tokenMintCost) :-> ())
                     :>>: (PLTPU (Mint 0 10_000_000) :-> True)
                     :>>: (PLTQ (GetTokenState "governanceAccount") :-> Just (encode (AccountIndex 0)))
                     :>>: (PLTQ (GetAccountIndex 0) :-> AccountIndex 0)
+                    :>>: (PLTQ (GetTokenState "paused") :-> Nothing)
                     :>>: (PLTQ (GetTokenState "burnable") :-> Just "")
                     :>>: (PLTE (PLTChargeEnergy tokenBurnCost) :-> ())
                     :>>: (PLTPU (Burn 0 5_000_000) :-> True)
@@ -1087,6 +1135,7 @@ testQueryTokenModuleState = describe "queryTokenModuleState" $ do
                     :>>: (PLTQ (GetTokenState "governanceAccount") :-> Just (encode (AccountIndex 1)))
                     :>>: (PLTQ (GetAccountByIndex (AccountIndex 1)) :-> Just 1)
                     :>>: (PLTQ (GetAccountCanonicalAddress 1) :-> dummyAccountAddress 1)
+                    :>>: (PLTQ (GetTokenState "paused") :-> Nothing)
                     :>>: (PLTQ (GetTokenState "allowList") :-> Just "")
                     :>>: (PLTQ (GetTokenState "denyList") :-> Nothing)
                     :>>: (PLTQ (GetTokenState "mintable") :-> Just "")
@@ -1097,6 +1146,7 @@ testQueryTokenModuleState = describe "queryTokenModuleState" $ do
                                 { tmsName = "My protocol-level token",
                                   tmsMetadata = metadata,
                                   tmsGovernanceAccount = governanceAccount,
+                                  tmsPaused = False,
                                   tmsAllowList = Just True,
                                   tmsDenyList = Just False,
                                   tmsMintable = Just True,
@@ -1119,6 +1169,7 @@ testQueryTokenModuleState = describe "queryTokenModuleState" $ do
                     :>>: (PLTQ (GetTokenState "governanceAccount") :-> Just (encode (AccountIndex 1)))
                     :>>: (PLTQ (GetAccountByIndex (AccountIndex 1)) :-> Just 1)
                     :>>: (PLTQ (GetAccountCanonicalAddress 1) :-> dummyAccountAddress 1)
+                    :>>: (PLTQ (GetTokenState "paused") :-> Nothing)
                     :>>: (PLTQ (GetTokenState "allowList") :-> Nothing)
                     :>>: (PLTQ (GetTokenState "denyList") :-> Just "")
                     :>>: (PLTQ (GetTokenState "mintable") :-> Nothing)
@@ -1129,6 +1180,7 @@ testQueryTokenModuleState = describe "queryTokenModuleState" $ do
                                 { tmsName = "Another PLT",
                                   tmsMetadata = metadata,
                                   tmsGovernanceAccount = governanceAccount,
+                                  tmsPaused = False,
                                   tmsAllowList = Just False,
                                   tmsDenyList = Just True,
                                   tmsMintable = Just False,
@@ -1452,7 +1504,8 @@ testTokenOutOfEnergy = describe "tokenOutOfEnergy" $ do
         bs2 <- bsoSetTokenState bs1 0 "mintable" (Just "")
         bs3 <- bsoSetTokenState bs2 0 "burnable" (Just "")
         bs4 <- bsoSetTokenState bs3 0 "governanceAccount" (Just (encode (AccountIndex 0)))
-        hashBlockState bs4
+        bs5 <- bsoSetTokenState bs4 0 "paused" Nothing
+        hashBlockState bs5
 
 tests :: Spec
 tests = describe "TokenModule" $ do

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TokenModule.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TokenModule.hs
@@ -511,12 +511,7 @@ testExecuteTokenUpdateTransactionTransfer = describe "executeTokenUpdateTransact
                     :>>: ( abortPLTError . encodeTokenRejectReason $
                             OperationNotPermitted
                                 { trrOperationIndex = 0,
-                                  trrAddressNotPermitted =
-                                    Just $
-                                        CborHolderAccount
-                                            { chaAccount = dummyAccountAddress 0,
-                                              chaCoinInfo = Just CoinInfoConcordium
-                                            },
+                                  trrAddressNotPermitted = Nothing,
                                   trrReason = Just "token operation transfer is paused"
                                 }
                          )
@@ -898,12 +893,7 @@ testExecuteTokenUpdateTransactionMintBurn = describe "executeTokenUpdateTransact
                     :>>: ( abortPLTError . encodeTokenRejectReason $
                             OperationNotPermitted
                                 { trrOperationIndex = 0,
-                                  trrAddressNotPermitted =
-                                    Just $
-                                        CborHolderAccount
-                                            { chaAccount = dummyAccountAddress 0,
-                                              chaCoinInfo = Just CoinInfoConcordium
-                                            },
+                                  trrAddressNotPermitted = Nothing,
                                   trrReason = Just "token operation mint is paused"
                                 }
                          )
@@ -993,12 +983,7 @@ testExecuteTokenUpdateTransactionMintBurn = describe "executeTokenUpdateTransact
                     :>>: ( abortPLTError . encodeTokenRejectReason $
                             OperationNotPermitted
                                 { trrOperationIndex = 0,
-                                  trrAddressNotPermitted =
-                                    Just $
-                                        CborHolderAccount
-                                            { chaAccount = dummyAccountAddress 0,
-                                              chaCoinInfo = Just CoinInfoConcordium
-                                            },
+                                  trrAddressNotPermitted = Nothing,
                                   trrReason = Just "token operation burn is paused"
                                 }
                          )


### PR DESCRIPTION
This adds the 'pause' logic to `executeTokenUpdateTransaction` in the scheduler.