### PR TITLE
Move KernelStub implementation to utils/kernel_stub.rs leaving tests

### DIFF
--- a/plt/plt-token-module/tests/kernel_stub_tests.rs
+++ b/plt/plt-token-module/tests/kernel_stub_tests.rs
@@ -1,0 +1,75 @@
+use concordium_base::base::ProtocolVersion;
+use concordium_base::contracts_common::AccountAddress;
+use plt_scheduler_interface::token_kernel_interface::TokenKernelQueries;
+use plt_scheduler_types::types::tokens::RawTokenAmount;
+use utils::kernel_stub::*;
+
+mod utils;
+
+// Tests for the kernel stub
+
+const TEST_ACCOUNT2: AccountAddress = AccountAddress([2u8; 32]);
+/// Default protocol version used across the tests.
+const PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::P11;
+
+/// Test lookup account address and account from address
+#[test]
+fn test_account_lookup_address() {
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let account = stub.create_account();
+
+    let address = stub.account_address(&account);
+    stub.account_by_address(&address)
+        .expect("Account is expected to exist");
+    assert!(
+        stub.account_by_address(&TEST_ACCOUNT2).is_err(),
+        "Account is not expected to exist"
+    );
+}
+
+/// Test lookup account index and account from index
+#[test]
+fn test_account_lookup_index() {
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let account = stub.create_account();
+
+    let index = stub.account_index(&account);
+    stub.account_by_index(index)
+        .expect("Account is expected to exist");
+    assert!(
+        stub.account_by_index(2.into()).is_err(),
+        "Account is not expected to exist"
+    );
+}
+
+/// Test get account balance
+#[test]
+fn test_account_balance() {
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+    let account0 = stub.create_account();
+    let account1 = stub.create_account();
+    stub.set_account_balance(account0, RawTokenAmount(245));
+
+    let balance = stub.account_token_balance(&account0);
+    assert_eq!(balance, RawTokenAmount(245));
+
+    let balance = stub.account_token_balance(&account1);
+    assert_eq!(balance, RawTokenAmount(0));
+}
+
+/// Test looking up account by alias.
+#[test]
+fn test_account_by_alias() {
+    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
+
+    let account = stub.create_account();
+    let account_address = stub.account_address(&account);
+    let account_by_alias = stub
+        .account_by_address(&account_address.get_alias(0).unwrap())
+        .unwrap();
+
+    assert_eq!(
+        stub.account_index(&account),
+        stub.account_index(&account_by_alias)
+    );
+}

--- a/plt/plt-token-module/tests/token_module_account_state.rs
+++ b/plt/plt-token-module/tests/token_module_account_state.rs
@@ -1,12 +1,11 @@
-use crate::kernel_stub::{KernelStub, TokenInitTestParams};
 use concordium_base::base::ProtocolVersion;
 use concordium_base::common::cbor;
 use concordium_base::protocol_level_tokens::TokenModuleAccountState;
 use plt_scheduler_interface::token_kernel_interface::TokenKernelQueries;
 use plt_token_module::token_module;
+use utils::kernel_stub::{KernelStub, TokenInitTestParams};
 
-mod kernel_stub;
-pub mod utils;
+mod utils;
 
 /// Default protocol version used across the tests.
 const PROTOCOL_VERSION: ProtocolVersion = utils::LATEST_PROTOCOL_VERSION;

--- a/plt/plt-token-module/tests/token_module_burn.rs
+++ b/plt/plt-token-module/tests/token_module_burn.rs
@@ -1,4 +1,3 @@
-use crate::kernel_stub::{TokenInitTestParams, TransactionExecutionTestImpl};
 use assert_matches::assert_matches;
 use concordium_base::base::ProtocolVersion;
 use concordium_base::common::cbor;
@@ -7,12 +6,11 @@ use concordium_base::protocol_level_tokens::{
     RawCbor, TokenAmount, TokenBalanceInsufficientRejectReason, TokenModuleRejectReason,
     TokenOperation, TokenSupplyUpdateDetails, UnsupportedOperationRejectReason,
 };
-use kernel_stub::KernelStub;
 use plt_scheduler_interface::token_kernel_interface::TokenKernelQueries;
 use plt_scheduler_types::types::tokens::RawTokenAmount;
 use plt_token_module::token_module;
+use utils::kernel_stub::{KernelStub, TokenInitTestParams, TransactionExecutionTestImpl};
 
-mod kernel_stub;
 mod utils;
 
 /// Default protocol version used across the tests.

--- a/plt/plt-token-module/tests/token_module_initialize.rs
+++ b/plt/plt-token-module/tests/token_module_initialize.rs
@@ -4,16 +4,15 @@ use concordium_base::common::cbor;
 use concordium_base::contracts_common::AccountAddress;
 use concordium_base::protocol_level_tokens::{CborHolderAccount, MetadataUrl, TokenModuleState};
 use concordium_base::protocol_level_tokens::{TokenAmount, TokenModuleInitializationParameters};
