### PR TITLE
use ubuntu 22.04 LTS

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -128,7 +128,7 @@ jobs:
   build:
     needs: [fourmolu, rustfmt]
     # Use fixed OS version because we install packages on the system.
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     if: ${{ !github.event.pull_request.draft }}
 
     strategy:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ on:
      - '*.*.*-*-alpha'
 
 env:
-  UBUNTU_VERSION: '24.04'
+  UBUNTU_VERSION: '22.04'
   STATIC_LIBRARIES_IMAGE_TAG: 'rust-1.82_ghc-9.10.2'
   RUST_VERSION: '1.82'
   STACK_VERSION: '3.7.1'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ## 9.0.7
 
-- Docker base images upgraded from Ubuntu 20.04 to 24.04
+- Ubuntu 20.04 LTS is no longer supported for running the node. Minimum supported version is 22.04 LTS. 
+  The Docker base images have been upgraded accordingly from Ubuntu 20.04 to 22.04
 - Node Docker image is now signed with Sigstore Cosign
 - Add P8 -> P9 update.
 - Update GHC version to 9.10.2 (lts-24.0).

--- a/collector-backend/Dockerfile
+++ b/collector-backend/Dockerfile
@@ -5,6 +5,6 @@ WORKDIR /build
 COPY . .
 RUN cargo build --release
 
-FROM ubuntu:24.04
+FROM ubuntu:22.04
 COPY --from=build /build/target/release/node-collector-backend /node-collector-backend
 ENTRYPOINT ["/node-collector-backend"]

--- a/scripts/distribution/docker/build-distribution-image.sh
+++ b/scripts/distribution/docker/build-distribution-image.sh
@@ -24,7 +24,7 @@
 set -euxo pipefail
 
 # Build the image and tag it as static-node-binaries
-GHC_VERSION="${ghc_version}" UBUNTU_VERSION=24.04 STATIC_LIBRARIES_IMAGE_TAG="${static_libraries_image_tag}" STATIC_BINARIES_IMAGE_TAG="${static_binaries_image_tag:-latest}" ./scripts/static-binaries/build-static-binaries.sh
+GHC_VERSION="${ghc_version}" UBUNTU_VERSION=22.04 STATIC_LIBRARIES_IMAGE_TAG="${static_libraries_image_tag}" STATIC_BINARIES_IMAGE_TAG="${static_binaries_image_tag:-latest}" ./scripts/static-binaries/build-static-binaries.sh
 
 # Then pack it all together with genesis
 DOCKER_BUILDKIT=1 docker build\

--- a/scripts/distribution/docker/builder.Dockerfile
+++ b/scripts/distribution/docker/builder.Dockerfile
@@ -28,7 +28,7 @@ RUN mkdir -p -m 0600 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
 RUN --mount=type=ssh git clone --depth 1 --branch "${genesis_ref}" git@github.com:Concordium/concordium-infra-genesis-data.git
 RUN mv "concordium-infra-genesis-data/${genesis_path}" /data
 
-FROM ubuntu:24.04
+FROM ubuntu:22.04
  
 # Which environment we are building the image for.
 # Currently it should be either

--- a/scripts/distribution/ubuntu-packages/README.md
+++ b/scripts/distribution/ubuntu-packages/README.md
@@ -82,7 +82,7 @@ The general strategy for building the package is as follows.
 
    For example use the [../../static-binaries/build-static-binaries.sh](../../static-binaries/build-static-binaries.sh).
    ```console
-   $ UBUNTU_VERSION=24.04 STATIC_LIBRARIES_IMAGE_TAG=rust-1.82_ghc-9.10.2
+   $ UBUNTU_VERSION=22.04 STATIC_LIBRARIES_IMAGE_TAG=rust-1.82_ghc-9.10.2
         STATIC_BINARIES_IMAGE_TAG=latest GHC_VERSION=9.10.2 EXTRA_FEATURES=collector ./scripts/static-binaries/build-static-binaries.sh
    ```
 
@@ -103,7 +103,7 @@ scripts are [./build-mainnet-deb.sh](./build-mainnet-deb.sh) and
 directory they are in as follows.
 
 ```console
-UBUNTU_VERSION=24.04 ./build-testnet-deb.sh
+UBUNTU_VERSION=22.04 ./build-testnet-deb.sh
 ```
 
 The script uses docker to build the binaries and the debian package. The output

--- a/scripts/static-binaries/README.md
+++ b/scripts/static-binaries/README.md
@@ -10,7 +10,7 @@ specific package manager for installing dependencies (and possibly renaming depe
 ## [build-static-binaries.sh](./build-static-binaries.sh)
     This is the main script that should be used. **It is intended to be run from
     the root of the repository.** The script supports the following environment variables
-    - `UBUNTU_VERSION`, numeric tag, 24.04, 18.04
+    - `UBUNTU_VERSION`, numeric tag, 22.04
     - `STATIC_LIBRARIES_IMAGE_TAG`, tag of the docker image used to build static
       libraries. `latest` should work, but otherwise see which tags are
       available on dockerhub.


### PR DESCRIPTION
## Purpose

Use Ubuntu 22.04 LTS for building and as base image. This will be the minimum supported version.

## Changes

_Describe the changes that were needed.
