### PR TITLE
Allow token module to branch on RBAC support

### DIFF
--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/RustPLTScheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/RustPLTScheduler.hs
@@ -188,6 +188,7 @@ executeTransaction depositContext tokenUpdate =
                                             getAccountAddressByIndexCallbackPtr
                                             getTokenAccountStatesCallbackPtr
                                             blockStatePtr
+                                            (Types.protocolVersionToWord64 $ Types.demoteProtocolVersion spv)
                                             (FFI.castPtr transactionPayloadPtr)
                                             (fromIntegral transactionPayloadLen)
                                             (fromIntegral senderAccountIndex)
@@ -279,6 +280,8 @@ foreign import ccall "ffi_execute_transaction"
         GetTokenAccountStatesCallbackPtr ->
         -- | Pointer to the input PLT block state.
         FFI.Ptr PLTBlockState.RustPLTBlockState ->
+        -- | The protocol version of the block.
+        Word.Word64 ->
         -- | Pointer to transaction payload bytes.
         FFI.Ptr Word.Word8 ->
         -- | Byte length of transaction payload.
@@ -415,6 +418,7 @@ executeChainUpdate updateHeader createPLT =
                                         getAccountAddressByIndexCallbackPtr
                                         getTokenAccountStatesCallbackPtr
                                         blockStatePtr
+                                        (Types.protocolVersionToWord64 $ Types.demoteProtocolVersion spv)
                                         (FFI.castPtr chainUpdatePayloadPtr)
                                         (fromIntegral chainUpdatePayloadLen)
                                         resultingBlockStateOutPtr
@@ -496,6 +500,8 @@ foreign import ccall "ffi_execute_chain_update"
         GetTokenAccountStatesCallbackPtr ->
         -- | Pointer to the input PLT block state.
         FFI.Ptr PLTBlockState.RustPLTBlockState ->
+        -- | Protocol version of the block.
+        Word.Word64 ->
         -- | Pointer to chain update payload bytes.
         FFI.Ptr Word.Word8 ->
         -- | Byte length of chain update payload.

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/RustPLTScheduler/Queries.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/RustPLTScheduler/Queries.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- | Bindings into the Rust PLT Scheduler library. The module contains bindings to query PLTs.
 --
@@ -44,7 +45,8 @@ queryPLTList ::
 queryPLTList bs = do
     queryCallbacks <- unliftBlockStateQueryCallbacks bs
     pltState <- BS.getRustPLTBlockState bs
-    BS.liftBlobStore $ queryPLTListInBlobStoreMonad pltState queryCallbacks
+    let protocolVersion = Types.demoteProtocolVersion $ Types.protocolVersion @(Types.MPV m)
+    BS.liftBlobStore $ queryPLTListInBlobStoreMonad pltState queryCallbacks protocolVersion
   where
     -- Query the list of PLTs in the blob store monad. The function is a wrapper around an FFI call
     -- to the Rust PLT Scheduler library.
@@ -54,11 +56,14 @@ queryPLTList bs = do
         PLTBlockState.ForeignPLTBlockStatePtr ->
         -- Callback need for queries.
         BlockStateQueryCallbacks ->
+        -- The protocol version of the block.
+        Types.ProtocolVersion ->
         -- The list of token ids
         m' [Types.TokenId]
     queryPLTListInBlobStoreMonad
         pltBlockState
-        queryCallbacks =
+        queryCallbacks
+        protocolVersion =
             do
                 loadCallbackPtr <- fst <$> BlobStore.getCallbacks
                 liftIO $ FFI.alloca $ \returnDataPtrOutPtr -> FFI.alloca $ \returnDataLenOutPtr ->
@@ -76,6 +81,7 @@ queryPLTList bs = do
                                 getAccountAddressByIndexCallbackPtr
                                 getTokenAccountStatesCallbackPtr
                                 pltBlockStatePtr
+                                (Types.protocolVersionToWord64 protocolVersion)
                                 returnDataPtrOutPtr
                                 returnDataLenOutPtr
                         -- Free the function pointers we have just created
@@ -125,6 +131,8 @@ foreign import ccall "ffi_query_plt_list"
         GetTokenAccountStatesCallbackPtr ->
         -- | Pointer to the input PLT block state.
         FFI.Ptr PLTBlockState.RustPLTBlockState ->
+        -- | Protocol version of the block.
+        Word.Word64 ->
         -- | Output location for array containing return data, which is a list of token ids.
         -- If the return value is `0`, the data is a serialized list of token ids.
         FFI.Ptr (FFI.Ptr Word.Word8) ->
@@ -147,7 +155,8 @@ queryTokenInfo ::
 queryTokenInfo bs tokenId = do
     queryCallbacks <- unliftBlockStateQueryCallbacks bs
     pltState <- BS.getRustPLTBlockState bs
-    BS.liftBlobStore $ queryTokenInfoInBlobStoreMonad pltState queryCallbacks
+    let protocolVersion = Types.demoteProtocolVersion $ Types.protocolVersion @(Types.MPV m)
+    BS.liftBlobStore $ queryTokenInfoInBlobStoreMonad pltState queryCallbacks protocolVersion
   where
     -- Get token info for the given token in the given block state. The function is a wrapper around an FFI call
     -- to the Rust PLT Scheduler library.
@@ -157,11 +166,14 @@ queryTokenInfo bs tokenId = do
         PLTBlockState.ForeignPLTBlockStatePtr ->
         -- Callback need for queries.
         BlockStateQueryCallbacks ->
+        -- The protocol version of the block.
+        Types.ProtocolVersion ->
         -- The token info.
         m' (Maybe QueriesTypes.TokenInfo)
     queryTokenInfoInBlobStoreMonad
         pltBlockState
-        queryCallbacks =
+        queryCallbacks
+        protocolVersion =
             do
                 loadCallbackPtr <- fst <$> BlobStore.getCallbacks
                 liftIO $ FFI.alloca $ \returnDataPtrOutPtr -> FFI.alloca $ \returnDataLenOutPtr ->
@@ -180,6 +192,7 @@ queryTokenInfo bs tokenId = do
                                     getAccountAddressByIndexCallbackPtr
                                     getTokenAccountStatesCallbackPtr
                                     pltBlockStatePtr
+                                    (Types.protocolVersionToWord64 protocolVersion)
                                     (FFI.castPtr tokenIdPtr)
                                     (fromIntegral tokenIdLen)
                                     returnDataPtrOutPtr
@@ -234,6 +247,8 @@ foreign import ccall "ffi_query_token_info"
         GetTokenAccountStatesCallbackPtr ->
         -- | Pointer to the input PLT block state.
         FFI.Ptr PLTBlockState.RustPLTBlockState ->
+        -- | Protocol version of the block.
+        Word.Word64 ->
         -- | Pointer to token id UTF-8 bytes.
         FFI.Ptr Word.Word8 ->
         -- | Byte length of token id UTF-8.
@@ -262,7 +277,8 @@ queryTokenAccountInfos ::
 queryTokenAccountInfos bs accountIndex = do
     queryCallbacks <- unliftBlockStateQueryCallbacks bs
     pltState <- BS.getRustPLTBlockState bs
-    BS.liftBlobStore $ queryTokenAccountInfosInBlobStoreMonad pltState queryCallbacks
+    let protocolVersion = Types.demoteProtocolVersion $ Types.protocolVersion @(Types.MPV m)
+    BS.liftBlobStore $ queryTokenAccountInfosInBlobStoreMonad pltState queryCallbacks protocolVersion
   where
     -- Get token account infos for the given account in the given block state. The function is a wrapper around an FFI call
     -- to the Rust PLT Scheduler library.
@@ -272,11 +288,14 @@ queryTokenAccountInfos bs accountIndex = do
         PLTBlockState.ForeignPLTBlockStatePtr ->
         -- Callback need for queries.
         BlockStateQueryCallbacks ->
+        -- The protocol version of the block.
+        Types.ProtocolVersion ->
         -- The token account infos.
         m' [QueriesTypes.Token]
     queryTokenAccountInfosInBlobStoreMonad
         pltBlockState
-        queryCallbacks =
+        queryCallbacks
+        protocolVersion =
             do
                 loadCallbackPtr <- fst <$> BlobStore.getCallbacks
                 liftIO $ FFI.alloca $ \returnDataPtrOutPtr -> FFI.alloca $ \returnDataLenOutPtr ->
@@ -294,6 +313,7 @@ queryTokenAccountInfos bs accountIndex = do
                                 getAccountAddressByIndexCallbackPtr
                                 getTokenAccountStatesCallbackPtr
                                 pltBlockStatePtr
+                                (Types.protocolVersionToWord64 protocolVersion)
                                 (fromIntegral accountIndex)
                                 returnDataPtrOutPtr
                                 returnDataLenOutPtr
@@ -344,6 +364,8 @@ foreign import ccall "ffi_query_token_account_infos"
         GetTokenAccountStatesCallbackPtr ->
         -- | Pointer to the input PLT block state.
         FFI.Ptr PLTBlockState.RustPLTBlockState ->
+        -- | Protocol version of the block.
+        Word.Word64 ->
         -- | The account index to get token account infos for.
         Word.Word64 ->
         -- | Output location for array containing return data, which is a list of token account infos.

--- a/plt/plt-block-state/src/block_state.rs
+++ b/plt/plt-block-state/src/block_state.rs
@@ -10,7 +10,7 @@ use crate::block_state_interface::{
     BlockStateOperations, BlockStateQuery, OverflowError, RawTokenAmountDelta,
     TokenNotFoundByIdError,
 };
-use concordium_base::base::AccountIndex;
+use concordium_base::base::{AccountIndex, ProtocolVersion};
 use concordium_base::common;
 use concordium_base::common::Serialize;
 use concordium_base::constants::SHA256;
@@ -151,6 +151,8 @@ impl PltBlockState {
 /// for the parts of the state that is managed on the Haskell side.
 #[derive(Debug)]
 pub struct ExecutionTimePltBlockState<IntState, Load, ExtState> {
+    /// The protocol version of the block state.
+    pub protocol_version: ProtocolVersion,
     /// The library block state implementation.
     pub internal_block_state: IntState,
     /// External function for reading from the blob store.
@@ -300,6 +302,10 @@ impl<IntState: HasQueryableBlockState, Load: BackingStoreLoad, ExtState: Externa
         self.external_block_state
             .token_account_states(*account)
             .into_iter()
+    }
+
+    fn protocol_version(&self) -> ProtocolVersion {
+        self.protocol_version
     }
 }
 

--- a/plt/plt-block-state/src/block_state_interface.rs
+++ b/plt/plt-block-state/src/block_state_interface.rs
@@ -3,7 +3,7 @@ use crate::block_state::types::{
     TokenStateValue,
 };
 use crate::block_state::{AccountNotFoundByAddressError, AccountNotFoundByIndexError};
-use concordium_base::base::AccountIndex;
+use concordium_base::base::{AccountIndex, ProtocolVersion};
 use concordium_base::contracts_common::AccountAddress;
 use concordium_base::protocol_level_tokens::TokenId;
 use plt_scheduler_types::types::tokens::RawTokenAmount;
@@ -130,6 +130,9 @@ pub trait BlockStateQuery {
         &self,
         account: &Self::Account,
     ) -> impl Iterator<Item = (Self::Token, TokenAccountState)>;
+
+    /// Query the protocol version of the block state.
+    fn protocol_version(&self) -> ProtocolVersion;
 }
 
 /// Operations on the state of a block in the chain.

--- a/plt/plt-block-state/tests/block_state_no_external.rs
+++ b/plt/plt-block-state/tests/block_state_no_external.rs
@@ -4,7 +4,7 @@
 #![allow(unused)]
 
 use assert_matches::assert_matches;
