### PR TITLE
Require TokenModuleRef to match defined value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Protocol-level tokens:
   - Adjusted energy cost of mint/burn from 100 to 50
+  - PLTs can now only be created with the module reference:
+    5c5c2645db84a7026d78f2501740f60a8ccb8fae5c166dc2428077fd9a699a4a
 
 ## 9.0.5 (DevNet)
 

--- a/concordium-consensus/src/Concordium/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler.hs
@@ -2900,11 +2900,13 @@ handleCreatePLT updateHeader payload = runExceptT $ do
     let tokenId = payload ^. cpltTokenId
     maybeExistingToken <- lift $ getTokenIndex tokenId
     when (isJust maybeExistingToken) $ throwError $ DuplicateTokenId tokenId
+    let tokenModuleRef = payload ^. cpltTokenModule
+    unless (tokenModuleRef == TokenModule.tokenModuleV0Ref) $ throwError $ InvalidTokenModuleRef tokenModuleRef
     createResult <- lift . withBlockStateRollback $ do
         let config =
                 PLTConfiguration
                     { _pltTokenId = tokenId,
-                      _pltModule = payload ^. cpltTokenModule,
+                      _pltModule = tokenModuleRef,
                       _pltDecimals = payload ^. cpltDecimals
                     }
         tokenIx <- createToken config

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Module.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Module.hs
@@ -16,11 +16,19 @@ import qualified Data.Text.Encoding as Text
 import Data.Word
 
 import Concordium.Cost
+import Concordium.Crypto.SHA256 as Hash
 import Concordium.Types
 import Concordium.Types.ProtocolLevelTokens.CBOR
 import Concordium.Types.Tokens
 
 import Concordium.Scheduler.ProtocolLevelTokens.Kernel
+
+-- | The token module reference for version 0 of the token module.
+--  This is the hash of "TokenModuleV0".
+--
+--  5c5c2645db84a7026d78f2501740f60a8ccb8fae5c166dc2428077fd9a699a4a
+tokenModuleV0Ref :: TokenModuleRef
+tokenModuleV0Ref = TokenModuleRef $ Hash.hash "TokenModuleV0"
 
 -- | The context for a token-holder or token-governance transaction.
 data TransactionContext' account = TransactionContext

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TokenHolderTransactions.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TokenHolderTransactions.hs
@@ -17,12 +17,12 @@ import qualified Concordium.GlobalState.DummyData as DummyData
 import qualified Concordium.GlobalState.Persistent.Account as BS
 import qualified Concordium.GlobalState.Persistent.BlobStore as Blob
 import qualified Concordium.GlobalState.Persistent.BlockState as BS
+import Concordium.Scheduler.DummyData
+import Concordium.Scheduler.ProtocolLevelTokens.Module (tokenModuleV0Ref)
 import qualified Concordium.Scheduler.Runner as Runner
 import Concordium.Scheduler.Types
 import qualified Concordium.Scheduler.Types as Types
 import qualified Concordium.Types.DummyData as DummyData
-
-import Concordium.Scheduler.DummyData
 
 import Data.Bool.Singletons
 import qualified Data.ByteString.Short as BSS
@@ -149,7 +149,7 @@ testTokenHolder _ pvString =
               tipBurnable = True
             }
     tp = Types.TokenParameter $ BSS.toShort $ CBOR.tokenInitializationParametersToBytes params
-    createPLT = Types.CreatePLT gtu (TokenModuleRef dummyHash) 0 tp
+    createPLT = Types.CreatePLT gtu tokenModuleV0Ref 0 tp
     plt = Types.CreatePLTUpdatePayload createPLT
     gtuEvent = TokenCreated{etcPayload = createPLT}
     -- This is CBOR-encoding of {"cause": "DeserialiseFailure 0 \"end of input\""}


### PR DESCRIPTION
## Purpose

Closes [COR-1553](https://linear.app/concordium/issue/COR-1553/require-tokenmoduleref-to-match-defined-value)

This adds a check that the `TokenModuleRef` used when creating a PLT is a specific value, namely the SHA256 hash of the String `TokenModuleV0`.

## Changes

- Introduce `tokenModuleV0Ref` constant to reference the current token module implementation.
- `handleCreatePLT` tests for the appropriate reference and fails if it does not match `tokenModuleV0Ref`.
- Tests are updated to use the correct ref and test for failure with a different ref.


## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
