### PR TITLE
Cor 2330/audit

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -98,7 +98,7 @@ jobs:
     strategy:
       matrix:
         plan:
-        - rust: "1.88"
+        - rust: "stable"
 
     steps:
     - name: Checkout
@@ -132,7 +132,7 @@ jobs:
     strategy:
       matrix:
         plan:
-        - rust: 1.88
+        - rust: stable
           ghc: 9.10.2
 
     steps:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -132,7 +132,7 @@ jobs:
     strategy:
       matrix:
         plan:
-        - rust: 1.82
+        - rust: stable
           ghc: 9.10.2
 
     steps:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -98,7 +98,7 @@ jobs:
     strategy:
       matrix:
         plan:
-        - rust: "1.82"
+        - rust: "stable"
 
     steps:
     - name: Checkout

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -98,7 +98,7 @@ jobs:
     strategy:
       matrix:
         plan:
-        - rust: "stable"
+        - rust: "1.89"
 
     steps:
     - name: Checkout
@@ -132,7 +132,7 @@ jobs:
     strategy:
       matrix:
         plan:
-        - rust: stable
+        - rust: 1.89
           ghc: 9.10.2
 
     steps:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -98,7 +98,7 @@ jobs:
     strategy:
       matrix:
         plan:
-        - rust: "1.83"
+        - rust: "1.85"
 
     steps:
     - name: Checkout
@@ -132,7 +132,7 @@ jobs:
     strategy:
       matrix:
         plan:
-        - rust: 1.83
+        - rust: 1.85
           ghc: 9.10.2
 
     steps:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -98,7 +98,7 @@ jobs:
     strategy:
       matrix:
         plan:
-        - rust: "1.85"
+        - rust: "1.88"
 
     steps:
     - name: Checkout
@@ -132,7 +132,7 @@ jobs:
     strategy:
       matrix:
         plan:
-        - rust: 1.85
+        - rust: 1.88
           ghc: 9.10.2
 
     steps:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -98,7 +98,7 @@ jobs:
     strategy:
       matrix:
         plan:
-        - rust: "1.89"
+        - rust: "1.83"
 
     steps:
     - name: Checkout
@@ -132,7 +132,7 @@ jobs:
     strategy:
       matrix:
         plan:
-        - rust: 1.89
+        - rust: 1.83
           ghc: 9.10.2
 
     steps:

--- a/collector-backend/Cargo.lock
+++ b/collector-backend/Cargo.lock
@@ -418,7 +418,7 @@ dependencies = [
  "regex",
  "serde",
  "thiserror",
- "time 0.3.44",
+ "time 0.3.47",
  "tokio",
  "uuid",
 ]
