### PR TITLE
COR-1345: verification for CreatePLT in TransactionVerifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased changes
+- Protocol-level tokens:
+  - Additional check in transaction verification asserting that the effective
+    time equals zero of CreatePLT update transactions.
 
 - Add P8 -> P9 update.
 - Update GHC version to 9.10.2 (lts-24.0).

--- a/concordium-consensus/src/Concordium/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler.hs
@@ -210,6 +210,7 @@ checkTransactionVerificationResult (TVer.NotOk TVer.NormalTransactionDepositInsu
 checkTransactionVerificationResult (TVer.NotOk (TVer.NormalTransactionDuplicateNonce nonce)) = Left $ NonSequentialNonce nonce
 checkTransactionVerificationResult (TVer.NotOk TVer.Expired) = Left ExpiredTransaction
 checkTransactionVerificationResult (TVer.NotOk TVer.InvalidPayloadSize) = Left InvalidPayloadSize
+checkTransactionVerificationResult (TVer.NotOk TVer.ChainUpdateEffectiveTimeNonZeroForCreatePLT) = Left InvalidEffectiveTime
 
 -- | Execute a transaction on the current block state, charging valid accounts
 -- for the resulting energy cost.

--- a/concordium-consensus/src/Concordium/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler.hs
@@ -210,7 +210,7 @@ checkTransactionVerificationResult (TVer.NotOk TVer.NormalTransactionDepositInsu
 checkTransactionVerificationResult (TVer.NotOk (TVer.NormalTransactionDuplicateNonce nonce)) = Left $ NonSequentialNonce nonce
 checkTransactionVerificationResult (TVer.NotOk TVer.Expired) = Left ExpiredTransaction
 checkTransactionVerificationResult (TVer.NotOk TVer.InvalidPayloadSize) = Left InvalidPayloadSize
-checkTransactionVerificationResult (TVer.NotOk TVer.ChainUpdateEffectiveTimeNonZeroForCreatePLT) = Left InvalidEffectiveTime
+checkTransactionVerificationResult (TVer.NotOk TVer.ChainUpdateEffectiveTimeNonZeroForCreatePLT) = Left InvalidUpdateTime
 
 -- | Execute a transaction on the current block state, charging valid accounts
 -- for the resulting energy cost.

--- a/concordium-consensus/src/Concordium/Skov/Monad.hs
+++ b/concordium-consensus/src/Concordium/Skov/Monad.hs
@@ -140,6 +140,7 @@ transactionVerificationResultToUpdateResult (TV.NotOk TV.NormalTransactionDeposi
 transactionVerificationResultToUpdateResult (TV.NotOk (TV.NormalTransactionDuplicateNonce _)) = ResultDuplicateNonce
 transactionVerificationResultToUpdateResult (TV.NotOk TV.Expired) = ResultStale
 transactionVerificationResultToUpdateResult (TV.NotOk TV.InvalidPayloadSize) = ResultSerializationFail
+transactionVerificationResultToUpdateResult (TV.NotOk TV.ChainUpdateEffectiveTimeNonZeroForCreatePLT) = ResultChainUpdateInvalidEffectiveTime
 
 class
     ( Monad m,

--- a/concordium-consensus/src/Concordium/TransactionVerification.hs
+++ b/concordium-consensus/src/Concordium/TransactionVerification.hs
@@ -130,6 +130,8 @@ data NotOkResult
       CredentialDeploymentInvalidSignatures
     | -- | The 'ChainUpdate' had an expiry set too late.
       ChainUpdateEffectiveTimeBeforeTimeout
+    | -- | The 'ChainUpdate' is creating a PLT, but its effective time is non-zero.
+      ChainUpdateEffectiveTimeNonZeroForCreatePLT
     | -- | The `UpdateSequenceNumber` of the 'ChainUpdate' was too old.
       --  Reason for 'NotOk': the UpdateSequenceNumber can never be valid in a later block if the
       --  nonce is already used.
@@ -271,23 +273,28 @@ verifyChainUpdate ui@Updates.UpdateInstruction{..} =
                 unless (Types.validatePayloadSize (Types.protocolVersion @(Types.MPV m)) (Updates.updatePayloadSize uiHeader)) $
                     throwError $
                         NotOk InvalidPayloadSize
-                -- Check that the timeout is no later than the effective time,
-                -- or the update is immediate
-                when (Updates.updateTimeout uiHeader >= Updates.updateEffectiveTime uiHeader && Updates.updateEffectiveTime uiHeader /= 0) $
-                    throwError $
-                        NotOk ChainUpdateEffectiveTimeBeforeTimeout
-                -- check that the sequence number is not too old.
-                nextSN <- lift $ getNextUpdateSequenceNumber (Updates.updateType (Updates.uiPayload ui))
-                let nonce = Updates.updateSeqNumber (Updates.uiHeader ui)
-                when (nextSN > nonce) $ throwError $ NotOk $ ChainUpdateSequenceNumberTooOld nextSN
-                -- if this transaction was received individually then we also verify that the sequence
-                -- number is the next one.
-                exactSequenceNumber <- lift checkExactNonce
-                when (exactSequenceNumber && nonce /= nextSN) $ throwError (MaybeOk $ ChainUpdateInvalidNonce nextSN)
-                -- check the signature is valid
-                keys <- lift getUpdateKeysCollection
-                unless (Updates.checkAuthorizedUpdate keys ui) $ throwError $ MaybeOk ChainUpdateInvalidSignatures
-                return $ Ok $ ChainUpdateSuccess (getHash keys) nonce
+                case uiPayload of
+                    Updates.CreatePLTUpdatePayload _
+                        | Updates.updateEffectiveTime uiHeader > 0 ->
+                            throwError $ NotOk ChainUpdateEffectiveTimeNonZeroForCreatePLT
+                    _otherwise -> do
+                        -- Check that the timeout is no later than the effective time,
+                        -- or the update is immediate
+                        when (Updates.updateTimeout uiHeader >= Updates.updateEffectiveTime uiHeader && Updates.updateEffectiveTime uiHeader /= 0) $
+                            throwError $
+                                NotOk ChainUpdateEffectiveTimeBeforeTimeout
+                        -- check that the sequence number is not too old.
+                        nextSN <- lift $ getNextUpdateSequenceNumber (Updates.updateType (Updates.uiPayload ui))
+                        let nonce = Updates.updateSeqNumber (Updates.uiHeader ui)
+                        when (nextSN > nonce) $ throwError $ NotOk $ ChainUpdateSequenceNumberTooOld nextSN
+                        -- if this transaction was received individually then we also verify that the sequence
+                        -- number is the next one.
+                        exactSequenceNumber <- lift checkExactNonce
+                        when (exactSequenceNumber && nonce /= nextSN) $ throwError (MaybeOk $ ChainUpdateInvalidNonce nextSN)
+                        -- check the signature is valid
+                        keys <- lift getUpdateKeysCollection
+                        unless (Updates.checkAuthorizedUpdate keys ui) $ throwError $ MaybeOk ChainUpdateInvalidSignatures
+                        return $ Ok $ ChainUpdateSuccess (getHash keys) nonce
             )
 
 -- | Verifies a 'NormalTransaction' transaction.

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Common.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Common.hs
@@ -148,8 +148,8 @@ forEveryProtocolVersion check =
           check SP3 "P3",
           check SP4 "P4",
           check SP5 "P5",
-          check SP6 "P6"
-          -- check SP7 "P7",
+          check SP6 "P6",
+          check SP7 "P7"
           -- check SP8 "P8",
           -- check SP9 "P9"
         ]

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Common.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Common.hs
@@ -148,10 +148,10 @@ forEveryProtocolVersion check =
           check SP3 "P3",
           check SP4 "P4",
           check SP5 "P5",
-          check SP6 "P6",
-          check SP7 "P7",
-          check SP8 "P8",
-          check SP9 "P9"
+          check SP6 "P6"
+          -- check SP7 "P7",
+          -- check SP8 "P8",
+          -- check SP9 "P9"
         ]
 
 -- | Run tests for each protocol version using consensus v1 (P6 and onwards).

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Common.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Common.hs
@@ -149,7 +149,9 @@ forEveryProtocolVersion check =
           check SP4 "P4",
           check SP5 "P5",
           check SP6 "P6",
-          check SP7 "P7"
+          check SP7 "P7",
+          check SP8 "P8",
+          check SP9 "P9"
         ]
 
 -- | Run tests for each protocol version using consensus v1 (P6 and onwards).

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/TransactionProcessingTest.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/TransactionProcessingTest.hs
@@ -402,7 +402,7 @@ testTransactionVerification _ = describe "transaction verification" $ do
                 verifyBlockItem t (dummyChainUpdateBI 0) ctx
         assertEqual
             "A correct transaction should be verified"
