### PR TITLE
Fix mac build

### DIFF
--- a/scripts/distribution/macOS-package/build.sh
+++ b/scripts/distribution/macOS-package/build.sh
@@ -255,7 +255,7 @@ function collectDylibs() {
         # the results of previous calls to `collectDylibsFor`.
         "$macdylibbundlerDir/dylibbundler" --fix-file "$fileToFix" --bundle-deps --dest-dir "./libs" --install-path "@executable_path/libs/" --create-dir \
             -s "$concordiumDylibDir" \
-            -s "$concordiumDylibDir/$ghcVariant" \
+            -s "$concordiumDylibGhcDir" \
             -s "$stackSnapshotDir" \
             $stackLibDirs # Unquoted on purpose to use as arguments correctly
     }
@@ -263,10 +263,28 @@ function collectDylibs() {
     logInfo "Collecting dylibs with dylibbundler (this will take a few minutes)..."
 
     concordiumDylibDir=$(stack --stack-yaml "$baseDir/stack.yaml" path --local-install-root)"/lib"
-    stackSnapshotDir=$(stack --stack-yaml "$baseDir/stack.yaml" path --snapshot-install-root)"/lib/$ghcVariant"
+    # We use `find` to get the first directory that matches the GHC variant.
+    # There SHOULD be exactly one such directory. We do this because we do not want to
+    # hardcode the ABI short hash, which is the last part of the directory name.
+    concordiumDylibGhcDirs=$(find "$concordiumDylibDir" -maxdepth 1 -type d -name "${ghcVariant}*")
+    if [[ ${#concordiumDylibGhcDirs[@]} -ne 1 ]]; then
+        logInfo "Expected exactly one GHC variant directory matching '${ghcVariant}*' in '$concordiumDylibDir'. Found: ${#concordiumDylibGhcDirs[@]} directories."
+        logInfo "Directories found: $concordiumDylibGhcDirs"
+        exit 1
+    fi
+    concordiumDylibGhcDir="${concordiumDylibGhcDirs[0]}"
+    stackSnapshotRoot=$(stack --stack-yaml "$baseDir/stack.yaml" path --snapshot-install-root)"/lib"
+    stackSnapshotDirs=$(find "$stackSnapshotRoot" -maxdepth 1 -type d -name "${ghcVariant}*")
+    if [[ ${#stackSnapshotDirs[@]} -ne 1 ]]; then
+        logInfo "Expected exactly one stack snapshot directory matching '${ghcVariant}*' in '$stackSnapshotRoot'. Found: ${#stackSnapshotDirs[@]} directories."
+        logInfo "Directories found: $stackSnapshotDirs"
+        exit 1
+    fi
+    stackSnapshotDir="${stackSnapshotDirs[0]}"
     # Use awk to preprend '-s ' to each dylib, to be used as argument for dylibbundler directly.
     stackLibDirs=$(find "$(stack --stack-yaml "$baseDir/stack.yaml" ghc -- --print-libdir)" -maxdepth 1 -type d | awk '{print "-s "$0}')
     readonly concordiumDylibDir
+    readonly concordiumDylibGhcDir
     readonly stackSnapshotDir
     readonly stackLibDirs
 


### PR DESCRIPTION
## Purpose

Part of [COR-1669](https://linear.app/concordium/issue/COR-1669/investigate-the-macospackagebuildsh)

Fix where the Mac distribution build looks for libraries when bundling.

## Changes

- Instead of looking for a directory named `$ghcVariant` (e.g. `x86_64-osx-ghc-9.10.2`), look for a directory that matches this as a prefix (e.g.`x86_64-osx-ghc-9.10.2-cf08`) to account for the ABI short hash being included from GHC 9.8.

## Checklist

- [X] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
