### PR TITLE
COR-1627: streamline windows node signing process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -342,34 +342,7 @@ jobs:
       - name: Install LMDB
         run: stack exec -- pacman -S --noconfirm mingw-w64-x86_64-lmdb
 
-      - name: Build Windows Node
-        run: |
-          ./scripts/distribution/windows/build-all.ps1 -nodeVersion ${{ needs.validate-preconditions.outputs.version }} -rustVersion ${{ env.RUST_VERSION }}
-
-      - name: Extract files to prepare for signing 
-        run: |
-          dir service\windows\installer
-          "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22000.0\x86\MsiDb.exe" -d service\windows\installer/Node.msi -x Node.cab
-          mkdir Node
-          dir
-          expand -d Node.cab
-          expand -F:* Node.cab ./Node
-          dir Node
-        shell: cmd
-      
-      - name: Rename files to prepare for signing (smctl can only sign files of certain types supported by signtool)
-        # See: https://docs.digicert.com/it/digicert-keylocker/client-tools/signing-tools/files-supported-for-signing.html
-        run: |
-          mv ./Node/ConcordiumConsensusDLL ./Node/ConcordiumConsensusDLL.dll
-          mv ./Node/ConcordiumBaseDLL ./Node/ConcordiumBaseDLL.dll
-          mv ./Node/ConcordiumSmartContractEngineDLL ./Node/ConcordiumSmartContractEngineDLL.dll
-          mv ./Node/Sha2DLL ./Node/Sha2DLL.dll
-          mv ./Node/NodeRunnerService ./Node/NodeRunnerService.exe
-          mv ./Node/NodeCollector ./Node/NodeCollector.exe 
-          mv ./Node/ConcordiumNode ./Node/ConcordiumNode.exe
-
-      - name: Sign files with smctl
-        working-directory: ${{steps.build.outputs.bin_dir}}
+      - name: Build and Sign Windows Node
         env:
           WINDOWS_PKCS11_CONFIG: ${{ steps.digicert_client.outputs.PKCS11_CONFIG }}
           WINDOWS_SM_KEYPAIR_ALIAS: ${{ secrets.WINDOWS_SM_KEYPAIR_ALIAS }}
@@ -379,41 +352,9 @@ jobs:
           SM_CLIENT_CERT_PASSWORD: ${{ secrets.WINDOWS_SM_CLIENT_CERT_PASSWORD }}
           SM_ARGS: "--verbose --exit-non-zero-on-fail --failfast"
         run: |
-          smctl sign --keypair-alias ${{ env.WINDOWS_SM_KEYPAIR_ALIAS }} --input ./Node/ConcordiumConsensusDLL.dll --config-file ${{ env.WINDOWS_PKCS11_CONFIG }} ${{ env.SM_ARGS }}
-          smctl sign --keypair-alias ${{ env.WINDOWS_SM_KEYPAIR_ALIAS }} --input ./Node/ConcordiumBaseDLL.dll --config-file ${{ env.WINDOWS_PKCS11_CONFIG }} ${{ env.SM_ARGS }}
-          smctl sign --keypair-alias ${{ env.WINDOWS_SM_KEYPAIR_ALIAS }} --input ./Node/ConcordiumSmartContractEngineDLL.dll --config-file ${{ env.WINDOWS_PKCS11_CONFIG }} ${{ env.SM_ARGS }}
-          smctl sign --keypair-alias ${{ env.WINDOWS_SM_KEYPAIR_ALIAS }} --input ./Node/Sha2DLL.dll --config-file ${{ env.WINDOWS_PKCS11_CONFIG }}  ${{ env.SM_ARGS }}
-          smctl sign --keypair-alias ${{ env.WINDOWS_SM_KEYPAIR_ALIAS }} --input ./Node/NodeRunnerService.exe --config-file ${{ env.WINDOWS_PKCS11_CONFIG }} ${{ env.SM_ARGS }}
-          smctl sign --keypair-alias ${{ env.WINDOWS_SM_KEYPAIR_ALIAS }} --input ./Node/NodeCollector.exe  --config-file ${{ env.WINDOWS_PKCS11_CONFIG }} ${{ env.SM_ARGS }}
-          smctl sign --keypair-alias ${{ env.WINDOWS_SM_KEYPAIR_ALIAS }} --input ./Node/ConcordiumNode.exe  --config-file ${{ env.WINDOWS_PKCS11_CONFIG }} ${{ env.SM_ARGS }}
-        shell: cmd
+          ./scripts/distribution/windows/build-all.ps1 -nodeVersion ${{ needs.validate-preconditions.outputs.version }} -rustVersion ${{ env.RUST_VERSION }}
 