-use kernel_stub::KernelStub;
 use plt_block_state::block_state::AccountNotFoundByAddressError;
 use plt_scheduler_interface::token_kernel_interface::TokenKernelQueries;
 use plt_scheduler_types::types::tokens::RawTokenAmount;
 use plt_token_module::token_module::{
     self, TokenAmountDecimalsMismatchError, TokenInitializationError,
 };
+use utils::kernel_stub::KernelStub;
 
-mod kernel_stub;
-pub mod utils;
+mod utils;
 
 const NON_EXISTING_ACCOUNT: AccountAddress = AccountAddress([2u8; 32]);
 

--- a/plt/plt-token-module/tests/token_module_list_updates.rs
+++ b/plt/plt-token-module/tests/token_module_list_updates.rs
@@ -1,4 +1,3 @@
-use crate::kernel_stub::{KernelStub, TokenInitTestParams, TransactionExecutionTestImpl};
 use assert_matches::assert_matches;
 use concordium_base::base::{AccountIndex, ProtocolVersion};
 use concordium_base::common::cbor;
@@ -9,8 +8,8 @@ use concordium_base::protocol_level_tokens::{
 };
 use plt_scheduler_interface::token_kernel_interface::TokenKernelQueries;
 use plt_token_module::token_module;
+use utils::kernel_stub::{KernelStub, TokenInitTestParams, TransactionExecutionTestImpl};
 
-mod kernel_stub;
 mod utils;
 
 /// Default protocol version used across the tests.

--- a/plt/plt-token-module/tests/token_module_mint.rs
+++ b/plt/plt-token-module/tests/token_module_mint.rs
@@ -1,4 +1,3 @@
-use crate::kernel_stub::{TokenInitTestParams, TransactionExecutionTestImpl};
 use assert_matches::assert_matches;
 use concordium_base::base::ProtocolVersion;
 use concordium_base::common::cbor;
@@ -7,12 +6,11 @@ use concordium_base::protocol_level_tokens::{
     OperationNotPermittedRejectReason, RawCbor, TokenAmount, TokenModuleRejectReason,
     TokenOperation, TokenSupplyUpdateDetails, UnsupportedOperationRejectReason,
 };
-use kernel_stub::KernelStub;
 use plt_scheduler_interface::token_kernel_interface::TokenKernelQueries;
 use plt_scheduler_types::types::tokens::RawTokenAmount;
 use plt_token_module::token_module;
+use utils::kernel_stub::{KernelStub, TokenInitTestParams, TransactionExecutionTestImpl};
 
-mod kernel_stub;
 mod utils;
 
 /// Default protocol version used across the tests.

--- a/plt/plt-token-module/tests/token_module_pause.rs
+++ b/plt/plt-token-module/tests/token_module_pause.rs
@@ -1,4 +1,3 @@
-use crate::kernel_stub::{KernelStub, TokenInitTestParams, TransactionExecutionTestImpl};
 use assert_matches::assert_matches;
 use concordium_base::base::ProtocolVersion;
 use concordium_base::protocol_level_tokens::TokenPauseEventDetails;