@@ -663,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-traits"
@@ -927,18 +927,28 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1168,24 +1178,24 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
- "time-macros 0.2.24",
+ "time-macros 0.2.27",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
@@ -1199,9 +1209,9 @@ dependencies = [
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/collector-backend/Cargo.lock
+++ b/collector-backend/Cargo.lock
@@ -135,9 +135,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -228,9 +228,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -418,7 +418,7 @@ dependencies = [
  "regex",
  "serde",
  "thiserror",
- "time 0.3.36",
+ "time 0.3.44",
  "tokio",
  "uuid",
 ]
@@ -1168,9 +1168,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
  "itoa",
@@ -1178,14 +1178,14 @@ dependencies = [
  "powerfmt",
  "serde",
  "time-core",
- "time-macros 0.2.18",
+ "time-macros 0.2.24",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "time-macros"
@@ -1199,9 +1199,9 @@ dependencies = [
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -351,7 +351,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
- "serde 1.0.214",
+ "serde 1.0.228",
  "sync_wrapper 0.1.2",
  "tower",
  "tower-layer",
@@ -420,7 +420,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "serde 1.0.214",
+ "serde 1.0.228",
 ]
 
 [[package]]
@@ -551,9 +551,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytesize"
@@ -620,7 +620,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits 0.2.19",
- "serde 1.0.214",
+ "serde 1.0.228",
  "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
@@ -709,7 +709,7 @@ dependencies = [
  "num-integer",
  "num-traits 0.2.19",
  "rust_decimal",
- "serde 1.0.214",
+ "serde 1.0.228",
  "serde_json 1.0.132",
  "thiserror 1.0.68",
 ]
@@ -737,7 +737,7 @@ dependencies = [
  "num_enum",
  "rand 0.8.5",
  "secp256k1",
- "serde 1.0.214",
+ "serde 1.0.228",
  "sha2",
  "sha3",
  "slab",
@@ -795,7 +795,7 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "rust_decimal",
- "serde 1.0.214",
+ "serde 1.0.228",
  "serde_json 1.0.132",
  "serde_with",
  "sha2",
@@ -867,7 +867,7 @@ dependencies = [
  "rkv",
  "rpassword",
  "semver 1.0.23",
- "serde 1.0.214",
+ "serde 1.0.228",
  "serde_json 1.0.132",
  "sha2",
  "structopt",
@@ -984,7 +984,7 @@ dependencies = [
  "plotters",
  "rayon",
  "regex",
- "serde 1.0.214",
+ "serde 1.0.228",
  "serde_cbor",
  "serde_derive",
  "serde_json 1.0.132",
@@ -1061,7 +1061,7 @@ dependencies = [
  "csv-core",
  "itoa 1.0.11",
  "ryu",
- "serde 1.0.214",
+ "serde 1.0.228",
 ]
 
 [[package]]
@@ -1149,12 +1149,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
- "serde 1.0.214",
+ "serde_core",
 ]
 
 [[package]]
@@ -1246,7 +1246,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
- "serde 1.0.214",
+ "serde 1.0.228",
  "signature",
 ]
 
@@ -1259,7 +1259,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "rand_core 0.6.4",
- "serde 1.0.214",
+ "serde 1.0.228",
  "sha2",
  "subtle",
  "zeroize",
@@ -1276,7 +1276,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "hex",
  "rand_core 0.6.4",
- "serde 1.0.214",
+ "serde 1.0.228",
  "sha2",
  "zeroize",
 ]
@@ -1610,9 +1610,9 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "regex",
- "serde 1.0.214",
+ "serde 1.0.228",
  "thiserror 1.0.68",
- "time 0.3.36",
+ "time 0.3.47",
  "tokio",
  "uuid 1.11.0",
 ]
@@ -2180,7 +2180,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg 1.4.0",
  "hashbrown 0.12.3",
- "serde 1.0.214",
+ "serde 1.0.228",
 ]
 
 [[package]]
@@ -2191,7 +2191,7 @@ checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.1",
- "serde 1.0.214",
+ "serde 1.0.228",
 ]
 
 [[package]]
@@ -2294,9 +2294,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures",
 ]
@@ -2376,7 +2376,7 @@ version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 dependencies = [
- "serde 1.0.214",
+ "serde 1.0.228",
 ]
 
 [[package]]
@@ -2404,7 +2404,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "rand 0.8.5",
- "serde 1.0.214",
+ "serde 1.0.228",
  "serde-value",
  "serde_json 1.0.132",
  "serde_yaml",
@@ -2588,9 +2588,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-integer"
@@ -3386,7 +3386,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls-pemfile 1.0.4",
- "serde 1.0.214",
+ "serde 1.0.228",
  "serde_json 1.0.132",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
