### PR TITLE
Fix resolution of bootstrapper docker tag in release build.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -189,7 +189,7 @@ jobs:
           path: /tmp
 
       - name: Set tag
-        run: echo "TAG=$(echo '${{ needs.validate-preconditions.outputs.docker_tags }}' | jq -r '.["docker-p2p-bootstrapper"]')" >> $GITHUB_ENV
+        run: echo "TAG=$(echo '${{ needs.validate-preconditions.outputs.docker_tags }}' | jq -r '.["docker-bootstrapper"]')" >> $GITHUB_ENV
 
       - name: Extrapolate artifact name
         run: |


### PR DESCRIPTION
## Purpose

Change to look for the docker tag under `docker-bootstrapper` instead of `docker-p2p-bootstrapper`. This is to match:
```
  DOCKER_TAGS_TEMPLATES: '{
      \"docker-stagenet\": \"concordium/stagenet-node:${VERSION}\",
      \"docker-testnet\": \"concordium/testnet-node:${VERSION}\",
      \"docker-mainnet\": \"concordium/mainnet-node:${VERSION}\",
      \"docker-bootstrapper\": \"concordium/bootstrapper:${VERSION}\"
    }'
```