-            (TVer.Ok TVer.ChainUpdateSuccess{keysHash = Hash.hash "dummy", seqNumber = 1})
+            (TVer.Ok TVer.ChainUpdateSuccess{keysHash = getHash (dummyKeyCollection @(AuthorizationsVersionFor pv)), seqNumber = 1})
             verResult
     it "ChainUpdate: CreatePLT: Non-zero effective time for CreatePLT" $ do
         (verResult, _) <- runMyTestMonad @pv myIdentityProviders theTime $

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/TransactionProcessingTest.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/TransactionProcessingTest.hs
@@ -71,6 +71,8 @@ import Concordium.Types.Option
 import Concordium.Types.Parameters
 import Concordium.Types.TransactionOutcomes
 import Concordium.Types.Transactions
+import Concordium.Types.Updates
+import Concordium.Utils
 
 import Concordium.GlobalState.Transactions
 import Concordium.KonsensusV1.Transactions
@@ -329,8 +331,8 @@ dummyAccountAddress = fst $ randomAccountAddress (mkStdGen 42)
 --  relation to the tree state in this test, hence
 --  when processed it will fail on looking up the sender.
 --  Note. that the signature is not correct either.
-dummyTransaction :: Transaction
-dummyTransaction =
+dummyNormalTransaction :: Transaction
+dummyNormalTransaction =
     addMetadata NormalTransaction 0 $
         makeAccountTransaction
             dummyTransactionSignature