@@ -3432,7 +3432,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls-pemfile 2.2.0",
- "serde 1.0.214",
+ "serde 1.0.228",
  "serde_json 1.0.132",
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
@@ -3477,7 +3477,7 @@ dependencies = [
  "log",
  "ordered-float 3.9.2",
  "paste",
- "serde 1.0.214",
+ "serde 1.0.228",
  "serde_derive",
  "thiserror 1.0.68",
  "url",
@@ -3535,7 +3535,7 @@ dependencies = [
  "num-traits 0.2.19",
  "rand 0.8.5",
  "rkyv",
- "serde 1.0.214",
+ "serde 1.0.228",
  "serde_json 1.0.132",
 ]
 
@@ -3754,7 +3754,7 @@ version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 dependencies = [
- "serde 1.0.214",
+ "serde 1.0.228",
 ]
 
 [[package]]
@@ -3771,10 +3771,11 @@ checksum = "34b623917345a631dc9608d5194cc206b3fe6c3554cd1c75b937e55e285254af"
 
 [[package]]
 name = "serde"
-version = "1.0.214"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -3785,7 +3786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float 2.10.1",
- "serde 1.0.214",
+ "serde 1.0.228",
 ]
 
 [[package]]
@@ -3795,14 +3796,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
  "half 1.8.3",
- "serde 1.0.214",
+ "serde 1.0.228",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.214"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3830,7 +3840,7 @@ dependencies = [
  "itoa 1.0.11",
  "memchr",
  "ryu",
- "serde 1.0.214",
+ "serde 1.0.228",
 ]
 
 [[package]]
@@ -3839,7 +3849,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
- "serde 1.0.214",
+ "serde 1.0.228",
 ]
 
 [[package]]
@@ -3851,7 +3861,7 @@ dependencies = [
  "form_urlencoded",
  "itoa 1.0.11",
  "ryu",
- "serde 1.0.214",
+ "serde 1.0.228",
 ]
 
 [[package]]
@@ -3865,11 +3875,11 @@ dependencies = [
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.6.0",
- "serde 1.0.214",
+ "serde 1.0.228",
  "serde_derive",
  "serde_json 1.0.132",
  "serde_with_macros",
- "time 0.3.36",
+ "time 0.3.47",
 ]
 
 [[package]]
@@ -3893,7 +3903,7 @@ dependencies = [
  "indexmap 2.6.0",
  "itoa 1.0.11",
  "ryu",
- "serde 1.0.214",
+ "serde 1.0.228",
  "unsafe-libyaml",
 ]
 
@@ -4062,7 +4072,7 @@ checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "serde 1.0.214",
+ "serde 1.0.228",
  "serde_derive",
  "syn 1.0.109",
 ]
@@ -4076,7 +4086,7 @@ dependencies = [
  "base-x",
  "proc-macro2",
  "quote",
- "serde 1.0.214",
+ "serde 1.0.228",
  "serde_derive",
  "serde_json 1.0.132",
  "sha1",
@@ -4337,24 +4347,24 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa 1.0.11",
  "num-conv",
  "powerfmt",
- "serde 1.0.214",
+ "serde_core",
  "time-core",
- "time-macros 0.2.18",
+ "time-macros 0.2.27",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
@@ -4368,9 +4378,9 @@ dependencies = [
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4405,7 +4415,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
- "serde 1.0.214",
+ "serde 1.0.228",
  "serde_json 1.0.132",
 ]
 
@@ -4523,7 +4533,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
- "serde 1.0.214",
+ "serde 1.0.228",
 ]
 
 [[package]]
@@ -4532,7 +4542,7 @@ version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
- "serde 1.0.214",
+ "serde 1.0.228",
  "serde_spanned",
  "toml_datetime",
  "toml_edit 0.22.26",
@@ -4544,7 +4554,7 @@ version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 dependencies = [
- "serde 1.0.214",
+ "serde 1.0.228",
 ]
 
 [[package]]
@@ -4565,7 +4575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap 2.6.0",
- "serde 1.0.214",
+ "serde 1.0.228",
  "serde_spanned",
  "toml_datetime",
  "toml_write",
