### PR TITLE
Remove libgmp10 libssl1.1 from built docker image.

### DIFF
--- a/scripts/distribution/docker/builder.Dockerfile
+++ b/scripts/distribution/docker/builder.Dockerfile
@@ -17,13 +17,13 @@
 # The build of the image will clone the genesis data repository so needs
 # credentials to access it.
 
-ARG static_binaries_image_tag
-FROM static-node-binaries:${static_binaries_image_tag} as binaries
+ARG static_binaries_image_tag=latest
+FROM static-node-binaries:${static_binaries_image_tag} AS binaries
 
 # Fetch genesis-data.
-FROM alpine/git:latest as genesis-data
-ARG genesis_ref
-ARG genesis_path
+FROM alpine/git:latest AS genesis-data
+ARG genesis_ref=main
+ARG genesis_path=testnet/2022-06-13/genesis_data
 RUN mkdir -p -m 0600 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
 RUN --mount=type=ssh git clone --depth 1 --branch "${genesis_ref}" git@github.com:Concordium/concordium-infra-genesis-data.git
 RUN mv "concordium-infra-genesis-data/${genesis_path}" /data
@@ -35,10 +35,10 @@ FROM ubuntu:24.04
 #   - stagenet
 #   - testnet
 #   - mainnet
-ARG environment
+ARG environment=testnet
 
 RUN apt-get update && \
-    apt-get install -y libgmp10 libssl1.1 ca-certificates && \
+    apt-get install -y ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=binaries /build/bin/concordium-node /concordium-node

--- a/scripts/distribution/ubuntu-packages/deb.Dockerfile
+++ b/scripts/distribution/ubuntu-packages/deb.Dockerfile
@@ -1,10 +1,10 @@
 # The ubuntu version to build the package in. This influences the dependencies
 # that will be added to the package. This should be the same as was used to
 # build the binaries.
-ARG ubuntu_version
-ARG static_binaries_image_tag
+ARG ubuntu_version=latest
+ARG static_binaries_image_tag=latest
 
-FROM static-node-binaries:$static_binaries_image_tag as binaries
+FROM static-node-binaries:$static_binaries_image_tag AS binaries
 
 COPY template /pkg-root
 


### PR DESCRIPTION
## Purpose

This is to fix a failing build of the docker image. The `libssl1.1` is not available on ubuntu:24.04 out of the box, and does not seem to be needed to run the node. `libgmp10` seems to be redundant.

## Changes

- Removed `apt-get install` for `libgmp10` and `libssl1.1`.
- Minor formatting.
- Set some default arguments for easier testing.
