### PR TITLE
Simplifytokenkernel2

### DIFF
--- a/plt/plt-scheduler-interface/src/token_kernel_interface.rs
+++ b/plt/plt-scheduler-interface/src/token_kernel_interface.rs
@@ -67,16 +67,6 @@ pub enum TokenBurnError {
     InsufficientBalance(#[from] InsufficientBalanceError),
 }
 
-/// Representation of an account, together with its address.
-#[derive(Debug, Clone)]
-pub struct AccountWithAddress<Account> {
-    /// Opaque type that represents an account on chain.
-    pub account: Account,
-    /// The account address of the account. This can be the canonical address or
-    /// an alias that was used to look up the account.
-    pub account_address: AccountAddress,
-}
-
 /// Queries provided by the token kernel. All queries are in context of
 /// a specific token that the kernel is initialized with.
 pub trait TokenKernelQueries {
@@ -88,7 +78,7 @@ pub trait TokenKernelQueries {
     fn account_by_address(
         &self,
         address: &AccountAddress,
-    ) -> Result<AccountWithAddress<Self::Account>, AccountNotFoundByAddressError>;
+    ) -> Result<Self::Account, AccountNotFoundByAddressError>;
 
     /// Lookup the account using an account index.
     /// Returns both the opaque account
@@ -138,7 +128,8 @@ pub trait TokenKernelOperations: TokenKernelQueries {
     /// - [`TokenMintError::StateInvariantViolation`] If an internal token state invariant is broken.
     fn mint(
         &mut self,
-        account: &AccountWithAddress<Self::Account>,
+        account: &Self::Account,
+        account_address: AccountAddress,
         amount: RawTokenAmount,
     ) -> Result<(), TokenMintError>;
 
@@ -154,7 +145,8 @@ pub trait TokenKernelOperations: TokenKernelQueries {
     /// - [`TokenBurnError::StateInvariantViolation`] If an internal token state invariant is broken.
     fn burn(
         &mut self,
-        account: &AccountWithAddress<Self::Account>,
+        account: &Self::Account,
+        account_address: AccountAddress,
         amount: RawTokenAmount,
     ) -> Result<(), TokenBurnError>;
 
@@ -170,8 +162,10 @@ pub trait TokenKernelOperations: TokenKernelQueries {
     /// - [`TokenTransferError::StateInvariantViolation`] If an internal token state invariant is broken.
     fn transfer(
         &mut self,
-        from: &AccountWithAddress<Self::Account>,
-        to: &AccountWithAddress<Self::Account>,
+        from: &Self::Account,
+        from_address: AccountAddress,
+        to: &Self::Account,
+        to_address: AccountAddress,
         amount: RawTokenAmount,
         memo: Option<Memo>,
     ) -> Result<(), TokenTransferError>;

--- a/plt/plt-scheduler-interface/src/token_kernel_interface.rs
+++ b/plt/plt-scheduler-interface/src/token_kernel_interface.rs
@@ -67,23 +67,28 @@ pub enum TokenBurnError {
     InsufficientBalance(#[from] InsufficientBalanceError),
 }
 
+/// Representation of an account, together with its address.
+#[derive(Debug, Clone)]
+pub struct AccountWithAddress<Account> {
+    /// Opaque type that represents an account on chain.
+    pub account: Account,
+    /// The account address of the account. This can be the canonical address or
+    /// an alias that was used to look up the account.
+    pub account_address: AccountAddress,
+}
+
 /// Queries provided by the token kernel. All queries are in context of
 /// a specific token that the kernel is initialized with.
 pub trait TokenKernelQueries {
-    /// Opaque type that identifies an account on chain including the address it was connected with
-    /// when looking up the account.
+    /// Opaque type that represents an account on chain.
     /// The account is guaranteed to exist on chain, when holding an instance of this type.
-    ///
-    /// The type corresponds to `BlockStateQuery::Account` but includes the account address also.
-    /// The account address is included to tie it together with the opaque identifier for the account
-    /// in a way that cannot be manipulated by the token module.
-    type AccountWithAddress;
+    type Account;
 
     /// Lookup the account using an account address.
     fn account_by_address(
         &self,
         address: &AccountAddress,
-    ) -> Result<Self::AccountWithAddress, AccountNotFoundByAddressError>;
+    ) -> Result<AccountWithAddress<Self::Account>, AccountNotFoundByAddressError>;
 
     /// Lookup the account using an account index.
     /// Returns both the opaque account
@@ -91,13 +96,13 @@ pub trait TokenKernelQueries {
     fn account_by_index(
         &self,
         index: AccountIndex,
-    ) -> Result<AccountWithCanonicalAddress<Self::AccountWithAddress>, AccountNotFoundByIndexError>;
+    ) -> Result<AccountWithCanonicalAddress<Self::Account>, AccountNotFoundByIndexError>;
 
     /// Get the account index for the account.
-    fn account_index(&self, account: &Self::AccountWithAddress) -> AccountIndex;
+    fn account_index(&self, account: &Self::Account) -> AccountIndex;
 
     /// Get the token balance of the account.
-    fn account_token_balance(&self, account: &Self::AccountWithAddress) -> RawTokenAmount;
+    fn account_token_balance(&self, account: &Self::Account) -> RawTokenAmount;
 
     /// The number of decimals used in the presentation of the token amount.
     fn decimals(&self) -> u8;
@@ -119,7 +124,7 @@ pub trait TokenKernelOperations: TokenKernelQueries {
     /// in order to make sure the token is returned when querying token account info.
     ///
     /// If the account already has a balance for the token in context, the operation has no effect
-    fn touch_account(&mut self, account: &Self::AccountWithAddress);
+    fn touch_account(&mut self, account: &Self::Account);
 
     /// Mint a specified amount and deposit it in the account.
     ///
@@ -133,7 +138,7 @@ pub trait TokenKernelOperations: TokenKernelQueries {
     /// - [`TokenMintError::StateInvariantViolation`] If an internal token state invariant is broken.
     fn mint(
         &mut self,
-        account: &Self::AccountWithAddress,
+        account: &AccountWithAddress<Self::Account>,
         amount: RawTokenAmount,
     ) -> Result<(), TokenMintError>;
 
@@ -149,7 +154,7 @@ pub trait TokenKernelOperations: TokenKernelQueries {
     /// - [`TokenBurnError::StateInvariantViolation`] If an internal token state invariant is broken.
     fn burn(
         &mut self,
-        account: &Self::AccountWithAddress,
+        account: &AccountWithAddress<Self::Account>,
         amount: RawTokenAmount,
     ) -> Result<(), TokenBurnError>;
 
@@ -165,8 +170,8 @@ pub trait TokenKernelOperations: TokenKernelQueries {
     /// - [`TokenTransferError::StateInvariantViolation`] If an internal token state invariant is broken.
     fn transfer(
         &mut self,
-        from: &Self::AccountWithAddress,
-        to: &Self::AccountWithAddress,
+        from: &AccountWithAddress<Self::Account>,
+        to: &AccountWithAddress<Self::Account>,
         amount: RawTokenAmount,
         memo: Option<Memo>,
     ) -> Result<(), TokenTransferError>;

--- a/plt/plt-scheduler-interface/src/transaction_execution_interface.rs
+++ b/plt/plt-scheduler-interface/src/transaction_execution_interface.rs
@@ -1,5 +1,6 @@
 //! Interface/context for transaction execution.
 
+use crate::token_kernel_interface::AccountWithAddress;
 use concordium_base::base::Energy;
 use concordium_base::contracts_common::AccountAddress;
 
@@ -16,10 +17,19 @@ pub trait TransactionExecution {
     type Account;
 
     /// The account initiating the transaction.
-    fn sender_account(&self) -> Self::Account;
+    fn sender_account(&self) -> &Self::Account {
+        &self.sender_account_with_address().account
+    }
 
-    /// The account address of the account initiating the transaction.
-    fn sender_account_address(&self) -> AccountAddress;
+    /// The account address of the account initiating the transaction. This need
+    /// not be canonical address of the account, it can be an alias.
+    fn sender_account_address(&self) -> AccountAddress {
+        self.sender_account_with_address().account_address
+    }
+
+    /// The account initiating the transaction together with the account address. The address
+    /// need not be canonical address of the account, it can be an alias
+    fn sender_account_with_address(&self) -> &AccountWithAddress<Self::Account>;
 
     /// Reduce the available energy for the execution.
     ///

--- a/plt/plt-scheduler-interface/src/transaction_execution_interface.rs
+++ b/plt/plt-scheduler-interface/src/transaction_execution_interface.rs
@@ -1,6 +1,5 @@
 //! Interface/context for transaction execution.
 
-use crate::token_kernel_interface::AccountWithAddress;
 use concordium_base::base::Energy;
 use concordium_base::contracts_common::AccountAddress;
 
@@ -17,19 +16,11 @@ pub trait TransactionExecution {
     type Account;
 
     /// The account initiating the transaction.
-    fn sender_account(&self) -> &Self::Account {
-        &self.sender_account_with_address().account
-    }
+    fn sender_account(&self) -> &Self::Account;
 
     /// The account address of the account initiating the transaction. This need
     /// not be canonical address of the account, it can be an alias.
-    fn sender_account_address(&self) -> AccountAddress {
-        self.sender_account_with_address().account_address
-    }
-
-    /// The account initiating the transaction together with the account address. The address
-    /// need not be canonical address of the account, it can be an alias
-    fn sender_account_with_address(&self) -> &AccountWithAddress<Self::Account>;
+    fn sender_account_address(&self) -> AccountAddress;
 
     /// Reduce the available energy for the execution.
     ///

--- a/plt/plt-scheduler/src/queries.rs
+++ b/plt/plt-scheduler/src/queries.rs
@@ -72,7 +72,6 @@ pub fn query_token_account_infos<BSQ>(
 ) -> Vec<TokenAccountInfo>
 where
     BSQ: BlockStateQuery,
-    BSQ::Account: Clone,
 {
     block_state
         .token_account_states(&account)

--- a/plt/plt-scheduler/src/scheduler.rs
+++ b/plt/plt-scheduler/src/scheduler.rs
@@ -6,6 +6,7 @@ use concordium_base::contracts_common::AccountAddress;
 use concordium_base::transactions::Payload;
 use concordium_base::updates::UpdatePayload;
 use plt_block_state::block_state_interface::BlockStateOperations;
+use plt_scheduler_interface::token_kernel_interface::AccountWithAddress;
 use plt_scheduler_interface::transaction_execution_interface::{
     OutOfEnergyError, TransactionExecution,
 };
@@ -20,21 +21,17 @@ struct TransactionExecutionImpl<Account> {
     energy_limit: Energy,
     /// Energy used so far by execution. Energy is always charged in advance for each step executed.
     energy_used: Energy,
-    /// The account which signed as the sender of the transaction.
-    sender_account: Account,
-    /// The address of the account which signed as the sender of the transaction.
-    sender_account_address: AccountAddress,
+    /// The account which signed as the sender of the transaction, together with the account
+    /// address specified as the sender. This need not be the canonical address of the account,
+    /// it can be an account alias.
+    sender_account: AccountWithAddress<Account>,
 }
 
 impl<Account: Clone> TransactionExecution for TransactionExecutionImpl<Account> {
     type Account = Account;
 
-    fn sender_account(&self) -> Account {
-        self.sender_account.clone()
-    }
-
-    fn sender_account_address(&self) -> AccountAddress {
-        self.sender_account_address
+    fn sender_account_with_address(&self) -> &AccountWithAddress<Self::Account> {
+        &self.sender_account
     }
 
     fn tick_energy(&mut self, energy: Energy) -> Result<(), OutOfEnergyError> {
@@ -99,8 +96,10 @@ where
     let mut execution = TransactionExecutionImpl {
         energy_limit,
         energy_used: Energy::default(),
-        sender_account,
-        sender_account_address,
+        sender_account: AccountWithAddress {
+            account: sender_account,
+            account_address: sender_account_address,
+        },
     };
 
     match payload {

--- a/plt/plt-scheduler/src/scheduler.rs
+++ b/plt/plt-scheduler/src/scheduler.rs
@@ -6,7 +6,6 @@ use concordium_base::contracts_common::AccountAddress;
 use concordium_base::transactions::Payload;
 use concordium_base::updates::UpdatePayload;
 use plt_block_state::block_state_interface::BlockStateOperations;
-use plt_scheduler_interface::token_kernel_interface::AccountWithAddress;
 use plt_scheduler_interface::transaction_execution_interface::{
     OutOfEnergyError, TransactionExecution,
 };
@@ -21,17 +20,22 @@ struct TransactionExecutionImpl<Account> {
     energy_limit: Energy,
     /// Energy used so far by execution. Energy is always charged in advance for each step executed.
     energy_used: Energy,
-    /// The account which signed as the sender of the transaction, together with the account
-    /// address specified as the sender. This need not be the canonical address of the account,
-    /// it can be an account alias.
-    sender_account: AccountWithAddress<Account>,
+    /// The account which signed as the sender of the transaction.
+    sender_account: Account,
+    /// The address of the account which signed as the sender of the transaction. This need not be
+    /// the canonical address of the account, it can be an account alias.
+    sender_account_address: AccountAddress,
 }
 
 impl<Account: Clone> TransactionExecution for TransactionExecutionImpl<Account> {
     type Account = Account;
 
-    fn sender_account_with_address(&self) -> &AccountWithAddress<Self::Account> {
+    fn sender_account(&self) -> &Self::Account {
         &self.sender_account
+    }
+
+    fn sender_account_address(&self) -> AccountAddress {
+        self.sender_account_address
     }
 
     fn tick_energy(&mut self, energy: Energy) -> Result<(), OutOfEnergyError> {
@@ -96,10 +100,8 @@ where
     let mut execution = TransactionExecutionImpl {
         energy_limit,
         energy_used: Energy::default(),
-        sender_account: AccountWithAddress {
-            account: sender_account,
-            account_address: sender_account_address,
-        },
+        sender_account,
+        sender_account_address,
     };
 
     match payload {

--- a/plt/plt-scheduler/src/scheduler.rs
+++ b/plt/plt-scheduler/src/scheduler.rs
@@ -27,7 +27,7 @@ struct TransactionExecutionImpl<Account> {
     sender_account_address: AccountAddress,
 }
 
-impl<Account: Clone> TransactionExecution for TransactionExecutionImpl<Account> {
+impl<Account> TransactionExecution for TransactionExecutionImpl<Account> {
     type Account = Account;
 
     fn sender_account(&self) -> &Self::Account {
@@ -93,10 +93,7 @@ pub fn execute_transaction<BSO: BlockStateOperations>(
     block_state: &mut BSO,
     payload: Payload,
     energy_limit: Energy,
-) -> Result<TransactionExecutionSummary, TransactionExecutionError>
-where
-    BSO::Account: Clone,
-{
+) -> Result<TransactionExecutionSummary, TransactionExecutionError> {
     let mut execution = TransactionExecutionImpl {
         energy_limit,
         energy_used: Energy::default(),
@@ -149,10 +146,7 @@ pub enum ChainUpdateExecutionError {
 pub fn execute_chain_update<BSO: BlockStateOperations>(
     block_state: &mut BSO,
     payload: UpdatePayload,
-) -> Result<ChainUpdateOutcome, ChainUpdateExecutionError>
-where
-    BSO::Account: Clone,
-{
+) -> Result<ChainUpdateOutcome, ChainUpdateExecutionError> {
     match payload {
         UpdatePayload::CreatePlt(create_plt) => {
             plt_scheduler::execute_create_plt_chain_update(block_state, create_plt)

--- a/plt/plt-scheduler/src/scheduler/plt_scheduler.rs
+++ b/plt/plt-scheduler/src/scheduler/plt_scheduler.rs
@@ -3,8 +3,6 @@
 
 use crate::scheduler::{ChainUpdateExecutionError, TransactionExecutionError};
 use crate::token_kernel::TokenKernelOperationsImpl;
-use concordium_base::base::Energy;
-use concordium_base::contracts_common::AccountAddress;
 use concordium_base::protocol_level_tokens::TokenOperationsPayload;
 use concordium_base::transactions;
 use concordium_base::updates::CreatePlt;
@@ -82,20 +80,9 @@ pub fn execute_token_update_transaction<
         events: &mut events,
     };
 
-    // Create transaction execution that uses the account type (AccountIndex, AccountAddress).
-    // This is done in order to match the AccountWithAddress type in the kernel implementation
-    // which is also (AccountIndex, AccountAddress):
-    // TransactionExecution::Account = TokenKernelQueries::AccountWithAddress
-    // (see trait bounds on execute_token_update_transaction).
-    // See the documentation on TokenKernelQueries::AccountWithAddress for why the token kernel
-    // opaque account type includes the account address.
-    let mut kernel_transaction_execution = KernelTransactionExecutionImpl {
-        inner: transaction_execution,
-    };
-
     // Call token module to execute operations
     let token_update_result = token_module::execute_token_update_transaction(
-        &mut kernel_transaction_execution,
+        transaction_execution,
         &mut kernel,
         payload.operations,
     );
@@ -128,32 +115,6 @@ pub fn execute_token_update_transaction<
         Err(TokenUpdateError::StateInvariantViolation(err)) => Err(
             TransactionExecutionError::StateInvariantBroken(err.to_string()),
         ),
-    }
-}
-
-/// Transaction execution joining the opaque account identifier with the account address.
-/// This is needed by the token kernel type `TokenKernelQueries::AccountWithAddress`.
-#[derive(Debug)]
-struct KernelTransactionExecutionImpl<'a, TE> {
-    inner: &'a mut TE,
-}
-
-impl<TE: TransactionExecution> TransactionExecution for KernelTransactionExecutionImpl<'_, TE> {
-    type Account = (TE::Account, AccountAddress);
-
-    fn sender_account(&self) -> Self::Account {
-        (
-            self.inner.sender_account(),
-            self.inner.sender_account_address(),
-        )
-    }
-
-    fn sender_account_address(&self) -> AccountAddress {
-        self.inner.sender_account_address()
-    }
-
-    fn tick_energy(&mut self, energy: Energy) -> Result<(), OutOfEnergyError> {
-        self.inner.tick_energy(energy)
     }
 }
 

--- a/plt/plt-scheduler/src/token_kernel.rs
+++ b/plt/plt-scheduler/src/token_kernel.rs
@@ -12,8 +12,9 @@ use plt_block_state::block_state_interface::{
     BlockStateOperations, BlockStateQuery, OverflowError, RawTokenAmountDelta,
 };
 use plt_scheduler_interface::token_kernel_interface::{
-    InsufficientBalanceError, MintWouldOverflowError, TokenBurnError, TokenKernelOperations,
-    TokenKernelQueries, TokenMintError, TokenStateInvariantError, TokenTransferError,
+    AccountWithAddress, InsufficientBalanceError, MintWouldOverflowError, TokenBurnError,
+    TokenKernelOperations, TokenKernelQueries, TokenMintError, TokenStateInvariantError,
+    TokenTransferError,
 };
 use plt_scheduler_types::types::events::{
     BlockItemEvent, EncodedTokenModuleEvent, TokenBurnEvent, TokenMintEvent, TokenTransferEvent,
@@ -31,40 +32,33 @@ pub struct TokenKernelQueriesImpl<'a, BSQ: BlockStateQuery> {
 }
 
 impl<BSQ: BlockStateQuery> TokenKernelQueries for TokenKernelQueriesImpl<'_, BSQ> {
-    type AccountWithAddress = (BSQ::Account, AccountAddress);
+    type Account = BSQ::Account;
 
     fn account_by_address(
         &self,
         address: &AccountAddress,
-    ) -> Result<Self::AccountWithAddress, AccountNotFoundByAddressError> {
+    ) -> Result<AccountWithAddress<Self::Account>, AccountNotFoundByAddressError> {
         let account = self.block_state.account_by_address(address)?;
 
-        Ok((account, *address))
+        Ok(AccountWithAddress {
+            account,
+            account_address: *address,
+        })
     }
 
     fn account_by_index(
         &self,
         index: AccountIndex,
-    ) -> Result<AccountWithCanonicalAddress<Self::AccountWithAddress>, AccountNotFoundByIndexError>
-    {
-        let account_with_canonical_address = self.block_state.account_by_index(index)?;
-
-        Ok(AccountWithCanonicalAddress {
-            account: (
-                account_with_canonical_address.account,
-                account_with_canonical_address.canonical_account_address,
-            ),
-            canonical_account_address: account_with_canonical_address.canonical_account_address,
-        })
+    ) -> Result<AccountWithCanonicalAddress<Self::Account>, AccountNotFoundByIndexError> {
+        self.block_state.account_by_index(index)
     }
 
-    fn account_index(&self, account: &Self::AccountWithAddress) -> AccountIndex {
-        self.block_state.account_index(&account.0)
+    fn account_index(&self, account: &Self::Account) -> AccountIndex {
+        self.block_state.account_index(account)
     }
 
-    fn account_token_balance(&self, account: &Self::AccountWithAddress) -> RawTokenAmount {
-        self.block_state
-            .account_token_balance(&account.0, self.token)
+    fn account_token_balance(&self, account: &Self::Account) -> RawTokenAmount {
+        self.block_state.account_token_balance(account, self.token)
     }
 
     fn decimals(&self) -> u8 {
@@ -94,13 +88,13 @@ pub struct TokenKernelOperationsImpl<'a, BSQ: BlockStateQuery> {
 }
 
 impl<BSO: BlockStateOperations> TokenKernelOperations for TokenKernelOperationsImpl<'_, BSO> {
-    fn touch_account(&mut self, account: &Self::AccountWithAddress) {
-        self.block_state.touch_token_account(self.token, &account.0);
+    fn touch_account(&mut self, account: &Self::Account) {
+        self.block_state.touch_token_account(self.token, account);
     }
 
     fn mint(
         &mut self,
-        account: &Self::AccountWithAddress,
+        account: &AccountWithAddress<Self::Account>,
         amount: RawTokenAmount,
     ) -> Result<(), TokenMintError> {
         // Update total supply
@@ -119,7 +113,11 @@ impl<BSO: BlockStateOperations> TokenKernelOperations for TokenKernelOperationsI
 
         // Update balance of the account
         self.block_state
-            .update_token_account_balance(self.token, &account.0, RawTokenAmountDelta::Add(amount))
+            .update_token_account_balance(
+                self.token,
+                &account.account,
+                RawTokenAmountDelta::Add(amount),
+            )
             .map_err(|_err: OverflowError| {
                 // We should never overflow account balance at mint, since the total circulating supply of the token
                 // is always less that what is representable as a token amount.
@@ -129,7 +127,7 @@ impl<BSO: BlockStateOperations> TokenKernelOperations for TokenKernelOperationsI
         // Issue event
         let event = BlockItemEvent::TokenMint(TokenMintEvent {
             token_id: self.token_configuration.token_id.clone(),
-            target: TokenHolder::Account(account.1),
+            target: TokenHolder::Account(account.account_address),
             amount: TokenAmount {
                 amount,
                 decimals: self.block_state.token_configuration(self.token).decimals,
@@ -143,18 +141,18 @@ impl<BSO: BlockStateOperations> TokenKernelOperations for TokenKernelOperationsI
 
     fn burn(
         &mut self,
-        account: &Self::AccountWithAddress,
+        account: &AccountWithAddress<Self::Account>,
         amount: RawTokenAmount,
     ) -> Result<(), TokenBurnError> {
         // Update balance of the account
         self.block_state
             .update_token_account_balance(
                 self.token,
-                &account.0,
+                &account.account,
                 RawTokenAmountDelta::Subtract(amount),
             )
             .map_err(|_err: OverflowError| InsufficientBalanceError {
-                available: self.account_token_balance(account),
+                available: self.account_token_balance(&account.account),
                 required: amount,
             })?;
 
@@ -172,7 +170,7 @@ impl<BSO: BlockStateOperations> TokenKernelOperations for TokenKernelOperationsI
         // Issue event
         let event = BlockItemEvent::TokenBurn(TokenBurnEvent {
             token_id: self.token_configuration.token_id.clone(),
-            target: TokenHolder::Account(account.1),
+            target: TokenHolder::Account(account.account_address),
             amount: TokenAmount {
                 amount,
                 decimals: self.block_state.token_configuration(self.token).decimals,
@@ -186,8 +184,8 @@ impl<BSO: BlockStateOperations> TokenKernelOperations for TokenKernelOperationsI
 
     fn transfer(
         &mut self,
-        from: &Self::AccountWithAddress,
-        to: &Self::AccountWithAddress,
+        from: &AccountWithAddress<Self::Account>,
+        to: &AccountWithAddress<Self::Account>,
         amount: RawTokenAmount,
         memo: Option<Memo>,
     ) -> Result<(), TokenTransferError> {
@@ -195,17 +193,17 @@ impl<BSO: BlockStateOperations> TokenKernelOperations for TokenKernelOperationsI
         self.block_state
             .update_token_account_balance(
                 self.token,
-                &from.0,
+                &from.account,
                 RawTokenAmountDelta::Subtract(amount),
             )
             .map_err(|_err: OverflowError| InsufficientBalanceError {
-                available: self.account_token_balance(from),
+                available: self.account_token_balance(&from.account),
                 required: amount,
             })?;
 
         // Update receiver balance
         self.block_state
-            .update_token_account_balance(self.token, &to.0, RawTokenAmountDelta::Add(amount))
+            .update_token_account_balance(self.token, &to.account, RawTokenAmountDelta::Add(amount))
             .map_err(|_err: OverflowError| {
                 // We should never overflow at transfer, since the total circulating supply of the token
                 // is always less that what is representable as a token amount.
@@ -215,8 +213,8 @@ impl<BSO: BlockStateOperations> TokenKernelOperations for TokenKernelOperationsI
         // Issue event
         let event = BlockItemEvent::TokenTransfer(TokenTransferEvent {
             token_id: self.token_configuration.token_id.clone(),
-            from: TokenHolder::Account(from.1),
-            to: TokenHolder::Account(to.1),
+            from: TokenHolder::Account(from.account_address),
+            to: TokenHolder::Account(to.account_address),
             amount: TokenAmount {
                 amount,
                 decimals: self.block_state.token_configuration(self.token).decimals,
@@ -246,40 +244,33 @@ impl<BSO: BlockStateOperations> TokenKernelOperations for TokenKernelOperationsI
 }
 
 impl<BSO: BlockStateOperations> TokenKernelQueries for TokenKernelOperationsImpl<'_, BSO> {
-    type AccountWithAddress = (BSO::Account, AccountAddress);
+    type Account = BSO::Account;
 
     fn account_by_address(
         &self,
         address: &AccountAddress,
-    ) -> Result<Self::AccountWithAddress, AccountNotFoundByAddressError> {
+    ) -> Result<AccountWithAddress<Self::Account>, AccountNotFoundByAddressError> {
         let account = self.block_state.account_by_address(address)?;
 
-        Ok((account, *address))
+        Ok(AccountWithAddress {
+            account,
+            account_address: *address,
+        })
     }
 
     fn account_by_index(
         &self,
         index: AccountIndex,
-    ) -> Result<AccountWithCanonicalAddress<Self::AccountWithAddress>, AccountNotFoundByIndexError>
-    {
-        let account_with_canonical_address = self.block_state.account_by_index(index)?;
-
-        Ok(AccountWithCanonicalAddress {
-            account: (
-                account_with_canonical_address.account,
-                account_with_canonical_address.canonical_account_address,
-            ),
-            canonical_account_address: account_with_canonical_address.canonical_account_address,
-        })
+    ) -> Result<AccountWithCanonicalAddress<Self::Account>, AccountNotFoundByIndexError> {
+        self.block_state.account_by_index(index)
     }
 
-    fn account_index(&self, account: &Self::AccountWithAddress) -> AccountIndex {
-        self.block_state.account_index(&account.0)
+    fn account_index(&self, account: &Self::Account) -> AccountIndex {
+        self.block_state.account_index(account)
     }
 
-    fn account_token_balance(&self, account: &Self::AccountWithAddress) -> RawTokenAmount {
-        self.block_state
-            .account_token_balance(&account.0, self.token)
+    fn account_token_balance(&self, account: &Self::Account) -> RawTokenAmount {
+        self.block_state.account_token_balance(account, self.token)
     }
 
     fn decimals(&self) -> u8 {

--- a/plt/plt-scheduler/src/token_kernel.rs
+++ b/plt/plt-scheduler/src/token_kernel.rs
@@ -12,9 +12,8 @@ use plt_block_state::block_state_interface::{
     BlockStateOperations, BlockStateQuery, OverflowError, RawTokenAmountDelta,
 };
 use plt_scheduler_interface::token_kernel_interface::{
-    AccountWithAddress, InsufficientBalanceError, MintWouldOverflowError, TokenBurnError,
-    TokenKernelOperations, TokenKernelQueries, TokenMintError, TokenStateInvariantError,
-    TokenTransferError,
+    InsufficientBalanceError, MintWouldOverflowError, TokenBurnError, TokenKernelOperations,
+    TokenKernelQueries, TokenMintError, TokenStateInvariantError, TokenTransferError,
 };
 use plt_scheduler_types::types::events::{
     BlockItemEvent, EncodedTokenModuleEvent, TokenBurnEvent, TokenMintEvent, TokenTransferEvent,
@@ -37,13 +36,8 @@ impl<BSQ: BlockStateQuery> TokenKernelQueries for TokenKernelQueriesImpl<'_, BSQ
     fn account_by_address(
         &self,
         address: &AccountAddress,
-    ) -> Result<AccountWithAddress<Self::Account>, AccountNotFoundByAddressError> {
-        let account = self.block_state.account_by_address(address)?;
-
-        Ok(AccountWithAddress {
-            account,
-            account_address: *address,
-        })
+    ) -> Result<Self::Account, AccountNotFoundByAddressError> {
+        self.block_state.account_by_address(address)
     }
 
     fn account_by_index(
@@ -94,7 +88,8 @@ impl<BSO: BlockStateOperations> TokenKernelOperations for TokenKernelOperationsI
 
     fn mint(
         &mut self,
-        account: &AccountWithAddress<Self::Account>,
+        account: &Self::Account,
+        account_address: AccountAddress,
         amount: RawTokenAmount,
     ) -> Result<(), TokenMintError> {
         // Update total supply
@@ -113,11 +108,7 @@ impl<BSO: BlockStateOperations> TokenKernelOperations for TokenKernelOperationsI
 
         // Update balance of the account
         self.block_state
-            .update_token_account_balance(
-                self.token,
-                &account.account,
-                RawTokenAmountDelta::Add(amount),
-            )
+            .update_token_account_balance(self.token, account, RawTokenAmountDelta::Add(amount))
             .map_err(|_err: OverflowError| {
                 // We should never overflow account balance at mint, since the total circulating supply of the token
                 // is always less that what is representable as a token amount.
@@ -127,7 +118,7 @@ impl<BSO: BlockStateOperations> TokenKernelOperations for TokenKernelOperationsI
         // Issue event
         let event = BlockItemEvent::TokenMint(TokenMintEvent {
             token_id: self.token_configuration.token_id.clone(),
-            target: TokenHolder::Account(account.account_address),
+            target: TokenHolder::Account(account_address),
             amount: TokenAmount {
                 amount,
                 decimals: self.block_state.token_configuration(self.token).decimals,
@@ -141,18 +132,19 @@ impl<BSO: BlockStateOperations> TokenKernelOperations for TokenKernelOperationsI
 
     fn burn(
         &mut self,
-        account: &AccountWithAddress<Self::Account>,
+        account: &Self::Account,
+        account_address: AccountAddress,
         amount: RawTokenAmount,
     ) -> Result<(), TokenBurnError> {
         // Update balance of the account
         self.block_state
             .update_token_account_balance(
                 self.token,
-                &account.account,
+                account,
                 RawTokenAmountDelta::Subtract(amount),
             )
             .map_err(|_err: OverflowError| InsufficientBalanceError {
-                available: self.account_token_balance(&account.account),
+                available: self.account_token_balance(account),
                 required: amount,
             })?;
 
@@ -170,7 +162,7 @@ impl<BSO: BlockStateOperations> TokenKernelOperations for TokenKernelOperationsI
         // Issue event
         let event = BlockItemEvent::TokenBurn(TokenBurnEvent {
             token_id: self.token_configuration.token_id.clone(),
-            target: TokenHolder::Account(account.account_address),
+            target: TokenHolder::Account(account_address),
             amount: TokenAmount {
                 amount,
                 decimals: self.block_state.token_configuration(self.token).decimals,
@@ -184,26 +176,24 @@ impl<BSO: BlockStateOperations> TokenKernelOperations for TokenKernelOperationsI
 
     fn transfer(
         &mut self,
-        from: &AccountWithAddress<Self::Account>,
-        to: &AccountWithAddress<Self::Account>,
+        from: &Self::Account,
+        from_address: AccountAddress,
+        to: &Self::Account,
+        to_address: AccountAddress,
         amount: RawTokenAmount,
         memo: Option<Memo>,
     ) -> Result<(), TokenTransferError> {
         // Update sender balance
         self.block_state
-            .update_token_account_balance(
-                self.token,
-                &from.account,
-                RawTokenAmountDelta::Subtract(amount),
-            )
+            .update_token_account_balance(self.token, from, RawTokenAmountDelta::Subtract(amount))
             .map_err(|_err: OverflowError| InsufficientBalanceError {
-                available: self.account_token_balance(&from.account),
+                available: self.account_token_balance(from),
                 required: amount,
             })?;
 
         // Update receiver balance
         self.block_state
-            .update_token_account_balance(self.token, &to.account, RawTokenAmountDelta::Add(amount))
+            .update_token_account_balance(self.token, to, RawTokenAmountDelta::Add(amount))
             .map_err(|_err: OverflowError| {
                 // We should never overflow at transfer, since the total circulating supply of the token
                 // is always less that what is representable as a token amount.
@@ -213,8 +203,8 @@ impl<BSO: BlockStateOperations> TokenKernelOperations for TokenKernelOperationsI
         // Issue event
         let event = BlockItemEvent::TokenTransfer(TokenTransferEvent {
             token_id: self.token_configuration.token_id.clone(),
-            from: TokenHolder::Account(from.account_address),
-            to: TokenHolder::Account(to.account_address),
+            from: TokenHolder::Account(from_address),
+            to: TokenHolder::Account(to_address),
             amount: TokenAmount {
                 amount,
                 decimals: self.block_state.token_configuration(self.token).decimals,
@@ -249,13 +239,8 @@ impl<BSO: BlockStateOperations> TokenKernelQueries for TokenKernelOperationsImpl
     fn account_by_address(
         &self,
         address: &AccountAddress,
-    ) -> Result<AccountWithAddress<Self::Account>, AccountNotFoundByAddressError> {
-        let account = self.block_state.account_by_address(address)?;
-
-        Ok(AccountWithAddress {
-            account,
-            account_address: *address,
-        })
+    ) -> Result<Self::Account, AccountNotFoundByAddressError> {
+        self.block_state.account_by_address(address)
     }
 
     fn account_by_index(

--- a/plt/plt-token-module/src/token_module/initialize.rs
+++ b/plt/plt-token-module/src/token_module/initialize.rs
@@ -64,7 +64,7 @@ fn initialize_token_impl(
             "Token metadata is missing".to_string(),
         )
     })?;
-    let governance_account = init_params.governance_account.ok_or_else(|| {
+    let cbor_governance_account = init_params.governance_account.ok_or_else(|| {
         TokenInitializationError::InvalidInitializationParameters(
             "Token governance account is missing".to_string(),
         )
@@ -85,15 +85,19 @@ fn initialize_token_impl(
         kernel.set_module_state(STATE_KEY_BURNABLE, Some(vec![]));
     }
 
-    let governance_account = kernel.account_by_address(&governance_account.address)?;
-    let governance_account_index = kernel.account_index(&governance_account.account);
+    let governance_account = kernel.account_by_address(&cbor_governance_account.address)?;
+    let governance_account_index = kernel.account_index(&governance_account);
     kernel.set_module_state(
         STATE_KEY_GOVERNANCE_ACCOUNT,
         Some(common::to_bytes(&governance_account_index.index)),
     );
     if let Some(initial_supply) = init_params.initial_supply {
         let mint_amount = util::to_raw_token_amount(kernel, initial_supply)?;
-        kernel.mint(&governance_account, mint_amount)?;
+        kernel.mint(
+            &governance_account,
+            cbor_governance_account.address,
+            mint_amount,
+        )?;
     }
     Ok(())
 }

--- a/plt/plt-token-module/src/token_module/initialize.rs
+++ b/plt/plt-token-module/src/token_module/initialize.rs
@@ -86,7 +86,7 @@ fn initialize_token_impl(
     }
 
     let governance_account = kernel.account_by_address(&governance_account.address)?;
-    let governance_account_index = kernel.account_index(&governance_account);
+    let governance_account_index = kernel.account_index(&governance_account.account);
     kernel.set_module_state(
         STATE_KEY_GOVERNANCE_ACCOUNT,
         Some(common::to_bytes(&governance_account_index.index)),

--- a/plt/plt-token-module/src/token_module/update.rs
+++ b/plt/plt-token-module/src/token_module/update.rs
@@ -370,17 +370,18 @@ fn execute_token_transfer<
 
     // operation execution
     check_not_paused(kernel)?;
-    let sender = transaction_execution.sender_account_with_address();
+    let sender = transaction_execution.sender_account();
+    let sender_address = transaction_execution.sender_account_address();
     let receiver = kernel.account_by_address(&transfer_operation.recipient.address)?;
 
     if key_value_state::has_allow_list(kernel) {
-        if !key_value_state::get_allow_list_for(kernel, kernel.account_index(&sender.account)) {
+        if !key_value_state::get_allow_list_for(kernel, kernel.account_index(sender)) {
             return Err(TokenUpdateErrorInternal::OperationNotPermitted {
-                account_address: Some(sender.account_address),
+                account_address: Some(sender_address),
                 reason: "sender not in allow list",
             });
         }
-        if !key_value_state::get_allow_list_for(kernel, kernel.account_index(&receiver.account)) {
+        if !key_value_state::get_allow_list_for(kernel, kernel.account_index(&receiver)) {
             return Err(TokenUpdateErrorInternal::OperationNotPermitted {
                 account_address: Some(transfer_operation.recipient.address),
                 reason: "recipient not in allow list",
@@ -389,13 +390,13 @@ fn execute_token_transfer<
     }
 
     if key_value_state::has_deny_list(kernel) {
-        if key_value_state::get_deny_list_for(kernel, kernel.account_index(&sender.account)) {
+        if key_value_state::get_deny_list_for(kernel, kernel.account_index(sender)) {
             return Err(TokenUpdateErrorInternal::OperationNotPermitted {
-                account_address: Some(sender.account_address),
+                account_address: Some(sender_address),
                 reason: "sender in deny list",
             });
         }
-        if key_value_state::get_deny_list_for(kernel, kernel.account_index(&receiver.account)) {
+        if key_value_state::get_deny_list_for(kernel, kernel.account_index(&receiver)) {
             return Err(TokenUpdateErrorInternal::OperationNotPermitted {
                 account_address: Some(transfer_operation.recipient.address),
                 reason: "recipient in deny list",
@@ -405,7 +406,9 @@ fn execute_token_transfer<
 
     kernel.transfer(
         sender,
+        sender_address,
         &receiver,
+        transfer_operation.recipient.address,
         raw_amount,
         transfer_operation.memo.clone().map(Memo::from),
     )?;
@@ -433,7 +436,8 @@ fn execute_token_mint<
     };
 
     kernel.mint(
-        transaction_execution.sender_account_with_address(),
+        transaction_execution.sender_account(),
+        transaction_execution.sender_account_address(),
         raw_amount,
     )?;
     Ok(())
@@ -460,7 +464,8 @@ fn execute_token_burn<
     }
 
     kernel.burn(
-        transaction_execution.sender_account_with_address(),
+        transaction_execution.sender_account(),
+        transaction_execution.sender_account_address(),
         raw_amount,
     )?;
     Ok(())
@@ -514,8 +519,8 @@ fn execute_add_allow_list<
     }
     let account = kernel.account_by_address(&list_operation.target.address)?;
 
-    kernel.touch_account(&account.account);
-    key_value_state::set_allow_list_for(kernel, kernel.account_index(&account.account), true);
+    kernel.touch_account(&account);
+    key_value_state::set_allow_list_for(kernel, kernel.account_index(&account), true);
 
     let event_details = TokenListUpdateEventDetails {
         target: list_operation.target.clone(),
@@ -543,8 +548,8 @@ fn execute_add_deny_list<
 
     let account = kernel.account_by_address(&list_operation.target.address)?;
 
-    kernel.touch_account(&account.account);
-    key_value_state::set_deny_list_for(kernel, kernel.account_index(&account.account), true);
+    kernel.touch_account(&account);
+    key_value_state::set_deny_list_for(kernel, kernel.account_index(&account), true);
 
     let event_details = TokenListUpdateEventDetails {
         target: list_operation.target.clone(),
@@ -572,8 +577,8 @@ fn execute_remove_allow_list<
 
     let account = kernel.account_by_address(&list_operation.target.address)?;
 
-    kernel.touch_account(&account.account);
-    key_value_state::set_allow_list_for(kernel, kernel.account_index(&account.account), false);
+    kernel.touch_account(&account);
+    key_value_state::set_allow_list_for(kernel, kernel.account_index(&account), false);
 
     let event_details = TokenListUpdateEventDetails {
         target: list_operation.target.clone(),
@@ -601,8 +606,8 @@ fn execute_remove_deny_list<
 
     let account = kernel.account_by_address(&list_operation.target.address)?;
 
-    kernel.touch_account(&account.account);
-    key_value_state::set_deny_list_for(kernel, kernel.account_index(&account.account), false);
+    kernel.touch_account(&account);
+    key_value_state::set_deny_list_for(kernel, kernel.account_index(&account), false);
 
     let event_details = TokenListUpdateEventDetails {
         target: list_operation.target.clone(),

--- a/plt/plt-token-module/src/token_module/update.rs
+++ b/plt/plt-token-module/src/token_module/update.rs
@@ -99,7 +99,7 @@ pub enum TokenUpdateError {
 /// is returned. This is an unrecoverable error and should never happen.
 pub fn execute_token_update_transaction<
     TK: TokenKernelOperations,
-    TE: TransactionExecution<Account = TK::AccountWithAddress>,
+    TE: TransactionExecution<Account = TK::Account>,
 >(
     transaction_execution: &mut TE,
     kernel: &mut TK,
@@ -282,7 +282,7 @@ impl From<TokenBurnError> for TokenUpdateErrorInternal {
 
 fn execute_token_update_operation<
     TK: TokenKernelOperations,
-    TE: TransactionExecution<Account = TK::AccountWithAddress>,
+    TE: TransactionExecution<Account = TK::Account>,
 >(
     transaction_execution: &mut TE,
     kernel: &mut TK,
@@ -340,14 +340,11 @@ fn check_not_paused<TK: TokenKernelOperations>(
     Ok(())
 }
 
-fn check_authorized<
-    TK: TokenKernelOperations,
-    TE: TransactionExecution<Account = TK::AccountWithAddress>,
->(
+fn check_authorized<TK: TokenKernelOperations, TE: TransactionExecution<Account = TK::Account>>(
     transaction_execution: &mut TE,
     kernel: &TK,
 ) -> Result<(), TokenUpdateErrorInternal> {
-    let sender_index = kernel.account_index(&transaction_execution.sender_account());
+    let sender_index = kernel.account_index(transaction_execution.sender_account());
     let authorized = key_value_state::get_governance_account_index(kernel)
         .is_ok_and(|gov_index| gov_index == sender_index);
 
@@ -362,7 +359,7 @@ fn check_authorized<
 
 fn execute_token_transfer<
     TK: TokenKernelOperations,
-    TE: TransactionExecution<Account = TK::AccountWithAddress>,
+    TE: TransactionExecution<Account = TK::Account>,
 >(
     transaction_execution: &mut TE,
     kernel: &mut TK,
@@ -373,18 +370,17 @@ fn execute_token_transfer<
 
     // operation execution
     check_not_paused(kernel)?;
-    let sender = transaction_execution.sender_account();
-    let sender_address = transaction_execution.sender_account_address();
+    let sender = transaction_execution.sender_account_with_address();
     let receiver = kernel.account_by_address(&transfer_operation.recipient.address)?;
 
     if key_value_state::has_allow_list(kernel) {
-        if !key_value_state::get_allow_list_for(kernel, kernel.account_index(&sender)) {
+        if !key_value_state::get_allow_list_for(kernel, kernel.account_index(&sender.account)) {
             return Err(TokenUpdateErrorInternal::OperationNotPermitted {
-                account_address: Some(sender_address),
+                account_address: Some(sender.account_address),
                 reason: "sender not in allow list",
             });
         }
-        if !key_value_state::get_allow_list_for(kernel, kernel.account_index(&receiver)) {
+        if !key_value_state::get_allow_list_for(kernel, kernel.account_index(&receiver.account)) {
             return Err(TokenUpdateErrorInternal::OperationNotPermitted {
                 account_address: Some(transfer_operation.recipient.address),
                 reason: "recipient not in allow list",
@@ -393,13 +389,13 @@ fn execute_token_transfer<
     }
 
     if key_value_state::has_deny_list(kernel) {
-        if key_value_state::get_deny_list_for(kernel, kernel.account_index(&sender)) {
+        if key_value_state::get_deny_list_for(kernel, kernel.account_index(&sender.account)) {
             return Err(TokenUpdateErrorInternal::OperationNotPermitted {
-                account_address: Some(sender_address),
+                account_address: Some(sender.account_address),
                 reason: "sender in deny list",
             });
         }
-        if key_value_state::get_deny_list_for(kernel, kernel.account_index(&receiver)) {
+        if key_value_state::get_deny_list_for(kernel, kernel.account_index(&receiver.account)) {
             return Err(TokenUpdateErrorInternal::OperationNotPermitted {
                 account_address: Some(transfer_operation.recipient.address),
                 reason: "recipient in deny list",
@@ -408,7 +404,7 @@ fn execute_token_transfer<
     }
 
     kernel.transfer(
-        &sender,
+        sender,
         &receiver,
         raw_amount,
         transfer_operation.memo.clone().map(Memo::from),
@@ -418,7 +414,7 @@ fn execute_token_transfer<
 
 fn execute_token_mint<
     TK: TokenKernelOperations,
-    TE: TransactionExecution<Account = TK::AccountWithAddress>,
+    TE: TransactionExecution<Account = TK::Account>,
 >(
     transaction_execution: &mut TE,
     kernel: &mut TK,
@@ -436,13 +432,16 @@ fn execute_token_mint<
         });
     };
 
-    kernel.mint(&transaction_execution.sender_account(), raw_amount)?;
+    kernel.mint(
+        transaction_execution.sender_account_with_address(),
+        raw_amount,
+    )?;
     Ok(())
 }
 
 fn execute_token_burn<
     TK: TokenKernelOperations,
-    TE: TransactionExecution<Account = TK::AccountWithAddress>,
+    TE: TransactionExecution<Account = TK::Account>,
 >(
     transaction_execution: &mut TE,
     kernel: &mut TK,
@@ -460,13 +459,16 @@ fn execute_token_burn<
         });
     }
 
-    kernel.burn(&transaction_execution.sender_account(), raw_amount)?;
+    kernel.burn(
+        transaction_execution.sender_account_with_address(),
+        raw_amount,
+    )?;
     Ok(())
 }
 
 fn execute_token_pause<
     TK: TokenKernelOperations,
-    TE: TransactionExecution<Account = TK::AccountWithAddress>,
+    TE: TransactionExecution<Account = TK::Account>,
 >(
     transaction_execution: &mut TE,
     kernel: &mut TK,
@@ -482,7 +484,7 @@ fn execute_token_pause<
 
 fn execute_token_unpause<
     TK: TokenKernelOperations,
-    TE: TransactionExecution<Account = TK::AccountWithAddress>,
+    TE: TransactionExecution<Account = TK::Account>,
 >(
     transaction_execution: &mut TE,
     kernel: &mut TK,
@@ -498,7 +500,7 @@ fn execute_token_unpause<
 
 fn execute_add_allow_list<
     TK: TokenKernelOperations,
-    TE: TransactionExecution<Account = TK::AccountWithAddress>,
+    TE: TransactionExecution<Account = TK::Account>,
 >(
     transaction_execution: &mut TE,
     kernel: &mut TK,
@@ -512,8 +514,8 @@ fn execute_add_allow_list<
     }
     let account = kernel.account_by_address(&list_operation.target.address)?;
 
-    kernel.touch_account(&account);
-    key_value_state::set_allow_list_for(kernel, kernel.account_index(&account), true);
+    kernel.touch_account(&account.account);
+    key_value_state::set_allow_list_for(kernel, kernel.account_index(&account.account), true);
 
     let event_details = TokenListUpdateEventDetails {
         target: list_operation.target.clone(),
@@ -526,7 +528,7 @@ fn execute_add_allow_list<
 
 fn execute_add_deny_list<
     TK: TokenKernelOperations,
-    TE: TransactionExecution<Account = TK::AccountWithAddress>,
+    TE: TransactionExecution<Account = TK::Account>,
 >(
     transaction_execution: &mut TE,
     kernel: &mut TK,
@@ -541,8 +543,8 @@ fn execute_add_deny_list<
 
     let account = kernel.account_by_address(&list_operation.target.address)?;
 
-    kernel.touch_account(&account);
-    key_value_state::set_deny_list_for(kernel, kernel.account_index(&account), true);
+    kernel.touch_account(&account.account);
+    key_value_state::set_deny_list_for(kernel, kernel.account_index(&account.account), true);
 
     let event_details = TokenListUpdateEventDetails {
         target: list_operation.target.clone(),
@@ -555,7 +557,7 @@ fn execute_add_deny_list<
 
 fn execute_remove_allow_list<
     TK: TokenKernelOperations,
-    TE: TransactionExecution<Account = TK::AccountWithAddress>,
+    TE: TransactionExecution<Account = TK::Account>,
 >(
     transaction_execution: &mut TE,
     kernel: &mut TK,
@@ -570,8 +572,8 @@ fn execute_remove_allow_list<
 
     let account = kernel.account_by_address(&list_operation.target.address)?;
 
-    kernel.touch_account(&account);
-    key_value_state::set_allow_list_for(kernel, kernel.account_index(&account), false);
+    kernel.touch_account(&account.account);
+    key_value_state::set_allow_list_for(kernel, kernel.account_index(&account.account), false);
 
     let event_details = TokenListUpdateEventDetails {
         target: list_operation.target.clone(),
@@ -581,9 +583,10 @@ fn execute_remove_allow_list<
 
     Ok(())
 }
+
 fn execute_remove_deny_list<
     TK: TokenKernelOperations,
-    TE: TransactionExecution<Account = TK::AccountWithAddress>,
+    TE: TransactionExecution<Account = TK::Account>,
 >(
     transaction_execution: &mut TE,
     kernel: &mut TK,
@@ -598,8 +601,8 @@ fn execute_remove_deny_list<
 
     let account = kernel.account_by_address(&list_operation.target.address)?;
 
-    kernel.touch_account(&account);
-    key_value_state::set_deny_list_for(kernel, kernel.account_index(&account), false);
+    kernel.touch_account(&account.account);
+    key_value_state::set_deny_list_for(kernel, kernel.account_index(&account.account), false);
 
     let event_details = TokenListUpdateEventDetails {
         target: list_operation.target.clone(),

--- a/plt/plt-token-module/tests/kernel_stub.rs
+++ b/plt/plt-token-module/tests/kernel_stub.rs
@@ -18,8 +18,9 @@ use plt_block_state::block_state::types::{
 };
 use plt_block_state::block_state::{AccountNotFoundByAddressError, AccountNotFoundByIndexError};
 use plt_scheduler_interface::token_kernel_interface::{
-    InsufficientBalanceError, MintWouldOverflowError, TokenBurnError, TokenKernelOperations,
-    TokenKernelQueries, TokenMintError, TokenStateInvariantError, TokenTransferError,
+    AccountWithAddress, InsufficientBalanceError, MintWouldOverflowError, TokenBurnError,
+    TokenKernelOperations, TokenKernelQueries, TokenMintError, TokenStateInvariantError,
+    TokenTransferError,
 };
 use plt_scheduler_interface::transaction_execution_interface::{
     OutOfEnergyError, TransactionExecution,
@@ -106,7 +107,7 @@ impl KernelStub {
     /// let account = stub.create_account();
     /// assert!(host.account_by_address(account_address1).is_some(), "Account must exist");
     /// ```
-    pub fn create_account(&mut self) -> AccountStubIndexWithAddress {
+    pub fn create_account(&mut self) -> AccountStubIndex {
         let index = self.accounts.len();
         let mut address = AccountAddress([0u8; 32]);
         address.0[..8].copy_from_slice(&index.to_be_bytes());
@@ -119,24 +120,20 @@ impl KernelStub {
         let stub_index = AccountStubIndex(index);
         self.accounts.push(account);
 
-        (stub_index, address)
+        stub_index
     }
 
-    pub fn account_address(&self, account: &AccountStubIndexWithAddress) -> AccountAddress {
-        account.1
+    pub fn account_address(&self, account: &AccountStubIndex) -> AccountAddress {
+        self.accounts[account.0].address
     }
 
-    pub fn account_touched(&self, account: &AccountStubIndexWithAddress) -> bool {
-        self.accounts[account.0.0].balance.is_some()
+    pub fn account_touched(&self, account: &AccountStubIndex) -> bool {
+        self.accounts[account.0].balance.is_some()
     }
 
     /// Set account balance in the stub
-    pub fn set_account_balance(
-        &mut self,
-        account: AccountStubIndexWithAddress,
-        new_balance: RawTokenAmount,
-    ) {
-        let balance = self.accounts[account.0.0].balance.get_or_insert_default();
+    pub fn set_account_balance(&mut self, account: AccountStubIndex, new_balance: RawTokenAmount) {
+        let balance = self.accounts[account.0].balance.get_or_insert_default();
         self.circulating_supply.0 = self
             .circulating_supply
             .0
@@ -148,7 +145,7 @@ impl KernelStub {
     }
 
     /// Set the account allow-list entry in token state.
-    pub fn set_allow_list(&mut self, account: AccountStubIndexWithAddress, value: bool) {
+    pub fn set_allow_list(&mut self, account: AccountStubIndex, value: bool) {
         self.set_token_state_value(
             account_state_key(self.account_index(&account), STATE_KEY_ALLOW_LIST),
             value.then_some(vec![]),
@@ -156,7 +153,7 @@ impl KernelStub {
     }
 
     /// Set the account deny-list entry in token state.
-    pub fn set_deny_list(&mut self, account: AccountStubIndexWithAddress, value: bool) {
+    pub fn set_deny_list(&mut self, account: AccountStubIndex, value: bool) {
         self.set_token_state_value(
             account_state_key(self.account_index(&account), STATE_KEY_DENY_LIST),
             value.then_some(vec![]),
@@ -169,7 +166,7 @@ impl KernelStub {
     }
 
     /// Initialize token and return the governance account
-    pub fn init_token(&mut self, params: TokenInitTestParams) -> AccountStubIndexWithAddress {
+    pub fn init_token(&mut self, params: TokenInitTestParams) -> AccountStubIndex {
         let gov_account = self.create_account();
         let gov_holder_account = CborHolderAccount::from(self.account_address(&gov_account));
         let metadata = MetadataUrl::from("https://plt.token".to_string());
@@ -186,6 +183,20 @@ impl KernelStub {
         let encoded_parameters = cbor::cbor_encode(&parameters).into();
         token_module::initialize_token(self, encoded_parameters).expect("initialize token");
         gov_account
+    }
+
+    pub fn execution_with_sender(&self, account: AccountStubIndex) -> TransactionExecutionTestImpl {
+        TransactionExecutionTestImpl::with_sender(AccountWithAddress {
+            account,
+            account_address: self.account_address(&account),
+        })
+    }
+
+    pub fn execution_with_sender_and_energy(&self, account: AccountStubIndex, energy: Energy) -> TransactionExecutionTestImpl {
+        TransactionExecutionTestImpl::with_sender_and_energy(AccountWithAddress {
+            account,
+            account_address: self.account_address(&account),
+        }, energy)
     }
 
     /// The circulating supply
@@ -255,21 +266,23 @@ impl TokenInitTestParams {
 /// Holding
 #[derive(Debug, Clone, Copy)]
 pub struct AccountStubIndex(usize);
-pub type AccountStubIndexWithAddress = (AccountStubIndex, AccountAddress);
 
 impl TokenKernelQueries for KernelStub {
-    type AccountWithAddress = AccountStubIndexWithAddress;
+    type Account = AccountStubIndex;
 
     fn account_by_address(
         &self,
         address: &AccountAddress,
-    ) -> Result<Self::AccountWithAddress, AccountNotFoundByAddressError> {
+    ) -> Result<AccountWithAddress<Self::Account>, AccountNotFoundByAddressError> {
         self.accounts
             .iter()
             .enumerate()
             .find_map(|(i, account)| {
                 if account.address.is_alias(address) {
-                    Some((AccountStubIndex(i), *address))
+                    Some(AccountWithAddress {
+                        account: AccountStubIndex(i),
+                        account_address: *address,
+                    })
                 } else {
                     None
                 }
@@ -280,11 +293,10 @@ impl TokenKernelQueries for KernelStub {
     fn account_by_index(
         &self,
         index: AccountIndex,
-    ) -> Result<AccountWithCanonicalAddress<Self::AccountWithAddress>, AccountNotFoundByIndexError>
-    {
+    ) -> Result<AccountWithCanonicalAddress<Self::Account>, AccountNotFoundByIndexError> {
         if let Some(account) = self.accounts.get(index.index as usize) {
             let account_with_canonical_address = AccountWithCanonicalAddress {
-                account: (AccountStubIndex(index.index as usize), account.address),
+                account: AccountStubIndex(index.index as usize),
                 canonical_account_address: account.address,
             };
             Ok(account_with_canonical_address)
@@ -293,12 +305,12 @@ impl TokenKernelQueries for KernelStub {
         }
     }
 
-    fn account_index(&self, account: &Self::AccountWithAddress) -> AccountIndex {
-        self.accounts[account.0.0].index
+    fn account_index(&self, account: &Self::Account) -> AccountIndex {
+        self.accounts[account.0].index
     }
 
-    fn account_token_balance(&self, account: &Self::AccountWithAddress) -> RawTokenAmount {
-        self.accounts[account.0.0].balance.unwrap_or_default()
+    fn account_token_balance(&self, account: &Self::Account) -> RawTokenAmount {
+        self.accounts[account.0].balance.unwrap_or_default()
     }
 
     fn decimals(&self) -> u8 {
@@ -311,13 +323,13 @@ impl TokenKernelQueries for KernelStub {
 }
 
 impl TokenKernelOperations for KernelStub {
-    fn touch_account(&mut self, account: &Self::AccountWithAddress) {
-        self.accounts[account.0.0].balance.get_or_insert_default();
+    fn touch_account(&mut self, account: &Self::Account) {
+        self.accounts[account.0].balance.get_or_insert_default();
     }
 
     fn mint(
         &mut self,
-        account: &Self::AccountWithAddress,
+        account: &AccountWithAddress<Self::Account>,
         amount: RawTokenAmount,
     ) -> Result<(), TokenMintError> {
         self.circulating_supply.0 =
@@ -330,7 +342,9 @@ impl TokenKernelOperations for KernelStub {
                     max_representable_amount: RawTokenAmount::MAX,
                 })?;
 
-        let balance = self.accounts[account.0.0].balance.get_or_insert_default();
+        let balance = self.accounts[account.account.0]
+            .balance
+            .get_or_insert_default();
         balance.0 = balance
             .0
             .checked_add(amount.0)
@@ -340,10 +354,12 @@ impl TokenKernelOperations for KernelStub {
 
     fn burn(
         &mut self,
-        account: &Self::AccountWithAddress,
+        account: &AccountWithAddress<Self::Account>,
         amount: RawTokenAmount,
     ) -> Result<(), TokenBurnError> {
-        let balance = self.accounts[account.0.0].balance.get_or_insert_default();
+        let balance = self.accounts[account.account.0]
+            .balance
+            .get_or_insert_default();
         balance.0 = balance
             .0
             .checked_sub(amount.0)
@@ -365,12 +381,14 @@ impl TokenKernelOperations for KernelStub {
 
     fn transfer(
         &mut self,
-        from: &Self::AccountWithAddress,
-        to: &Self::AccountWithAddress,
+        from: &AccountWithAddress<Self::Account>,
+        to: &AccountWithAddress<Self::Account>,
         amount: RawTokenAmount,
         memo: Option<Memo>,
     ) -> Result<(), TokenTransferError> {
-        let from_balance = self.accounts[from.0.0].balance.get_or_insert_default();
+        let from_balance = self.accounts[from.account.0]
+            .balance
+            .get_or_insert_default();
         from_balance.0 = from_balance
             .0
             .checked_sub(amount.0)
@@ -379,13 +397,14 @@ impl TokenKernelOperations for KernelStub {
                 required: amount,
             })?;
 
-        let to_balance = self.accounts[to.0.0].balance.get_or_insert_default();
+        let to_balance = self.accounts[to.account.0].balance.get_or_insert_default();
         to_balance.0 = to_balance
             .0
             .checked_add(amount.0)
             .ok_or_else(|| TokenStateInvariantError("Overflow".to_string()))?;
 
-        self.transfers.push_back((from.0, to.0, amount, memo));
+        self.transfers
+            .push_back((from.account, to.account, amount, memo));
 
         Ok(())
     }
@@ -405,13 +424,13 @@ impl TokenKernelOperations for KernelStub {
 /// Token kernel transaction execution context for test.
 #[derive(Debug)]
 pub struct TransactionExecutionTestImpl {
-    sender: AccountStubIndexWithAddress,
+    sender: AccountWithAddress<AccountStubIndex>,
     remaining_energy: Energy,
 }
 
 impl TransactionExecutionTestImpl {
     pub fn with_sender_and_energy(
-        sender: AccountStubIndexWithAddress,
+        sender: AccountWithAddress<AccountStubIndex>,
         remaining_energy: Energy,
     ) -> Self {
         Self {
@@ -420,7 +439,7 @@ impl TransactionExecutionTestImpl {
         }
     }
 
-    pub fn with_sender(sender: AccountStubIndexWithAddress) -> Self {
+    pub fn with_sender(sender: AccountWithAddress<AccountStubIndex>) -> Self {
         Self::with_sender_and_energy(sender, Energy::from(u64::MAX))
     }
 
@@ -430,14 +449,10 @@ impl TransactionExecutionTestImpl {
 }
 
 impl TransactionExecution for TransactionExecutionTestImpl {
-    type Account = AccountStubIndexWithAddress;
+    type Account = AccountStubIndex;
 
-    fn sender_account(&self) -> Self::Account {
-        self.sender
-    }
-
-    fn sender_account_address(&self) -> AccountAddress {
-        self.sender.1
+    fn sender_account_with_address(&self) -> &AccountWithAddress<Self::Account> {
+        &self.sender
     }
 
     fn tick_energy(&mut self, energy: Energy) -> Result<(), OutOfEnergyError> {
@@ -509,6 +524,6 @@ fn test_account_by_alias() {
 
     assert_eq!(
         stub.account_index(&account),
-        stub.account_index(&account_by_alias)
+        stub.account_index(&account_by_alias.account)
     );
 }

--- a/plt/plt-token-module/tests/kernel_stub.rs
+++ b/plt/plt-token-module/tests/kernel_stub.rs
@@ -122,7 +122,7 @@ impl KernelStub {
         stub_index
     }
 
-    pub fn account_address(&self, account: &AccountStubIndex) -> AccountAddress {
+    pub fn account_canonical_address(&self, account: &AccountStubIndex) -> AccountAddress {
         self.accounts[account.0].address
     }
 
@@ -167,7 +167,8 @@ impl KernelStub {
     /// Initialize token and return the governance account
     pub fn init_token(&mut self, params: TokenInitTestParams) -> AccountStubIndex {
         let gov_account = self.create_account();
-        let gov_holder_account = CborHolderAccount::from(self.account_address(&gov_account));
+        let gov_holder_account =
+            CborHolderAccount::from(self.account_canonical_address(&gov_account));
         let metadata = MetadataUrl::from("https://plt.token".to_string());
         let parameters = TokenModuleInitializationParameters {
             name: Some("Protocol-level token".to_owned()),
@@ -185,7 +186,7 @@ impl KernelStub {
     }
 
     pub fn execution_with_sender(&self, account: AccountStubIndex) -> TransactionExecutionTestImpl {
-        TransactionExecutionTestImpl::with_sender(account, self.account_address(&account))
+        TransactionExecutionTestImpl::with_sender(account, self.account_canonical_address(&account))
     }
 
     pub fn execution_with_sender_and_energy(
@@ -195,7 +196,7 @@ impl KernelStub {
     ) -> TransactionExecutionTestImpl {
         TransactionExecutionTestImpl::with_sender_and_energy(
             account,
-            self.account_address(&account),
+            self.account_canonical_address(&account),
             energy,
         )
     }
@@ -474,7 +475,7 @@ fn test_account_lookup_address() {
     let mut stub = KernelStub::with_decimals(0);
     let account = stub.create_account();
 
-    let address = stub.account_address(&account);
+    let address = stub.account_canonical_address(&account);
     stub.account_by_address(&address)
         .expect("Account is expected to exist");
     assert!(
@@ -519,7 +520,7 @@ fn test_account_by_alias() {
     let mut stub = KernelStub::with_decimals(0);
 
     let account = stub.create_account();
-    let account_address = stub.account_address(&account);
+    let account_address = stub.account_canonical_address(&account);
     let account_by_alias = stub
         .account_by_address(&account_address.get_alias(0).unwrap())
         .unwrap();

--- a/plt/plt-token-module/tests/kernel_stub.rs
+++ b/plt/plt-token-module/tests/kernel_stub.rs
@@ -18,9 +18,8 @@ use plt_block_state::block_state::types::{
 };
 use plt_block_state::block_state::{AccountNotFoundByAddressError, AccountNotFoundByIndexError};
 use plt_scheduler_interface::token_kernel_interface::{
-    AccountWithAddress, InsufficientBalanceError, MintWouldOverflowError, TokenBurnError,
-    TokenKernelOperations, TokenKernelQueries, TokenMintError, TokenStateInvariantError,
-    TokenTransferError,
+    InsufficientBalanceError, MintWouldOverflowError, TokenBurnError, TokenKernelOperations,
+    TokenKernelQueries, TokenMintError, TokenStateInvariantError, TokenTransferError,
 };
 use plt_scheduler_interface::transaction_execution_interface::{
     OutOfEnergyError, TransactionExecution,
@@ -186,17 +185,19 @@ impl KernelStub {
     }
 
     pub fn execution_with_sender(&self, account: AccountStubIndex) -> TransactionExecutionTestImpl {
-        TransactionExecutionTestImpl::with_sender(AccountWithAddress {
-            account,
-            account_address: self.account_address(&account),
-        })
+        TransactionExecutionTestImpl::with_sender(account, self.account_address(&account))
     }
 
-    pub fn execution_with_sender_and_energy(&self, account: AccountStubIndex, energy: Energy) -> TransactionExecutionTestImpl {
-        TransactionExecutionTestImpl::with_sender_and_energy(AccountWithAddress {
+    pub fn execution_with_sender_and_energy(
+        &self,
+        account: AccountStubIndex,
+        energy: Energy,
+    ) -> TransactionExecutionTestImpl {
+        TransactionExecutionTestImpl::with_sender_and_energy(
             account,
-            account_address: self.account_address(&account),
-        }, energy)
+            self.account_address(&account),
+            energy,
+        )
     }
 
     /// The circulating supply
@@ -273,16 +274,13 @@ impl TokenKernelQueries for KernelStub {
     fn account_by_address(
         &self,
         address: &AccountAddress,
-    ) -> Result<AccountWithAddress<Self::Account>, AccountNotFoundByAddressError> {
+    ) -> Result<Self::Account, AccountNotFoundByAddressError> {
         self.accounts
             .iter()
             .enumerate()
             .find_map(|(i, account)| {
                 if account.address.is_alias(address) {
-                    Some(AccountWithAddress {
-                        account: AccountStubIndex(i),
-                        account_address: *address,
-                    })
+                    Some(AccountStubIndex(i))
                 } else {
                     None
                 }
@@ -329,7 +327,8 @@ impl TokenKernelOperations for KernelStub {
 
     fn mint(
         &mut self,
-        account: &AccountWithAddress<Self::Account>,
+        account: &Self::Account,
+        account_address: AccountAddress,
         amount: RawTokenAmount,
     ) -> Result<(), TokenMintError> {
         self.circulating_supply.0 =
@@ -342,9 +341,7 @@ impl TokenKernelOperations for KernelStub {
                     max_representable_amount: RawTokenAmount::MAX,
                 })?;
 
-        let balance = self.accounts[account.account.0]
-            .balance
-            .get_or_insert_default();
+        let balance = self.accounts[account.0].balance.get_or_insert_default();
         balance.0 = balance
             .0
             .checked_add(amount.0)
@@ -354,12 +351,11 @@ impl TokenKernelOperations for KernelStub {
 
     fn burn(
         &mut self,
-        account: &AccountWithAddress<Self::Account>,
+        account: &Self::Account,
+        account_address: AccountAddress,
         amount: RawTokenAmount,
     ) -> Result<(), TokenBurnError> {
-        let balance = self.accounts[account.account.0]
-            .balance
-            .get_or_insert_default();
+        let balance = self.accounts[account.0].balance.get_or_insert_default();
         balance.0 = balance
             .0
             .checked_sub(amount.0)
@@ -381,14 +377,14 @@ impl TokenKernelOperations for KernelStub {
 
     fn transfer(
         &mut self,
-        from: &AccountWithAddress<Self::Account>,
-        to: &AccountWithAddress<Self::Account>,
+        from: &Self::Account,
+        from_address: AccountAddress,
+        to: &Self::Account,
+        to_address: AccountAddress,
         amount: RawTokenAmount,
         memo: Option<Memo>,
     ) -> Result<(), TokenTransferError> {
-        let from_balance = self.accounts[from.account.0]
-            .balance
-            .get_or_insert_default();
+        let from_balance = self.accounts[from.0].balance.get_or_insert_default();
         from_balance.0 = from_balance
             .0
             .checked_sub(amount.0)
@@ -397,14 +393,13 @@ impl TokenKernelOperations for KernelStub {
                 required: amount,
             })?;
 
-        let to_balance = self.accounts[to.account.0].balance.get_or_insert_default();
+        let to_balance = self.accounts[to.0].balance.get_or_insert_default();
         to_balance.0 = to_balance
             .0
             .checked_add(amount.0)
             .ok_or_else(|| TokenStateInvariantError("Overflow".to_string()))?;
 
-        self.transfers
-            .push_back((from.account, to.account, amount, memo));
+        self.transfers.push_back((*from, *to, amount, memo));
 
         Ok(())
     }
@@ -424,23 +419,26 @@ impl TokenKernelOperations for KernelStub {
 /// Token kernel transaction execution context for test.
 #[derive(Debug)]
 pub struct TransactionExecutionTestImpl {
-    sender: AccountWithAddress<AccountStubIndex>,
+    sender: AccountStubIndex,
+    sender_address: AccountAddress,
     remaining_energy: Energy,
 }
 
 impl TransactionExecutionTestImpl {
     pub fn with_sender_and_energy(
-        sender: AccountWithAddress<AccountStubIndex>,
+        sender: AccountStubIndex,
+        sender_address: AccountAddress,
         remaining_energy: Energy,
     ) -> Self {
         Self {
             sender,
+            sender_address,
             remaining_energy,
         }
     }
 
-    pub fn with_sender(sender: AccountWithAddress<AccountStubIndex>) -> Self {
-        Self::with_sender_and_energy(sender, Energy::from(u64::MAX))
+    pub fn with_sender(sender: AccountStubIndex, sender_address: AccountAddress) -> Self {
+        Self::with_sender_and_energy(sender, sender_address, Energy::from(u64::MAX))
     }
 
     pub fn remaining_energy(&self) -> Energy {
@@ -451,8 +449,12 @@ impl TransactionExecutionTestImpl {
 impl TransactionExecution for TransactionExecutionTestImpl {
     type Account = AccountStubIndex;
 
-    fn sender_account_with_address(&self) -> &AccountWithAddress<Self::Account> {
+    fn sender_account(&self) -> &Self::Account {
         &self.sender
+    }
+
+    fn sender_account_address(&self) -> AccountAddress {
+        self.sender_address
     }
 
     fn tick_energy(&mut self, energy: Energy) -> Result<(), OutOfEnergyError> {
@@ -524,6 +526,6 @@ fn test_account_by_alias() {
 
     assert_eq!(
         stub.account_index(&account),
-        stub.account_index(&account_by_alias.account)
+        stub.account_index(&account_by_alias)
     );
 }

--- a/plt/plt-token-module/tests/token_module_burn.rs
+++ b/plt/plt-token-module/tests/token_module_burn.rs
@@ -89,7 +89,7 @@ fn test_unauthorized_burn() {
             assert_eq!(
                 address,
                 Some(CborHolderAccount::from(
-                    stub.account_address(&non_governance_account)
+                    stub.account_canonical_address(&non_governance_account)
                 ))
             );
         }

--- a/plt/plt-token-module/tests/token_module_burn.rs
+++ b/plt/plt-token-module/tests/token_module_burn.rs
@@ -22,7 +22,7 @@ fn test_burn() {
     stub.set_account_balance(gov_account, RawTokenAmount(5000));
 
     // First burn
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::Burn(TokenSupplyUpdateDetails {
         amount: TokenAmount::from_raw(1000, 2),
     })];
@@ -39,7 +39,7 @@ fn test_burn() {
     );
 
     // Second burn
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::Burn(TokenSupplyUpdateDetails {
         amount: TokenAmount::from_raw(2000, 2),
     })];
@@ -66,7 +66,7 @@ fn test_unauthorized_burn() {
     stub.set_account_balance(non_governance_account, RawTokenAmount(5000));
 
     // Attempt to burn as a non-governance account.
-    let mut execution = TransactionExecutionTestImpl::with_sender(non_governance_account);
+    let mut execution = stub.execution_with_sender(non_governance_account);
     let operations = vec![TokenOperation::Burn(TokenSupplyUpdateDetails {
         amount: TokenAmount::from_raw(1000, 2),
     })];
@@ -112,7 +112,7 @@ fn test_burn_insufficient_balance() {
     let gov_account = stub.init_token(TokenInitTestParams::default().burnable());
     stub.set_account_balance(gov_account, RawTokenAmount(1000));
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::Burn(TokenSupplyUpdateDetails {
         amount: TokenAmount::from_raw(2000, 2),
     })];
@@ -140,7 +140,7 @@ fn test_burn_decimals_mismatch() {
     let mut stub = KernelStub::with_decimals(2);
     let gov_account = stub.init_token(TokenInitTestParams::default());
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::Burn(TokenSupplyUpdateDetails {
         amount: TokenAmount::from_raw(1000, 4),
     })];
@@ -167,7 +167,7 @@ fn test_burn_paused() {
     stub.set_account_balance(gov_account, RawTokenAmount(5000));
     stub.set_paused(true);
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::Burn(TokenSupplyUpdateDetails {
         amount: TokenAmount::from_raw(1000, 2),
     })];
@@ -194,7 +194,7 @@ fn test_not_burnable() {
     let mut stub = KernelStub::with_decimals(2);
     let gov_account = stub.init_token(TokenInitTestParams::default());
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::Burn(TokenSupplyUpdateDetails {
         amount: TokenAmount::from_raw(RawTokenAmount::MAX.0 - 500, 2),
     })];

--- a/plt/plt-token-module/tests/token_module_burn.rs
+++ b/plt/plt-token-module/tests/token_module_burn.rs
@@ -1,4 +1,4 @@
-use crate::kernel_stub::{TokenInitTestParams, TransactionExecutionTestImpl};
+use crate::kernel_stub::TokenInitTestParams;
 use assert_matches::assert_matches;
 use concordium_base::common::cbor;
 use concordium_base::protocol_level_tokens::{

--- a/plt/plt-token-module/tests/token_module_initialize.rs
+++ b/plt/plt-token-module/tests/token_module_initialize.rs
@@ -37,7 +37,7 @@ fn test_initialize_token_parameters_missing() {
     let parameters = TokenModuleInitializationParameters {
         name: None,
         metadata: Some("https://plt.token".to_owned().into()),
-        governance_account: Some(stub.account_address(&gov_account).into()),
+        governance_account: Some(stub.account_canonical_address(&gov_account).into()),
         allow_list: Some(true),
         deny_list: Some(false),
         initial_supply: None,
@@ -62,7 +62,7 @@ fn test_initialize_token_additional_parameter() {
     let parameters = TokenModuleInitializationParameters {
         name: Some("Protocol-level token".to_owned()),
         metadata: Some("https://plt.token".to_owned().into()),
-        governance_account: Some(stub.account_address(&gov_account).into()),
+        governance_account: Some(stub.account_canonical_address(&gov_account).into()),
         allow_list: Some(true),
         deny_list: Some(false),
         initial_supply: None,
@@ -92,7 +92,7 @@ fn test_initialize_token_additional_parameter() {
 fn test_initialize_token_default_values() {
     let mut stub = KernelStub::with_decimals(0);
     let gov_account = stub.create_account();
-    let gov_holder_account = CborHolderAccount::from(stub.account_address(&gov_account));
+    let gov_holder_account = CborHolderAccount::from(stub.account_canonical_address(&gov_account));
 
     let metadata = MetadataUrl::from("https://plt.token".to_string());
     let encoded_metadata = cbor::cbor_encode(&metadata);
@@ -148,7 +148,7 @@ fn test_initialize_token_default_values() {
 fn test_initialize_token_no_minting() {
     let mut stub = KernelStub::with_decimals(0);
     let gov_account = stub.create_account();
-    let gov_holder_account = CborHolderAccount::from(stub.account_address(&gov_account));
+    let gov_holder_account = CborHolderAccount::from(stub.account_canonical_address(&gov_account));
     let metadata = MetadataUrl::from("https://plt.token".to_string());
     let encoded_metadata = cbor::cbor_encode(&metadata);
     let parameters = TokenModuleInitializationParameters {
@@ -212,7 +212,7 @@ fn test_initialize_token_no_minting() {
 fn test_initialize_token_with_minting() {
     let mut stub = KernelStub::with_decimals(2);
     let gov_account = stub.create_account();
-    let gov_holder_account = CborHolderAccount::from(stub.account_address(&gov_account));
+    let gov_holder_account = CborHolderAccount::from(stub.account_canonical_address(&gov_account));
     let metadata = MetadataUrl::from("https://plt.token".to_string());
     let encoded_metadata = cbor::cbor_encode(&metadata);
     let parameters = TokenModuleInitializationParameters {
@@ -278,7 +278,7 @@ fn test_initialize_token_excessive_mint_decimals() {
     let parameters = TokenModuleInitializationParameters {
         name: Some("Protocol-level token".to_owned()),
         metadata: Some(metadata),
-        governance_account: Some(stub.account_address(&gov_account).into()),
+        governance_account: Some(stub.account_canonical_address(&gov_account).into()),
         allow_list: Some(false),
         deny_list: Some(false),
         initial_supply: Some(TokenAmount::from_raw(500000, 6)),
@@ -308,7 +308,7 @@ fn test_initialize_token_insufficient_mint_decimals() {
     let parameters = TokenModuleInitializationParameters {
         name: Some("Protocol-level token".to_owned()),
         metadata: Some(metadata),
-        governance_account: Some(stub.account_address(&gov_account).into()),
+        governance_account: Some(stub.account_canonical_address(&gov_account).into()),
         allow_list: Some(false),
         deny_list: Some(false),
         initial_supply: Some(TokenAmount::from_raw(500000, 2)),

--- a/plt/plt-token-module/tests/token_module_list_updates.rs
+++ b/plt/plt-token-module/tests/token_module_list_updates.rs
@@ -1,4 +1,4 @@
-use crate::kernel_stub::{KernelStub, TokenInitTestParams, TransactionExecutionTestImpl};
+use crate::kernel_stub::{KernelStub, TokenInitTestParams};
 use assert_matches::assert_matches;
 use concordium_base::base::AccountIndex;
 use concordium_base::common::cbor;

--- a/plt/plt-token-module/tests/token_module_list_updates.rs
+++ b/plt/plt-token-module/tests/token_module_list_updates.rs
@@ -35,7 +35,7 @@ fn test_allow_list_updates() {
     assert_eq!(state.deny_list, None);
 
     // Add an acccount to the allow list
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::AddAllowList(TokenListUpdateDetails {
         target: CborHolderAccount::from(stub.account_address(&target_account)),
     })];
@@ -53,7 +53,7 @@ fn test_allow_list_updates() {
     assert_eq!(state.deny_list, None);
 
     // Remove the same acccount to the allow list
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::RemoveAllowList(TokenListUpdateDetails {
         target: CborHolderAccount::from(stub.account_address(&target_account)),
     })];
@@ -106,7 +106,7 @@ fn test_deny_list_updates() {
     assert_eq!(state.deny_list, Some(false));
 
     // Add an acccount to the deny list
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::AddDenyList(TokenListUpdateDetails {
         target: CborHolderAccount::from(stub.account_address(&target_account)),
     })];
@@ -124,7 +124,7 @@ fn test_deny_list_updates() {
     assert_eq!(state.deny_list, Some(true));
 
     // Remove the same acccount to the deny list
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::RemoveDenyList(TokenListUpdateDetails {
         target: CborHolderAccount::from(stub.account_address(&target_account)),
     })];
@@ -170,7 +170,7 @@ fn test_add_allow_list_reject_non_governance() {
     let sender = stub.create_account();
     let target_account = stub.create_account();
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(sender);
+    let mut execution = stub.execution_with_sender(sender);
     let operations = vec![TokenOperation::AddAllowList(TokenListUpdateDetails {
         target: CborHolderAccount::from(stub.account_address(&target_account)),
     })];
@@ -216,7 +216,7 @@ fn test_remove_allow_list_reject_non_governance() {
     let sender = stub.create_account();
     let target_account = stub.create_account();
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(sender);
+    let mut execution = stub.execution_with_sender(sender);
     let operations = vec![TokenOperation::RemoveAllowList(TokenListUpdateDetails {
         target: CborHolderAccount::from(stub.account_address(&target_account)),
     })];
@@ -262,7 +262,7 @@ fn test_add_deny_list_reject_non_governance() {
     let sender = stub.create_account();
     let target_account = stub.create_account();
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(sender);
+    let mut execution = stub.execution_with_sender(sender);
     let operations = vec![TokenOperation::AddDenyList(TokenListUpdateDetails {
         target: CborHolderAccount::from(stub.account_address(&target_account)),
     })];
@@ -308,7 +308,7 @@ fn test_remove_deny_list_reject_non_governance() {
     let sender = stub.create_account();
     let target_account = stub.create_account();
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(sender);
+    let mut execution = stub.execution_with_sender(sender);
     let operations = vec![TokenOperation::RemoveDenyList(TokenListUpdateDetails {
         target: CborHolderAccount::from(stub.account_address(&target_account)),
     })];
@@ -355,7 +355,7 @@ fn test_add_allow_list_touches_account() {
 
     assert!(!stub.account_touched(&target_account));
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::AddAllowList(TokenListUpdateDetails {
         target: CborHolderAccount::from(stub.account_address(&target_account)),
     })];
@@ -377,7 +377,7 @@ fn test_remove_allow_list_touches_account() {
 
     assert!(!stub.account_touched(&target_account));
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::RemoveAllowList(TokenListUpdateDetails {
         target: CborHolderAccount::from(stub.account_address(&target_account)),
     })];
@@ -399,7 +399,7 @@ fn test_add_deny_list_touches_account() {
 
     assert!(!stub.account_touched(&target_account));
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::AddDenyList(TokenListUpdateDetails {
         target: CborHolderAccount::from(stub.account_address(&target_account)),
     })];
@@ -421,7 +421,7 @@ fn test_remove_deny_list_touches_account() {
 
     assert!(!stub.account_touched(&target_account));
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::RemoveDenyList(TokenListUpdateDetails {
         target: CborHolderAccount::from(stub.account_address(&target_account)),
     })];
@@ -441,7 +441,7 @@ fn test_add_to_not_enabled_allow_list() {
     let gov_account = stub.init_token(TokenInitTestParams::default());
     let allow_account = stub.create_account();
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::AddAllowList(TokenListUpdateDetails {
         target: CborHolderAccount::from(stub.account_address(&allow_account)),
     })];
@@ -471,7 +471,7 @@ fn test_remove_from_not_enabled_allow_list() {
     let gov_account = stub.init_token(TokenInitTestParams::default());
     let allow_account = stub.create_account();
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::RemoveAllowList(TokenListUpdateDetails {
         target: CborHolderAccount::from(stub.account_address(&allow_account)),
     })];
@@ -501,7 +501,7 @@ fn test_add_to_not_enabled_deny_list() {
     let gov_account = stub.init_token(TokenInitTestParams::default());
     let deny_account = stub.create_account();
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::AddDenyList(TokenListUpdateDetails {
         target: CborHolderAccount::from(stub.account_address(&deny_account)),
     })];
@@ -531,7 +531,7 @@ fn test_remove_from_not_enabled_deny_list() {
     let gov_account = stub.init_token(TokenInitTestParams::default());
     let deny_account = stub.create_account();
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::RemoveDenyList(TokenListUpdateDetails {
         target: CborHolderAccount::from(stub.account_address(&deny_account)),
     })];

--- a/plt/plt-token-module/tests/token_module_list_updates.rs
+++ b/plt/plt-token-module/tests/token_module_list_updates.rs
@@ -37,7 +37,7 @@ fn test_allow_list_updates() {
     // Add an acccount to the allow list
     let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::AddAllowList(TokenListUpdateDetails {
-        target: CborHolderAccount::from(stub.account_address(&target_account)),
+        target: CborHolderAccount::from(stub.account_canonical_address(&target_account)),
     })];
     token_module::execute_token_update_transaction(
         &mut execution,
@@ -55,7 +55,7 @@ fn test_allow_list_updates() {
     // Remove the same acccount to the allow list
     let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::RemoveAllowList(TokenListUpdateDetails {
-        target: CborHolderAccount::from(stub.account_address(&target_account)),
+        target: CborHolderAccount::from(stub.account_canonical_address(&target_account)),
     })];
     token_module::execute_token_update_transaction(
         &mut execution,
@@ -79,7 +79,7 @@ fn test_allow_list_updates() {
     let add_event: TokenListUpdateEventDetails = cbor::cbor_decode(&stub.events()[0].1).unwrap();
     assert_eq!(
         add_event.target,
-        CborHolderAccount::from(stub.account_address(&target_account))
+        CborHolderAccount::from(stub.account_canonical_address(&target_account))
     );
     assert_eq!(
         stub.events()[1].0,
@@ -88,7 +88,7 @@ fn test_allow_list_updates() {
     let remove_event: TokenListUpdateEventDetails = cbor::cbor_decode(&stub.events()[1].1).unwrap();
     assert_eq!(
         remove_event.target,
-        CborHolderAccount::from(stub.account_address(&target_account))
+        CborHolderAccount::from(stub.account_canonical_address(&target_account))
     );
 }
 
@@ -108,7 +108,7 @@ fn test_deny_list_updates() {
     // Add an acccount to the deny list
     let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::AddDenyList(TokenListUpdateDetails {
-        target: CborHolderAccount::from(stub.account_address(&target_account)),
+        target: CborHolderAccount::from(stub.account_canonical_address(&target_account)),
     })];
     token_module::execute_token_update_transaction(
         &mut execution,
@@ -126,7 +126,7 @@ fn test_deny_list_updates() {
     // Remove the same acccount to the deny list
     let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::RemoveDenyList(TokenListUpdateDetails {
-        target: CborHolderAccount::from(stub.account_address(&target_account)),
+        target: CborHolderAccount::from(stub.account_canonical_address(&target_account)),
     })];
     token_module::execute_token_update_transaction(
         &mut execution,
@@ -150,7 +150,7 @@ fn test_deny_list_updates() {
     let add_event: TokenListUpdateEventDetails = cbor::cbor_decode(&stub.events()[0].1).unwrap();
     assert_eq!(
         add_event.target,
-        CborHolderAccount::from(stub.account_address(&target_account))
+        CborHolderAccount::from(stub.account_canonical_address(&target_account))
     );
     assert_eq!(
         stub.events()[1].0,
@@ -159,7 +159,7 @@ fn test_deny_list_updates() {
     let remove_event: TokenListUpdateEventDetails = cbor::cbor_decode(&stub.events()[1].1).unwrap();
     assert_eq!(
         remove_event.target,
-        CborHolderAccount::from(stub.account_address(&target_account))
+        CborHolderAccount::from(stub.account_canonical_address(&target_account))
     );
 }
 
@@ -172,7 +172,7 @@ fn test_add_allow_list_reject_non_governance() {
 
     let mut execution = stub.execution_with_sender(sender);
     let operations = vec![TokenOperation::AddAllowList(TokenListUpdateDetails {
-        target: CborHolderAccount::from(stub.account_address(&target_account)),
+        target: CborHolderAccount::from(stub.account_canonical_address(&target_account)),
     })];
     let res = token_module::execute_token_update_transaction(
         &mut execution,
@@ -188,7 +188,7 @@ fn test_add_allow_list_reject_non_governance() {
             reason: Some(reason),
             ..
         }) => {
-            assert_eq!(address, CborHolderAccount::from(stub.account_address(&sender)));
+            assert_eq!(address, CborHolderAccount::from(stub.account_canonical_address(&sender)));
             assert_eq!(reason, "sender is not the token governance account");
         }
     );
@@ -218,7 +218,7 @@ fn test_remove_allow_list_reject_non_governance() {
 
     let mut execution = stub.execution_with_sender(sender);
     let operations = vec![TokenOperation::RemoveAllowList(TokenListUpdateDetails {
-        target: CborHolderAccount::from(stub.account_address(&target_account)),
+        target: CborHolderAccount::from(stub.account_canonical_address(&target_account)),
     })];
     let res = token_module::execute_token_update_transaction(
         &mut execution,
@@ -234,7 +234,7 @@ fn test_remove_allow_list_reject_non_governance() {
             reason: Some(reason),
             ..
         }) => {
-            assert_eq!(address, CborHolderAccount::from(stub.account_address(&sender)));
+            assert_eq!(address, CborHolderAccount::from(stub.account_canonical_address(&sender)));
             assert_eq!(reason, "sender is not the token governance account");
         }
     );
@@ -264,7 +264,7 @@ fn test_add_deny_list_reject_non_governance() {
 
     let mut execution = stub.execution_with_sender(sender);
     let operations = vec![TokenOperation::AddDenyList(TokenListUpdateDetails {
-        target: CborHolderAccount::from(stub.account_address(&target_account)),
+        target: CborHolderAccount::from(stub.account_canonical_address(&target_account)),
     })];
     let res = token_module::execute_token_update_transaction(
         &mut execution,
@@ -280,7 +280,7 @@ fn test_add_deny_list_reject_non_governance() {
             reason: Some(reason),
             ..
         }) => {
-            assert_eq!(address, CborHolderAccount::from(stub.account_address(&sender)));
+            assert_eq!(address, CborHolderAccount::from(stub.account_canonical_address(&sender)));
             assert_eq!(reason, "sender is not the token governance account");
         }
     );
@@ -310,7 +310,7 @@ fn test_remove_deny_list_reject_non_governance() {
 
     let mut execution = stub.execution_with_sender(sender);
     let operations = vec![TokenOperation::RemoveDenyList(TokenListUpdateDetails {
-        target: CborHolderAccount::from(stub.account_address(&target_account)),
+        target: CborHolderAccount::from(stub.account_canonical_address(&target_account)),
     })];
     let res = token_module::execute_token_update_transaction(
         &mut execution,
@@ -326,7 +326,7 @@ fn test_remove_deny_list_reject_non_governance() {
             reason: Some(reason),
             ..
         }) => {
-            assert_eq!(address, CborHolderAccount::from(stub.account_address(&sender)));
+            assert_eq!(address, CborHolderAccount::from(stub.account_canonical_address(&sender)));
             assert_eq!(reason, "sender is not the token governance account");
         }
     );
@@ -357,7 +357,7 @@ fn test_add_allow_list_touches_account() {
 
     let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::AddAllowList(TokenListUpdateDetails {
-        target: CborHolderAccount::from(stub.account_address(&target_account)),
+        target: CborHolderAccount::from(stub.account_canonical_address(&target_account)),
     })];
     token_module::execute_token_update_transaction(
         &mut execution,
@@ -379,7 +379,7 @@ fn test_remove_allow_list_touches_account() {
 
     let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::RemoveAllowList(TokenListUpdateDetails {
-        target: CborHolderAccount::from(stub.account_address(&target_account)),
+        target: CborHolderAccount::from(stub.account_canonical_address(&target_account)),
     })];
     token_module::execute_token_update_transaction(
         &mut execution,
@@ -401,7 +401,7 @@ fn test_add_deny_list_touches_account() {
 
     let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::AddDenyList(TokenListUpdateDetails {
-        target: CborHolderAccount::from(stub.account_address(&target_account)),
+        target: CborHolderAccount::from(stub.account_canonical_address(&target_account)),
     })];
     token_module::execute_token_update_transaction(
         &mut execution,
@@ -423,7 +423,7 @@ fn test_remove_deny_list_touches_account() {
 
     let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::RemoveDenyList(TokenListUpdateDetails {
-        target: CborHolderAccount::from(stub.account_address(&target_account)),
+        target: CborHolderAccount::from(stub.account_canonical_address(&target_account)),
     })];
     token_module::execute_token_update_transaction(
         &mut execution,
@@ -443,7 +443,7 @@ fn test_add_to_not_enabled_allow_list() {
 
     let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::AddAllowList(TokenListUpdateDetails {
-        target: CborHolderAccount::from(stub.account_address(&allow_account)),
+        target: CborHolderAccount::from(stub.account_canonical_address(&allow_account)),
     })];
 
     let res = token_module::execute_token_update_transaction(
@@ -473,7 +473,7 @@ fn test_remove_from_not_enabled_allow_list() {
 
     let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::RemoveAllowList(TokenListUpdateDetails {
-        target: CborHolderAccount::from(stub.account_address(&allow_account)),
+        target: CborHolderAccount::from(stub.account_canonical_address(&allow_account)),
     })];
 
     let res = token_module::execute_token_update_transaction(
@@ -503,7 +503,7 @@ fn test_add_to_not_enabled_deny_list() {
 
     let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::AddDenyList(TokenListUpdateDetails {
-        target: CborHolderAccount::from(stub.account_address(&deny_account)),
+        target: CborHolderAccount::from(stub.account_canonical_address(&deny_account)),
     })];
 
     let res = token_module::execute_token_update_transaction(
@@ -533,7 +533,7 @@ fn test_remove_from_not_enabled_deny_list() {
 
     let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::RemoveDenyList(TokenListUpdateDetails {
-        target: CborHolderAccount::from(stub.account_address(&deny_account)),
+        target: CborHolderAccount::from(stub.account_canonical_address(&deny_account)),
     })];
 
     let res = token_module::execute_token_update_transaction(

--- a/plt/plt-token-module/tests/token_module_mint.rs
+++ b/plt/plt-token-module/tests/token_module_mint.rs
@@ -116,12 +116,10 @@ fn test_unauthorized_mint_using_alias() {
 
     let non_gov_account_address_alias =
         stub.account_address(&non_gov_account).get_alias(5).unwrap();
-    let non_gov_account_alias = stub
-        .account_by_address(&non_gov_account_address_alias)
-        .unwrap();
 
     // Attempt to mint as a non-governance account.
-    let mut execution = TransactionExecutionTestImpl::with_sender(non_gov_account_alias.clone());
+    let mut execution =
+        TransactionExecutionTestImpl::with_sender(non_gov_account, non_gov_account_address_alias);
     let operations = vec![TokenOperation::Mint(TokenSupplyUpdateDetails {
         amount: TokenAmount::from_raw(1000, 2),
     })];
@@ -142,7 +140,7 @@ fn test_unauthorized_mint_using_alias() {
             assert_eq!(
                 address,
                 Some(CborHolderAccount::from(
-                    non_gov_account_alias.account_address
+                    non_gov_account_address_alias
                 ))
             );
         }

--- a/plt/plt-token-module/tests/token_module_mint.rs
+++ b/plt/plt-token-module/tests/token_module_mint.rs
@@ -87,7 +87,7 @@ fn test_unauthorized_mint() {
             assert_eq!(
                 address,
                 Some(CborHolderAccount::from(
-                    stub.account_address(&non_governance_account)
+                    stub.account_canonical_address(&non_governance_account)
                 ))
             );
         }
@@ -114,8 +114,10 @@ fn test_unauthorized_mint_using_alias() {
     stub.init_token(TokenInitTestParams::default());
     let non_gov_account = stub.create_account();
 
-    let non_gov_account_address_alias =
-        stub.account_address(&non_gov_account).get_alias(5).unwrap();
+    let non_gov_account_address_alias = stub
+        .account_canonical_address(&non_gov_account)
+        .get_alias(5)
+        .unwrap();
 
     // Attempt to mint as a non-governance account.
     let mut execution =

--- a/plt/plt-token-module/tests/token_module_mint.rs
+++ b/plt/plt-token-module/tests/token_module_mint.rs
@@ -21,7 +21,7 @@ fn test_mint() {
     let gov_account = stub.init_token(TokenInitTestParams::default().mintable());
 
     // First mint
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::Mint(TokenSupplyUpdateDetails {
         amount: TokenAmount::from_raw(1000, 2),
     })];
@@ -38,7 +38,7 @@ fn test_mint() {
     );
 
     // Second mint
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::Mint(TokenSupplyUpdateDetails {
         amount: TokenAmount::from_raw(4000, 2),
     })];
@@ -64,7 +64,7 @@ fn test_unauthorized_mint() {
     let non_governance_account = stub.create_account();
 
     // Attempt to mint as a non-governance account.
-    let mut execution = TransactionExecutionTestImpl::with_sender(non_governance_account);
+    let mut execution = stub.execution_with_sender(non_governance_account);
     let operations = vec![TokenOperation::Mint(TokenSupplyUpdateDetails {
         amount: TokenAmount::from_raw(1000, 2),
     })];
@@ -121,7 +121,7 @@ fn test_unauthorized_mint_using_alias() {
         .unwrap();
 
     // Attempt to mint as a non-governance account.
-    let mut execution = TransactionExecutionTestImpl::with_sender(non_gov_account_alias);
+    let mut execution = TransactionExecutionTestImpl::with_sender(non_gov_account_alias.clone());
     let operations = vec![TokenOperation::Mint(TokenSupplyUpdateDetails {
         amount: TokenAmount::from_raw(1000, 2),
     })];
@@ -142,7 +142,7 @@ fn test_unauthorized_mint_using_alias() {
             assert_eq!(
                 address,
                 Some(CborHolderAccount::from(
-                    stub.account_address(&non_gov_account_alias)
+                    non_gov_account_alias.account_address
                 ))
             );
         }
@@ -156,7 +156,7 @@ fn test_mint_overflow() {
     let gov_account = stub.init_token(TokenInitTestParams::default().mintable());
     stub.set_account_balance(gov_account, RawTokenAmount(1000));
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::Mint(TokenSupplyUpdateDetails {
         amount: TokenAmount::from_raw(RawTokenAmount::MAX.0 - 500, 2),
     })];
@@ -186,7 +186,7 @@ fn test_mint_decimals_mismatch() {
     let mut stub = KernelStub::with_decimals(2);
     let gov_account = stub.init_token(TokenInitTestParams::default());
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::Mint(TokenSupplyUpdateDetails {
         amount: TokenAmount::from_raw(1000, 4),
     })];
@@ -212,7 +212,7 @@ fn test_mint_paused() {
     let gov_account = stub.init_token(TokenInitTestParams::default());
     stub.set_paused(true);
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::Mint(TokenSupplyUpdateDetails {
         amount: TokenAmount::from_raw(1000, 2),
     })];
@@ -239,7 +239,7 @@ fn test_not_mintable() {
     let mut stub = KernelStub::with_decimals(2);
     let gov_account = stub.init_token(TokenInitTestParams::default());
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::Mint(TokenSupplyUpdateDetails {
         amount: TokenAmount::from_raw(RawTokenAmount::MAX.0 - 500, 2),
     })];

--- a/plt/plt-token-module/tests/token_module_pause.rs
+++ b/plt/plt-token-module/tests/token_module_pause.rs
@@ -29,7 +29,7 @@ fn test_token_pause_state() {
     assert_eq!(state.paused, Some(false));
 
     // First we pause the token
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::Pause(TokenPauseDetails {})];
     token_module::execute_token_update_transaction(
         &mut execution,
@@ -48,7 +48,7 @@ fn test_token_pause_state() {
     assert_eq!(state.paused, Some(true));
 
     // Then we unpause the token
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::Unpause(TokenPauseDetails {})];
     token_module::execute_token_update_transaction(
         &mut execution,
@@ -86,7 +86,7 @@ fn test_double_pause() {
     let gov_account = stub.init_token(TokenInitTestParams::default());
 
     // First we try to perform a double "pause" operation within the same transaction.
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![
         TokenOperation::Pause(TokenPauseDetails {}),
         TokenOperation::Pause(TokenPauseDetails {}),
@@ -100,7 +100,7 @@ fn test_double_pause() {
 
     // Then we try to perform an "pause" operation on top of this state in a subsequent
     // transaction (with a new transaction execution context, for good measure).
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::Pause(TokenPauseDetails {})];
     token_module::execute_token_update_transaction(
         &mut execution,
@@ -131,7 +131,7 @@ fn test_redundant_unpause() {
 
     // We already verified that the token moodule is initially _not_ paused, so performing an
     // "unpause" operation on this state is already redundant.
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::Unpause(TokenPauseDetails {})];
     token_module::execute_token_update_transaction(
         &mut execution,
@@ -161,7 +161,7 @@ fn test_unauthorized_pause() {
     let non_governance_account = stub.create_account();
 
     // Attempt to pause as a non-governance account.
-    let mut execution = TransactionExecutionTestImpl::with_sender(non_governance_account);
+    let mut execution = stub.execution_with_sender(non_governance_account);
     let operations = vec![TokenOperation::Pause(TokenPauseDetails {})];
     let res = token_module::execute_token_update_transaction(
         &mut execution,
@@ -207,7 +207,7 @@ fn test_unauthorized_unpause() {
 
     // First we pause the token in order to verify that the state is not changed from performing
     // the unauthorized "unpause" operation subsequently.
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::Pause(TokenPauseDetails {})];
     token_module::execute_token_update_transaction(
         &mut execution,
@@ -217,7 +217,7 @@ fn test_unauthorized_unpause() {
     .expect("executes successfully");
 
     // Attempt to unpause as a non-governance account.
-    let mut execution = TransactionExecutionTestImpl::with_sender(non_governance_account);
+    let mut execution = stub.execution_with_sender(non_governance_account);
     let operations = vec![TokenOperation::Unpause(TokenPauseDetails {})];
     let res = token_module::execute_token_update_transaction(
         &mut execution,
@@ -263,7 +263,7 @@ fn test_pause_multiple_ops() {
 
     // We test that a transaction consisting of a "pause" and "mint" operation fails, as minting is
     // not allowed while a token is paused.
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![
         TokenOperation::Pause(TokenPauseDetails {}),
         TokenOperation::Mint(TokenSupplyUpdateDetails {
@@ -306,7 +306,7 @@ fn test_unpause_multiple_ops() {
     let gov_account = stub.init_token(TokenInitTestParams::default().mintable());
 
     // First we set the token to paused.
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::Pause(TokenPauseDetails {})];
     token_module::execute_token_update_transaction(
         &mut execution,
@@ -317,7 +317,7 @@ fn test_unpause_multiple_ops() {
 
     // We test that a transaction consisting of an "unpause" and "mint" operation succeeds when
     // executed sequentially within the same transaction.
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![
         TokenOperation::Unpause(TokenPauseDetails {}),
         TokenOperation::Mint(TokenSupplyUpdateDetails {

--- a/plt/plt-token-module/tests/token_module_pause.rs
+++ b/plt/plt-token-module/tests/token_module_pause.rs
@@ -182,7 +182,7 @@ fn test_unauthorized_pause() {
             assert_eq!(
                 address,
                 Some(CborHolderAccount::from(
-                    stub.account_address(&non_governance_account)
+                    stub.account_canonical_address(&non_governance_account)
                 ))
             );
         }
@@ -238,7 +238,7 @@ fn test_unauthorized_unpause() {
             assert_eq!(
                 address,
                 Some(CborHolderAccount::from(
-                    stub.account_address(&non_governance_account)
+                    stub.account_canonical_address(&non_governance_account)
                 ))
             );
         }

--- a/plt/plt-token-module/tests/token_module_pause.rs
+++ b/plt/plt-token-module/tests/token_module_pause.rs
@@ -1,4 +1,4 @@
-use crate::kernel_stub::{KernelStub, TokenInitTestParams, TransactionExecutionTestImpl};
+use crate::kernel_stub::{KernelStub, TokenInitTestParams};
 use assert_matches::assert_matches;
 use concordium_base::protocol_level_tokens::TokenPauseEventDetails;
 use concordium_base::{

--- a/plt/plt-token-module/tests/token_module_transfer.rs
+++ b/plt/plt-token-module/tests/token_module_transfer.rs
@@ -28,7 +28,7 @@ fn test_transfer() {
     stub.set_account_balance(sender, RawTokenAmount(5000));
     stub.set_account_balance(receiver, RawTokenAmount(2000));
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(sender);
+    let mut execution = stub.execution_with_sender(sender);
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(1000, 2),
         recipient: CborHolderAccount::from(stub.account_address(&receiver)),
@@ -56,7 +56,7 @@ fn test_transfer_with_memo() {
     let receiver = stub.create_account();
     stub.set_account_balance(sender, RawTokenAmount(5000));
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(sender);
+    let mut execution = stub.execution_with_sender(sender);
     let memo = Memo::try_from(cbor::cbor_encode("testvalue")).unwrap();
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(1000, 2),
@@ -84,7 +84,7 @@ fn test_transfer_self() {
     let sender = stub.create_account();
     stub.set_account_balance(sender, RawTokenAmount(5000));
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(sender);
+    let mut execution = stub.execution_with_sender(sender);
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(1000, 2),
         recipient: CborHolderAccount::from(stub.account_address(&sender)),
@@ -109,7 +109,7 @@ fn test_transfer_insufficient_balance() {
     let receiver = stub.create_account();
     stub.set_account_balance(sender, RawTokenAmount(5000));
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(sender);
+    let mut execution = stub.execution_with_sender(sender);
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(10000, 2),
         recipient: CborHolderAccount::from(stub.account_address(&receiver)),
@@ -142,7 +142,7 @@ fn test_transfer_decimals_mismatch() {
     let receiver = stub.create_account();
     stub.set_account_balance(sender, RawTokenAmount(5000));
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(sender);
+    let mut execution = stub.execution_with_sender(sender);
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(1000, 4),
         recipient: CborHolderAccount::from(stub.account_address(&receiver)),
@@ -171,7 +171,7 @@ fn test_transfer_to_non_existing_receiver() {
     let sender = stub.create_account();
     stub.set_account_balance(sender, RawTokenAmount(5000));
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(sender);
+    let mut execution = stub.execution_with_sender(sender);
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(1000, 2),
         recipient: CborHolderAccount::from(NON_EXISTING_ACCOUNT),
@@ -208,7 +208,7 @@ fn test_transfer_allow_list_success() {
     stub.set_allow_list(receiver, true);
 
     // Transfer succeeds when both accounts are allow-listed.
-    let mut execution = TransactionExecutionTestImpl::with_sender(sender);
+    let mut execution = stub.execution_with_sender(sender);
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(1000, 2),
         recipient: CborHolderAccount::from(stub.account_address(&receiver)),
@@ -241,7 +241,7 @@ fn test_transfer_deny_list_success() {
     stub.set_deny_list(denied, true);
 
     // Transfer succeeds when neither sender nor recipient is denied.
-    let mut execution = TransactionExecutionTestImpl::with_sender(sender);
+    let mut execution = stub.execution_with_sender(sender);
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(1000, 2),
         recipient: CborHolderAccount::from(stub.account_address(&receiver)),
@@ -271,7 +271,7 @@ fn test_transfer_sender_not_in_allow_list() {
 
     stub.set_allow_list(receiver, true);
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(sender);
+    let mut execution = stub.execution_with_sender(sender);
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(1000, 2),
         recipient: CborHolderAccount::from(stub.account_address(&receiver)),
@@ -313,7 +313,7 @@ fn test_transfer_recipient_not_in_allow_list() {
 
     stub.set_allow_list(sender, true);
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(sender);
+    let mut execution = stub.execution_with_sender(sender);
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(1000, 2),
         recipient: CborHolderAccount::from(stub.account_address(&receiver)),
@@ -355,7 +355,7 @@ fn test_transfer_sender_in_deny_list() {
 
     stub.set_deny_list(sender, true);
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(sender);
+    let mut execution = stub.execution_with_sender(sender);
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(1000, 2),
         recipient: CborHolderAccount::from(stub.account_address(&receiver)),
@@ -397,7 +397,7 @@ fn test_transfer_recipient_in_deny_list() {
 
     stub.set_deny_list(receiver, true);
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(sender);
+    let mut execution = stub.execution_with_sender(sender);
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(1000, 2),
         recipient: CborHolderAccount::from(stub.account_address(&receiver)),
@@ -438,7 +438,7 @@ fn test_transfer_paused() {
 
     stub.set_paused(true);
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(gov_account);
+    let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(1000, 2),
         recipient: CborHolderAccount::from(stub.account_address(&receiver)),

--- a/plt/plt-token-module/tests/token_module_transfer.rs
+++ b/plt/plt-token-module/tests/token_module_transfer.rs
@@ -1,4 +1,4 @@
-use crate::kernel_stub::{TokenInitTestParams, TransactionExecutionTestImpl};
+use crate::kernel_stub::TokenInitTestParams;
 use assert_matches::assert_matches;
 use concordium_base::common::cbor;
 use concordium_base::contracts_common::AccountAddress;

--- a/plt/plt-token-module/tests/token_module_transfer.rs
+++ b/plt/plt-token-module/tests/token_module_transfer.rs
@@ -31,7 +31,7 @@ fn test_transfer() {
     let mut execution = stub.execution_with_sender(sender);
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(1000, 2),
-        recipient: CborHolderAccount::from(stub.account_address(&receiver)),
+        recipient: CborHolderAccount::from(stub.account_canonical_address(&receiver)),
         memo: None,
     })];
     token_module::execute_token_update_transaction(
@@ -60,7 +60,7 @@ fn test_transfer_with_memo() {
     let memo = Memo::try_from(cbor::cbor_encode("testvalue")).unwrap();
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(1000, 2),
-        recipient: CborHolderAccount::from(stub.account_address(&receiver)),
+        recipient: CborHolderAccount::from(stub.account_canonical_address(&receiver)),
         memo: Some(CborMemo::Cbor(memo.clone())),
     })];
     token_module::execute_token_update_transaction(
@@ -87,7 +87,7 @@ fn test_transfer_self() {
     let mut execution = stub.execution_with_sender(sender);
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(1000, 2),
-        recipient: CborHolderAccount::from(stub.account_address(&sender)),
+        recipient: CborHolderAccount::from(stub.account_canonical_address(&sender)),
         memo: None,
     })];
     token_module::execute_token_update_transaction(
@@ -112,7 +112,7 @@ fn test_transfer_insufficient_balance() {
     let mut execution = stub.execution_with_sender(sender);
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(10000, 2),
-        recipient: CborHolderAccount::from(stub.account_address(&receiver)),
+        recipient: CborHolderAccount::from(stub.account_canonical_address(&receiver)),
         memo: None,
     })];
     let res = token_module::execute_token_update_transaction(
@@ -145,7 +145,7 @@ fn test_transfer_decimals_mismatch() {
     let mut execution = stub.execution_with_sender(sender);
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(1000, 4),
-        recipient: CborHolderAccount::from(stub.account_address(&receiver)),
+        recipient: CborHolderAccount::from(stub.account_canonical_address(&receiver)),
         memo: None,
     })];
     let res = token_module::execute_token_update_transaction(
@@ -211,7 +211,7 @@ fn test_transfer_allow_list_success() {
     let mut execution = stub.execution_with_sender(sender);
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(1000, 2),
-        recipient: CborHolderAccount::from(stub.account_address(&receiver)),
+        recipient: CborHolderAccount::from(stub.account_canonical_address(&receiver)),
         memo: None,
     })];
     token_module::execute_token_update_transaction(
@@ -244,7 +244,7 @@ fn test_transfer_deny_list_success() {
     let mut execution = stub.execution_with_sender(sender);
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(1000, 2),
-        recipient: CborHolderAccount::from(stub.account_address(&receiver)),
+        recipient: CborHolderAccount::from(stub.account_canonical_address(&receiver)),
         memo: None,
     })];
     token_module::execute_token_update_transaction(
@@ -274,7 +274,7 @@ fn test_transfer_sender_not_in_allow_list() {
     let mut execution = stub.execution_with_sender(sender);
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(1000, 2),
-        recipient: CborHolderAccount::from(stub.account_address(&receiver)),
+        recipient: CborHolderAccount::from(stub.account_canonical_address(&receiver)),
         memo: None,
     })];
 
@@ -292,7 +292,7 @@ fn test_transfer_sender_not_in_allow_list() {
             address: Some(address),
             reason: Some(reason),
         }) => {
-            assert_eq!(address, CborHolderAccount::from(stub.account_address(&sender)));
+            assert_eq!(address, CborHolderAccount::from(stub.account_canonical_address(&sender)));
             assert_eq!(reason, "sender not in allow list");
         }
     );
@@ -316,7 +316,7 @@ fn test_transfer_recipient_not_in_allow_list() {
     let mut execution = stub.execution_with_sender(sender);
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(1000, 2),
-        recipient: CborHolderAccount::from(stub.account_address(&receiver)),
+        recipient: CborHolderAccount::from(stub.account_canonical_address(&receiver)),
         memo: None,
     })];
 
@@ -334,7 +334,7 @@ fn test_transfer_recipient_not_in_allow_list() {
             address: Some(address),
             reason: Some(reason),
         }) => {
-            assert_eq!(address, CborHolderAccount::from(stub.account_address(&receiver)));
+            assert_eq!(address, CborHolderAccount::from(stub.account_canonical_address(&receiver)));
             assert_eq!(reason, "recipient not in allow list");
         }
     );
@@ -358,7 +358,7 @@ fn test_transfer_sender_in_deny_list() {
     let mut execution = stub.execution_with_sender(sender);
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(1000, 2),
-        recipient: CborHolderAccount::from(stub.account_address(&receiver)),
+        recipient: CborHolderAccount::from(stub.account_canonical_address(&receiver)),
         memo: None,
     })];
 
@@ -376,7 +376,7 @@ fn test_transfer_sender_in_deny_list() {
             address: Some(address),
             reason: Some(reason),
         }) => {
-            assert_eq!(address, CborHolderAccount::from(stub.account_address(&sender)));
+            assert_eq!(address, CborHolderAccount::from(stub.account_canonical_address(&sender)));
             assert_eq!(reason, "sender in deny list");
         }
     );
@@ -400,7 +400,7 @@ fn test_transfer_recipient_in_deny_list() {
     let mut execution = stub.execution_with_sender(sender);
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(1000, 2),
-        recipient: CborHolderAccount::from(stub.account_address(&receiver)),
+        recipient: CborHolderAccount::from(stub.account_canonical_address(&receiver)),
         memo: None,
     })];
 
@@ -418,7 +418,7 @@ fn test_transfer_recipient_in_deny_list() {
             address: Some(address),
             reason: Some(reason),
         }) => {
-            assert_eq!(address, CborHolderAccount::from(stub.account_address(&receiver)));
+            assert_eq!(address, CborHolderAccount::from(stub.account_canonical_address(&receiver)));
             assert_eq!(reason, "recipient in deny list");
         }
     );
@@ -441,7 +441,7 @@ fn test_transfer_paused() {
     let mut execution = stub.execution_with_sender(gov_account);
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(1000, 2),
-        recipient: CborHolderAccount::from(stub.account_address(&receiver)),
+        recipient: CborHolderAccount::from(stub.account_canonical_address(&receiver)),
         memo: None,
     })];
 

--- a/plt/plt-token-module/tests/token_module_update_general.rs
+++ b/plt/plt-token-module/tests/token_module_update_general.rs
@@ -47,7 +47,7 @@ fn test_update_token_additional_fields() {
     let mut execution = stub.execution_with_sender(sender);
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(1000, 2),
-        recipient: CborHolderAccount::from(stub.account_address(&receiver)),
+        recipient: CborHolderAccount::from(stub.account_canonical_address(&receiver)),
         memo: None,
     })];
 
@@ -93,12 +93,12 @@ fn test_multiple_operations() {
     let operations = vec![
         TokenOperation::Transfer(TokenTransfer {
             amount: TokenAmount::from_raw(1000, 2),
-            recipient: CborHolderAccount::from(stub.account_address(&receiver)),
+            recipient: CborHolderAccount::from(stub.account_canonical_address(&receiver)),
             memo: None,
         }),
         TokenOperation::Transfer(TokenTransfer {
             amount: TokenAmount::from_raw(2000, 2),
-            recipient: CborHolderAccount::from(stub.account_address(&receiver)),
+            recipient: CborHolderAccount::from(stub.account_canonical_address(&receiver)),
             memo: None,
         }),
     ];
@@ -126,7 +126,7 @@ fn test_single_failing_operation() {
     let operations = vec![
         TokenOperation::Transfer(TokenTransfer {
             amount: TokenAmount::from_raw(1000, 2),
-            recipient: CborHolderAccount::from(stub.account_address(&receiver)),
+            recipient: CborHolderAccount::from(stub.account_canonical_address(&receiver)),
             memo: None,
         }),
         TokenOperation::Transfer(TokenTransfer {
@@ -165,7 +165,7 @@ fn test_energy_charge() {
     let mut execution = stub.execution_with_sender_and_energy(sender, Energy::from(1000));
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(1000, 2),
-        recipient: CborHolderAccount::from(stub.account_address(&receiver)),
+        recipient: CborHolderAccount::from(stub.account_canonical_address(&receiver)),
         memo: None,
     })];
     token_module::execute_token_update_transaction(
@@ -192,7 +192,7 @@ fn test_out_of_energy_error() {
     let mut execution = stub.execution_with_sender_and_energy(sender, Energy::from(50));
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(1000, 2),
-        recipient: CborHolderAccount::from(stub.account_address(&receiver)),
+        recipient: CborHolderAccount::from(stub.account_canonical_address(&receiver)),
         memo: None,
     })];
     let result = token_module::execute_token_update_transaction(

--- a/plt/plt-token-module/tests/token_module_update_general.rs
+++ b/plt/plt-token-module/tests/token_module_update_general.rs
@@ -22,7 +22,7 @@ const NON_EXISTING_ACCOUNT: AccountAddress = AccountAddress([2u8; 32]);
 fn test_update_token_decode_failure() {
     let mut stub = KernelStub::with_decimals(0);
     let sender = stub.create_account();
-    let mut execution = TransactionExecutionTestImpl::with_sender(sender);
+    let mut execution = stub.execution_with_sender(sender);
     let res = token_module::execute_token_update_transaction(
         &mut execution,
         &mut stub,
@@ -44,7 +44,7 @@ fn test_update_token_additional_fields() {
     let mut stub = KernelStub::with_decimals(0);
     let sender = stub.create_account();
     let receiver = stub.create_account();
-    let mut execution = TransactionExecutionTestImpl::with_sender(sender);
+    let mut execution = stub.execution_with_sender(sender);
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(1000, 2),
         recipient: CborHolderAccount::from(stub.account_address(&receiver)),
@@ -89,7 +89,7 @@ fn test_multiple_operations() {
     stub.set_account_balance(sender, RawTokenAmount(5000));
     stub.set_account_balance(receiver, RawTokenAmount(2000));
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(sender);
+    let mut execution = stub.execution_with_sender(sender);
     let operations = vec![
         TokenOperation::Transfer(TokenTransfer {
             amount: TokenAmount::from_raw(1000, 2),
@@ -122,7 +122,7 @@ fn test_single_failing_operation() {
     let receiver = stub.create_account();
     stub.set_account_balance(sender, RawTokenAmount(5000));
 
-    let mut execution = TransactionExecutionTestImpl::with_sender(sender);
+    let mut execution = stub.execution_with_sender(sender);
     let operations = vec![
         TokenOperation::Transfer(TokenTransfer {
             amount: TokenAmount::from_raw(1000, 2),
@@ -163,7 +163,7 @@ fn test_energy_charge() {
     stub.set_account_balance(receiver, RawTokenAmount(2000));
 
     let mut execution =
-        TransactionExecutionTestImpl::with_sender_and_energy(sender, Energy::from(1000));
+        stub.execution_with_sender_and_energy(sender, Energy::from(1000));
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(1000, 2),
         recipient: CborHolderAccount::from(stub.account_address(&receiver)),
@@ -191,7 +191,7 @@ fn test_out_of_energy_error() {
     stub.set_account_balance(receiver, RawTokenAmount(2000));
 
     let mut execution =
-        TransactionExecutionTestImpl::with_sender_and_energy(sender, Energy::from(50));
+        stub.execution_with_sender_and_energy(sender, Energy::from(50));
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(1000, 2),
         recipient: CborHolderAccount::from(stub.account_address(&receiver)),

--- a/plt/plt-token-module/tests/token_module_update_general.rs
+++ b/plt/plt-token-module/tests/token_module_update_general.rs
@@ -1,4 +1,4 @@
-use crate::kernel_stub::{TokenInitTestParams, TransactionExecutionTestImpl};
+use crate::kernel_stub::TokenInitTestParams;
 use assert_matches::assert_matches;
 use concordium_base::base::Energy;
 use concordium_base::common::cbor;
@@ -162,8 +162,7 @@ fn test_energy_charge() {
     stub.set_account_balance(sender, RawTokenAmount(5000));
     stub.set_account_balance(receiver, RawTokenAmount(2000));
 
-    let mut execution =
-        stub.execution_with_sender_and_energy(sender, Energy::from(1000));
+    let mut execution = stub.execution_with_sender_and_energy(sender, Energy::from(1000));
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(1000, 2),
         recipient: CborHolderAccount::from(stub.account_address(&receiver)),
@@ -190,8 +189,7 @@ fn test_out_of_energy_error() {
     stub.set_account_balance(sender, RawTokenAmount(5000));
     stub.set_account_balance(receiver, RawTokenAmount(2000));
 
-    let mut execution =
-        stub.execution_with_sender_and_energy(sender, Energy::from(50));
+    let mut execution = stub.execution_with_sender_and_energy(sender, Energy::from(50));
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
         amount: TokenAmount::from_raw(1000, 2),
         recipient: CborHolderAccount::from(stub.account_address(&receiver)),


### PR DESCRIPTION
## Purpose

Simplify token kernel interface. Specifically change the associated type `TokenKernelQuery::Account` to not include address.

## Changes

_Describe the changes that were needed.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