@@ -5359,7 +5369,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
 dependencies = [
- "serde 1.0.214",
+ "serde 1.0.228",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",

--- a/concordium-node/build.rs
+++ b/concordium-node/build.rs
@@ -21,8 +21,7 @@ fn main() -> std::io::Result<()> {
     let cargo_dir = env!("CARGO_MANIFEST_DIR");
     // Compile the flatbuffers schema
     println!(
-        "cargo:rerun-if-changed={}/src/network/serialization/schema.fbs",
-        cargo_dir
+        "cargo:rerun-if-changed={cargo_dir}/src/network/serialization/schema.fbs"
     );
     flatc_rust::run(flatc_rust::Args {
         inputs: &[Path::new("src/network/serialization/schema.fbs")],
@@ -33,7 +32,7 @@ fn main() -> std::io::Result<()> {
 
     // Build GRPC
 
-    let proto_root_input = format!("{}/../concordium-base/concordium-grpc-api", cargo_dir);
+    let proto_root_input = format!("{cargo_dir}/../concordium-base/concordium-grpc-api");
 
     #[cfg(not(feature = "static"))]
     {
@@ -64,10 +63,10 @@ fn main() -> std::io::Result<()> {
             // below.
             if let Ok(root) = env::var("CONCORDIUM_HASKELL_ROOT") {
                 if let Err(e) = std::fs::read_dir(&root) {
-                    println!("Cannot read CONCORDIUM_HASKELL_ROOT: {}", e);
+                    println!("Cannot read CONCORDIUM_HASKELL_ROOT: {e}");
                     return Err(e);
                 }
-                println!("cargo:rustc-link-search=native={}", root);
+                println!("cargo:rustc-link-search=native={root}");
                 println!("cargo:rustc-link-lib=dylib=concordium-consensus");
                 println!("cargo:rustc-link-lib=dylib=HSconcordium-consensus-0.1.0.0");
                 println!("cargo:rustc-link-lib=dylib=HSconcordium-base-0.1.0.0");
@@ -115,11 +114,11 @@ fn main() -> std::io::Result<()> {
                             .unwrap()
                             .strip_prefix("lib")
                             .unwrap();
-                        println!("cargo:rustc-link-lib=dylib={}", name);
+                        println!("cargo:rustc-link-lib=dylib={name}");
                     }
                 }
                 if let Ok(ref extra_libs_path) = env::var("EXTRA_LIBS_PATH").as_ref() {
-                    println!("cargo:rustc-link-search=native={}", extra_libs_path);
+                    println!("cargo:rustc-link-search=native={extra_libs_path}");
                 }
                 let ghc_lib_dir = link_ghc_libs()?;
                 let lib_path = if cfg!(target_os = "linux") {
@@ -150,15 +149,14 @@ fn main() -> std::io::Result<()> {
 // GRPC2 interface.
 fn build_grpc2(proto_root_input: &str) -> std::io::Result<()> {
     {
-        let types = format!("{}/v2/concordium/types.proto", proto_root_input);
-        println!("cargo:rerun-if-changed={}", types);
+        let types = format!("{proto_root_input}/v2/concordium/types.proto");
+        println!("cargo:rerun-if-changed={types}");
         let plts = format!(
-            "{}/v2/concordium/protocol-level-tokens.proto",
-            proto_root_input
+            "{proto_root_input}/v2/concordium/protocol-level-tokens.proto"
         );
-        println!("cargo:rerun-if-changed={}", plts);
-        let kernel = format!("{}/v2/concordium/kernel.proto", proto_root_input);
-        println!("cargo:rerun-if-changed={}", kernel);
+        println!("cargo:rerun-if-changed={plts}");
+        let kernel = format!("{proto_root_input}/v2/concordium/kernel.proto");
+        println!("cargo:rerun-if-changed={kernel}");
         prost_build::compile_protos(&[kernel, plts, types], &[proto_root_input])?;
     }
 
@@ -784,7 +782,7 @@ fn build_grpc2(proto_root_input: &str) -> std::io::Result<()> {
         .compile(&[query_service]);
 
     {
-        let health = format!("{}/v2/concordium/health.proto", proto_root_input);
+        let health = format!("{proto_root_input}/v2/concordium/health.proto");
         let descriptor_path =
             std::path::PathBuf::from(env::var("OUT_DIR").unwrap()).join("health_descriptor.bin");
         // build the health service with reflection support
@@ -796,7 +794,7 @@ fn build_grpc2(proto_root_input: &str) -> std::io::Result<()> {
             .expect("Failed to compile gRPC health definitions!");
     }
     {
-        let grpc_health_v1 = format!("{}/grpc/health/v1/health.proto", proto_root_input);
+        let grpc_health_v1 = format!("{proto_root_input}/grpc/health/v1/health.proto");
         let descriptor_path = std::path::PathBuf::from(env::var("OUT_DIR").unwrap())
             .join("grpc_health_v1_descriptor.bin");
         // build the health service with reflection support
@@ -847,7 +845,7 @@ fn link_ghc_libs() -> std::io::Result<std::path::PathBuf> {
         if file_stem.starts_with(&rts_variant) {
             if let Some(true) = item.path().extension().map(|ext| ext == DYLIB_EXTENSION) {
                 let lib_name = file_stem.strip_prefix("lib").unwrap();
-                println!("cargo:rustc-link-lib=dylib={}", lib_name);
+                println!("cargo:rustc-link-lib=dylib={lib_name}");
             }
         }
     }
@@ -922,8 +920,7 @@ fn ghc_variant(stack_install_lib: &Path) -> std::io::Result<std::path::PathBuf> 
         Some(path) => Ok(path),
         None => {
             eprintln!(
-                "No subdirectory in {:?} with prefix {}",
-                stack_install_lib, GHC_VARIANT
+                "No subdirectory in {stack_install_lib:?} with prefix {GHC_VARIANT}"                
             );
             Err(std::io::Error::new(
                 std::io::ErrorKind::NotFound,

--- a/concordium-node/src/configuration.rs
+++ b/concordium-node/src/configuration.rs
@@ -1115,7 +1115,7 @@ impl AppPreferences {
 
     fn calculate_config_file_path(config_path: &Path, key: &str) -> PathBuf {
         let mut new_path = config_path.to_path_buf();
-        new_path.push(format!("{}.json", key));
+        new_path.push(format!("{key}.json"));
         new_path
     }
 

--- a/concordium-node/src/connection/mod.rs
+++ b/concordium-node/src/connection/mod.rs
@@ -458,11 +458,11 @@ impl Eq for Connection {}
 impl fmt::Display for Connection {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let target = if let Some(id) = self.remote_id() {
-            format!("peer {}", id)
+            format!("peer {id}")
         } else {
             self.remote_addr().to_string()
         };
-        write!(f, "{}", target)
+        write!(f, "{target}")
     }
 }
 

--- a/concordium-node/src/consensus_ffi/ffi.rs
+++ b/concordium-node/src/consensus_ffi/ffi.rs
@@ -2161,7 +2161,7 @@ impl ConsensusContainer {
 
         (
             ConsensusFfiResponse::try_from(result)
-                .unwrap_or_else(|code| panic!("Unknown FFI return code: {}", code))
+                .unwrap_or_else(|code| panic!("Unknown FFI return code: {code}"))
                 .check_consistent(),
             callback,
         )
@@ -2174,7 +2174,7 @@ impl ConsensusContainer {
         let consensus = self.consensus.load(Ordering::SeqCst);
         let result = unsafe { executeBlock(consensus, execute_block_callback) };
         ConsensusFfiResponse::try_from(result)
-            .unwrap_or_else(|code| panic!("Unknown FFI return code: {}", code))
+            .unwrap_or_else(|code| panic!("Unknown FFI return code: {code}"))
             .check_consistent()
     }
 
@@ -2199,7 +2199,7 @@ impl ConsensusContainer {
         };
 
         let return_code = ConsensusFfiResponse::try_from(result)
-            .unwrap_or_else(|code| panic!("Unknown FFI return code: {}", code))
+            .unwrap_or_else(|code| panic!("Unknown FFI return code: {code}"))
             .check_consistent();
         if return_code == ConsensusFfiResponse::Success {
             (Some(out_hash.into()), return_code)
@@ -2260,7 +2260,7 @@ impl ConsensusContainer {
         };
 
         ConsensusFfiResponse::try_from(result)
-            .unwrap_or_else(|code| panic!("Unknown FFI return code: {}", code))
+            .unwrap_or_else(|code| panic!("Unknown FFI return code: {code}"))
             .check_consistent()
     }
 

--- a/concordium-node/src/consensus_ffi/helpers.rs
+++ b/concordium-node/src/consensus_ffi/helpers.rs
@@ -76,7 +76,7 @@ impl TryFrom<u8> for PacketType {
         PACKET_TYPE_FROM_INT
             .get(value as usize)
             .copied()
-            .context(format! {"Unsupported packet type ({})", value})
+            .context(format! {"Unsupported packet type ({value})"})
     }
 }
 
@@ -90,7 +90,7 @@ impl fmt::Display for PacketType {
             PacketType::CatchUpStatus => "catch-up status message",
         };
 
-        write!(f, "{}", name)
+        write!(f, "{name}")
     }
 }
 
@@ -443,9 +443,9 @@ impl ConsensusQueryResponse {
     pub fn ensure_ok(self, msg: impl std::fmt::Display) -> Result<(), tonic::Status> {
         match self {
             Self::InvalidArgument => Err(tonic::Status::invalid_argument("Invalid argument.")),
-            Self::InternalError => Err(tonic::Status::internal(format!("Internal error: {}. Please report this bug at https://github.com/Concordium/concordium-node/issues.", msg))),
+            Self::InternalError => Err(tonic::Status::internal(format!("Internal error: {msg}. Please report this bug at https://github.com/Concordium/concordium-node/issues."))),
             Self::Ok => Ok(()),
-            Self::NotFound => Err(tonic::Status::not_found(format!("{} not found.", msg))),
+            Self::NotFound => Err(tonic::Status::not_found(format!("{msg} not found."))),
             Self::Unavailable => Err(tonic::Status::unavailable("The service is not available at the current protocol version.")),
             Self::FutureEpoch => Err(tonic::Status::unavailable("Future epoch.")),
         }

--- a/concordium-node/src/consensus_ffi/messaging.rs
+++ b/concordium-node/src/consensus_ffi/messaging.rs
@@ -66,8 +66,8 @@ impl ConsensusMessage {
 impl fmt::Display for ConsensusMessage {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let party_name = match self.direction {
-            MessageType::Inbound(peer_id, _) => format!("from peer {}", peer_id),
-            MessageType::Outbound(Some(peer_id)) => format!("to peer {}", peer_id),
+            MessageType::Inbound(peer_id, _) => format!("from peer {peer_id}"),
+            MessageType::Outbound(Some(peer_id)) => format!("to peer {peer_id}"),
             _ => "from our consensus layer".to_owned(),
         };
 

--- a/concordium-node/src/grpc2.rs
+++ b/concordium-node/src/grpc2.rs
@@ -253,7 +253,7 @@ pub mod types {
 
         fn try_from(value: InitName) -> Result<Self, Self::Error> {
             Self::new(value.value).map_err(|e| {
-                tonic::Status::invalid_argument(format!("Invalid contract init name: {}", e))
+                tonic::Status::invalid_argument(format!("Invalid contract init name: {e}"))
             })
         }
     }
@@ -263,7 +263,7 @@ pub mod types {
 
         fn try_from(value: ReceiveName) -> Result<Self, Self::Error> {
             Self::new(value.value).map_err(|e| {
-                tonic::Status::invalid_argument(format!("Invalid contract receive name: {}", e))
+                tonic::Status::invalid_argument(format!("Invalid contract receive name: {e}"))
             })
         }
     }
@@ -273,7 +273,7 @@ pub mod types {
 
         fn try_from(value: Parameter) -> Result<Self, Self::Error> {
             Self::try_from(value.value)
-                .map_err(|e| tonic::Status::invalid_argument(format!("Invalid parameter: {}", e)))
+                .map_err(|e| tonic::Status::invalid_argument(format!("Invalid parameter: {e}")))
         }
     }
 
@@ -298,7 +298,7 @@ pub mod types {
 
         fn try_from(value: RegisteredData) -> Result<Self, Self::Error> {
             value.value.try_into().map_err(|e| {
-                tonic::Status::invalid_argument(format!("Invalid register data payload: {}", e))
+                tonic::Status::invalid_argument(format!("Invalid register data payload: {e}"))
             })
         }
     }
@@ -2703,8 +2703,7 @@ pub mod server {
             match self.node.close() {
                 Ok(_) => Ok(tonic::Response::new(crate::grpc2::types::Empty {})),
                 Err(e) => Err(tonic::Status::internal(format!(
-                    "Unable to shutdown server {}.",
-                    e
+                    "Unable to shutdown server {e}."
                 ))),
             }
         }
@@ -2808,13 +2807,11 @@ pub mod server {
                 Ok(ip_addr) => match self.node.drop_by_ip_and_ban(ip_addr) {
                     Ok(_) => Ok(tonic::Response::new(crate::grpc2::types::Empty {})),
                     Err(e) => Err(tonic::Status::internal(format!(
-                        "Could not ban peer {}.",
-                        e
+                        "Could not ban peer {e}."
                     ))),
                 },
                 Err(e) => Err(tonic::Status::invalid_argument(format!(
-                    "Invalid IP address provided {}",
-                    e
+                    "Invalid IP address provided {e}"
                 ))),
             }
         }
@@ -2838,14 +2835,12 @@ pub mod server {
                     match self.node.unban_node(banned_id) {
                         Ok(_) => Ok(tonic::Response::new(crate::grpc2::types::Empty {})),
                         Err(e) => Err(tonic::Status::internal(format!(
-                            "Could not unban peer {}.",
-                            e
+                            "Could not unban peer {e}."
                         ))),
                     }
                 }
                 Err(e) => Err(tonic::Status::invalid_argument(format!(
-                    "Invalid IP address {}.",
-                    e
+                    "Invalid IP address {e}."
                 ))),
             }
         }
@@ -3193,8 +3188,7 @@ pub mod server {
                     Err(tonic::Status::new(
                         tonic::Code::Internal,
                         format!(
-                            "Couldn't put a transaction in the outbound queue due to {:?}",
-                            e
+                            "Couldn't put a transaction in the outbound queue due to {e:?}"
                         ),
                     ))
                 }

--- a/concordium-node/src/p2p/connectivity.rs
+++ b/concordium-node/src/p2p/connectivity.rs
@@ -487,7 +487,7 @@ pub fn connect(
         "Attempting to connect to {}{}",
         peer_addr,
         if let Some(id) = peer_id {
-            format!(" ({})", id)
+            format!(" ({id})")
         } else {
             "".to_owned()
         }

--- a/concordium-node/src/plugins/consensus.rs
+++ b/concordium-node/src/plugins/consensus.rs
@@ -447,7 +447,7 @@ fn send_consensus_msg_to_net(
 
     if sent > 0 {
         let target_desc = if let Some(id) = target_id {
-            format!("direct message to peer {}", id)
+            format!("direct message to peer {id}")
         } else {
             "broadcast".to_string()
         };


### PR DESCRIPTION
## Purpose
Cargo deny gave these alerts:
ID: RUSTSEC-2026-0007
   ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0007
Recommended: cargo update -p bytes

ID: RUSTSEC-2026-0009
    ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0009
Recommended: cargo update -p time

detected yanked crate keccak 0.1.5 registry+https://github.com/rust-lang/crates.io-index
Recommended: cargo update -p keccak


## Changes
Ran on affected folders:
cargo update -p bytes
cargo update -p time
cargo update -p keccak

for collector-backend folder: Please note that the time alert is now highlighting "Upgrade to >=0.3.47", had to do cargo update -p time:0.3.44 --precise 0.3.47

## Checklist

- [ x ] My code follows the style of this project.
- [ x ] The code compiles without warnings.
- [ x ] I have performed a self-review of the changes.
- [ x ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