-      - name: Rename files back to their original form without extension. 
-        run: |
-          mv ./Node/ConcordiumConsensusDLL.dll ./Node/ConcordiumConsensusDLL
-          mv ./Node/ConcordiumBaseDLL.dll ./Node/ConcordiumBaseDLL
-          mv ./Node/ConcordiumSmartContractEngineDLL.dll ./Node/ConcordiumSmartContractEngineDLL
-          mv ./Node/Sha2DLL.dll ./Node/Sha2DLL
-          mv ./Node/NodeRunnerService.exe ./Node/NodeRunnerService
-          mv ./Node/NodeCollector.exe ./Node/NodeCollector
-          mv ./Node/ConcordiumNode.exe ./Node/ConcordiumNode
-
-      - name: Recreate the cabinet file. 
-        run: |
-          dir Node /b /a-d > cabfiles.txt
-          makecab.exe /D MaxDiskSize=0 /D Cabinet=ON /D Compress=ON /D CabinetName1=Node.cab /D SourceDir=Node /f cabfiles.txt
-        shell: cmd
-
-      - name: Repackage the cabinet file. 
-        run: |
-          del Node.cab
-          move disk1\Node.cab .
-          expand -d Node.cab
-          "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22000.0\x86\MsiDb.exe" -d service\windows\installer\Node.msi -k Node.cab
-          "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22000.0\x86\MsiDb.exe" -d service\windows\installer\Node.msi -a Node.cab
-        shell: cmd
-  
-      - name: Sign files with smctl
+      - name: Sign installer with smctl
         working-directory: ${{steps.build.outputs.bin_dir}}
         env:
           WINDOWS_PKCS11_CONFIG: ${{ steps.digicert_client.outputs.PKCS11_CONFIG }}

--- a/scripts/distribution/windows/build-all.ps1
+++ b/scripts/distribution/windows/build-all.ps1
@@ -30,4 +30,58 @@ cargo +$rustVersion-x86_64-pc-windows-msvc build --release --locked
 Pop-Location
 if ($LASTEXITCODE -ne 0) { throw "Failed building node runner service" }
 
+if (-not $env:WINDOWS_SM_KEYPAIR_ALIAS) {
+    Write-Output "WINDOWS_SM_KEYPAIR_ALIAS is not set. Not signing."
+}
+if (-not $env:WINDOWS_PKCS11_CONFIG) {
+    Write-Output "WINDOWS_PKCS11_CONFIG is not set. Not signing."
+}
+if (-not $env:SM_ARGS) {
+    Write-Output "SM_ARGS is not set. Not signing."
+}
+
+if (-not (Get-Command "smctl" -ErrorAction SilentlyContinue)){
+    Write-Output "smctl not available. Not signing"
+}
+# Sign files if smctl is available and necessary environment variables are set.
+if ($env:WINDOWS_SM_KEYPAIR_ALIAS -and $env:WINDOWS_PKCS11_CONFIG -and $env:SM_ARGS -and (Get-Command "smctl" -ErrorAction SilentlyContinue)) {
+
+
+try {
+    # Move to the location of the script so that relative paths make sense
+    Push-Location $PSScriptRoot
+    $StackInstallRoot = stack path --local-install-root
+    
+    # Split the SM_ARGS into an array and remove quotes
+    $smArgs = $env:SM_ARGS.Trim('"') -split '\s+'
+    
+    # Define array of files to sign
+    $filesToSign = @(
+        "$StackInstallRoot\lib\concordium-consensus.dll",
+        "..\..\..\concordium-base\lib\concordium_base.dll",
+        "..\..\..\concordium-base\smart-contracts\lib\concordium_smart_contract_engine.dll",
+        "..\..\..\concordium-base\lib\sha_2.dll",
+        "..\..\..\service\windows\target\x86_64-pc-windows-msvc\release\node-runner-service.exe",
+        "..\..\..\collector\target\release\node-collector.exe",
+        "..\..\..\concordium-node\target\release\concordium-node.exe"
+    )
+    
+    # Sign all files
+    foreach ($filePath in $filesToSign) {
+        if (Test-Path $filePath) {
+            Write-Host "Signing $filePath"
+            & smctl sign --keypair-alias $env:WINDOWS_SM_KEYPAIR_ALIAS --input $filePath --config-file $env:WINDOWS_PKCS11_CONFIG @smArgs
+        } else {
+            Write-Warning "File not found for signing: $filePath"
+        }
+    }
+}
+finally {
+    Pop-Location
+}
+} else {
+    Write-Output "Not signing: Missing required environment variables or smctl utility missing."
+}
+
+# Build the installer
 service\windows\installer\build.ps1 -toolchain $rustVersion-x86_64-pc-windows-msvc -nodeVersion $nodeVersion


### PR DESCRIPTION
- Moves the signing of the libraries and executables into the build script
- Avoids repacking of cabinet files
