### PR TITLE
Ar/cor 1781 clean up haskell cbor model to match cis 7 spec rename token holder

### DIFF
--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Module.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Module.hs
@@ -131,7 +131,7 @@ data PreprocessedTokenOperation
         { -- | The raw amount to transfer.
           pthoAmount :: !TokenRawAmount,
           -- | The recipient account address.
-          pthoRecipient :: !CborTokenHolder,
+          pthoRecipient :: !CborHolderAccount,
           -- | The (optional) memo.
           pthoMemo :: !(Maybe Memo),
           -- | The original, unprocessed, 'TokenTransferBody'.
@@ -146,13 +146,13 @@ data PreprocessedTokenOperation
           ptgoUnprocessedAmount :: !TokenAmount
         }
     | PTOTokenAddAllowList
-        {ptgoTarget :: !CborTokenHolder}
+        {ptgoTarget :: !CborHolderAccount}
     | PTOTokenRemoveAllowList
-        {ptgoTarget :: !CborTokenHolder}
+        {ptgoTarget :: !CborHolderAccount}
     | PTOTokenAddDenyList
-        {ptgoTarget :: !CborTokenHolder}
+        {ptgoTarget :: !CborHolderAccount}
     | PTOTokenRemoveDenyList
-        {ptgoTarget :: !CborTokenHolder}
+        {ptgoTarget :: !CborHolderAccount}
     | PTOTokenPause
     | PTOTokenUnpause
     deriving (Eq, Show)
@@ -497,7 +497,7 @@ requireAccount ::
     -- | The operation index.
     Word64 ->
     -- | The account to check.
-    CborTokenHolder ->
+    CborHolderAccount ->
     m (PLTAccount m)
 requireAccount trrOperationIndex holder@CborHolderAccount{..} = do
     getAccount chaAccount >>= \case

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TokenCreation.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TokenCreation.hs
@@ -41,7 +41,7 @@ dummyAddress2 = Helpers.accountAddressFromSeed 2
 dummyTokenHolder :: TokenHolder
 dummyTokenHolder = HolderAccount dummyAddress2
 
-dummyCborTokenHolder :: CBOR.CborTokenHolder
+dummyCborTokenHolder :: CBOR.CborHolderAccount
 dummyCborTokenHolder =
     CBOR.CborHolderAccount
         { chaAccount = dummyAddress2,

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TokenHolderTransactions.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TokenHolderTransactions.hs
@@ -38,8 +38,8 @@ dummyAddress = Helpers.accountAddressFromSeed 1
 dummyAddress2 :: AccountAddress
 dummyAddress2 = Helpers.accountAddressFromSeed 2
 
-dummyCborTokenHolder :: CBOR.CborTokenHolder
-dummyCborTokenHolder =
+dummyCborHolderAccount :: CBOR.CborHolderAccount
+dummyCborHolderAccount =
     CBOR.CborHolderAccount
         { chaAccount = dummyAddress2,
           chaCoinInfo = Nothing
@@ -140,7 +140,7 @@ testTokenHolder _ pvString =
         CBOR.TokenInitializationParameters
             { tipName = Just "Protocol-level token",
               tipMetadata = Just $ CBOR.createTokenMetadataUrl "https://plt.token",
-              tipGovernanceAccount = Just dummyCborTokenHolder,
+              tipGovernanceAccount = Just dummyCborHolderAccount,
               tipAllowList = Just True,
               tipDenyList = Just False,
               tipInitialSupply = Nothing,

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TokenModule.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TokenModule.hs
@@ -1265,7 +1265,7 @@ testLists = do
         ltcAction (Remove, _) = "remove"
         ltcList (_, Allow) = "Allow"
         ltcList (_, Deny) = "Deny"
-    ltcMakeOperation :: ListTestConf -> CborTokenHolder -> TokenOperation
+    ltcMakeOperation :: ListTestConf -> CborHolderAccount -> TokenOperation
     ltcMakeOperation (Add, Allow) = TokenAddAllowList
     ltcMakeOperation (Remove, Allow) = TokenRemoveAllowList
     ltcMakeOperation (Add, Deny) = TokenAddDenyList


### PR DESCRIPTION
## Purpose

Rename the `CborTokenHolder` type to `CborHolderAccount` (same name as in the Rust code)

## Changes

_Describe the changes that were needed.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