-use concordium_base::base::{AccountIndex, Energy};
+use concordium_base::base::{AccountIndex, Energy, ProtocolVersion};
 use concordium_base::common::cbor;
 use concordium_base::contracts_common::AccountAddress;
 use concordium_base::protocol_level_tokens::{
@@ -63,6 +63,7 @@ impl BlockStateWithNoExternalState {
         let inner_block_state = PltBlockStateSavepoint::empty().mutable_state();
 
         let block_state = ExecutionTimePltBlockState {
+            protocol_version: ProtocolVersion::P10,
             internal_block_state: inner_block_state,
             backing_store_load: BlobStoreLoadStub,
             external_block_state: NoExternalBlockStateStub,

--- a/plt/plt-scheduler-interface/src/token_kernel_interface.rs
+++ b/plt/plt-scheduler-interface/src/token_kernel_interface.rs
@@ -2,7 +2,7 @@
 //! by the token module. The kernel handles all operations affecting token
 //! balance and supply and manages the state and events related to balances and supply.
 
-use concordium_base::base::AccountIndex;
+use concordium_base::base::{AccountIndex, ProtocolVersion};
 use concordium_base::contracts_common::AccountAddress;
 use concordium_base::protocol_level_tokens::{RawCbor, TokenModuleCborTypeDiscriminator};
 use concordium_base::transactions::Memo;
@@ -104,6 +104,14 @@ pub trait TokenKernelQueries {
 
     /// Lookup a key in the token state.
     fn lookup_token_state_value(&self, key: TokenStateKey) -> Option<TokenStateValue>;
+
+    /// Query the protocol version for this block.
+    fn protocol_version(&self) -> ProtocolVersion;
+
+    /// Query whether to support RBAC operations.
+    fn support_rbac(&self) -> bool {
+        self.protocol_version() >= ProtocolVersion::P11
+    }
 }
 
 /// Operations provided by the token kernel. All operations are in context of

--- a/plt/plt-scheduler/src/ffi/queries.rs
+++ b/plt/plt-scheduler/src/ffi/queries.rs
@@ -4,7 +4,7 @@
 
 use crate::queries;
 use crate::queries::QueryTokenInfoError;
-use concordium_base::base::AccountIndex;
+use concordium_base::base::{AccountIndex, ProtocolVersion};
 use concordium_base::common;
 use libc::size_t;
 use plt_block_state::block_state::{ExecutionTimePltBlockState, PltBlockStateSavepoint};
@@ -52,6 +52,7 @@ extern "C" fn ffi_query_plt_list(
     get_account_address_by_index_callback: GetCanonicalAddressByAccountIndexCallback,
     get_token_account_states_callback: GetTokenAccountStatesCallback,
     block_state: *const PltBlockStateSavepoint,
+    protocol_version: u64,
     return_data_out: *mut *mut u8,
     return_data_len_out: *mut size_t,
 ) -> u8 {
@@ -72,8 +73,11 @@ extern "C" fn ffi_query_plt_list(
         get_token_account_states_ptr: get_token_account_states_callback,
     };
 
+    let protocol_version =
+        ProtocolVersion::try_from(protocol_version).expect("Unknown protocol version");
     let internal_block_state = unsafe { &*block_state };
     let block_state = ExecutionTimePltBlockState {
+        protocol_version,
         internal_block_state,
         backing_store_load: load_callback,
         external_block_state: external_callbacks,
@@ -134,6 +138,7 @@ extern "C" fn ffi_query_token_info(
     get_account_address_by_index_callback: GetCanonicalAddressByAccountIndexCallback,
     get_token_account_states_callback: GetTokenAccountStatesCallback,
     block_state: *const PltBlockStateSavepoint,
+    protocol_version: u64,
     token_id: *const u8,
     token_id_len: size_t,
     return_data_out: *mut *mut u8,
@@ -156,8 +161,11 @@ extern "C" fn ffi_query_token_info(
         get_token_account_states_ptr: get_token_account_states_callback,
     };
 
+    let protocol_version =
+        ProtocolVersion::try_from(protocol_version).expect("Unknown protocol version");
     let internal_block_state = unsafe { &*block_state };
     let block_state = ExecutionTimePltBlockState {
+        protocol_version,
         internal_block_state,
         backing_store_load: load_callback,
         external_block_state: external_callbacks,
@@ -227,6 +235,7 @@ extern "C" fn ffi_query_token_account_infos(
     get_account_address_by_index_callback: GetCanonicalAddressByAccountIndexCallback,
     get_token_account_states_callback: GetTokenAccountStatesCallback,
     block_state: *const PltBlockStateSavepoint,
+    protocol_version: u64,
     account_index: u64,
     return_data_out: *mut *mut u8,
     return_data_len_out: *mut size_t,
@@ -248,8 +257,11 @@ extern "C" fn ffi_query_token_account_infos(
         get_token_account_states_ptr: get_token_account_states_callback,
     };
 
+    let protocol_version =
+        ProtocolVersion::try_from(protocol_version).expect("Unknown protocol version");
     let internal_block_state = unsafe { &*block_state };
     let block_state = ExecutionTimePltBlockState {
+        protocol_version,
         internal_block_state,
         backing_store_load: load_callback,
         external_block_state: external_callbacks,

--- a/plt/plt-scheduler/src/ffi/scheduler.rs
+++ b/plt/plt-scheduler/src/ffi/scheduler.rs
@@ -3,7 +3,7 @@
 //! It is only available if the `ffi` feature is enabled.
 
 use crate::scheduler;
-use concordium_base::base::{AccountIndex, Energy};
+use concordium_base::base::{AccountIndex, Energy, ProtocolVersion};
 use concordium_base::contracts_common::AccountAddress;
 use concordium_base::transactions::Payload;
 use concordium_base::updates::UpdatePayload;
@@ -78,6 +78,7 @@ extern "C" fn ffi_execute_transaction(
     get_account_address_by_index_callback: GetCanonicalAddressByAccountIndexCallback,
     get_token_account_states_callback: GetTokenAccountStatesCallback,
     block_state: *const PltBlockStateSavepoint,
+    protocol_version: u64,
     payload: *const u8,
     payload_len: size_t,
     sender_account_index: u64,
@@ -123,8 +124,11 @@ extern "C" fn ffi_execute_transaction(
         increment_plt_update_sequence_number_ptr: increment_plt_update_sequence_number_callback,
     };
 
+    let protocol_version =
+        ProtocolVersion::try_from(protocol_version).expect("Unknown protocol version");
     let internal_block_state = unsafe { (*block_state).mutable_state() };
     let mut block_state = ExecutionTimePltBlockState {
+        protocol_version,
         internal_block_state,
         backing_store_load: load_callback,
         external_block_state: external_callbacks,
@@ -236,6 +240,7 @@ extern "C" fn ffi_execute_chain_update(
     get_account_address_by_index_callback: GetCanonicalAddressByAccountIndexCallback,
     get_token_account_states_callback: GetTokenAccountStatesCallback,
     block_state: *const PltBlockStateSavepoint,
+    protocol_version: u64,
     payload: *const u8,
     payload_len: size_t,
     block_state_out: *mut *mut PltBlockStateSavepoint,
@@ -269,8 +274,11 @@ extern "C" fn ffi_execute_chain_update(
         increment_plt_update_sequence_number_ptr: increment_plt_update_sequence_number_callback,
     };
 
+    let protocol_version =
+        ProtocolVersion::try_from(protocol_version).expect("Unknown protocol version");
     let internal_block_state = unsafe { (*block_state).mutable_state() };
     let mut block_state = ExecutionTimePltBlockState {
+        protocol_version,
         internal_block_state,
         backing_store_load: load_callback,
         external_block_state: external_callbacks,

--- a/plt/plt-scheduler/src/token_kernel.rs
+++ b/plt/plt-scheduler/src/token_kernel.rs
@@ -1,6 +1,6 @@
 //! Implementation of the protocol-level token kernel.
 
-use concordium_base::base::AccountIndex;
+use concordium_base::base::{AccountIndex, ProtocolVersion};
 use concordium_base::contracts_common::AccountAddress;
 use concordium_base::protocol_level_tokens::{RawCbor, TokenModuleCborTypeDiscriminator};
 use concordium_base::transactions::Memo;
@@ -74,6 +74,10 @@ impl<BSQ: BlockStateQuery> TokenKernelQueries for TokenKernelQueriesImpl<'_, BSQ
     fn lookup_token_state_value(&self, key: TokenStateKey) -> Option<TokenStateValue> {
         self.block_state
             .lookup_token_state_value(self.token_module_state, &key)
+    }
+
+    fn protocol_version(&self) -> ProtocolVersion {
+        self.block_state.protocol_version()
     }
 }
 
@@ -289,5 +293,9 @@ impl<BSO: BlockStateOperations> TokenKernelQueries for TokenKernelOperationsImpl
     fn lookup_token_state_value(&self, key: TokenStateKey) -> Option<TokenStateValue> {
         self.block_state
             .lookup_token_state_value(self.token_module_state, &key)
+    }
+
+    fn protocol_version(&self) -> ProtocolVersion {
+        self.block_state.protocol_version()
     }
 }

--- a/plt/plt-scheduler/tests/block_state_external_stubbed.rs
+++ b/plt/plt-scheduler/tests/block_state_external_stubbed.rs
@@ -4,7 +4,7 @@
 #![allow(unused)]
 
 use assert_matches::assert_matches;
-use concordium_base::base::{AccountIndex, Energy};
+use concordium_base::base::{AccountIndex, Energy, ProtocolVersion};
 use concordium_base::common::cbor;
 use concordium_base::contracts_common::AccountAddress;
 use concordium_base::protocol_level_tokens::{
@@ -84,7 +84,7 @@ struct AccountToken {
 impl BlockStateWithExternalStateStubbed {
     /// Create block state stub
     #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
+    pub fn new(protocol_version: ProtocolVersion) -> Self {
         let inner_block_state = PltBlockStateSavepoint::empty().mutable_state();
 
         let external_block_state = ExternalBlockStateStub {
@@ -93,6 +93,7 @@ impl BlockStateWithExternalStateStubbed {
         };
 
         let block_state = ExecutionTimePltBlockState {
+            protocol_version,
             internal_block_state: inner_block_state,
             backing_store_load: BlobStoreLoadStub,
             external_block_state,
@@ -364,7 +365,7 @@ impl ExternalBlockStateOperations for ExternalBlockStateStub {
 /// Test looking up account by alias.
 #[test]
 fn test_account_by_alias() {
-    let mut stub = BlockStateWithExternalStateStubbed::new();
+    let mut stub = BlockStateWithExternalStateStubbed::new(ProtocolVersion::P10);
 
     let account = stub.create_account();
     let account_address = stub.account_canonical_address(&account);

--- a/plt/plt-scheduler/tests/plt_create.rs
+++ b/plt/plt-scheduler/tests/plt_create.rs
@@ -4,6 +4,7 @@
 
 use crate::block_state_external_stubbed::BlockStateWithExternalStateStubbed;
 use assert_matches::assert_matches;
+use concordium_base::base::ProtocolVersion;
 use concordium_base::common::cbor;
 use concordium_base::protocol_level_tokens::{
     CborHolderAccount, MetadataUrl, RawCbor, TokenAmount, TokenId,
@@ -22,7 +23,7 @@ mod block_state_external_stubbed;
 /// Test create protocol-level token.
 #[test]
 fn test_plt_create() {
-    let mut stub = BlockStateWithExternalStateStubbed::new();
+    let mut stub = BlockStateWithExternalStateStubbed::new(ProtocolVersion::P10);
     assert_eq!(stub.plt_update_instruction_sequence_number(), 0);
 
     let token_id: TokenId = "testtokenid".parse().unwrap();
@@ -84,7 +85,7 @@ fn test_plt_create() {
 /// Test create protocol-level token.
 #[test]
 fn test_plt_create_with_minting() {
-    let mut stub = BlockStateWithExternalStateStubbed::new();
+    let mut stub = BlockStateWithExternalStateStubbed::new(ProtocolVersion::P10);
     assert_eq!(stub.plt_update_instruction_sequence_number(), 0);
 
     let token_id: TokenId = "testtokenid".parse().unwrap();
@@ -145,7 +146,7 @@ fn test_plt_create_with_minting() {
 /// ids which only differ in casing are considered equal.
 #[test]
 fn test_plt_create_duplicate_id() {
-    let mut stub = BlockStateWithExternalStateStubbed::new();
+    let mut stub = BlockStateWithExternalStateStubbed::new(ProtocolVersion::P10);
 
     let gov_account = stub.create_account();
     let gov_holder_account = CborHolderAccount::from(stub.account_canonical_address(&gov_account));
@@ -199,7 +200,7 @@ fn test_plt_create_duplicate_id() {
 /// Test create protocol-level token where the token module reference is to an unknown token module.
 #[test]
 fn test_plt_create_unknown_token_module_reference() {
-    let mut stub = BlockStateWithExternalStateStubbed::new();
+    let mut stub = BlockStateWithExternalStateStubbed::new(ProtocolVersion::P10);
 
     let gov_account = stub.create_account();
     let gov_holder_account = CborHolderAccount::from(stub.account_canonical_address(&gov_account));
@@ -240,7 +241,7 @@ fn test_plt_create_unknown_token_module_reference() {
 /// Test create protocol-level token where the token module returns an error.
 #[test]
 fn test_plt_create_token_module_initialization_error() {
-    let mut stub = BlockStateWithExternalStateStubbed::new();
+    let mut stub = BlockStateWithExternalStateStubbed::new(ProtocolVersion::P10);
 
     let gov_account = stub.create_account();
     let gov_holder_account = CborHolderAccount::from(stub.account_canonical_address(&gov_account));

--- a/plt/plt-scheduler/tests/plt_queries.rs
+++ b/plt/plt-scheduler/tests/plt_queries.rs
@@ -5,7 +5,7 @@ use crate::block_state_external_stubbed::{
     BlockStateWithExternalStateStubbed, TokenInitTestParams,
 };
 use assert_matches::assert_matches;
-use concordium_base::base::Energy;
+use concordium_base::base::{Energy, ProtocolVersion};
 use concordium_base::common::cbor;
 use concordium_base::protocol_level_tokens::{
     CborHolderAccount, RawCbor, TokenId, TokenListUpdateDetails, TokenModuleAccountState,
@@ -23,7 +23,7 @@ mod block_state_external_stubbed;
 /// Test query token state
 #[test]
 fn test_query_plt_list() {
-    let mut stub = BlockStateWithExternalStateStubbed::new();
+    let mut stub = BlockStateWithExternalStateStubbed::new(ProtocolVersion::P10);
     let token_id1 = "TokenId1".parse().unwrap();
     let (token1, _) =
         stub.create_and_init_token(token_id1, TokenInitTestParams::default(), 4, None);
@@ -41,7 +41,7 @@ fn test_query_plt_list() {
 /// Test query token info
 #[test]
 fn test_query_token_info() {
-    let mut stub = BlockStateWithExternalStateStubbed::new();
+    let mut stub = BlockStateWithExternalStateStubbed::new(ProtocolVersion::P10);
     let token_id: TokenId = "TokenId1".parse().unwrap();
     let (_token, _) =
         stub.create_and_init_token(token_id.clone(), TokenInitTestParams::default(), 4, None);
@@ -66,7 +66,7 @@ fn test_query_token_info() {
 /// Test query token account info
 #[test]
 fn test_query_token_account_info() {
-    let mut stub = BlockStateWithExternalStateStubbed::new();
+    let mut stub = BlockStateWithExternalStateStubbed::new(ProtocolVersion::P10);
     let account = stub.create_account();
     let token_id1: TokenId = "TokenId1".parse().unwrap();
     let (token1, _) = stub.create_and_init_token(
@@ -109,7 +109,7 @@ fn test_query_token_account_info() {
 // Test that adding an account to a token list properly touches the account
 #[test]
 fn test_query_token_account_info_allow_list_no_balance() {
-    let mut stub = BlockStateWithExternalStateStubbed::new();
+    let mut stub = BlockStateWithExternalStateStubbed::new(ProtocolVersion::P10);
     let account = stub.create_account();
     let token_id: TokenId = "TokenId3".parse().unwrap();
     let (_token, gov_account) = stub.create_and_init_token(

--- a/plt/plt-scheduler/tests/plt_updates.rs
+++ b/plt/plt-scheduler/tests/plt_updates.rs
@@ -6,7 +6,7 @@ use crate::block_state_external_stubbed::{
     BlockStateWithExternalStateStubbed, TokenInitTestParams,
 };
 use assert_matches::assert_matches;
-use concordium_base::base::Energy;
+use concordium_base::base::{Energy, ProtocolVersion};
 use concordium_base::common::cbor;
 use concordium_base::protocol_level_tokens::{
     CborHolderAccount, CborMemo, OperationNotPermittedRejectReason, RawCbor, TokenAmount, TokenId,
@@ -30,7 +30,7 @@ mod utils;
 /// a second transfer from the destination of the first transfer.
 #[test]
 fn test_plt_transfer() {
-    let mut stub = BlockStateWithExternalStateStubbed::new();
+    let mut stub = BlockStateWithExternalStateStubbed::new(ProtocolVersion::P10);
     let token_id: TokenId = "TokenId1".parse().unwrap();
     let (token, gov_account) = stub.create_and_init_token(
         token_id.clone(),
@@ -144,7 +144,7 @@ fn test_plt_transfer() {
 /// Test protocol-level token transfer using address aliases for sender and receiver.
 #[test]
 fn test_plt_transfer_using_aliases() {
-    let mut stub = BlockStateWithExternalStateStubbed::new();
+    let mut stub = BlockStateWithExternalStateStubbed::new(ProtocolVersion::P10);
     let token_id: TokenId = "TokenId1".parse().unwrap();
     let (token, gov_account) = stub.create_and_init_token(
         token_id.clone(),
@@ -210,7 +210,7 @@ fn test_plt_transfer_using_aliases() {
 /// Test protocol-level token transfer that is rejected.
 #[test]
 fn test_plt_transfer_reject() {
-    let mut stub = BlockStateWithExternalStateStubbed::new();
+    let mut stub = BlockStateWithExternalStateStubbed::new(ProtocolVersion::P10);
     let token_id: TokenId = "TokenId1".parse().unwrap();
     let (token, gov_account) = stub.create_and_init_token(
         token_id.clone(),
@@ -267,7 +267,7 @@ fn test_plt_transfer_reject() {
 /// * transfer (successful)
 #[test]
 fn test_plt_transfer_allow_list_flow() {
-    let mut stub = BlockStateWithExternalStateStubbed::new();
+    let mut stub = BlockStateWithExternalStateStubbed::new(ProtocolVersion::P10);
     let token_id: TokenId = "TokenId1".parse().unwrap();
     let (token, gov_account) = stub.create_and_init_token(
         token_id.clone(),
@@ -422,7 +422,7 @@ fn test_plt_transfer_allow_list_flow() {
 /// Test add account to allow list for a token where allow lists are not enabled.
 #[test]
 fn test_plt_allow_list_disabled() {
-    let mut stub = BlockStateWithExternalStateStubbed::new();
+    let mut stub = BlockStateWithExternalStateStubbed::new(ProtocolVersion::P10);
     let token_id: TokenId = "TokenId1".parse().unwrap();
     let (_token, gov_account) =
         stub.create_and_init_token(token_id.clone(), TokenInitTestParams::default(), 4, None);
@@ -461,7 +461,7 @@ fn test_plt_allow_list_disabled() {
 /// Test protocol-level token mint.
 #[test]
 fn test_plt_mint() {
-    let mut stub = BlockStateWithExternalStateStubbed::new();
+    let mut stub = BlockStateWithExternalStateStubbed::new(ProtocolVersion::P10);
     let token_id: TokenId = "TokenId1".parse().unwrap();
     let (token, gov_account) = stub.create_and_init_token(
         token_id.clone(),
@@ -513,7 +513,7 @@ fn test_plt_mint() {
 /// Test protocol-level token mint using account address alias.
 #[test]
 fn test_plt_mint_using_alias() {
-    let mut stub = BlockStateWithExternalStateStubbed::new();
+    let mut stub = BlockStateWithExternalStateStubbed::new(ProtocolVersion::P10);
     let token_id: TokenId = "TokenId1".parse().unwrap();
     let (token, gov_account) = stub.create_and_init_token(
         token_id.clone(),
@@ -570,7 +570,7 @@ fn test_plt_mint_using_alias() {
 /// Test protocol-level token mint that is rejected.
 #[test]
 fn test_plt_mint_reject() {
-    let mut stub = BlockStateWithExternalStateStubbed::new();
+    let mut stub = BlockStateWithExternalStateStubbed::new(ProtocolVersion::P10);
     let token_id: TokenId = "TokenId1".parse().unwrap();
     let (token, gov_account) = stub.create_and_init_token(
         token_id.clone(),
@@ -614,7 +614,7 @@ fn test_plt_mint_reject() {
 /// Test protocol-level token mint from unauthorized sender.
 #[test]
 fn test_plt_mint_unauthorized() {
-    let mut stub = BlockStateWithExternalStateStubbed::new();
+    let mut stub = BlockStateWithExternalStateStubbed::new(ProtocolVersion::P10);
     let token_id: TokenId = "TokenId1".parse().unwrap();
     let (token, _gov_account) =
         stub.create_and_init_token(token_id.clone(), TokenInitTestParams::default(), 4, None);
@@ -672,7 +672,7 @@ fn test_plt_mint_unauthorized() {
 /// Test protocol-level token burn.
 #[test]
 fn test_plt_burn() {
-    let mut stub = BlockStateWithExternalStateStubbed::new();
+    let mut stub = BlockStateWithExternalStateStubbed::new(ProtocolVersion::P10);
     let token_id: TokenId = "TokenId1".parse().unwrap();
     let (token, gov_account) = stub.create_and_init_token(
         token_id.clone(),
@@ -724,7 +724,7 @@ fn test_plt_burn() {
 /// Test protocol-level token burn using address alias for governance account
 #[test]
 fn test_plt_burn_using_alias() {
-    let mut stub = BlockStateWithExternalStateStubbed::new();
+    let mut stub = BlockStateWithExternalStateStubbed::new(ProtocolVersion::P10);
     let token_id: TokenId = "TokenId1".parse().unwrap();
     let (token, gov_account) = stub.create_and_init_token(
         token_id.clone(),
@@ -781,7 +781,7 @@ fn test_plt_burn_using_alias() {
 /// Test protocol-level token burn rejection.
 #[test]
 fn test_plt_burn_reject() {
-    let mut stub = BlockStateWithExternalStateStubbed::new();
+    let mut stub = BlockStateWithExternalStateStubbed::new(ProtocolVersion::P10);
     let token_id: TokenId = "TokenId1".parse().unwrap();
     let (token, gov_account) = stub.create_and_init_token(
         token_id.clone(),
@@ -828,7 +828,7 @@ fn test_plt_burn_reject() {
 /// Test multiple protocol-level token update operations in one transaction.
 #[test]
 fn test_plt_multiple_operations() {
-    let mut stub = BlockStateWithExternalStateStubbed::new();
+    let mut stub = BlockStateWithExternalStateStubbed::new(ProtocolVersion::P10);
     let token_id: TokenId = "TokenId1".parse().unwrap();
     let (token, gov_account) = stub.create_and_init_token(
         token_id.clone(),
@@ -900,7 +900,7 @@ fn test_plt_multiple_operations() {
 /// Test protocol-level token "pause" operation.
 #[test]
 fn test_plt_pause() {
-    let mut stub = BlockStateWithExternalStateStubbed::new();
+    let mut stub = BlockStateWithExternalStateStubbed::new(ProtocolVersion::P10);
     let token_id: TokenId = "TokenId1".parse().unwrap();
     let (_token, gov_account) =
         stub.create_and_init_token(token_id.clone(), TokenInitTestParams::default(), 4, None);
@@ -970,7 +970,7 @@ fn test_plt_pause() {
 /// Test protocol-level token "unpause" operation.
 #[test]
 fn test_plt_unpause() {
-    let mut stub = BlockStateWithExternalStateStubbed::new();
+    let mut stub = BlockStateWithExternalStateStubbed::new(ProtocolVersion::P10);
     let token_id: TokenId = "TokenId1".parse().unwrap();
     let (_, gov_account) =
         stub.create_and_init_token(token_id.clone(), TokenInitTestParams::default(), 4, None);
@@ -1004,7 +1004,7 @@ fn test_plt_unpause() {
 /// Test protocol-level token transfer that is rejected because token does not exist.
 #[test]
 fn test_non_existing_token_id() {
-    let mut stub = BlockStateWithExternalStateStubbed::new();
+    let mut stub = BlockStateWithExternalStateStubbed::new(ProtocolVersion::P10);
     let account1 = stub.create_account();
     let account2 = stub.create_account();
 
@@ -1040,7 +1040,7 @@ fn test_non_existing_token_id() {
 /// Test that energy is charged during execution and the correct amount of used energy returned.
 #[test]
 fn test_energy_charge() {
-    let mut stub = BlockStateWithExternalStateStubbed::new();
+    let mut stub = BlockStateWithExternalStateStubbed::new(ProtocolVersion::P10);
     let token_id: TokenId = "TokenId1".parse().unwrap();
     let (token, gov_account) = stub.create_and_init_token(
         token_id.clone(),
@@ -1079,7 +1079,7 @@ fn test_energy_charge() {
 /// also if the transaction is rejected.
 #[test]
 fn test_energy_charge_at_reject() {
-    let mut stub = BlockStateWithExternalStateStubbed::new();
+    let mut stub = BlockStateWithExternalStateStubbed::new(ProtocolVersion::P10);
     let token_id: TokenId = "TokenId1".parse().unwrap();
     let (token, gov_account) = stub.create_and_init_token(
         token_id.clone(),
@@ -1122,7 +1122,7 @@ fn test_energy_charge_at_reject() {
 /// Test that an out of energy reject reason is returned if we run out of energy.
 #[test]
 fn test_out_of_energy_error() {
-    let mut stub = BlockStateWithExternalStateStubbed::new();
+    let mut stub = BlockStateWithExternalStateStubbed::new(ProtocolVersion::P10);
     let token_id: TokenId = "TokenId1".parse().unwrap();
     let (token, gov_account) = stub.create_and_init_token(
         token_id.clone(),

--- a/plt/plt-token-module/tests/kernel_stub.rs
+++ b/plt/plt-token-module/tests/kernel_stub.rs
@@ -5,7 +5,7 @@
 
 use std::collections::{BTreeMap, VecDeque};
 
-use concordium_base::base::{AccountIndex, Energy, InsufficientEnergy};
+use concordium_base::base::{AccountIndex, Energy, InsufficientEnergy, ProtocolVersion};
 use concordium_base::common::{Serial, cbor};
 use concordium_base::contracts_common::AccountAddress;
 use concordium_base::protocol_level_tokens::{
@@ -32,6 +32,8 @@ use plt_token_module::token_module;
 /// configuring the state of the kernel.
 #[derive(Debug)]
 pub struct KernelStub {
+    /// Protocol version of the kernel implementation.
+    protocol_version: ProtocolVersion,
     /// List of accounts existing.
     accounts: Vec<Account>,
     /// Token module managed state.
@@ -86,8 +88,9 @@ fn account_state_key(account_index: AccountIndex, key: &[u8]) -> TokenStateKey {
 
 impl KernelStub {
     /// Create new kernel stub
-    pub fn with_decimals(decimals: u8) -> Self {
+    pub fn with_decimals(decimals: u8, protocol_version: ProtocolVersion) -> Self {
         Self {
+            protocol_version,
             accounts: vec![],
             state: Default::default(),
             decimals,
@@ -308,6 +311,10 @@ impl TokenKernelQueries for KernelStub {
     fn lookup_token_state_value(&self, key: TokenStateKey) -> Option<TokenStateValue> {
         self.state.get(&key).cloned()
     }
+
+    fn protocol_version(&self) -> ProtocolVersion {
+        self.protocol_version
+    }
 }
 
 impl TokenKernelOperations for KernelStub {
@@ -454,7 +461,11 @@ const TEST_ACCOUNT2: AccountAddress = AccountAddress([2u8; 32]);
 /// Test lookup account address and account from address
 #[test]
 fn test_account_lookup_address() {
-    let mut stub = KernelStub::with_decimals(0);
+    test_account_lookup_address_worker(ProtocolVersion::P10);
+}
+
+fn test_account_lookup_address_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     let account = stub.create_account();
 
     let address = stub.account_address(&account);
@@ -469,7 +480,11 @@ fn test_account_lookup_address() {
 /// Test lookup account index and account from index
 #[test]
 fn test_account_lookup_index() {
-    let mut stub = KernelStub::with_decimals(0);
+    test_account_lookup_index_worker(ProtocolVersion::P10);
+}
+
+fn test_account_lookup_index_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     let account = stub.create_account();
 
     let index = stub.account_index(&account);
@@ -484,7 +499,10 @@ fn test_account_lookup_index() {
 /// Test get account balance
 #[test]
 fn test_account_balance() {
-    let mut stub = KernelStub::with_decimals(0);
+    test_account_balance_worker(ProtocolVersion::P10);
+}
+fn test_account_balance_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     let account0 = stub.create_account();
     let account1 = stub.create_account();
     stub.set_account_balance(account0, RawTokenAmount(245));
@@ -499,7 +517,11 @@ fn test_account_balance() {
 /// Test looking up account by alias.
 #[test]
 fn test_account_by_alias() {
-    let mut stub = KernelStub::with_decimals(0);
+    test_account_by_alias_worker(ProtocolVersion::P10);
+}
+
+fn test_account_by_alias_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
 
     let account = stub.create_account();
     let account_address = stub.account_address(&account);

--- a/plt/plt-token-module/tests/kernel_stub.rs
+++ b/plt/plt-token-module/tests/kernel_stub.rs
@@ -457,15 +457,13 @@ impl TransactionExecution for TransactionExecutionTestImpl {
 // Tests for the kernel stub
 
 const TEST_ACCOUNT2: AccountAddress = AccountAddress([2u8; 32]);
+/// Default protocol version used across the tests.
+const PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::P11;
 
 /// Test lookup account address and account from address
 #[test]
 fn test_account_lookup_address() {
-    test_account_lookup_address_worker(ProtocolVersion::P10);
-}
-
-fn test_account_lookup_address_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     let account = stub.create_account();
 
     let address = stub.account_address(&account);
@@ -480,11 +478,7 @@ fn test_account_lookup_address_worker(protocol_version: ProtocolVersion) {
 /// Test lookup account index and account from index
 #[test]
 fn test_account_lookup_index() {
-    test_account_lookup_index_worker(ProtocolVersion::P10);
-}
-
-fn test_account_lookup_index_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     let account = stub.create_account();
 
     let index = stub.account_index(&account);
@@ -499,10 +493,7 @@ fn test_account_lookup_index_worker(protocol_version: ProtocolVersion) {
 /// Test get account balance
 #[test]
 fn test_account_balance() {
-    test_account_balance_worker(ProtocolVersion::P10);
-}
-fn test_account_balance_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     let account0 = stub.create_account();
     let account1 = stub.create_account();
     stub.set_account_balance(account0, RawTokenAmount(245));
@@ -517,11 +508,7 @@ fn test_account_balance_worker(protocol_version: ProtocolVersion) {
 /// Test looking up account by alias.
 #[test]
 fn test_account_by_alias() {
-    test_account_by_alias_worker(ProtocolVersion::P10);
-}
-
-fn test_account_by_alias_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
 
     let account = stub.create_account();
     let account_address = stub.account_address(&account);

--- a/plt/plt-token-module/tests/token_module_account_state.rs
+++ b/plt/plt-token-module/tests/token_module_account_state.rs
@@ -1,5 +1,4 @@
 use crate::kernel_stub::{KernelStub, TokenInitTestParams};
-use concordium_base::base::ProtocolVersion;
 use concordium_base::common::cbor;
 use concordium_base::protocol_level_tokens::TokenModuleAccountState;
 use plt_scheduler_interface::token_kernel_interface::TokenKernelQueries;

--- a/plt/plt-token-module/tests/token_module_account_state.rs
+++ b/plt/plt-token-module/tests/token_module_account_state.rs
@@ -1,4 +1,5 @@
 use crate::kernel_stub::{KernelStub, TokenInitTestParams};
+use concordium_base::base::ProtocolVersion;
 use concordium_base::common::cbor;
 use concordium_base::protocol_level_tokens::TokenModuleAccountState;
 use plt_scheduler_interface::token_kernel_interface::TokenKernelQueries;
@@ -9,7 +10,10 @@ mod kernel_stub;
 /// Test token module account state without lists enabled.
 #[test]
 fn test_query_token_module_account_state_default() {
-    let mut stub = KernelStub::with_decimals(0);
+    test_query_token_module_account_state_default_worker(ProtocolVersion::P10);
+}
+fn test_query_token_module_account_state_default_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     stub.init_token(TokenInitTestParams::default());
     let account = stub.create_account();
 
@@ -23,7 +27,10 @@ fn test_query_token_module_account_state_default() {
 /// Test token module account state with lists.
 #[test]
 fn test_query_token_module_account_state_lists() {
-    let mut stub = KernelStub::with_decimals(0);
+    test_query_token_module_account_state_lists_worker(ProtocolVersion::P10);
+}
+fn test_query_token_module_account_state_lists_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     stub.init_token(TokenInitTestParams::default().allow_list().deny_list());
     let account = stub.create_account();
 

--- a/plt/plt-token-module/tests/token_module_account_state.rs
+++ b/plt/plt-token-module/tests/token_module_account_state.rs
@@ -8,13 +8,10 @@ use plt_token_module::token_module;
 mod kernel_stub;
 pub mod utils;
 
-/// Default protocol version used across the tests.
-const PROTOCOL_VERSION: ProtocolVersion = utils::LATEST_PROTOCOL_VERSION;
-
 /// Test token module account state without lists enabled.
 #[test]
 fn test_query_token_module_account_state_default() {
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(0, utils::LATEST_PROTOCOL_VERSION);
     stub.init_token(TokenInitTestParams::default());
     let account = stub.create_account();
 
@@ -28,7 +25,7 @@ fn test_query_token_module_account_state_default() {
 /// Test token module account state with lists.
 #[test]
 fn test_query_token_module_account_state_lists() {
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(0, utils::LATEST_PROTOCOL_VERSION);
     stub.init_token(TokenInitTestParams::default().allow_list().deny_list());
     let account = stub.create_account();
 

--- a/plt/plt-token-module/tests/token_module_account_state.rs
+++ b/plt/plt-token-module/tests/token_module_account_state.rs
@@ -6,14 +6,15 @@ use plt_scheduler_interface::token_kernel_interface::TokenKernelQueries;
 use plt_token_module::token_module;
 
 mod kernel_stub;
+pub mod utils;
+
+/// Default protocol version used across the tests.
+const PROTOCOL_VERSION: ProtocolVersion = utils::LATEST_PROTOCOL_VERSION;
 
 /// Test token module account state without lists enabled.
 #[test]
 fn test_query_token_module_account_state_default() {
-    test_query_token_module_account_state_default_worker(ProtocolVersion::P10);
-}
-fn test_query_token_module_account_state_default_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     stub.init_token(TokenInitTestParams::default());
     let account = stub.create_account();
 
@@ -27,10 +28,7 @@ fn test_query_token_module_account_state_default_worker(protocol_version: Protoc
 /// Test token module account state with lists.
 #[test]
 fn test_query_token_module_account_state_lists() {
-    test_query_token_module_account_state_lists_worker(ProtocolVersion::P10);
-}
-fn test_query_token_module_account_state_lists_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     stub.init_token(TokenInitTestParams::default().allow_list().deny_list());
     let account = stub.create_account();
 

--- a/plt/plt-token-module/tests/token_module_burn.rs
+++ b/plt/plt-token-module/tests/token_module_burn.rs
@@ -1,6 +1,5 @@
 use crate::kernel_stub::{TokenInitTestParams, TransactionExecutionTestImpl};
 use assert_matches::assert_matches;
-use concordium_base::base::ProtocolVersion;
 use concordium_base::common::cbor;
 use concordium_base::protocol_level_tokens::{
     CborHolderAccount, DeserializationFailureRejectReason, OperationNotPermittedRejectReason,

--- a/plt/plt-token-module/tests/token_module_burn.rs
+++ b/plt/plt-token-module/tests/token_module_burn.rs
@@ -1,5 +1,6 @@
 use crate::kernel_stub::{TokenInitTestParams, TransactionExecutionTestImpl};
 use assert_matches::assert_matches;
+use concordium_base::base::ProtocolVersion;
 use concordium_base::common::cbor;
 use concordium_base::protocol_level_tokens::{
     CborHolderAccount, DeserializationFailureRejectReason, OperationNotPermittedRejectReason,
@@ -9,7 +10,7 @@ use concordium_base::protocol_level_tokens::{
 use kernel_stub::KernelStub;
 use plt_scheduler_interface::token_kernel_interface::TokenKernelQueries;
 use plt_scheduler_types::types::tokens::RawTokenAmount;
-use plt_token_module::token_module::{self};
+use plt_token_module::token_module;
 
 mod kernel_stub;
 mod utils;
@@ -17,7 +18,10 @@ mod utils;
 /// Test successful burns.
 #[test]
 fn test_burn() {
-    let mut stub = KernelStub::with_decimals(2);
+    test_burn_worker(ProtocolVersion::P10);
+}
+fn test_burn_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     let gov_account = stub.init_token(TokenInitTestParams::default().burnable());
     stub.set_account_balance(gov_account, RawTokenAmount(5000));
 
@@ -59,8 +63,11 @@ fn test_burn() {
 /// Rejects burn operations from non-governance accounts.
 #[test]
 fn test_unauthorized_burn() {
+    test_unauthorized_burn_worker(ProtocolVersion::P10);
+}
+fn test_unauthorized_burn_worker(protocol_version: ProtocolVersion) {
     // Arrange a token and an unauthorized sender.
-    let mut stub = KernelStub::with_decimals(2);
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     stub.init_token(TokenInitTestParams::default());
     let non_governance_account = stub.create_account();
     stub.set_account_balance(non_governance_account, RawTokenAmount(5000));
@@ -108,7 +115,10 @@ fn test_unauthorized_burn() {
 /// Test burn amount that is not available on account.
 #[test]
 fn test_burn_insufficient_balance() {
-    let mut stub = KernelStub::with_decimals(2);
+    test_burn_insufficient_balance_worker(ProtocolVersion::P10);
+}
+fn test_burn_insufficient_balance_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     let gov_account = stub.init_token(TokenInitTestParams::default().burnable());
     stub.set_account_balance(gov_account, RawTokenAmount(1000));
 
@@ -137,7 +147,10 @@ fn test_burn_insufficient_balance() {
 /// Test burn with amount specified with wrong number of decimals
 #[test]
 fn test_burn_decimals_mismatch() {
-    let mut stub = KernelStub::with_decimals(2);
+    test_burn_decimals_mismatch_worker(ProtocolVersion::P10)
+}
+fn test_burn_decimals_mismatch_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     let gov_account = stub.init_token(TokenInitTestParams::default());
 
     let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
@@ -162,7 +175,10 @@ fn test_burn_decimals_mismatch() {
 /// Reject "burn" operations while token is paused
 #[test]
 fn test_burn_paused() {
-    let mut stub = KernelStub::with_decimals(2);
+    test_burn_paused_worker(ProtocolVersion::P10);
+}
+fn test_burn_paused_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     let gov_account = stub.init_token(TokenInitTestParams::default());
     stub.set_account_balance(gov_account, RawTokenAmount(5000));
     stub.set_paused(true);
@@ -191,7 +207,10 @@ fn test_burn_paused() {
 /// Reject "burn" operation if the feature is not enabled.
 #[test]
 fn test_not_burnable() {
-    let mut stub = KernelStub::with_decimals(2);
+    test_not_burnable_worker(ProtocolVersion::P10);
+}
+fn test_not_burnable_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     let gov_account = stub.init_token(TokenInitTestParams::default());
 
     let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);

--- a/plt/plt-token-module/tests/token_module_burn.rs
+++ b/plt/plt-token-module/tests/token_module_burn.rs
@@ -15,13 +15,13 @@ use plt_token_module::token_module;
 mod kernel_stub;
 mod utils;
 
+/// Default protocol version used across the tests.
+const PROTOCOL_VERSION: ProtocolVersion = utils::LATEST_PROTOCOL_VERSION;
+
 /// Test successful burns.
 #[test]
 fn test_burn() {
-    test_burn_worker(ProtocolVersion::P10);
-}
-fn test_burn_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default().burnable());
     stub.set_account_balance(gov_account, RawTokenAmount(5000));
 
@@ -63,11 +63,8 @@ fn test_burn_worker(protocol_version: ProtocolVersion) {
 /// Rejects burn operations from non-governance accounts.
 #[test]
 fn test_unauthorized_burn() {
-    test_unauthorized_burn_worker(ProtocolVersion::P10);
-}
-fn test_unauthorized_burn_worker(protocol_version: ProtocolVersion) {
     // Arrange a token and an unauthorized sender.
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     stub.init_token(TokenInitTestParams::default());
     let non_governance_account = stub.create_account();
     stub.set_account_balance(non_governance_account, RawTokenAmount(5000));
@@ -115,10 +112,7 @@ fn test_unauthorized_burn_worker(protocol_version: ProtocolVersion) {
 /// Test burn amount that is not available on account.
 #[test]
 fn test_burn_insufficient_balance() {
-    test_burn_insufficient_balance_worker(ProtocolVersion::P10);
-}
-fn test_burn_insufficient_balance_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default().burnable());
     stub.set_account_balance(gov_account, RawTokenAmount(1000));
 
@@ -147,10 +141,7 @@ fn test_burn_insufficient_balance_worker(protocol_version: ProtocolVersion) {
 /// Test burn with amount specified with wrong number of decimals
 #[test]
 fn test_burn_decimals_mismatch() {
-    test_burn_decimals_mismatch_worker(ProtocolVersion::P10)
-}
-fn test_burn_decimals_mismatch_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
 
     let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
@@ -175,10 +166,7 @@ fn test_burn_decimals_mismatch_worker(protocol_version: ProtocolVersion) {
 /// Reject "burn" operations while token is paused
 #[test]
 fn test_burn_paused() {
-    test_burn_paused_worker(ProtocolVersion::P10);
-}
-fn test_burn_paused_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
     stub.set_account_balance(gov_account, RawTokenAmount(5000));
     stub.set_paused(true);
@@ -207,10 +195,7 @@ fn test_burn_paused_worker(protocol_version: ProtocolVersion) {
 /// Reject "burn" operation if the feature is not enabled.
 #[test]
 fn test_not_burnable() {
-    test_not_burnable_worker(ProtocolVersion::P10);
-}
-fn test_not_burnable_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
 
     let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);

--- a/plt/plt-token-module/tests/token_module_burn.rs
+++ b/plt/plt-token-module/tests/token_module_burn.rs
@@ -15,13 +15,10 @@ use plt_token_module::token_module;
 mod kernel_stub;
 mod utils;
 
-/// Default protocol version used across the tests.
-const PROTOCOL_VERSION: ProtocolVersion = utils::LATEST_PROTOCOL_VERSION;
-
 /// Test successful burns.
 #[test]
 fn test_burn() {
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default().burnable());
     stub.set_account_balance(gov_account, RawTokenAmount(5000));
 
@@ -64,7 +61,7 @@ fn test_burn() {
 #[test]
 fn test_unauthorized_burn() {
     // Arrange a token and an unauthorized sender.
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     stub.init_token(TokenInitTestParams::default());
     let non_governance_account = stub.create_account();
     stub.set_account_balance(non_governance_account, RawTokenAmount(5000));
@@ -112,7 +109,7 @@ fn test_unauthorized_burn() {
 /// Test burn amount that is not available on account.
 #[test]
 fn test_burn_insufficient_balance() {
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default().burnable());
     stub.set_account_balance(gov_account, RawTokenAmount(1000));
 
@@ -141,7 +138,7 @@ fn test_burn_insufficient_balance() {
 /// Test burn with amount specified with wrong number of decimals
 #[test]
 fn test_burn_decimals_mismatch() {
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
 
     let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
@@ -166,7 +163,7 @@ fn test_burn_decimals_mismatch() {
 /// Reject "burn" operations while token is paused
 #[test]
 fn test_burn_paused() {
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
     stub.set_account_balance(gov_account, RawTokenAmount(5000));
     stub.set_paused(true);
@@ -195,7 +192,7 @@ fn test_burn_paused() {
 /// Reject "burn" operation if the feature is not enabled.
 #[test]
 fn test_not_burnable() {
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
 
     let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);

--- a/plt/plt-token-module/tests/token_module_initialize.rs
+++ b/plt/plt-token-module/tests/token_module_initialize.rs
@@ -1,4 +1,5 @@
 use assert_matches::assert_matches;
+use concordium_base::base::ProtocolVersion;
 use concordium_base::common::cbor;
 use concordium_base::contracts_common::AccountAddress;
 use concordium_base::protocol_level_tokens::{CborHolderAccount, MetadataUrl, TokenModuleState};
@@ -18,7 +19,10 @@ const NON_EXISTING_ACCOUNT: AccountAddress = AccountAddress([2u8; 32]);
 /// In this example, the parameters are not a valid encoding.
 #[test]
 fn test_initialize_token_parameters_decode_failure() {
-    let mut stub = KernelStub::with_decimals(0);
+    test_initialize_token_parameters_decode_failure_worker(ProtocolVersion::P10);
+}
+fn test_initialize_token_parameters_decode_failure_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     let res = token_module::initialize_token(&mut stub, vec![].into());
     assert_matches!(
         &res,
@@ -32,7 +36,10 @@ fn test_initialize_token_parameters_decode_failure() {
 /// In this example, a parameter is missing from the required initialization parameters.
 #[test]
 fn test_initialize_token_parameters_missing() {
-    let mut stub = KernelStub::with_decimals(0);
+    test_initialize_token_parameters_missing_worker(ProtocolVersion::P10);
+}
+fn test_initialize_token_parameters_missing_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     let gov_account = stub.create_account();
     let parameters = TokenModuleInitializationParameters {
         name: None,
@@ -56,7 +63,10 @@ fn test_initialize_token_parameters_missing() {
 /// initialization parameters.
 #[test]
 fn test_initialize_token_additional_parameter() {
-    let mut stub = KernelStub::with_decimals(0);
+    test_initialize_token_additional_parameter_worker(ProtocolVersion::P10);
+}
+fn test_initialize_token_additional_parameter_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     let gov_account = stub.create_account();
 
     let parameters = TokenModuleInitializationParameters {
@@ -90,7 +100,10 @@ fn test_initialize_token_additional_parameter() {
 /// behaviour.
 #[test]
 fn test_initialize_token_default_values() {
-    let mut stub = KernelStub::with_decimals(0);
+    test_initialize_token_default_values_worker(ProtocolVersion::P10);
+}
+fn test_initialize_token_default_values_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     let gov_account = stub.create_account();
     let gov_holder_account = CborHolderAccount::from(stub.account_address(&gov_account));
 
@@ -146,7 +159,11 @@ fn test_initialize_token_default_values() {
 /// In this example, the parameters are valid, no minting.
 #[test]
 fn test_initialize_token_no_minting() {
-    let mut stub = KernelStub::with_decimals(0);
+    test_initialize_token_no_minting_worker(ProtocolVersion::P10);
+}
+
+fn test_initialize_token_no_minting_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     let gov_account = stub.create_account();
     let gov_holder_account = CborHolderAccount::from(stub.account_address(&gov_account));
     let metadata = MetadataUrl::from("https://plt.token".to_string());
@@ -210,7 +227,10 @@ fn test_initialize_token_no_minting() {
 /// In this example, the parameters are valid, with minting.
 #[test]
 fn test_initialize_token_with_minting() {
-    let mut stub = KernelStub::with_decimals(2);
+    test_initialize_token_with_minting_worker(ProtocolVersion::P10);
+}
+fn test_initialize_token_with_minting_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     let gov_account = stub.create_account();
     let gov_holder_account = CborHolderAccount::from(stub.account_address(&gov_account));
     let metadata = MetadataUrl::from("https://plt.token".to_string());
@@ -272,7 +292,10 @@ fn test_initialize_token_with_minting() {
 /// than the token allows.
 #[test]
 fn test_initialize_token_excessive_mint_decimals() {
-    let mut stub = KernelStub::with_decimals(2);
+    test_initialize_token_excessive_mint_decimals_worker(ProtocolVersion::P10);
+}
+fn test_initialize_token_excessive_mint_decimals_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     let gov_account = stub.create_account();
     let metadata = "https://plt.token".to_owned().into();
     let parameters = TokenModuleInitializationParameters {
@@ -302,7 +325,11 @@ fn test_initialize_token_excessive_mint_decimals() {
 /// than the token allows.
 #[test]
 fn test_initialize_token_insufficient_mint_decimals() {
-    let mut stub = KernelStub::with_decimals(6);
+    test_initialize_token_insufficient_mint_decimals_worker(ProtocolVersion::P10);
+}
+
+fn test_initialize_token_insufficient_mint_decimals_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(6, protocol_version);
     let gov_account = stub.create_account();
     let metadata = "https://plt.token".to_owned().into();
     let parameters = TokenModuleInitializationParameters {
@@ -332,7 +359,11 @@ fn test_initialize_token_insufficient_mint_decimals() {
 /// than the token allows.
 #[test]
 fn test_initialize_token_non_existing_governance_account() {
-    let mut stub = KernelStub::with_decimals(0);
+    test_initialize_token_non_existing_governance_account_worker(ProtocolVersion::P10);
+}
+
+fn test_initialize_token_non_existing_governance_account_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     let metadata = "https://plt.token".to_owned().into();
     let parameters = TokenModuleInitializationParameters {
         name: Some("Protocol-level token".to_owned()),

--- a/plt/plt-token-module/tests/token_module_initialize.rs
+++ b/plt/plt-token-module/tests/token_module_initialize.rs
@@ -17,13 +17,10 @@ pub mod utils;
 
 const NON_EXISTING_ACCOUNT: AccountAddress = AccountAddress([2u8; 32]);
 
-/// Default protocol version used across the tests.
-const PROTOCOL_VERSION: ProtocolVersion = utils::LATEST_PROTOCOL_VERSION;
-
 /// In this example, the parameters are not a valid encoding.
 #[test]
 fn test_initialize_token_parameters_decode_failure() {
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(0, utils::LATEST_PROTOCOL_VERSION);
     let res = token_module::initialize_token(&mut stub, vec![].into());
     assert_matches!(
         &res,
@@ -37,7 +34,7 @@ fn test_initialize_token_parameters_decode_failure() {
 /// In this example, a parameter is missing from the required initialization parameters.
 #[test]
 fn test_initialize_token_parameters_missing() {
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(0, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.create_account();
     let parameters = TokenModuleInitializationParameters {
         name: None,
@@ -61,7 +58,7 @@ fn test_initialize_token_parameters_missing() {
 /// initialization parameters.
 #[test]
 fn test_initialize_token_additional_parameter() {
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(0, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.create_account();
 
     let parameters = TokenModuleInitializationParameters {
@@ -95,7 +92,7 @@ fn test_initialize_token_additional_parameter() {
 /// behaviour.
 #[test]
 fn test_initialize_token_default_values() {
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(0, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.create_account();
     let gov_holder_account = CborHolderAccount::from(stub.account_address(&gov_account));
 
@@ -151,7 +148,7 @@ fn test_initialize_token_default_values() {
 /// In this example, the parameters are valid, no minting.
 #[test]
 fn test_initialize_token_no_minting() {
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(0, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.create_account();
     let gov_holder_account = CborHolderAccount::from(stub.account_address(&gov_account));
     let metadata = MetadataUrl::from("https://plt.token".to_string());
@@ -215,7 +212,7 @@ fn test_initialize_token_no_minting() {
 /// In this example, the parameters are valid, with minting.
 #[test]
 fn test_initialize_token_with_minting() {
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.create_account();
     let gov_holder_account = CborHolderAccount::from(stub.account_address(&gov_account));
     let metadata = MetadataUrl::from("https://plt.token".to_string());
@@ -277,7 +274,7 @@ fn test_initialize_token_with_minting() {
 /// than the token allows.
 #[test]
 fn test_initialize_token_excessive_mint_decimals() {
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.create_account();
     let metadata = "https://plt.token".to_owned().into();
     let parameters = TokenModuleInitializationParameters {
@@ -307,7 +304,7 @@ fn test_initialize_token_excessive_mint_decimals() {
 /// than the token allows.
 #[test]
 fn test_initialize_token_insufficient_mint_decimals() {
-    let mut stub = KernelStub::with_decimals(6, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(6, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.create_account();
     let metadata = "https://plt.token".to_owned().into();
     let parameters = TokenModuleInitializationParameters {
@@ -337,7 +334,7 @@ fn test_initialize_token_insufficient_mint_decimals() {
 /// than the token allows.
 #[test]
 fn test_initialize_token_non_existing_governance_account() {
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(0, utils::LATEST_PROTOCOL_VERSION);
     let metadata = "https://plt.token".to_owned().into();
     let parameters = TokenModuleInitializationParameters {
         name: Some("Protocol-level token".to_owned()),

--- a/plt/plt-token-module/tests/token_module_initialize.rs
+++ b/plt/plt-token-module/tests/token_module_initialize.rs
@@ -1,5 +1,4 @@
 use assert_matches::assert_matches;
-use concordium_base::base::ProtocolVersion;
 use concordium_base::common::cbor;
 use concordium_base::contracts_common::AccountAddress;
 use concordium_base::protocol_level_tokens::{CborHolderAccount, MetadataUrl, TokenModuleState};

--- a/plt/plt-token-module/tests/token_module_initialize.rs
+++ b/plt/plt-token-module/tests/token_module_initialize.rs
@@ -13,16 +13,17 @@ use plt_token_module::token_module::{
 };
 
 mod kernel_stub;
+pub mod utils;
 
 const NON_EXISTING_ACCOUNT: AccountAddress = AccountAddress([2u8; 32]);
+
+/// Default protocol version used across the tests.
+const PROTOCOL_VERSION: ProtocolVersion = utils::LATEST_PROTOCOL_VERSION;
 
 /// In this example, the parameters are not a valid encoding.
 #[test]
 fn test_initialize_token_parameters_decode_failure() {
-    test_initialize_token_parameters_decode_failure_worker(ProtocolVersion::P10);
-}
-fn test_initialize_token_parameters_decode_failure_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     let res = token_module::initialize_token(&mut stub, vec![].into());
     assert_matches!(
         &res,
@@ -36,10 +37,7 @@ fn test_initialize_token_parameters_decode_failure_worker(protocol_version: Prot
 /// In this example, a parameter is missing from the required initialization parameters.
 #[test]
 fn test_initialize_token_parameters_missing() {
-    test_initialize_token_parameters_missing_worker(ProtocolVersion::P10);
-}
-fn test_initialize_token_parameters_missing_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     let gov_account = stub.create_account();
     let parameters = TokenModuleInitializationParameters {
         name: None,
@@ -63,10 +61,7 @@ fn test_initialize_token_parameters_missing_worker(protocol_version: ProtocolVer
 /// initialization parameters.
 #[test]
 fn test_initialize_token_additional_parameter() {
-    test_initialize_token_additional_parameter_worker(ProtocolVersion::P10);
-}
-fn test_initialize_token_additional_parameter_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     let gov_account = stub.create_account();
 
     let parameters = TokenModuleInitializationParameters {
@@ -100,10 +95,7 @@ fn test_initialize_token_additional_parameter_worker(protocol_version: ProtocolV
 /// behaviour.
 #[test]
 fn test_initialize_token_default_values() {
-    test_initialize_token_default_values_worker(ProtocolVersion::P10);
-}
-fn test_initialize_token_default_values_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     let gov_account = stub.create_account();
     let gov_holder_account = CborHolderAccount::from(stub.account_address(&gov_account));
 
@@ -159,11 +151,7 @@ fn test_initialize_token_default_values_worker(protocol_version: ProtocolVersion
 /// In this example, the parameters are valid, no minting.
 #[test]
 fn test_initialize_token_no_minting() {
-    test_initialize_token_no_minting_worker(ProtocolVersion::P10);
-}
-
-fn test_initialize_token_no_minting_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     let gov_account = stub.create_account();
     let gov_holder_account = CborHolderAccount::from(stub.account_address(&gov_account));
     let metadata = MetadataUrl::from("https://plt.token".to_string());
@@ -227,10 +215,7 @@ fn test_initialize_token_no_minting_worker(protocol_version: ProtocolVersion) {
 /// In this example, the parameters are valid, with minting.
 #[test]
 fn test_initialize_token_with_minting() {
-    test_initialize_token_with_minting_worker(ProtocolVersion::P10);
-}
-fn test_initialize_token_with_minting_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     let gov_account = stub.create_account();
     let gov_holder_account = CborHolderAccount::from(stub.account_address(&gov_account));
     let metadata = MetadataUrl::from("https://plt.token".to_string());
@@ -292,10 +277,7 @@ fn test_initialize_token_with_minting_worker(protocol_version: ProtocolVersion) 
 /// than the token allows.
 #[test]
 fn test_initialize_token_excessive_mint_decimals() {
-    test_initialize_token_excessive_mint_decimals_worker(ProtocolVersion::P10);
-}
-fn test_initialize_token_excessive_mint_decimals_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     let gov_account = stub.create_account();
     let metadata = "https://plt.token".to_owned().into();
     let parameters = TokenModuleInitializationParameters {
@@ -325,11 +307,7 @@ fn test_initialize_token_excessive_mint_decimals_worker(protocol_version: Protoc
 /// than the token allows.
 #[test]
 fn test_initialize_token_insufficient_mint_decimals() {
-    test_initialize_token_insufficient_mint_decimals_worker(ProtocolVersion::P10);
-}
-
-fn test_initialize_token_insufficient_mint_decimals_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(6, protocol_version);
+    let mut stub = KernelStub::with_decimals(6, PROTOCOL_VERSION);
     let gov_account = stub.create_account();
     let metadata = "https://plt.token".to_owned().into();
     let parameters = TokenModuleInitializationParameters {
@@ -359,11 +337,7 @@ fn test_initialize_token_insufficient_mint_decimals_worker(protocol_version: Pro
 /// than the token allows.
 #[test]
 fn test_initialize_token_non_existing_governance_account() {
-    test_initialize_token_non_existing_governance_account_worker(ProtocolVersion::P10);
-}
-
-fn test_initialize_token_non_existing_governance_account_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     let metadata = "https://plt.token".to_owned().into();
     let parameters = TokenModuleInitializationParameters {
         name: Some("Protocol-level token".to_owned()),

--- a/plt/plt-token-module/tests/token_module_list_updates.rs
+++ b/plt/plt-token-module/tests/token_module_list_updates.rs
@@ -13,6 +13,9 @@ use plt_token_module::token_module;
 mod kernel_stub;
 mod utils;
 
+/// Default protocol version used across the tests.
+const PROTOCOL_VERSION: ProtocolVersion = utils::LATEST_PROTOCOL_VERSION;
+
 fn account_state_key(account_index: AccountIndex, subkey: &[u8]) -> Vec<u8> {
     let mut key = Vec::with_capacity(2 + 8 + subkey.len());
     key.extend_from_slice(&40307u16.to_le_bytes());
@@ -23,10 +26,7 @@ fn account_state_key(account_index: AccountIndex, subkey: &[u8]) -> Vec<u8> {
 
 #[test]
 fn test_allow_list_updates() {
-    test_allow_list_updates_worker(ProtocolVersion::P10);
-}
-fn test_allow_list_updates_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default().allow_list());
     let target_account = stub.create_account();
 
@@ -97,10 +97,7 @@ fn test_allow_list_updates_worker(protocol_version: ProtocolVersion) {
 
 #[test]
 fn test_deny_list_updates() {
-    test_deny_list_updates_worker(ProtocolVersion::P10);
-}
-fn test_deny_list_updates_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default().deny_list());
     let target_account = stub.create_account();
 
@@ -171,11 +168,7 @@ fn test_deny_list_updates_worker(protocol_version: ProtocolVersion) {
 
 #[test]
 fn test_add_allow_list_reject_non_governance() {
-    test_add_allow_list_reject_non_governance_worker(ProtocolVersion::P10);
-}
-
-fn test_add_allow_list_reject_non_governance_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     let _gov_account = stub.init_token(TokenInitTestParams::default().allow_list());
     let sender = stub.create_account();
     let target_account = stub.create_account();
@@ -221,11 +214,7 @@ fn test_add_allow_list_reject_non_governance_worker(protocol_version: ProtocolVe
 
 #[test]
 fn test_remove_allow_list_reject_non_governance() {
-    test_remove_allow_list_reject_non_governance_worker(ProtocolVersion::P10);
-}
-
-fn test_remove_allow_list_reject_non_governance_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     let _gov_account = stub.init_token(TokenInitTestParams::default().allow_list());
     let sender = stub.create_account();
     let target_account = stub.create_account();
@@ -271,11 +260,7 @@ fn test_remove_allow_list_reject_non_governance_worker(protocol_version: Protoco
 
 #[test]
 fn test_add_deny_list_reject_non_governance() {
-    test_add_deny_list_reject_non_governance_worker(ProtocolVersion::P10);
-}
-
-fn test_add_deny_list_reject_non_governance_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     let _gov_account = stub.init_token(TokenInitTestParams::default().deny_list());
     let sender = stub.create_account();
     let target_account = stub.create_account();
@@ -321,10 +306,7 @@ fn test_add_deny_list_reject_non_governance_worker(protocol_version: ProtocolVer
 
 #[test]
 fn test_remove_deny_list_reject_non_governance() {
-    test_remove_deny_list_reject_non_governance_worker(ProtocolVersion::P10);
-}
-fn test_remove_deny_list_reject_non_governance_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     let _gov_account = stub.init_token(TokenInitTestParams::default().deny_list());
     let sender = stub.create_account();
     let target_account = stub.create_account();
@@ -370,11 +352,7 @@ fn test_remove_deny_list_reject_non_governance_worker(protocol_version: Protocol
 
 #[test]
 fn test_add_allow_list_touches_account() {
-    test_add_allow_list_touches_account_worker(ProtocolVersion::P10);
-}
-
-fn test_add_allow_list_touches_account_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default().allow_list());
     let target_account = stub.create_account();
 
@@ -396,10 +374,7 @@ fn test_add_allow_list_touches_account_worker(protocol_version: ProtocolVersion)
 
 #[test]
 fn test_remove_allow_list_touches_account() {
-    test_remove_allow_list_touches_account_worker(ProtocolVersion::P10);
-}
-fn test_remove_allow_list_touches_account_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default().allow_list());
     let target_account = stub.create_account();
 
@@ -421,10 +396,7 @@ fn test_remove_allow_list_touches_account_worker(protocol_version: ProtocolVersi
 
 #[test]
 fn test_add_deny_list_touches_account() {
-    test_add_deny_list_touches_account_worker(ProtocolVersion::P10);
-}
-fn test_add_deny_list_touches_account_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default().deny_list());
     let target_account = stub.create_account();
 
@@ -446,10 +418,7 @@ fn test_add_deny_list_touches_account_worker(protocol_version: ProtocolVersion) 
 
 #[test]
 fn test_remove_deny_list_touches_account() {
-    test_remove_deny_list_touches_account_worker(ProtocolVersion::P10)
-}
-fn test_remove_deny_list_touches_account_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default().deny_list());
     let target_account = stub.create_account();
 
@@ -471,10 +440,7 @@ fn test_remove_deny_list_touches_account_worker(protocol_version: ProtocolVersio
 
 #[test]
 fn test_add_to_not_enabled_allow_list() {
-    test_add_to_not_enabled_allow_list_worker(ProtocolVersion::P10);
-}
-fn test_add_to_not_enabled_allow_list_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
     let allow_account = stub.create_account();
 
@@ -504,10 +470,7 @@ fn test_add_to_not_enabled_allow_list_worker(protocol_version: ProtocolVersion) 
 
 #[test]
 fn test_remove_from_not_enabled_allow_list() {
-    test_remove_from_not_enabled_allow_list_worker(ProtocolVersion::P10);
-}
-fn test_remove_from_not_enabled_allow_list_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
     let allow_account = stub.create_account();
 
@@ -537,10 +500,7 @@ fn test_remove_from_not_enabled_allow_list_worker(protocol_version: ProtocolVers
 
 #[test]
 fn test_add_to_not_enabled_deny_list() {
-    test_add_to_not_enabled_deny_list_worker(ProtocolVersion::P10);
-}
-fn test_add_to_not_enabled_deny_list_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
     let deny_account = stub.create_account();
 
@@ -570,10 +530,7 @@ fn test_add_to_not_enabled_deny_list_worker(protocol_version: ProtocolVersion) {
 
 #[test]
 fn test_remove_from_not_enabled_deny_list() {
-    test_remove_from_not_enabled_deny_list_worker(ProtocolVersion::P10);
-}
-fn test_remove_from_not_enabled_deny_list_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
     let deny_account = stub.create_account();
 

--- a/plt/plt-token-module/tests/token_module_list_updates.rs
+++ b/plt/plt-token-module/tests/token_module_list_updates.rs
@@ -13,9 +13,6 @@ use plt_token_module::token_module;
 mod kernel_stub;
 mod utils;
 
-/// Default protocol version used across the tests.
-const PROTOCOL_VERSION: ProtocolVersion = utils::LATEST_PROTOCOL_VERSION;
-
 fn account_state_key(account_index: AccountIndex, subkey: &[u8]) -> Vec<u8> {
     let mut key = Vec::with_capacity(2 + 8 + subkey.len());
     key.extend_from_slice(&40307u16.to_le_bytes());
@@ -26,7 +23,7 @@ fn account_state_key(account_index: AccountIndex, subkey: &[u8]) -> Vec<u8> {
 
 #[test]
 fn test_allow_list_updates() {
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(0, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default().allow_list());
     let target_account = stub.create_account();
 
@@ -97,7 +94,7 @@ fn test_allow_list_updates() {
 
 #[test]
 fn test_deny_list_updates() {
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(0, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default().deny_list());
     let target_account = stub.create_account();
 
@@ -168,7 +165,7 @@ fn test_deny_list_updates() {
 
 #[test]
 fn test_add_allow_list_reject_non_governance() {
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(0, utils::LATEST_PROTOCOL_VERSION);
     let _gov_account = stub.init_token(TokenInitTestParams::default().allow_list());
     let sender = stub.create_account();
     let target_account = stub.create_account();
@@ -214,7 +211,7 @@ fn test_add_allow_list_reject_non_governance() {
 
 #[test]
 fn test_remove_allow_list_reject_non_governance() {
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(0, utils::LATEST_PROTOCOL_VERSION);
     let _gov_account = stub.init_token(TokenInitTestParams::default().allow_list());
     let sender = stub.create_account();
     let target_account = stub.create_account();
@@ -260,7 +257,7 @@ fn test_remove_allow_list_reject_non_governance() {
 
 #[test]
 fn test_add_deny_list_reject_non_governance() {
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(0, utils::LATEST_PROTOCOL_VERSION);
     let _gov_account = stub.init_token(TokenInitTestParams::default().deny_list());
     let sender = stub.create_account();
     let target_account = stub.create_account();
@@ -306,7 +303,7 @@ fn test_add_deny_list_reject_non_governance() {
 
 #[test]
 fn test_remove_deny_list_reject_non_governance() {
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(0, utils::LATEST_PROTOCOL_VERSION);
     let _gov_account = stub.init_token(TokenInitTestParams::default().deny_list());
     let sender = stub.create_account();
     let target_account = stub.create_account();
@@ -352,7 +349,7 @@ fn test_remove_deny_list_reject_non_governance() {
 
 #[test]
 fn test_add_allow_list_touches_account() {
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(0, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default().allow_list());
     let target_account = stub.create_account();
 
@@ -374,7 +371,7 @@ fn test_add_allow_list_touches_account() {
 
 #[test]
 fn test_remove_allow_list_touches_account() {
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(0, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default().allow_list());
     let target_account = stub.create_account();
 
@@ -396,7 +393,7 @@ fn test_remove_allow_list_touches_account() {
 
 #[test]
 fn test_add_deny_list_touches_account() {
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(0, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default().deny_list());
     let target_account = stub.create_account();
 
@@ -418,7 +415,7 @@ fn test_add_deny_list_touches_account() {
 
 #[test]
 fn test_remove_deny_list_touches_account() {
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(0, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default().deny_list());
     let target_account = stub.create_account();
 
@@ -440,7 +437,7 @@ fn test_remove_deny_list_touches_account() {
 
 #[test]
 fn test_add_to_not_enabled_allow_list() {
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(0, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
     let allow_account = stub.create_account();
 
@@ -470,7 +467,7 @@ fn test_add_to_not_enabled_allow_list() {
 
 #[test]
 fn test_remove_from_not_enabled_allow_list() {
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(0, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
     let allow_account = stub.create_account();
 
@@ -500,7 +497,7 @@ fn test_remove_from_not_enabled_allow_list() {
 
 #[test]
 fn test_add_to_not_enabled_deny_list() {
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(0, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
     let deny_account = stub.create_account();
 
@@ -530,7 +527,7 @@ fn test_add_to_not_enabled_deny_list() {
 
 #[test]
 fn test_remove_from_not_enabled_deny_list() {
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(0, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
     let deny_account = stub.create_account();
 

--- a/plt/plt-token-module/tests/token_module_list_updates.rs
+++ b/plt/plt-token-module/tests/token_module_list_updates.rs
@@ -1,6 +1,6 @@
 use crate::kernel_stub::{KernelStub, TokenInitTestParams, TransactionExecutionTestImpl};
 use assert_matches::assert_matches;
-use concordium_base::base::{AccountIndex, ProtocolVersion};
+use concordium_base::base::AccountIndex;
 use concordium_base::common::cbor;
 use concordium_base::protocol_level_tokens::{
     CborHolderAccount, OperationNotPermittedRejectReason, RawCbor, TokenListUpdateDetails,

--- a/plt/plt-token-module/tests/token_module_list_updates.rs
+++ b/plt/plt-token-module/tests/token_module_list_updates.rs
@@ -1,6 +1,6 @@
 use crate::kernel_stub::{KernelStub, TokenInitTestParams, TransactionExecutionTestImpl};
 use assert_matches::assert_matches;
-use concordium_base::base::AccountIndex;
+use concordium_base::base::{AccountIndex, ProtocolVersion};
 use concordium_base::common::cbor;
 use concordium_base::protocol_level_tokens::{
     CborHolderAccount, OperationNotPermittedRejectReason, RawCbor, TokenListUpdateDetails,
@@ -23,7 +23,10 @@ fn account_state_key(account_index: AccountIndex, subkey: &[u8]) -> Vec<u8> {
 
 #[test]
 fn test_allow_list_updates() {
-    let mut stub = KernelStub::with_decimals(0);
+    test_allow_list_updates_worker(ProtocolVersion::P10);
+}
+fn test_allow_list_updates_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     let gov_account = stub.init_token(TokenInitTestParams::default().allow_list());
     let target_account = stub.create_account();
 
@@ -94,7 +97,10 @@ fn test_allow_list_updates() {
 
 #[test]
 fn test_deny_list_updates() {
-    let mut stub = KernelStub::with_decimals(0);
+    test_deny_list_updates_worker(ProtocolVersion::P10);
+}
+fn test_deny_list_updates_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     let gov_account = stub.init_token(TokenInitTestParams::default().deny_list());
     let target_account = stub.create_account();
 
@@ -165,7 +171,11 @@ fn test_deny_list_updates() {
 
 #[test]
 fn test_add_allow_list_reject_non_governance() {
-    let mut stub = KernelStub::with_decimals(0);
+    test_add_allow_list_reject_non_governance_worker(ProtocolVersion::P10);
+}
+
+fn test_add_allow_list_reject_non_governance_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     let _gov_account = stub.init_token(TokenInitTestParams::default().allow_list());
     let sender = stub.create_account();
     let target_account = stub.create_account();
@@ -211,7 +221,11 @@ fn test_add_allow_list_reject_non_governance() {
 
 #[test]
 fn test_remove_allow_list_reject_non_governance() {
-    let mut stub = KernelStub::with_decimals(0);
+    test_remove_allow_list_reject_non_governance_worker(ProtocolVersion::P10);
+}
+
+fn test_remove_allow_list_reject_non_governance_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     let _gov_account = stub.init_token(TokenInitTestParams::default().allow_list());
     let sender = stub.create_account();
     let target_account = stub.create_account();
@@ -257,7 +271,11 @@ fn test_remove_allow_list_reject_non_governance() {
 
 #[test]
 fn test_add_deny_list_reject_non_governance() {
-    let mut stub = KernelStub::with_decimals(0);
+    test_add_deny_list_reject_non_governance_worker(ProtocolVersion::P10);
+}
+
+fn test_add_deny_list_reject_non_governance_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     let _gov_account = stub.init_token(TokenInitTestParams::default().deny_list());
     let sender = stub.create_account();
     let target_account = stub.create_account();
@@ -303,7 +321,10 @@ fn test_add_deny_list_reject_non_governance() {
 
 #[test]
 fn test_remove_deny_list_reject_non_governance() {
-    let mut stub = KernelStub::with_decimals(0);
+    test_remove_deny_list_reject_non_governance_worker(ProtocolVersion::P10);
+}
+fn test_remove_deny_list_reject_non_governance_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     let _gov_account = stub.init_token(TokenInitTestParams::default().deny_list());
     let sender = stub.create_account();
     let target_account = stub.create_account();
@@ -349,7 +370,11 @@ fn test_remove_deny_list_reject_non_governance() {
 
 #[test]
 fn test_add_allow_list_touches_account() {
-    let mut stub = KernelStub::with_decimals(0);
+    test_add_allow_list_touches_account_worker(ProtocolVersion::P10);
+}
+
+fn test_add_allow_list_touches_account_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     let gov_account = stub.init_token(TokenInitTestParams::default().allow_list());
     let target_account = stub.create_account();
 
@@ -371,7 +396,10 @@ fn test_add_allow_list_touches_account() {
 
 #[test]
 fn test_remove_allow_list_touches_account() {
-    let mut stub = KernelStub::with_decimals(0);
+    test_remove_allow_list_touches_account_worker(ProtocolVersion::P10);
+}
+fn test_remove_allow_list_touches_account_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     let gov_account = stub.init_token(TokenInitTestParams::default().allow_list());
     let target_account = stub.create_account();
 
@@ -393,7 +421,10 @@ fn test_remove_allow_list_touches_account() {
 
 #[test]
 fn test_add_deny_list_touches_account() {
-    let mut stub = KernelStub::with_decimals(0);
+    test_add_deny_list_touches_account_worker(ProtocolVersion::P10);
+}
+fn test_add_deny_list_touches_account_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     let gov_account = stub.init_token(TokenInitTestParams::default().deny_list());
     let target_account = stub.create_account();
 
@@ -415,7 +446,10 @@ fn test_add_deny_list_touches_account() {
 
 #[test]
 fn test_remove_deny_list_touches_account() {
-    let mut stub = KernelStub::with_decimals(0);
+    test_remove_deny_list_touches_account_worker(ProtocolVersion::P10)
+}
+fn test_remove_deny_list_touches_account_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     let gov_account = stub.init_token(TokenInitTestParams::default().deny_list());
     let target_account = stub.create_account();
 
@@ -437,7 +471,10 @@ fn test_remove_deny_list_touches_account() {
 
 #[test]
 fn test_add_to_not_enabled_allow_list() {
-    let mut stub = KernelStub::with_decimals(0);
+    test_add_to_not_enabled_allow_list_worker(ProtocolVersion::P10);
+}
+fn test_add_to_not_enabled_allow_list_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     let gov_account = stub.init_token(TokenInitTestParams::default());
     let allow_account = stub.create_account();
 
@@ -467,7 +504,10 @@ fn test_add_to_not_enabled_allow_list() {
 
 #[test]
 fn test_remove_from_not_enabled_allow_list() {
-    let mut stub = KernelStub::with_decimals(0);
+    test_remove_from_not_enabled_allow_list_worker(ProtocolVersion::P10);
+}
+fn test_remove_from_not_enabled_allow_list_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     let gov_account = stub.init_token(TokenInitTestParams::default());
     let allow_account = stub.create_account();
 
@@ -497,7 +537,10 @@ fn test_remove_from_not_enabled_allow_list() {
 
 #[test]
 fn test_add_to_not_enabled_deny_list() {
-    let mut stub = KernelStub::with_decimals(0);
+    test_add_to_not_enabled_deny_list_worker(ProtocolVersion::P10);
+}
+fn test_add_to_not_enabled_deny_list_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     let gov_account = stub.init_token(TokenInitTestParams::default());
     let deny_account = stub.create_account();
 
@@ -527,7 +570,10 @@ fn test_add_to_not_enabled_deny_list() {
 
 #[test]
 fn test_remove_from_not_enabled_deny_list() {
-    let mut stub = KernelStub::with_decimals(0);
+    test_remove_from_not_enabled_deny_list_worker(ProtocolVersion::P10);
+}
+fn test_remove_from_not_enabled_deny_list_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     let gov_account = stub.init_token(TokenInitTestParams::default());
     let deny_account = stub.create_account();
 

--- a/plt/plt-token-module/tests/token_module_mint.rs
+++ b/plt/plt-token-module/tests/token_module_mint.rs
@@ -1,5 +1,6 @@
 use crate::kernel_stub::{TokenInitTestParams, TransactionExecutionTestImpl};
 use assert_matches::assert_matches;
+use concordium_base::base::ProtocolVersion;
 use concordium_base::common::cbor;
 use concordium_base::protocol_level_tokens::{
     CborHolderAccount, DeserializationFailureRejectReason, MintWouldOverflowRejectReason,
@@ -9,7 +10,7 @@ use concordium_base::protocol_level_tokens::{
 use kernel_stub::KernelStub;
 use plt_scheduler_interface::token_kernel_interface::TokenKernelQueries;
 use plt_scheduler_types::types::tokens::RawTokenAmount;
-use plt_token_module::token_module::{self};
+use plt_token_module::token_module;
 
 mod kernel_stub;
 mod utils;
@@ -17,7 +18,10 @@ mod utils;
 /// Test successful mints.
 #[test]
 fn test_mint() {
-    let mut stub = KernelStub::with_decimals(2);
+    test_mint_worker(ProtocolVersion::P10);
+}
+fn test_mint_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     let gov_account = stub.init_token(TokenInitTestParams::default().mintable());
 
     // First mint
@@ -58,8 +62,11 @@ fn test_mint() {
 /// Rejects mint operations from non-governance accounts.
 #[test]
 fn test_unauthorized_mint() {
+    test_unauthorized_mint_worker(ProtocolVersion::P10);
+}
+fn test_unauthorized_mint_worker(protocol_version: ProtocolVersion) {
     // Arrange a token and an unauthorized sender.
-    let mut stub = KernelStub::with_decimals(2);
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     let gov_account = stub.init_token(TokenInitTestParams::default());
     let non_governance_account = stub.create_account();
 
@@ -109,8 +116,11 @@ fn test_unauthorized_mint() {
 /// address in reject reason is the alias and not the canonical address.
 #[test]
 fn test_unauthorized_mint_using_alias() {
+    test_unauthorized_mint_using_alias_worker(ProtocolVersion::P10);
+}
+fn test_unauthorized_mint_using_alias_worker(protocol_version: ProtocolVersion) {
     // Arrange a token and an unauthorized sender.
-    let mut stub = KernelStub::with_decimals(2);
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     stub.init_token(TokenInitTestParams::default());
     let non_gov_account = stub.create_account();
 
@@ -152,7 +162,10 @@ fn test_unauthorized_mint_using_alias() {
 /// Test mint that would overflow circulating supply
 #[test]
 fn test_mint_overflow() {
-    let mut stub = KernelStub::with_decimals(2);
+    test_mint_overflow_worker(ProtocolVersion::P10);
+}
+fn test_mint_overflow_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     let gov_account = stub.init_token(TokenInitTestParams::default().mintable());
     stub.set_account_balance(gov_account, RawTokenAmount(1000));
 
@@ -183,7 +196,10 @@ fn test_mint_overflow() {
 /// Test mint with initial supply specified with wrong number of decimals
 #[test]
 fn test_mint_decimals_mismatch() {
-    let mut stub = KernelStub::with_decimals(2);
+    test_mint_decimals_mismatch_worker(ProtocolVersion::P10);
+}
+fn test_mint_decimals_mismatch_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     let gov_account = stub.init_token(TokenInitTestParams::default());
 
     let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
@@ -208,7 +224,10 @@ fn test_mint_decimals_mismatch() {
 /// Reject "mint" operations while token is paused
 #[test]
 fn test_mint_paused() {
-    let mut stub = KernelStub::with_decimals(2);
+    test_mint_paused_worker(ProtocolVersion::P10);
+}
+fn test_mint_paused_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     let gov_account = stub.init_token(TokenInitTestParams::default());
     stub.set_paused(true);
 
@@ -236,7 +255,10 @@ fn test_mint_paused() {
 /// Reject "mint" operation if the feature is not enabled.
 #[test]
 fn test_not_mintable() {
-    let mut stub = KernelStub::with_decimals(2);
+    test_not_mintable_worker(ProtocolVersion::P10);
+}
+fn test_not_mintable_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     let gov_account = stub.init_token(TokenInitTestParams::default());
 
     let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);

--- a/plt/plt-token-module/tests/token_module_mint.rs
+++ b/plt/plt-token-module/tests/token_module_mint.rs
@@ -15,13 +15,10 @@ use plt_token_module::token_module;
 mod kernel_stub;
 mod utils;
 
-/// Default protocol version used across the tests.
-const PROTOCOL_VERSION: ProtocolVersion = utils::LATEST_PROTOCOL_VERSION;
-
 /// Test successful mints.
 #[test]
 fn test_mint() {
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default().mintable());
 
     // First mint
@@ -63,7 +60,7 @@ fn test_mint() {
 #[test]
 fn test_unauthorized_mint() {
     // Arrange a token and an unauthorized sender.
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
     let non_governance_account = stub.create_account();
 
@@ -114,7 +111,7 @@ fn test_unauthorized_mint() {
 #[test]
 fn test_unauthorized_mint_using_alias() {
     // Arrange a token and an unauthorized sender.
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     stub.init_token(TokenInitTestParams::default());
     let non_gov_account = stub.create_account();
 
@@ -156,7 +153,7 @@ fn test_unauthorized_mint_using_alias() {
 /// Test mint that would overflow circulating supply
 #[test]
 fn test_mint_overflow() {
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default().mintable());
     stub.set_account_balance(gov_account, RawTokenAmount(1000));
 
@@ -187,7 +184,7 @@ fn test_mint_overflow() {
 /// Test mint with initial supply specified with wrong number of decimals
 #[test]
 fn test_mint_decimals_mismatch() {
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
 
     let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
@@ -212,7 +209,7 @@ fn test_mint_decimals_mismatch() {
 /// Reject "mint" operations while token is paused
 #[test]
 fn test_mint_paused() {
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
     stub.set_paused(true);
 
@@ -240,7 +237,7 @@ fn test_mint_paused() {
 /// Reject "mint" operation if the feature is not enabled.
 #[test]
 fn test_not_mintable() {
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
 
     let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);

--- a/plt/plt-token-module/tests/token_module_mint.rs
+++ b/plt/plt-token-module/tests/token_module_mint.rs
@@ -1,6 +1,5 @@
 use crate::kernel_stub::{TokenInitTestParams, TransactionExecutionTestImpl};
 use assert_matches::assert_matches;
-use concordium_base::base::ProtocolVersion;
 use concordium_base::common::cbor;
 use concordium_base::protocol_level_tokens::{
     CborHolderAccount, DeserializationFailureRejectReason, MintWouldOverflowRejectReason,

--- a/plt/plt-token-module/tests/token_module_mint.rs
+++ b/plt/plt-token-module/tests/token_module_mint.rs
@@ -15,13 +15,13 @@ use plt_token_module::token_module;
 mod kernel_stub;
 mod utils;
 
+/// Default protocol version used across the tests.
+const PROTOCOL_VERSION: ProtocolVersion = utils::LATEST_PROTOCOL_VERSION;
+
 /// Test successful mints.
 #[test]
 fn test_mint() {
-    test_mint_worker(ProtocolVersion::P10);
-}
-fn test_mint_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default().mintable());
 
     // First mint
@@ -62,11 +62,8 @@ fn test_mint_worker(protocol_version: ProtocolVersion) {
 /// Rejects mint operations from non-governance accounts.
 #[test]
 fn test_unauthorized_mint() {
-    test_unauthorized_mint_worker(ProtocolVersion::P10);
-}
-fn test_unauthorized_mint_worker(protocol_version: ProtocolVersion) {
     // Arrange a token and an unauthorized sender.
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
     let non_governance_account = stub.create_account();
 
@@ -116,11 +113,8 @@ fn test_unauthorized_mint_worker(protocol_version: ProtocolVersion) {
 /// address in reject reason is the alias and not the canonical address.
 #[test]
 fn test_unauthorized_mint_using_alias() {
-    test_unauthorized_mint_using_alias_worker(ProtocolVersion::P10);
-}
-fn test_unauthorized_mint_using_alias_worker(protocol_version: ProtocolVersion) {
     // Arrange a token and an unauthorized sender.
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     stub.init_token(TokenInitTestParams::default());
     let non_gov_account = stub.create_account();
 
@@ -162,10 +156,7 @@ fn test_unauthorized_mint_using_alias_worker(protocol_version: ProtocolVersion) 
 /// Test mint that would overflow circulating supply
 #[test]
 fn test_mint_overflow() {
-    test_mint_overflow_worker(ProtocolVersion::P10);
-}
-fn test_mint_overflow_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default().mintable());
     stub.set_account_balance(gov_account, RawTokenAmount(1000));
 
@@ -196,10 +187,7 @@ fn test_mint_overflow_worker(protocol_version: ProtocolVersion) {
 /// Test mint with initial supply specified with wrong number of decimals
 #[test]
 fn test_mint_decimals_mismatch() {
-    test_mint_decimals_mismatch_worker(ProtocolVersion::P10);
-}
-fn test_mint_decimals_mismatch_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
 
     let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
@@ -224,10 +212,7 @@ fn test_mint_decimals_mismatch_worker(protocol_version: ProtocolVersion) {
 /// Reject "mint" operations while token is paused
 #[test]
 fn test_mint_paused() {
-    test_mint_paused_worker(ProtocolVersion::P10);
-}
-fn test_mint_paused_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
     stub.set_paused(true);
 
@@ -255,10 +240,7 @@ fn test_mint_paused_worker(protocol_version: ProtocolVersion) {
 /// Reject "mint" operation if the feature is not enabled.
 #[test]
 fn test_not_mintable() {
-    test_not_mintable_worker(ProtocolVersion::P10);
-}
-fn test_not_mintable_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
 
     let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);

--- a/plt/plt-token-module/tests/token_module_pause.rs
+++ b/plt/plt-token-module/tests/token_module_pause.rs
@@ -1,6 +1,5 @@
 use crate::kernel_stub::{KernelStub, TokenInitTestParams, TransactionExecutionTestImpl};
 use assert_matches::assert_matches;
-use concordium_base::base::ProtocolVersion;
 use concordium_base::protocol_level_tokens::TokenPauseEventDetails;
 use concordium_base::{
     common::cbor,

--- a/plt/plt-token-module/tests/token_module_pause.rs
+++ b/plt/plt-token-module/tests/token_module_pause.rs
@@ -17,13 +17,13 @@ use plt_token_module::token_module;
 mod kernel_stub;
 mod utils;
 
+/// Default protocol version used across the tests.
+const PROTOCOL_VERSION: ProtocolVersion = utils::LATEST_PROTOCOL_VERSION;
+
 /// Test that pause/unpause operations modify the token module state as expected
 #[test]
 fn test_token_pause_state() {
-    test_token_pause_state_worker(ProtocolVersion::P10);
-}
-fn test_token_pause_state_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
 
     // Assert initial state matches expectations
@@ -86,10 +86,7 @@ fn test_token_pause_state_worker(protocol_version: ProtocolVersion) {
 ///   operations.
 #[test]
 fn test_double_pause() {
-    test_double_pause_worker(ProtocolVersion::P10);
-}
-fn test_double_pause_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
 
     // First we try to perform a double "pause" operation within the same transaction.
@@ -133,10 +130,7 @@ fn test_double_pause_worker(protocol_version: ProtocolVersion) {
 /// Accept performing an "unpause" operation on a token that is _not_ paused is permitted
 #[test]
 fn test_redundant_unpause() {
-    test_redundant_unpause_worker(ProtocolVersion::P10);
-}
-fn test_redundant_unpause_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
 
     // We already verified that the token moodule is initially _not_ paused, so performing an
@@ -165,11 +159,8 @@ fn test_redundant_unpause_worker(protocol_version: ProtocolVersion) {
 /// Rejects pause operations from non-governance accounts.
 #[test]
 fn test_unauthorized_pause() {
-    test_unauthorized_pause_worker(ProtocolVersion::P10);
-}
-fn test_unauthorized_pause_worker(protocol_version: ProtocolVersion) {
     // Arrange a token and an unauthorized sender.
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     stub.init_token(TokenInitTestParams::default());
     let non_governance_account = stub.create_account();
 
@@ -213,11 +204,8 @@ fn test_unauthorized_pause_worker(protocol_version: ProtocolVersion) {
 /// Rejects unpause operations from non-governance accounts.
 #[test]
 fn test_unauthorized_unpause() {
-    test_unauthorized_unpause_worker(ProtocolVersion::P10);
-}
-fn test_unauthorized_unpause_worker(protocol_version: ProtocolVersion) {
     // Arrange a token and an unauthorized sender.
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
     let non_governance_account = stub.create_account();
 
@@ -274,10 +262,7 @@ fn test_unauthorized_unpause_worker(protocol_version: ProtocolVersion) {
 /// permitted due to the paused token state.
 #[test]
 fn test_pause_multiple_ops() {
-    test_pause_multiple_ops_worker(ProtocolVersion::P10);
-}
-fn test_pause_multiple_ops_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
 
     // We test that a transaction consisting of a "pause" and "mint" operation fails, as minting is
@@ -321,10 +306,7 @@ fn test_pause_multiple_ops_worker(protocol_version: ProtocolVersion) {
 /// permitted while token is paused.
 #[test]
 fn test_unpause_multiple_ops() {
-    test_unpause_multiple_ops_worker(ProtocolVersion::P10);
-}
-fn test_unpause_multiple_ops_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default().mintable());
 
     // First we set the token to paused.

--- a/plt/plt-token-module/tests/token_module_pause.rs
+++ b/plt/plt-token-module/tests/token_module_pause.rs
@@ -1,5 +1,6 @@
 use crate::kernel_stub::{KernelStub, TokenInitTestParams, TransactionExecutionTestImpl};
 use assert_matches::assert_matches;
+use concordium_base::base::ProtocolVersion;
 use concordium_base::protocol_level_tokens::TokenPauseEventDetails;
 use concordium_base::{
     common::cbor,
@@ -19,7 +20,10 @@ mod utils;
 /// Test that pause/unpause operations modify the token module state as expected
 #[test]
 fn test_token_pause_state() {
-    let mut stub = KernelStub::with_decimals(0);
+    test_token_pause_state_worker(ProtocolVersion::P10);
+}
+fn test_token_pause_state_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     let gov_account = stub.init_token(TokenInitTestParams::default());
 
     // Assert initial state matches expectations
@@ -82,7 +86,10 @@ fn test_token_pause_state() {
 ///   operations.
 #[test]
 fn test_double_pause() {
-    let mut stub = KernelStub::with_decimals(0);
+    test_double_pause_worker(ProtocolVersion::P10);
+}
+fn test_double_pause_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     let gov_account = stub.init_token(TokenInitTestParams::default());
 
     // First we try to perform a double "pause" operation within the same transaction.
@@ -126,7 +133,10 @@ fn test_double_pause() {
 /// Accept performing an "unpause" operation on a token that is _not_ paused is permitted
 #[test]
 fn test_redundant_unpause() {
-    let mut stub = KernelStub::with_decimals(0);
+    test_redundant_unpause_worker(ProtocolVersion::P10);
+}
+fn test_redundant_unpause_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     let gov_account = stub.init_token(TokenInitTestParams::default());
 
     // We already verified that the token moodule is initially _not_ paused, so performing an
@@ -155,8 +165,11 @@ fn test_redundant_unpause() {
 /// Rejects pause operations from non-governance accounts.
 #[test]
 fn test_unauthorized_pause() {
+    test_unauthorized_pause_worker(ProtocolVersion::P10);
+}
+fn test_unauthorized_pause_worker(protocol_version: ProtocolVersion) {
     // Arrange a token and an unauthorized sender.
-    let mut stub = KernelStub::with_decimals(0);
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     stub.init_token(TokenInitTestParams::default());
     let non_governance_account = stub.create_account();
 
@@ -200,8 +213,11 @@ fn test_unauthorized_pause() {
 /// Rejects unpause operations from non-governance accounts.
 #[test]
 fn test_unauthorized_unpause() {
+    test_unauthorized_unpause_worker(ProtocolVersion::P10);
+}
+fn test_unauthorized_unpause_worker(protocol_version: ProtocolVersion) {
     // Arrange a token and an unauthorized sender.
-    let mut stub = KernelStub::with_decimals(0);
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     let gov_account = stub.init_token(TokenInitTestParams::default());
     let non_governance_account = stub.create_account();
 
@@ -258,7 +274,10 @@ fn test_unauthorized_unpause() {
 /// permitted due to the paused token state.
 #[test]
 fn test_pause_multiple_ops() {
-    let mut stub = KernelStub::with_decimals(2);
+    test_pause_multiple_ops_worker(ProtocolVersion::P10);
+}
+fn test_pause_multiple_ops_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     let gov_account = stub.init_token(TokenInitTestParams::default());
 
     // We test that a transaction consisting of a "pause" and "mint" operation fails, as minting is
@@ -302,7 +321,10 @@ fn test_pause_multiple_ops() {
 /// permitted while token is paused.
 #[test]
 fn test_unpause_multiple_ops() {
-    let mut stub = KernelStub::with_decimals(2);
+    test_unpause_multiple_ops_worker(ProtocolVersion::P10);
+}
+fn test_unpause_multiple_ops_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     let gov_account = stub.init_token(TokenInitTestParams::default().mintable());
 
     // First we set the token to paused.

--- a/plt/plt-token-module/tests/token_module_pause.rs
+++ b/plt/plt-token-module/tests/token_module_pause.rs
@@ -17,13 +17,10 @@ use plt_token_module::token_module;
 mod kernel_stub;
 mod utils;
 
-/// Default protocol version used across the tests.
-const PROTOCOL_VERSION: ProtocolVersion = utils::LATEST_PROTOCOL_VERSION;
-
 /// Test that pause/unpause operations modify the token module state as expected
 #[test]
 fn test_token_pause_state() {
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(0, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
 
     // Assert initial state matches expectations
@@ -86,7 +83,7 @@ fn test_token_pause_state() {
 ///   operations.
 #[test]
 fn test_double_pause() {
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(0, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
 
     // First we try to perform a double "pause" operation within the same transaction.
@@ -130,7 +127,7 @@ fn test_double_pause() {
 /// Accept performing an "unpause" operation on a token that is _not_ paused is permitted
 #[test]
 fn test_redundant_unpause() {
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(0, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
 
     // We already verified that the token moodule is initially _not_ paused, so performing an
@@ -160,7 +157,7 @@ fn test_redundant_unpause() {
 #[test]
 fn test_unauthorized_pause() {
     // Arrange a token and an unauthorized sender.
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(0, utils::LATEST_PROTOCOL_VERSION);
     stub.init_token(TokenInitTestParams::default());
     let non_governance_account = stub.create_account();
 
@@ -205,7 +202,7 @@ fn test_unauthorized_pause() {
 #[test]
 fn test_unauthorized_unpause() {
     // Arrange a token and an unauthorized sender.
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(0, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
     let non_governance_account = stub.create_account();
 
@@ -262,7 +259,7 @@ fn test_unauthorized_unpause() {
 /// permitted due to the paused token state.
 #[test]
 fn test_pause_multiple_ops() {
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
 
     // We test that a transaction consisting of a "pause" and "mint" operation fails, as minting is
@@ -306,7 +303,7 @@ fn test_pause_multiple_ops() {
 /// permitted while token is paused.
 #[test]
 fn test_unpause_multiple_ops() {
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default().mintable());
 
     // First we set the token to paused.

--- a/plt/plt-token-module/tests/token_module_transfer.rs
+++ b/plt/plt-token-module/tests/token_module_transfer.rs
@@ -19,13 +19,10 @@ mod utils;
 
 const NON_EXISTING_ACCOUNT: AccountAddress = AccountAddress([2u8; 32]);
 
-/// Default protocol version used across the tests.
-const PROTOCOL_VERSION: ProtocolVersion = utils::LATEST_PROTOCOL_VERSION;
-
 /// Test successful transfer.
 #[test]
 fn test_transfer() {
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     stub.init_token(TokenInitTestParams::default());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -54,7 +51,7 @@ fn test_transfer() {
 /// Test successful transfer with memo.
 #[test]
 fn test_transfer_with_memo() {
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     stub.init_token(TokenInitTestParams::default());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -83,7 +80,7 @@ fn test_transfer_with_memo() {
 /// Test transfer to sending account
 #[test]
 fn test_transfer_self() {
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     stub.init_token(TokenInitTestParams::default());
     let sender = stub.create_account();
     stub.set_account_balance(sender, RawTokenAmount(5000));
@@ -107,7 +104,7 @@ fn test_transfer_self() {
 /// Test transfer with unsufficient funds
 #[test]
 fn test_transfer_insufficient_balance() {
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     stub.init_token(TokenInitTestParams::default());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -140,7 +137,7 @@ fn test_transfer_insufficient_balance() {
 /// Test transfer with amount specified with wrong number of decimals
 #[test]
 fn test_transfer_decimals_mismatch() {
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     stub.init_token(TokenInitTestParams::default());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -170,7 +167,7 @@ fn test_transfer_decimals_mismatch() {
 /// Test transfer where receiving account does not exist
 #[test]
 fn test_transfer_to_non_existing_receiver() {
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     stub.init_token(TokenInitTestParams::default());
     let sender = stub.create_account();
     stub.set_account_balance(sender, RawTokenAmount(5000));
@@ -200,7 +197,7 @@ fn test_transfer_to_non_existing_receiver() {
 /// Test transfer succeeds when both accounts are on allow list.
 #[test]
 fn test_transfer_allow_list_success() {
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     let _gov_account = stub.init_token(TokenInitTestParams::default().allow_list());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -233,7 +230,7 @@ fn test_transfer_allow_list_success() {
 /// Test transfer succeeds when accounts are not on deny list.
 #[test]
 fn test_transfer_deny_list_success() {
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     let _gov_account = stub.init_token(TokenInitTestParams::default().deny_list());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -266,7 +263,7 @@ fn test_transfer_deny_list_success() {
 /// Reject "transfer" operations when sender is not in allow list.
 #[test]
 fn test_transfer_sender_not_in_allow_list() {
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     let _gov_account = stub.init_token(TokenInitTestParams::default().allow_list());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -308,7 +305,7 @@ fn test_transfer_sender_not_in_allow_list() {
 /// Reject "transfer" operations when recipient is not in allow list.
 #[test]
 fn test_transfer_recipient_not_in_allow_list() {
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     let _gov_account = stub.init_token(TokenInitTestParams::default().allow_list());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -350,7 +347,7 @@ fn test_transfer_recipient_not_in_allow_list() {
 /// Reject "transfer" operations when sender is in deny list.
 #[test]
 fn test_transfer_sender_in_deny_list() {
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     let _gov_account = stub.init_token(TokenInitTestParams::default().deny_list());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -392,7 +389,7 @@ fn test_transfer_sender_in_deny_list() {
 /// Reject "transfer" operations when recipient is in deny list.
 #[test]
 fn test_transfer_recipient_in_deny_list() {
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     let _gov_account = stub.init_token(TokenInitTestParams::default().deny_list());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -434,7 +431,7 @@ fn test_transfer_recipient_in_deny_list() {
 /// Reject "transfer" operations while token is paused
 #[test]
 fn test_transfer_paused() {
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
     let receiver = stub.create_account();
     stub.set_account_balance(gov_account, RawTokenAmount(5000));

--- a/plt/plt-token-module/tests/token_module_transfer.rs
+++ b/plt/plt-token-module/tests/token_module_transfer.rs
@@ -1,5 +1,6 @@
 use crate::kernel_stub::{TokenInitTestParams, TransactionExecutionTestImpl};
 use assert_matches::assert_matches;
+use concordium_base::base::ProtocolVersion;
 use concordium_base::common::cbor;
 use concordium_base::contracts_common::AccountAddress;
 use concordium_base::protocol_level_tokens::{
@@ -11,7 +12,7 @@ use concordium_base::transactions::Memo;
 use kernel_stub::KernelStub;
 use plt_scheduler_interface::token_kernel_interface::TokenKernelQueries;
 use plt_scheduler_types::types::tokens::RawTokenAmount;
-use plt_token_module::token_module::{self};
+use plt_token_module::token_module;
 
 mod kernel_stub;
 mod utils;
@@ -21,7 +22,11 @@ const NON_EXISTING_ACCOUNT: AccountAddress = AccountAddress([2u8; 32]);
 /// Test successful transfer.
 #[test]
 fn test_transfer() {
-    let mut stub = KernelStub::with_decimals(2);
+    test_transfer_worker(ProtocolVersion::P10);
+}
+
+fn test_transfer_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     stub.init_token(TokenInitTestParams::default());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -50,7 +55,10 @@ fn test_transfer() {
 /// Test successful transfer with memo.
 #[test]
 fn test_transfer_with_memo() {
-    let mut stub = KernelStub::with_decimals(2);
+    test_transfer_with_memo_worker(ProtocolVersion::P10);
+}
+fn test_transfer_with_memo_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     stub.init_token(TokenInitTestParams::default());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -79,7 +87,10 @@ fn test_transfer_with_memo() {
 /// Test transfer to sending account
 #[test]
 fn test_transfer_self() {
-    let mut stub = KernelStub::with_decimals(2);
+    test_transfer_self_worker(ProtocolVersion::P10);
+}
+fn test_transfer_self_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     stub.init_token(TokenInitTestParams::default());
     let sender = stub.create_account();
     stub.set_account_balance(sender, RawTokenAmount(5000));
@@ -103,7 +114,10 @@ fn test_transfer_self() {
 /// Test transfer with unsufficient funds
 #[test]
 fn test_transfer_insufficient_balance() {
-    let mut stub = KernelStub::with_decimals(2);
+    test_transfer_insufficient_balance_worker(ProtocolVersion::P10);
+}
+fn test_transfer_insufficient_balance_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     stub.init_token(TokenInitTestParams::default());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -136,7 +150,11 @@ fn test_transfer_insufficient_balance() {
 /// Test transfer with amount specified with wrong number of decimals
 #[test]
 fn test_transfer_decimals_mismatch() {
-    let mut stub = KernelStub::with_decimals(2);
+    test_transfer_decimals_mismatch_worker(ProtocolVersion::P10);
+}
+
+fn test_transfer_decimals_mismatch_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     stub.init_token(TokenInitTestParams::default());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -166,7 +184,10 @@ fn test_transfer_decimals_mismatch() {
 /// Test transfer where receiving account does not exist
 #[test]
 fn test_transfer_to_non_existing_receiver() {
-    let mut stub = KernelStub::with_decimals(2);
+    test_transfer_to_non_existing_receiver_worker(ProtocolVersion::P10);
+}
+fn test_transfer_to_non_existing_receiver_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     stub.init_token(TokenInitTestParams::default());
     let sender = stub.create_account();
     stub.set_account_balance(sender, RawTokenAmount(5000));
@@ -196,7 +217,10 @@ fn test_transfer_to_non_existing_receiver() {
 /// Test transfer succeeds when both accounts are on allow list.
 #[test]
 fn test_transfer_allow_list_success() {
-    let mut stub = KernelStub::with_decimals(2);
+    test_transfer_allow_list_success_worker(ProtocolVersion::P10);
+}
+fn test_transfer_allow_list_success_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     let _gov_account = stub.init_token(TokenInitTestParams::default().allow_list());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -229,7 +253,10 @@ fn test_transfer_allow_list_success() {
 /// Test transfer succeeds when accounts are not on deny list.
 #[test]
 fn test_transfer_deny_list_success() {
-    let mut stub = KernelStub::with_decimals(2);
+    test_transfer_deny_list_success_worker(ProtocolVersion::P10);
+}
+fn test_transfer_deny_list_success_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     let _gov_account = stub.init_token(TokenInitTestParams::default().deny_list());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -262,7 +289,10 @@ fn test_transfer_deny_list_success() {
 /// Reject "transfer" operations when sender is not in allow list.
 #[test]
 fn test_transfer_sender_not_in_allow_list() {
-    let mut stub = KernelStub::with_decimals(2);
+    test_transfer_sender_not_in_allow_list_worker(ProtocolVersion::P10);
+}
+fn test_transfer_sender_not_in_allow_list_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     let _gov_account = stub.init_token(TokenInitTestParams::default().allow_list());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -304,7 +334,10 @@ fn test_transfer_sender_not_in_allow_list() {
 /// Reject "transfer" operations when recipient is not in allow list.
 #[test]
 fn test_transfer_recipient_not_in_allow_list() {
-    let mut stub = KernelStub::with_decimals(2);
+    test_transfer_recipient_not_in_allow_list_worker(ProtocolVersion::P10);
+}
+fn test_transfer_recipient_not_in_allow_list_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     let _gov_account = stub.init_token(TokenInitTestParams::default().allow_list());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -346,7 +379,10 @@ fn test_transfer_recipient_not_in_allow_list() {
 /// Reject "transfer" operations when sender is in deny list.
 #[test]
 fn test_transfer_sender_in_deny_list() {
-    let mut stub = KernelStub::with_decimals(2);
+    test_transfer_sender_in_deny_list_worker(ProtocolVersion::P10);
+}
+fn test_transfer_sender_in_deny_list_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     let _gov_account = stub.init_token(TokenInitTestParams::default().deny_list());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -388,7 +424,10 @@ fn test_transfer_sender_in_deny_list() {
 /// Reject "transfer" operations when recipient is in deny list.
 #[test]
 fn test_transfer_recipient_in_deny_list() {
-    let mut stub = KernelStub::with_decimals(2);
+    test_transfer_recipient_in_deny_list_worker(ProtocolVersion::P10);
+}
+fn test_transfer_recipient_in_deny_list_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     let _gov_account = stub.init_token(TokenInitTestParams::default().deny_list());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -430,7 +469,10 @@ fn test_transfer_recipient_in_deny_list() {
 /// Reject "transfer" operations while token is paused
 #[test]
 fn test_transfer_paused() {
-    let mut stub = KernelStub::with_decimals(2);
+    test_transfer_paused_worker(ProtocolVersion::P10);
+}
+fn test_transfer_paused_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     let gov_account = stub.init_token(TokenInitTestParams::default());
     let receiver = stub.create_account();
     stub.set_account_balance(gov_account, RawTokenAmount(5000));

--- a/plt/plt-token-module/tests/token_module_transfer.rs
+++ b/plt/plt-token-module/tests/token_module_transfer.rs
@@ -19,14 +19,13 @@ mod utils;
 
 const NON_EXISTING_ACCOUNT: AccountAddress = AccountAddress([2u8; 32]);
 
+/// Default protocol version used across the tests.
+const PROTOCOL_VERSION: ProtocolVersion = utils::LATEST_PROTOCOL_VERSION;
+
 /// Test successful transfer.
 #[test]
 fn test_transfer() {
-    test_transfer_worker(ProtocolVersion::P10);
-}
-
-fn test_transfer_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     stub.init_token(TokenInitTestParams::default());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -55,10 +54,7 @@ fn test_transfer_worker(protocol_version: ProtocolVersion) {
 /// Test successful transfer with memo.
 #[test]
 fn test_transfer_with_memo() {
-    test_transfer_with_memo_worker(ProtocolVersion::P10);
-}
-fn test_transfer_with_memo_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     stub.init_token(TokenInitTestParams::default());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -87,10 +83,7 @@ fn test_transfer_with_memo_worker(protocol_version: ProtocolVersion) {
 /// Test transfer to sending account
 #[test]
 fn test_transfer_self() {
-    test_transfer_self_worker(ProtocolVersion::P10);
-}
-fn test_transfer_self_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     stub.init_token(TokenInitTestParams::default());
     let sender = stub.create_account();
     stub.set_account_balance(sender, RawTokenAmount(5000));
@@ -114,10 +107,7 @@ fn test_transfer_self_worker(protocol_version: ProtocolVersion) {
 /// Test transfer with unsufficient funds
 #[test]
 fn test_transfer_insufficient_balance() {
-    test_transfer_insufficient_balance_worker(ProtocolVersion::P10);
-}
-fn test_transfer_insufficient_balance_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     stub.init_token(TokenInitTestParams::default());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -150,11 +140,7 @@ fn test_transfer_insufficient_balance_worker(protocol_version: ProtocolVersion) 
 /// Test transfer with amount specified with wrong number of decimals
 #[test]
 fn test_transfer_decimals_mismatch() {
-    test_transfer_decimals_mismatch_worker(ProtocolVersion::P10);
-}
-
-fn test_transfer_decimals_mismatch_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     stub.init_token(TokenInitTestParams::default());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -184,10 +170,7 @@ fn test_transfer_decimals_mismatch_worker(protocol_version: ProtocolVersion) {
 /// Test transfer where receiving account does not exist
 #[test]
 fn test_transfer_to_non_existing_receiver() {
-    test_transfer_to_non_existing_receiver_worker(ProtocolVersion::P10);
-}
-fn test_transfer_to_non_existing_receiver_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     stub.init_token(TokenInitTestParams::default());
     let sender = stub.create_account();
     stub.set_account_balance(sender, RawTokenAmount(5000));
@@ -217,10 +200,7 @@ fn test_transfer_to_non_existing_receiver_worker(protocol_version: ProtocolVersi
 /// Test transfer succeeds when both accounts are on allow list.
 #[test]
 fn test_transfer_allow_list_success() {
-    test_transfer_allow_list_success_worker(ProtocolVersion::P10);
-}
-fn test_transfer_allow_list_success_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     let _gov_account = stub.init_token(TokenInitTestParams::default().allow_list());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -253,10 +233,7 @@ fn test_transfer_allow_list_success_worker(protocol_version: ProtocolVersion) {
 /// Test transfer succeeds when accounts are not on deny list.
 #[test]
 fn test_transfer_deny_list_success() {
-    test_transfer_deny_list_success_worker(ProtocolVersion::P10);
-}
-fn test_transfer_deny_list_success_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     let _gov_account = stub.init_token(TokenInitTestParams::default().deny_list());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -289,10 +266,7 @@ fn test_transfer_deny_list_success_worker(protocol_version: ProtocolVersion) {
 /// Reject "transfer" operations when sender is not in allow list.
 #[test]
 fn test_transfer_sender_not_in_allow_list() {
-    test_transfer_sender_not_in_allow_list_worker(ProtocolVersion::P10);
-}
-fn test_transfer_sender_not_in_allow_list_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     let _gov_account = stub.init_token(TokenInitTestParams::default().allow_list());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -334,10 +308,7 @@ fn test_transfer_sender_not_in_allow_list_worker(protocol_version: ProtocolVersi
 /// Reject "transfer" operations when recipient is not in allow list.
 #[test]
 fn test_transfer_recipient_not_in_allow_list() {
-    test_transfer_recipient_not_in_allow_list_worker(ProtocolVersion::P10);
-}
-fn test_transfer_recipient_not_in_allow_list_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     let _gov_account = stub.init_token(TokenInitTestParams::default().allow_list());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -379,10 +350,7 @@ fn test_transfer_recipient_not_in_allow_list_worker(protocol_version: ProtocolVe
 /// Reject "transfer" operations when sender is in deny list.
 #[test]
 fn test_transfer_sender_in_deny_list() {
-    test_transfer_sender_in_deny_list_worker(ProtocolVersion::P10);
-}
-fn test_transfer_sender_in_deny_list_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     let _gov_account = stub.init_token(TokenInitTestParams::default().deny_list());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -424,10 +392,7 @@ fn test_transfer_sender_in_deny_list_worker(protocol_version: ProtocolVersion) {
 /// Reject "transfer" operations when recipient is in deny list.
 #[test]
 fn test_transfer_recipient_in_deny_list() {
-    test_transfer_recipient_in_deny_list_worker(ProtocolVersion::P10);
-}
-fn test_transfer_recipient_in_deny_list_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     let _gov_account = stub.init_token(TokenInitTestParams::default().deny_list());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -469,10 +434,7 @@ fn test_transfer_recipient_in_deny_list_worker(protocol_version: ProtocolVersion
 /// Reject "transfer" operations while token is paused
 #[test]
 fn test_transfer_paused() {
-    test_transfer_paused_worker(ProtocolVersion::P10);
-}
-fn test_transfer_paused_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     let gov_account = stub.init_token(TokenInitTestParams::default());
     let receiver = stub.create_account();
     stub.set_account_balance(gov_account, RawTokenAmount(5000));

--- a/plt/plt-token-module/tests/token_module_transfer.rs
+++ b/plt/plt-token-module/tests/token_module_transfer.rs
@@ -1,6 +1,5 @@
 use crate::kernel_stub::{TokenInitTestParams, TransactionExecutionTestImpl};
 use assert_matches::assert_matches;
-use concordium_base::base::ProtocolVersion;
 use concordium_base::common::cbor;
 use concordium_base::contracts_common::AccountAddress;
 use concordium_base::protocol_level_tokens::{

--- a/plt/plt-token-module/tests/token_module_update_general.rs
+++ b/plt/plt-token-module/tests/token_module_update_general.rs
@@ -16,14 +16,13 @@ mod kernel_stub;
 mod utils;
 
 const NON_EXISTING_ACCOUNT: AccountAddress = AccountAddress([2u8; 32]);
+/// Default protocol version used across the tests.
+const PROTOCOL_VERSION: ProtocolVersion = utils::LATEST_PROTOCOL_VERSION;
 
 /// Test failure to decode token operations
 #[test]
 fn test_update_token_decode_failure() {
-    test_update_token_decode_failure_worker(ProtocolVersion::P10);
-}
-fn test_update_token_decode_failure_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     let sender = stub.create_account();
     let mut execution = TransactionExecutionTestImpl::with_sender(sender);
     let res = token_module::execute_token_update_transaction(
@@ -44,10 +43,7 @@ fn test_update_token_decode_failure_worker(protocol_version: ProtocolVersion) {
 /// Test additional fields specifeid in token update operation.
 #[test]
 fn test_update_token_additional_fields() {
-    test_update_token_additional_fields_worker(ProtocolVersion::P10);
-}
-fn test_update_token_additional_fields_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(0, protocol_version);
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
     let sender = stub.create_account();
     let receiver = stub.create_account();
     let mut execution = TransactionExecutionTestImpl::with_sender(sender);
@@ -88,10 +84,7 @@ fn test_update_token_additional_fields_worker(protocol_version: ProtocolVersion)
 /// Test transaction with multiple operations
 #[test]
 fn test_multiple_operations() {
-    test_multiple_operations_worker(ProtocolVersion::P10);
-}
-fn test_multiple_operations_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     stub.init_token(TokenInitTestParams::default());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -125,10 +118,7 @@ fn test_multiple_operations_worker(protocol_version: ProtocolVersion) {
 /// Test transaction with multiple operations where one of them fail.
 #[test]
 fn test_single_failing_operation() {
-    test_single_failing_operation_worker(ProtocolVersion::P10);
-}
-fn test_single_failing_operation_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     stub.init_token(TokenInitTestParams::default());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -167,11 +157,7 @@ fn test_single_failing_operation_worker(protocol_version: ProtocolVersion) {
 /// Test that energy is charged for execution of operations.
 #[test]
 fn test_energy_charge() {
-    test_energy_charge_worker(ProtocolVersion::P10);
-}
-
-fn test_energy_charge_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     stub.init_token(TokenInitTestParams::default());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -199,10 +185,7 @@ fn test_energy_charge_worker(protocol_version: ProtocolVersion) {
 /// Test hitting out of energy error.
 #[test]
 fn test_out_of_energy_error() {
-    test_out_of_energy_error_worker(ProtocolVersion::P10);
-}
-fn test_out_of_energy_error_worker(protocol_version: ProtocolVersion) {
-    let mut stub = KernelStub::with_decimals(2, protocol_version);
+    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
     stub.init_token(TokenInitTestParams::default());
     let sender = stub.create_account();
     let receiver = stub.create_account();

--- a/plt/plt-token-module/tests/token_module_update_general.rs
+++ b/plt/plt-token-module/tests/token_module_update_general.rs
@@ -1,6 +1,6 @@
 use crate::kernel_stub::{TokenInitTestParams, TransactionExecutionTestImpl};
 use assert_matches::assert_matches;
-use concordium_base::base::Energy;
+use concordium_base::base::{Energy, ProtocolVersion};
 use concordium_base::common::cbor;
 use concordium_base::contracts_common::AccountAddress;
 use concordium_base::protocol_level_tokens::{
@@ -20,7 +20,10 @@ const NON_EXISTING_ACCOUNT: AccountAddress = AccountAddress([2u8; 32]);
 /// Test failure to decode token operations
 #[test]
 fn test_update_token_decode_failure() {
-    let mut stub = KernelStub::with_decimals(0);
+    test_update_token_decode_failure_worker(ProtocolVersion::P10);
+}
+fn test_update_token_decode_failure_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     let sender = stub.create_account();
     let mut execution = TransactionExecutionTestImpl::with_sender(sender);
     let res = token_module::execute_token_update_transaction(
@@ -41,7 +44,10 @@ fn test_update_token_decode_failure() {
 /// Test additional fields specifeid in token update operation.
 #[test]
 fn test_update_token_additional_fields() {
-    let mut stub = KernelStub::with_decimals(0);
+    test_update_token_additional_fields_worker(ProtocolVersion::P10);
+}
+fn test_update_token_additional_fields_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(0, protocol_version);
     let sender = stub.create_account();
     let receiver = stub.create_account();
     let mut execution = TransactionExecutionTestImpl::with_sender(sender);
@@ -82,7 +88,10 @@ fn test_update_token_additional_fields() {
 /// Test transaction with multiple operations
 #[test]
 fn test_multiple_operations() {
-    let mut stub = KernelStub::with_decimals(2);
+    test_multiple_operations_worker(ProtocolVersion::P10);
+}
+fn test_multiple_operations_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     stub.init_token(TokenInitTestParams::default());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -116,7 +125,10 @@ fn test_multiple_operations() {
 /// Test transaction with multiple operations where one of them fail.
 #[test]
 fn test_single_failing_operation() {
-    let mut stub = KernelStub::with_decimals(2);
+    test_single_failing_operation_worker(ProtocolVersion::P10);
+}
+fn test_single_failing_operation_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     stub.init_token(TokenInitTestParams::default());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -155,7 +167,11 @@ fn test_single_failing_operation() {
 /// Test that energy is charged for execution of operations.
 #[test]
 fn test_energy_charge() {
-    let mut stub = KernelStub::with_decimals(2);
+    test_energy_charge_worker(ProtocolVersion::P10);
+}
+
+fn test_energy_charge_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     stub.init_token(TokenInitTestParams::default());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -183,7 +199,10 @@ fn test_energy_charge() {
 /// Test hitting out of energy error.
 #[test]
 fn test_out_of_energy_error() {
-    let mut stub = KernelStub::with_decimals(2);
+    test_out_of_energy_error_worker(ProtocolVersion::P10);
+}
+fn test_out_of_energy_error_worker(protocol_version: ProtocolVersion) {
+    let mut stub = KernelStub::with_decimals(2, protocol_version);
     stub.init_token(TokenInitTestParams::default());
     let sender = stub.create_account();
     let receiver = stub.create_account();

--- a/plt/plt-token-module/tests/token_module_update_general.rs
+++ b/plt/plt-token-module/tests/token_module_update_general.rs
@@ -1,6 +1,6 @@
 use crate::kernel_stub::{TokenInitTestParams, TransactionExecutionTestImpl};
 use assert_matches::assert_matches;
-use concordium_base::base::{Energy, ProtocolVersion};
+use concordium_base::base::Energy;
 use concordium_base::common::cbor;
 use concordium_base::contracts_common::AccountAddress;
 use concordium_base::protocol_level_tokens::{

--- a/plt/plt-token-module/tests/token_module_update_general.rs
+++ b/plt/plt-token-module/tests/token_module_update_general.rs
@@ -16,13 +16,11 @@ mod kernel_stub;
 mod utils;
 
 const NON_EXISTING_ACCOUNT: AccountAddress = AccountAddress([2u8; 32]);
-/// Default protocol version used across the tests.
-const PROTOCOL_VERSION: ProtocolVersion = utils::LATEST_PROTOCOL_VERSION;
 
 /// Test failure to decode token operations
 #[test]
 fn test_update_token_decode_failure() {
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(0, utils::LATEST_PROTOCOL_VERSION);
     let sender = stub.create_account();
     let mut execution = TransactionExecutionTestImpl::with_sender(sender);
     let res = token_module::execute_token_update_transaction(
@@ -43,7 +41,7 @@ fn test_update_token_decode_failure() {
 /// Test additional fields specifeid in token update operation.
 #[test]
 fn test_update_token_additional_fields() {
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(0, utils::LATEST_PROTOCOL_VERSION);
     let sender = stub.create_account();
     let receiver = stub.create_account();
     let mut execution = TransactionExecutionTestImpl::with_sender(sender);
@@ -84,7 +82,7 @@ fn test_update_token_additional_fields() {
 /// Test transaction with multiple operations
 #[test]
 fn test_multiple_operations() {
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     stub.init_token(TokenInitTestParams::default());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -118,7 +116,7 @@ fn test_multiple_operations() {
 /// Test transaction with multiple operations where one of them fail.
 #[test]
 fn test_single_failing_operation() {
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     stub.init_token(TokenInitTestParams::default());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -157,7 +155,7 @@ fn test_single_failing_operation() {
 /// Test that energy is charged for execution of operations.
 #[test]
 fn test_energy_charge() {
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     stub.init_token(TokenInitTestParams::default());
     let sender = stub.create_account();
     let receiver = stub.create_account();
@@ -185,7 +183,7 @@ fn test_energy_charge() {
 /// Test hitting out of energy error.
 #[test]
 fn test_out_of_energy_error() {
-    let mut stub = KernelStub::with_decimals(2, PROTOCOL_VERSION);
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
     stub.init_token(TokenInitTestParams::default());
     let sender = stub.create_account();
     let receiver = stub.create_account();

--- a/plt/plt-token-module/tests/utils/mod.rs
+++ b/plt/plt-token-module/tests/utils/mod.rs
@@ -1,8 +1,12 @@
 use assert_matches::assert_matches;
+use concordium_base::base::ProtocolVersion;
 use concordium_base::protocol_level_tokens::{
     TokenModuleRejectReason, TokenModuleRejectReasonType,
 };
 use plt_token_module::token_module::{RejectReason, TokenUpdateError};
+
+/// The most recent protocol version.
+pub const LATEST_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::P11;
 
 fn decode_reject_reason(reject_reason: &RejectReason) -> TokenModuleRejectReason {
     let reject_reason_type =


### PR DESCRIPTION
## Purpose

Expose whether RBAC should be enabled to the token module.
[Linear task](https://linear.app/concordium/issue/PSR-71/support-running-multiple-protocol-version-in-the-rust-scheduler).

No unit tests were added as part of this, since this will be covered as part of the unit tests for the RBAC implementation.

## Changes

- Pass in the protocol version to the rust scheduler lib.
- Parameterize unit tests on the protocol version.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