@@ -347,9 +349,81 @@ dummyTransaction =
             }
     payload = encodePayload $ Transfer dummyAccountAddress 10
 
--- | The block item for 'dummyTransaction'.
-dummyTransactionBI :: BlockItem
-dummyTransactionBI = normalTransaction dummyTransaction
+-- | A dummy update instruction.
+--
+-- TODO (drsk) The signature needs to be changed to a correct one.
+dummyUpdateInstruction :: TransactionTime -> WithMetadata UpdateInstruction
+dummyUpdateInstruction effTime =
+    addMetadata ChainUpdate 0 $
+        UpdateInstruction
+            { uiHeader = hdr,
+              uiPayload = cplt,
+              uiSignHash = makeUpdateInstructionSignHash "dummy",
+              uiSignatures = UpdateInstructionSignatures{signatures = Map.singleton 0 sig}
+            }
+  where
+    sig = SigScheme.sign dummySigSchemeKeys "updateInstruction"
+    hdr =
+        UpdateHeader
+            { updateSeqNumber = 1,
+              updateEffectiveTime = effTime,
+              updateTimeout = 2,
+              updatePayloadSize = 100
+            }
+    cplt =
+        CreatePLTUpdatePayload $
+            CreatePLT
+                { _cpltTokenId = TokenId "dummyToken",
+                  _cpltTokenModule = TokenModuleRef $ Hash.hash "dummyToken",
+                  _cpltDecimals = 4,
+                  _cpltInitializationParameters = TokenParameter ""
+                }
+
+-- | The block item for 'dummyNormalTransaction'.
+dummyNormalTransactionBI :: BlockItem
+dummyNormalTransactionBI = normalTransaction dummyNormalTransaction
+
+-- | The block item for 'dummyUpdateInstruction'.
+dummyChainUpdateBI :: TransactionTime -> BlockItem
+dummyChainUpdateBI effTime = chainUpdate $ dummyUpdateInstruction effTime
+
+-- | Test for transaction verification
+testTransactionVerification ::
+    forall pv.
+    (IsConsensusV1 pv, IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    Spec
+testTransactionVerification _ = describe "transaction verification" $ do
+    it "ChainUpdate: CreatePLT: Ok" $ do
+        (verResult, _) <- runMyTestMonad @pv myIdentityProviders theTime $
+            do
+                t <- utcTimeToTimestamp <$> currentTime
+                ctx <- getCtx
+                verifyBlockItem t (dummyChainUpdateBI 0) ctx
+        assertEqual
+            "A correct transaction should be verified"
+            (TVer.Ok TVer.ChainUpdateSuccess{keysHash = Hash.hash "dummy", seqNumber = 1})
+            verResult
+    it "ChainUpdate: CreatePLT: Non-zero effective time for CreatePLT" $ do
+        (verResult, _) <- runMyTestMonad @pv myIdentityProviders theTime $
+            do
+                t <- utcTimeToTimestamp <$> currentTime
+                ctx <- getCtx
+                verifyBlockItem t (dummyChainUpdateBI 1) ctx
+        assertEqual
+            "A CreatePLT update with non-zero effective time should be rejected"
+            (TVer.NotOk TVer.ChainUpdateEffectiveTimeNonZeroForCreatePLT)
+            verResult
+  where
+    -- Create a context suitable for verifying a transaction within a 'Individual' context.
+    getCtx = do
+        _ctxBs <- bpState <$> gets' _lastFinalized
+        let chainParams = dummyChainParameters @(ChainParametersVersionFor pv)
+        let _ctxMaxBlockEnergy = chainParams ^. cpConsensusParameters . cpBlockEnergyLimit
+        return $! Context{_ctxTransactionOrigin = TVer.Individual, ..}
+
+    theTime :: UTCTime
+    theTime = posixSecondsToUTCTime 1 -- after genesis
 
 -- | Testing various cases for processing a block item individually.
 testProcessBlockItem ::
@@ -384,7 +458,7 @@ testProcessBlockItem _ = describe "processBlockItem" $ do
     it "MaybeOk transaction" $ do
         -- We use a normal transfer transaction here with an invalid sender as it will yield a
         -- 'MaybeOk' verification result.
-        (pbiRes, sd') <- runMyTestMonad @pv dummyIdentityProviders theTime (processBlockItem dummyTransactionBI)
+        (pbiRes, sd') <- runMyTestMonad @pv dummyIdentityProviders theTime (processBlockItem dummyNormalTransactionBI)
         assertEqual
             "The credential deployment should be rejected (the identity provider has correct id but wrong keys used for the credential deployment)"
             (NotAdded $ TVer.MaybeOk $ TVer.NormalTransactionInvalidSender dummyAccountAddress)
@@ -454,7 +528,7 @@ testProcessBlockItems sProtocolVersion = describe "processBlockItems" $ do
     it "A non verifiable transaction first in the block makes it fail and stop processing the rest" $ do
         (processed, sd') <-
             runMyTestMonad dummyIdentityProviders theTime $
-                processBlockItems (blockToProcess [dummyCredentialDeployment, dummyTransactionBI]) =<< _lastFinalized <$> get
+                processBlockItems (blockToProcess [dummyCredentialDeployment, dummyNormalTransactionBI]) =<< _lastFinalized <$> get
         assertBool
             "Block should not have been successfully processed"
             (null processed)
@@ -465,7 +539,7 @@ testProcessBlockItems sProtocolVersion = describe "processBlockItems" $ do
     it "A non verifiable transaction last in the block makes it fail but the valid ones have been put into the state." $ do
         (processed, sd') <-
             runMyTestMonad dummyIdentityProviders theTime $
-                processBlockItems (blockToProcess [dummyTransactionBI, dummyCredentialDeployment]) =<< _lastFinalized <$> get
+                processBlockItems (blockToProcess [dummyNormalTransactionBI, dummyCredentialDeployment]) =<< _lastFinalized <$> get
         assertBool
             "Block should not have been successfully processed"
             (null processed)
@@ -476,7 +550,7 @@ testProcessBlockItems sProtocolVersion = describe "processBlockItems" $ do
     it "A block consisting of verifiable transactions only is accepted" $ do
         (processed, sd') <-
             runMyTestMonad myIdentityProviders theTime $
-                processBlockItems (blockToProcess [dummyTransactionBI, dummyCredentialDeployment]) =<< _lastFinalized <$> get
+                processBlockItems (blockToProcess [dummyNormalTransactionBI, dummyCredentialDeployment]) =<< _lastFinalized <$> get
         assertBool
             "Block should have been successfully processed"
             (isJust processed)
@@ -546,6 +620,8 @@ tests :: Spec
 tests = describe "KonsensusV1.TransactionProcessing" $ do
     Common.forEveryProtocolVersionConsensusV1 $ \spv pvString ->
         describe pvString $ do
+            describe "Transaction verification" $ do
+                testTransactionVerification spv
             describe "Individual transaction processing" $ do
                 testProcessBlockItem spv
             describe "Batch transaction processing" $ do


### PR DESCRIPTION
This adds an additional check in the `verifyChainUpdate` function for transactions with payloads of type `CreatePLTUpdatePayload` and assert that the effective time of the transaction is zero in this case.

## Changes

- New check in TransactionVerifier
- Additional error conversions
- Tests

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
