### PR TITLE
Fix url for out of band catchup in Ubuntu distribution

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -588,7 +588,7 @@ jobs:
              static_binaries_image_tag=${{ github.run_id }}
              build_env_name=${{ env.BUILD_ENV_NAME }}
              build_env_name_lower=${{ matrix.node.env }}
-             build_catchup_url=https://${{ env.DOMAIN }}/blocks.idx
+             build_catchup_url=https://catchup.${{ env.DOMAIN }}/blocks.idx
              build_genesis_hash=${{ env.BUILD_GENESIS_HASH }}
              build_collector_backend_url=https://dashboard.${{ env.DOMAIN }}/nodes/post
              build_grpc2_listen_port=${{ matrix.node.grpc_port }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   where token name, metadata and governance account are now optional in the token module initialization parameterts and
   the token module state. They are still required by the current token module implementation, and initialization
   without the parameters set will be rejected, so there are no observable changes to PLT behaviour.
+- Fixed the `build_catchup_url` in the Ubuntu build release pipeline.
 
 ## 9.0.7
 


### PR DESCRIPTION
## Purpose

Currently the Ubuntu distribution has the wrong url for out-of-band catchup

## Changes

Prepend catchup url with `catchup.`

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