@@ -13,8 +12,8 @@ use concordium_base::{
 use plt_scheduler_interface::token_kernel_interface::TokenKernelQueries;
 use plt_scheduler_types::types::tokens::RawTokenAmount;
 use plt_token_module::token_module;
+use utils::kernel_stub::{KernelStub, TokenInitTestParams, TransactionExecutionTestImpl};
 
-mod kernel_stub;
 mod utils;
 
 /// Default protocol version used across the tests.

--- a/plt/plt-token-module/tests/token_module_transfer.rs
+++ b/plt/plt-token-module/tests/token_module_transfer.rs
@@ -1,4 +1,3 @@
-use crate::kernel_stub::{TokenInitTestParams, TransactionExecutionTestImpl};
 use assert_matches::assert_matches;
 use concordium_base::base::ProtocolVersion;
 use concordium_base::common::cbor;
@@ -9,12 +8,11 @@ use concordium_base::protocol_level_tokens::{
     TokenModuleRejectReason, TokenOperation, TokenTransfer,
 };
 use concordium_base::transactions::Memo;
-use kernel_stub::KernelStub;
 use plt_scheduler_interface::token_kernel_interface::TokenKernelQueries;
 use plt_scheduler_types::types::tokens::RawTokenAmount;
 use plt_token_module::token_module;
+use utils::kernel_stub::{KernelStub, TokenInitTestParams, TransactionExecutionTestImpl};
 
-mod kernel_stub;
 mod utils;
 
 const NON_EXISTING_ACCOUNT: AccountAddress = AccountAddress([2u8; 32]);

--- a/plt/plt-token-module/tests/token_module_update_general.rs
+++ b/plt/plt-token-module/tests/token_module_update_general.rs
@@ -1,4 +1,3 @@
-use crate::kernel_stub::{TokenInitTestParams, TransactionExecutionTestImpl};
 use assert_matches::assert_matches;
 use concordium_base::base::{Energy, ProtocolVersion};
 use concordium_base::common::cbor;
@@ -7,12 +6,11 @@ use concordium_base::protocol_level_tokens::{
     AddressNotFoundRejectReason, CborHolderAccount, DeserializationFailureRejectReason, RawCbor,
     TokenAmount, TokenModuleRejectReason, TokenOperation, TokenTransfer,
 };
-use kernel_stub::KernelStub;
 use plt_scheduler_interface::token_kernel_interface::TokenKernelQueries;
 use plt_scheduler_types::types::tokens::RawTokenAmount;
 use plt_token_module::token_module::{self, TokenUpdateError};
+use utils::kernel_stub::{KernelStub, TokenInitTestParams, TransactionExecutionTestImpl};
 
-mod kernel_stub;
 mod utils;
 
 const NON_EXISTING_ACCOUNT: AccountAddress = AccountAddress([2u8; 32]);

--- a/plt/plt-token-module/tests/utils/kernel_stub.rs
+++ b/plt/plt-token-module/tests/utils/kernel_stub.rs
@@ -1,8 +1,3 @@
-// Allow items in this file to be unused. This is needed because it is imported from multiple
-// compile targets (each of the integration tests), and some of the targets may not use all
-// items in the file.
-#![allow(unused)]
-
 use std::collections::{BTreeMap, VecDeque};
 
 use concordium_base::base::{AccountIndex, Energy, InsufficientEnergy, ProtocolVersion};
@@ -452,72 +447,4 @@ impl TransactionExecution for TransactionExecutionTestImpl {
             .tick_energy(energy)
             .map_err(|_err: InsufficientEnergy| OutOfEnergyError)
     }
-}
-
-// Tests for the kernel stub
-
-const TEST_ACCOUNT2: AccountAddress = AccountAddress([2u8; 32]);
-/// Default protocol version used across the tests.
-const PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::P11;
-
-/// Test lookup account address and account from address
-#[test]
-fn test_account_lookup_address() {
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
-    let account = stub.create_account();
-
-    let address = stub.account_address(&account);
-    stub.account_by_address(&address)
-        .expect("Account is expected to exist");
-    assert!(
-        stub.account_by_address(&TEST_ACCOUNT2).is_err(),
-        "Account is not expected to exist"
-    );
-}
-
-/// Test lookup account index and account from index
-#[test]
-fn test_account_lookup_index() {
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
-    let account = stub.create_account();
-
-    let index = stub.account_index(&account);
-    stub.account_by_index(index)
-        .expect("Account is expected to exist");
-    assert!(
-        stub.account_by_index(2.into()).is_err(),
-        "Account is not expected to exist"
-    );
-}
-
-/// Test get account balance
-#[test]
-fn test_account_balance() {
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
-    let account0 = stub.create_account();
-    let account1 = stub.create_account();
-    stub.set_account_balance(account0, RawTokenAmount(245));
-
-    let balance = stub.account_token_balance(&account0);
-    assert_eq!(balance, RawTokenAmount(245));
-
-    let balance = stub.account_token_balance(&account1);
-    assert_eq!(balance, RawTokenAmount(0));
-}
-
-/// Test looking up account by alias.
-#[test]
-fn test_account_by_alias() {
-    let mut stub = KernelStub::with_decimals(0, PROTOCOL_VERSION);
-
-    let account = stub.create_account();
-    let account_address = stub.account_address(&account);
-    let account_by_alias = stub
-        .account_by_address(&account_address.get_alias(0).unwrap())
-        .unwrap();
-
-    assert_eq!(
-        stub.account_index(&account),
-        stub.account_index(&account_by_alias)
-    );
 }

--- a/plt/plt-token-module/tests/utils/mod.rs
+++ b/plt/plt-token-module/tests/utils/mod.rs
@@ -1,9 +1,16 @@
+// Allow items in this file to be unused. This is needed because it is imported from multiple
+// compile targets (each of the integration tests), and some of the targets may not use all
+// items in the file.
+#![allow(unused)]
+
 use assert_matches::assert_matches;
 use concordium_base::base::ProtocolVersion;
 use concordium_base::protocol_level_tokens::{
     TokenModuleRejectReason, TokenModuleRejectReasonType,
 };
 use plt_token_module::token_module::{RejectReason, TokenUpdateError};
+
+pub mod kernel_stub;
 
 /// The most recent protocol version.
 pub const LATEST_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::P11;


### PR DESCRIPTION
## Purpose

Currently every test suite in plt-token-module/tests also runs the tests for kernel stub, this PR factor out the implementation into the `utils/kernels_stub.rs`.
This ensures every other test suite does not also include the KernelStub test suite as well.

## Changes

Purely code structure changes.
