### PR TITLE
Ar/psr 12 implement left full merkle binary tree in rust

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlobStore.hs
@@ -54,6 +54,7 @@ module Concordium.GlobalState.Persistent.BlobStore (
     -- * In-memory blob store
     MemBlobStore (..),
     newMemBlobStore,
+    newMemBlobStoreWithBytes,
     destroyMemBlobStore,
     MemBlobStoreT (..),
 
@@ -698,6 +699,10 @@ data MemBlobStore = MemBlobStore
 -- | Create a fresh, empty 'MemBlobStore'.
 newMemBlobStore :: IO MemBlobStore
 newMemBlobStore = MemBlobStore <$> newMVar LBS.empty <*> newEmptyMVar
+
+-- | Create a new 'MemBlobStore' containing given bytes.
+newMemBlobStoreWithBytes :: LBS.ByteString -> IO MemBlobStore
+newMemBlobStoreWithBytes bs = MemBlobStore <$> newMVar bs <*> newEmptyMVar
 
 -- | Destroy a 'MemBlobStore'. The caller should ensure that no operations on the 'MemBlobStore'
 --  can happen after the call to 'destroyMemBlobStore'.

--- a/plt/plt-block-state/src/block_state.rs
+++ b/plt/plt-block-state/src/block_state.rs
@@ -1,150 +1,135 @@
-//! This module contains the [`PltBlockState`] which provides an implementation of [`BlockStateOperations`].
+//! This module contains the [`BlockState`] which provides an implementation of [`BlockStateOperations`].
 
-use crate::block_state::blob_reference::BlobStoreLocation;
-use crate::block_state::blob_store::{BlobStoreLoad, BlobStoreStore, ParseResultExt};
+use crate::block_state::blob_store::{BlobStoreLoad, BlobStoreStore, Loadable, Storable};
+use crate::block_state::cacheable::Cacheable;
 use crate::block_state::external::{ExternalBlockStateOperations, ExternalBlockStateQuery};
-use crate::block_state::types::{
-    AccountWithCanonicalAddress, TokenAccountState, TokenConfiguration, TokenIndex, TokenStateKey,
-    TokenStateValue,
+use crate::block_state::hash::Hashable;
+use crate::block_state::state::protocol_level_tokens::{
+    ProtocolLevelTokens, SimplisticTokenKeyValueState,
+};
+use crate::block_state::types::AccountWithCanonicalAddress;
+use crate::block_state::types::protocol_level_tokens::{
+    TokenAccountState, TokenConfiguration, TokenIndex, TokenStateKey, TokenStateValue,
 };
 use crate::block_state_interface::{
-    BlockStateOperations, BlockStateQuery, BlockStateResult, OverflowError, RawTokenAmountDelta,
-    TokenNotFoundByIdError,
+    AccountNotFoundByAddressError, AccountNotFoundByIndexError, BlockStateOperations,
+    BlockStateQuery, BlockStateResult, OverflowError, RawTokenAmountDelta, TokenNotFoundByIdError,
 };
 use concordium_base::base::{AccountIndex, ProtocolVersion};
-use concordium_base::common;
-use concordium_base::common::Serialize;
-use concordium_base::constants::SHA256;
+use concordium_base::common::Buffer;
 use concordium_base::contracts_common::AccountAddress;
+use concordium_base::hashes::Hash;
 use concordium_base::protocol_level_tokens::TokenId;
 use plt_scheduler_types::types::tokens::RawTokenAmount;
-use sha2::Digest;
-use std::collections::BTreeMap;
 use std::io::Read;
+use std::mem;
 
 pub mod blob_reference;
 pub mod blob_store;
 pub mod cacheable;
 pub mod external;
 pub mod hash;
+mod lfmb_tree;
+mod state;
 pub mod types;
-pub mod lfmb_tree;
 mod utils;
 
-/// Account with given address does not exist
-#[derive(Debug, thiserror::Error)]
-#[error("Account with address {0} does not exist")]
-pub struct AccountNotFoundByAddressError(pub AccountAddress);
-
-/// Account with given index does not exist
-#[derive(Debug, thiserror::Error)]
-#[error("Account with index {0} does not exist")]
-pub struct AccountNotFoundByIndexError(pub AccountIndex);
-
-/// Marker for PLT block state hash type.
-pub enum PltBlockStateHashMarker {}
-/// Hash of PLT block state
-pub type PltBlockStateHash = concordium_base::hashes::HashBytes<PltBlockStateHashMarker>;
-
-/// Immutable block state save-point.
+/// Immutable block state. The block state is immutable in the sense,
+/// that the state it represents never changes during the lifetime of values of type [`BlockState`].
+/// In order to perform mutating operations on the block state, a new [`BlockState`]
+/// must be created.
 ///
-/// This is a wrapper around a [`PltBlockState`] ensuring further mutations can only be done by
-/// unwrapping using [`PltBlockStateSavepoint::mutable_state`].
-#[derive(Debug)]
-pub struct PltBlockStateSavepoint {
-    /// The inner block state, which will not be mutated.
-    block_state: PltBlockState,
+/// The internal representation in [`BlockState`] may change during the lifetime via interior mutability.
+/// This happens if state are cached, stored or hashes are lazily calculated.
+#[derive(Debug, Clone, Default)]
+pub struct BlockState {
+    /// Simplistic state that is used as a temporary implementation of the block state
+    tokens: ProtocolLevelTokens,
 }
 
-impl PltBlockStateSavepoint {
-    /// Initialize a new block state.
+impl BlockState {
+    /// Construct an empty block state.
     pub fn empty() -> Self {
-        Self {
-            block_state: PltBlockState::empty(),
+        BlockState {
+            tokens: ProtocolLevelTokens::empty(),
         }
     }
 
-    /// Compute the hash.
-    pub fn hash(&self, _loader: &mut impl BlobStoreLoad) -> PltBlockStateHash {
-        // todo do real implementation as part of https://linear.app/concordium/issue/PSR-11/port-the-plt-block-state-to-rust
-        if self.block_state.state.tokens.is_empty() {
-            // For empty state, use a hash equal to the Haskell side. Else test suites in consensus must be updated
-            // with new hashes. Also, eventually, our hashing must be compatible with Haskell PLT state anyway.
-            PltBlockStateHash::from(
-                <[u8; SHA256]>::try_from(
-                    hex::decode("c423f9e91ee218b2b5303485dd87a3093a653ddb9bdb839d30aa1924de1dbf05")
-                        .unwrap(),
-                )
-                .unwrap(),
-            )
-        } else {
-            let block_state_bytes = common::to_bytes(&self.block_state.state);
-            PltBlockStateHash::from(<[u8; SHA256]>::from(sha2::Sha256::digest(
-                &block_state_bytes,
-            )))
-        }
-    }
-
-    /// Store a PLT block state in a blob store.
-    pub fn store_update(&self, storer: &mut impl BlobStoreStore) -> BlobStoreLocation {
-        // todo do real implementation as part of https://linear.app/concordium/issue/PSR-11/port-the-plt-block-state-to-rust
-        let block_state_bytes = common::to_bytes(&self.block_state.state);
-        storer.store_raw(&block_state_bytes)
+    /// Consume the immutable block state and create a mutable block state.
+    pub fn into_mutable(self) -> MutableBlockState {
+        MutableBlockState::new(self)
     }
 
     /// Migrate the PLT block state from one blob store to another.
-    pub fn migrate(
-        &self,
-        _loader: &mut impl BlobStoreLoad,
-        _storer: &mut impl BlobStoreStore,
-    ) -> Self {
+    pub fn migrate(&self, _loader: impl BlobStoreLoad, _storer: impl BlobStoreStore) -> Self {
         // todo implement as part of https://linear.app/concordium/issue/PSR-11/port-the-plt-block-state-to-rust
         todo!()
     }
-
-    /// Cache the block state in memory.
-    pub fn cache(&self, _loader: &mut impl BlobStoreLoad) {
-        // todo implement as part of https://linear.app/concordium/issue/PSR-11/port-the-plt-block-state-to-rust
-    }
-
-    /// Construct a mutable block state which can be mutated without affecting this
-    /// save-point.
-    pub fn mutable_state(&self) -> PltBlockState {
-        self.block_state.clone()
-    }
 }
 
-impl blob_store::Loadable for PltBlockStateSavepoint {
+impl Loadable for BlockState {
     fn load_from_buffer(mut buffer: impl Read) -> BlockStateResult<Self> {
-        // todo do real implementation as part of https://linear.app/concordium/issue/PSR-11/port-the-plt-block-state-to-rust
-        let state: SimplisticPltBlockState =
-            common::from_bytes(&mut buffer).map_parse_err_to_block_state_err()?;
+        let tokens = Loadable::load_from_buffer(&mut buffer)?;
 
-        Ok(Self {
-            block_state: PltBlockState { state },
-        })
+        Ok(Self { tokens })
     }
 }
 
-/// Block state providing the various block state operations.
-#[derive(Debug, Clone)]
-pub struct PltBlockState {
-    // todo implement real block state as part of https://linear.app/concordium/issue/PSR-11/port-the-plt-block-state-to-rust
-    /// Simplistic state that is used as a temporary implementation of the block state
-    state: SimplisticPltBlockState,
+impl Storable for BlockState {
+    fn store_to_buffer(&self, mut buffer: impl Buffer, storer: &mut impl BlobStoreStore) {
+        self.tokens.store_to_buffer(&mut buffer, storer);
+    }
 }
 
-impl PltBlockState {
-    /// Construct an empty block state.
-    fn empty() -> Self {
-        PltBlockState {
-            state: Default::default(),
+impl Cacheable for BlockState {
+    fn cache_reference_values(&self, loader: &impl BlobStoreLoad) -> BlockStateResult<()> {
+        self.tokens.cache_reference_values(loader)?;
+        Ok(())
+    }
+}
+
+impl Hashable for BlockState {
+    fn hash(&self, loader: &impl BlobStoreLoad) -> BlockStateResult<Hash> {
+        self.tokens.hash(loader)
+    }
+}
+
+/// Mutable block state. In contrast to the immutable block state [`BlockState`],
+/// operations on the mutable block state changes the state that
+/// the value represents.
+#[derive(Debug, Clone)]
+pub struct MutableBlockState {
+    /// Immutable block state value. The block state represented by [`MutableBlockState`] is
+    /// mutated simply by setting a new value for the immutable block state [`BlockState`].
+    immutable_state: BlockState,
+}
+
+impl MutableBlockState {
+    fn new(mutable_state: BlockState) -> Self {
+        Self {
+            immutable_state: mutable_state,
         }
     }
 
-    /// Consume the mutable block state and create an immutable save-point.
-    pub fn savepoint(self) -> PltBlockStateSavepoint {
-        PltBlockStateSavepoint { block_state: self }
+    pub fn into_immutable(self) -> BlockState {
+        self.immutable_state
+    }
+
+    fn update_block_state_(
+        &mut self,
+        update: impl FnOnce(BlockState) -> BlockStateResult<BlockState>,
+    ) -> BlockStateResult<()> {
+        self.immutable_state = update(mem::take(&mut self.immutable_state))?;
+        Ok(())
+    }
+
+    fn update_block_state<T>(
+        &mut self,
+        update: impl FnOnce(BlockState) -> BlockStateResult<(T, BlockState)>,
+    ) -> BlockStateResult<T> {
+        let ret;
+        (ret, self.immutable_state) = update(mem::take(&mut self.immutable_state))?;
+        Ok(ret)
     }
 }
 
@@ -154,90 +139,98 @@ impl PltBlockState {
 /// In addition to the PLT block state, this type contains callbacks
 /// for the parts of the state that is managed on the Haskell side.
 #[derive(Debug)]
-pub struct ExecutionTimePltBlockState<IntState, Load, ExtState> {
+pub struct ExecutionTimeBlockState<IntState, Load, ExtState> {
     /// The protocol version of the block state.
     pub protocol_version: ProtocolVersion,
     /// The library block state implementation.
     pub internal_block_state: IntState,
     /// External function for reading from the blob store.
-    pub backing_store_load: Load,
+    pub blob_store_load: Load,
     /// Part of block state that is managed externally.
     pub external_block_state: ExtState,
 }
 
 /// Provides access needed for querying block state (but not to do operations on the block state).
-trait HasQueryableBlockState {
-    fn block_state(&self) -> &SimplisticPltBlockState;
+trait HasBlockState {
+    fn block_state(&self) -> &BlockState;
 }
 
-impl HasQueryableBlockState for PltBlockState {
-    fn block_state(&self) -> &SimplisticPltBlockState {
-        &self.state
+impl HasBlockState for &BlockState {
+    fn block_state(&self) -> &BlockState {
+        self
     }
 }
 
-impl HasQueryableBlockState for &PltBlockStateSavepoint {
-    fn block_state(&self) -> &SimplisticPltBlockState {
-        &self.block_state.state
+impl HasBlockState for MutableBlockState {
+    fn block_state(&self) -> &BlockState {
+        &self.immutable_state
     }
 }
 
-impl<IntState: HasQueryableBlockState, Load: BlobStoreLoad, ExtState: ExternalBlockStateQuery>
-    BlockStateQuery for ExecutionTimePltBlockState<IntState, Load, ExtState>
+impl<IntState: HasBlockState, Load: BlobStoreLoad, ExtState: ExternalBlockStateQuery>
+    BlockStateQuery for ExecutionTimeBlockState<IntState, Load, ExtState>
 {
     type TokenKeyValueState = SimplisticTokenKeyValueState;
     type Account = AccountIndex;
     type Token = TokenIndex;
 
     fn plt_list(&self) -> impl Iterator<Item = TokenId> {
+        // todo propagate block state error as part of https://linear.app/concordium/issue/COR-2346/push-blockstateerror-to-scheduler-code
         self.internal_block_state
             .block_state()
             .tokens
-            .iter()
-            .map(|token| token.configuration.token_id.clone())
+            .plt_list(&self.blob_store_load)
+            .map(|item| item.unwrap())
     }
 
-    fn token_by_id(&self, token_id: &TokenId) -> Result<Self::Token, TokenNotFoundByIdError> {
-        self.internal_block_state
-            .block_state()
-            .tokens
-            .iter()
-            .enumerate()
-            .find_map(|(i, token)| {
-                if token
-                    .configuration
-                    .token_id
-                    .as_ref()
-                    .eq_ignore_ascii_case(token_id.as_ref())
-                {
-                    Some(TokenIndex(i as u64))
-                } else {
-                    None
-                }
-            })
-            .ok_or(TokenNotFoundByIdError(token_id.clone()))
+    fn token_by_id(&self, _token_id: &TokenId) -> Result<Self::Token, TokenNotFoundByIdError> {
+        // todo ar look up via normalized token id map
+        // self.internal_block_state
+        //     .block_state()
+        //     .tokens
+        //     .iter()
+        //     .enumerate()
+        //     .find_map(|(i, token)| {
+        //         if token
+        //             .configuration
+        //             .token_id
+        //             .as_ref()
+        //             .eq_ignore_ascii_case(token_id.as_ref())
+        //         {
+        //             Some(TokenIndex(i as u64))
+        //         } else {
+        //             None
+        //         }
+        //     })
+        //     .ok_or(TokenNotFoundByIdError(token_id.clone()))
+        todo!()
     }
 
     fn mutable_token_key_value_state(&self, token: &TokenIndex) -> Self::TokenKeyValueState {
-        self.internal_block_state.block_state().tokens[token.0 as usize]
-            .key_value_state
-            .clone()
+        // todo propagate block state error as part of https://linear.app/concordium/issue/COR-2346/push-blockstateerror-to-scheduler-code
+        self.internal_block_state
+            .block_state()
+            .tokens
+            .mutable_token_key_value_state(&self.blob_store_load, *token)
+            .unwrap()
     }
 
     fn token_configuration(&self, token: &Self::Token) -> TokenConfiguration {
-        let configuration = self.internal_block_state.block_state().tokens[token.0 as usize]
-            .configuration
-            .clone();
-
-        TokenConfiguration {
-            token_id: configuration.token_id,
-            module_ref: configuration.module_ref,
-            decimals: configuration.decimals,
-        }
+        // todo propagate block state error as part of https://linear.app/concordium/issue/COR-2346/push-blockstateerror-to-scheduler-code
+        self.internal_block_state
+            .block_state()
+            .tokens
+            .token_configuration(&self.blob_store_load, *token)
+            .unwrap()
     }
 
     fn token_circulating_supply(&self, token: &Self::Token) -> RawTokenAmount {
-        self.internal_block_state.block_state().tokens[token.0 as usize].circulating_supply
+        // todo propagate block state error as part of https://linear.app/concordium/issue/COR-2346/push-blockstateerror-to-scheduler-code
+        self.internal_block_state
+            .block_state()
+            .tokens
+            .token_circulating_supply(&self.blob_store_load, *token)
+            .unwrap()
     }
 
     fn lookup_token_state_value(
@@ -245,7 +238,7 @@ impl<IntState: HasQueryableBlockState, Load: BlobStoreLoad, ExtState: ExternalBl
         token_key_value_state: &Self::TokenKeyValueState,
         key: &TokenStateKey,
     ) -> Option<TokenStateValue> {
-        token_key_value_state.state.get(key).cloned()
+        token_key_value_state.lookup_value(key)
     }
 
     fn update_token_state_value(
@@ -254,11 +247,7 @@ impl<IntState: HasQueryableBlockState, Load: BlobStoreLoad, ExtState: ExternalBl
         key: &TokenStateKey,
         value: Option<TokenStateValue>,
     ) {
-        if let Some(value) = value {
-            token_key_value_state.state.insert(key.clone(), value);
-        } else {
-            token_key_value_state.state.remove(key);
-        }
+        token_key_value_state.update_value(key, value)
     }
 
     fn account_by_address(
@@ -322,26 +311,37 @@ impl<IntState: HasQueryableBlockState, Load: BlobStoreLoad, ExtState: ExternalBl
 }
 
 impl<Load: BlobStoreLoad, ExtState: ExternalBlockStateOperations> BlockStateOperations
-    for ExecutionTimePltBlockState<PltBlockState, Load, ExtState>
+    for ExecutionTimeBlockState<MutableBlockState, Load, ExtState>
 {
     fn set_token_circulating_supply(
         &mut self,
         token: &Self::Token,
         circulating_supply: RawTokenAmount,
     ) {
-        self.internal_block_state.state.tokens[token.0 as usize].circulating_supply =
-            circulating_supply;
+        // todo propagate block state error as part of https://linear.app/concordium/issue/COR-2346/push-blockstateerror-to-scheduler-code
+        self.internal_block_state
+            .update_block_state_(|state| {
+                Ok(BlockState {
+                    tokens: state.tokens.set_token_circulating_supply(
+                        &self.blob_store_load,
+                        *token,
+                        circulating_supply,
+                    )?,
+                })
+            })
+            .unwrap();
     }
 
     fn create_token(&mut self, configuration: TokenConfiguration) -> Self::Token {
-        let token_index = TokenIndex(self.internal_block_state.state.tokens.len() as u64);
-        let token = Token {
-            key_value_state: Default::default(),
-            configuration,
-            circulating_supply: Default::default(),
-        };
-        self.internal_block_state.state.tokens.push(token);
-        token_index
+        // todo propagate block state error as part of https://linear.app/concordium/issue/COR-2346/push-blockstateerror-to-scheduler-code
+        self.internal_block_state
+            .update_block_state(|state| {
+                let (token_index, tokens) = state
+                    .tokens
+                    .create_token(&self.blob_store_load, configuration)?;
+                Ok((token_index, BlockState { tokens }))
+            })
+            .unwrap()
     }
 
     fn update_token_account_balance(
@@ -369,43 +369,17 @@ impl<Load: BlobStoreLoad, ExtState: ExternalBlockStateOperations> BlockStateOper
         token: &Self::Token,
         token_key_value_state: Self::TokenKeyValueState,
     ) {
-        self.internal_block_state.state.tokens[token.0 as usize].key_value_state =
-            token_key_value_state;
-    }
-}
-
-/// Simplistic implementation of the block state that serializes as a flat sequence of bytes.
-// todo do real implementation as part of https://linear.app/concordium/issue/PSR-11/port-the-plt-block-state-to-rust
-#[derive(Debug, Default, Clone, Serialize)]
-struct SimplisticPltBlockState {
-    tokens: Vec<Token>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-struct Token {
-    key_value_state: SimplisticTokenKeyValueState,
-    configuration: TokenConfiguration,
-    circulating_supply: RawTokenAmount,
-}
-
-#[derive(Debug, Clone, Default, Serialize)]
-pub struct SimplisticTokenKeyValueState {
-    state: BTreeMap<TokenStateKey, TokenStateValue>,
-}
-
-impl SimplisticTokenKeyValueState {
-    fn iter_prefix(
-        &self,
-        prefix: TokenStateKey,
-    ) -> impl Iterator<Item = (&TokenStateKey, &TokenStateValue)> {
-        // This is just a temporary implementation and will not scale.
-        // However implementation should be trivial once using the actual trie.
-        let mut out = Vec::new();
-        for (key, value) in self.state.iter() {
-            if key.starts_with(prefix.as_slice()) {
-                out.push((key, value));
-            }
-        }
-        out.into_iter()
+        // todo propagate block state error as part of https://linear.app/concordium/issue/COR-2346/push-blockstateerror-to-scheduler-code
+        self.internal_block_state
+            .update_block_state_(|state| {
+                Ok(BlockState {
+                    tokens: state.tokens.set_token_key_value_state(
+                        &self.blob_store_load,
+                        *token,
+                        token_key_value_state,
+                    )?,
+                })
+            })
+            .unwrap();
     }
 }

--- a/plt/plt-block-state/src/block_state/external.rs
+++ b/plt/plt-block-state/src/block_state/external.rs
@@ -1,8 +1,9 @@
-//! Interactions with block state managed externally in Haskell.
+//! Interactions with the part of the block state that is managed externally in Haskell.
 
-use crate::block_state::types::{TokenAccountState, TokenIndex};
-use crate::block_state::{AccountNotFoundByAddressError, AccountNotFoundByIndexError};
-use crate::block_state_interface::{OverflowError, RawTokenAmountDelta};
+use crate::block_state::types::protocol_level_tokens::{TokenAccountState, TokenIndex};
+use crate::block_state_interface::{
+    AccountNotFoundByAddressError, AccountNotFoundByIndexError, OverflowError, RawTokenAmountDelta,
+};
 use concordium_base::base::AccountIndex;
 use concordium_base::contracts_common::AccountAddress;
 use plt_scheduler_types::types::tokens::RawTokenAmount;

--- a/plt/plt-block-state/src/block_state/state.rs
+++ b/plt/plt-block-state/src/block_state/state.rs
@@ -1,0 +1,3 @@
+//! Persistent and in-memory model for the block state.
+
+pub mod protocol_level_tokens;

--- a/plt/plt-block-state/src/block_state/state/protocol_level_tokens.rs
+++ b/plt/plt-block-state/src/block_state/state/protocol_level_tokens.rs
@@ -1,0 +1,280 @@
+//! Persistent and in-memory model for protocol-level tokens in the block state.
+
+use crate::block_state::blob_reference::hashed_cacheable_reference::HashedCacheableRef;
+use crate::block_state::blob_store::{
+    BlobStoreLoad, BlobStoreStore, Loadable, Storable, StoreSerialized,
+};
+use crate::block_state::cacheable::Cacheable;
+use crate::block_state::hash;
+use crate::block_state::hash::Hashable;
+use crate::block_state::lfmb_tree::{LFMBTree, LFMBTreeKey};
+use crate::block_state::types::protocol_level_tokens::{
+    TokenConfiguration, TokenIndex, TokenStateKey, TokenStateValue,
+};
+use crate::block_state::utils::OwnedOrBorrowed;
+use crate::block_state_interface::{BlockStateError, BlockStateResult};
+use concordium_base::common::{Buffer, Serialize};
+use concordium_base::hashes::Hash;
+use concordium_base::protocol_level_tokens::TokenId;
+use plt_scheduler_types::types::tokens::RawTokenAmount;
+use std::collections::BTreeMap;
+use std::io::Read;
+
+/// Block state for protocol level tokens
+#[derive(Debug, Clone, Default)]
+pub struct ProtocolLevelTokens {
+    /// Simplistic state that is used as a temporary implementation of the block state
+    tokens: LFMBTree<TokenIndex, Token>,
+}
+
+impl ProtocolLevelTokens {
+    pub fn empty() -> Self {
+        Self {
+            tokens: LFMBTree::empty(),
+        }
+    }
+
+    pub fn plt_list(
+        &self,
+        loader: &impl BlobStoreLoad,
+    ) -> impl Iterator<Item = BlockStateResult<TokenId>> {
+        self.tokens.values(loader, |token| {
+            token.configuration.with_value(loader, |conf| {
+                Ok(match conf {
+                    OwnedOrBorrowed::Owned(v) => v.0.token_id,
+                    OwnedOrBorrowed::Borrowed(r) => r.0.token_id.clone(),
+                })
+            })
+        })
+    }
+
+    pub fn mutable_token_key_value_state(
+        &self,
+        loader: &impl BlobStoreLoad,
+        token_index: TokenIndex,
+    ) -> BlockStateResult<SimplisticTokenKeyValueState> {
+        self.tokens
+            .with_value(loader, token_index, |token| {
+                Ok(match token {
+                    OwnedOrBorrowed::Owned(v) => v.key_value_state.0,
+                    OwnedOrBorrowed::Borrowed(r) => r.key_value_state.0.clone(),
+                })
+            })
+            .ok_or_else(|| {
+                BlockStateError::Invariant(format!("token not found by index: {:?}", token_index))
+            })?
+    }
+
+    pub fn token_configuration(
+        &self,
+        loader: &impl BlobStoreLoad,
+        token_index: TokenIndex,
+    ) -> BlockStateResult<TokenConfiguration> {
+        self.tokens
+            .with_value(loader, token_index, |token| {
+                token
+                    .configuration
+                    .with_value(loader, |conf| Ok(conf.into_owned().0))
+            })
+            .ok_or_else(|| {
+                BlockStateError::Invariant(format!("token not found by index: {:?}", token_index))
+            })?
+    }
+
+    pub fn token_circulating_supply(
+        &self,
+        loader: &impl BlobStoreLoad,
+        token_index: TokenIndex,
+    ) -> BlockStateResult<RawTokenAmount> {
+        self.tokens
+            .with_value(loader, token_index, |token| Ok(token.circulating_supply.0))
+            .ok_or_else(|| {
+                BlockStateError::Invariant(format!("token not found by index: {:?}", token_index))
+            })?
+    }
+
+    pub fn set_token_circulating_supply(
+        self,
+        loader: &impl BlobStoreLoad,
+        token_index: TokenIndex,
+        circulating_supply: RawTokenAmount,
+    ) -> BlockStateResult<ProtocolLevelTokens> {
+        Ok(ProtocolLevelTokens {
+            tokens: self
+                .tokens
+                .update_value(loader, token_index, |token| {
+                    Ok(Token {
+                        circulating_supply: StoreSerialized(circulating_supply),
+                        ..token.into_owned()
+                    })
+                })
+                .ok_or_else(|| {
+                    BlockStateError::Invariant(format!(
+                        "token not found by index: {:?}",
+                        token_index
+                    ))
+                })??,
+        })
+    }
+
+    pub fn create_token(
+        self,
+        loader: &impl BlobStoreLoad,
+        configuration: TokenConfiguration,
+    ) -> BlockStateResult<(TokenIndex, ProtocolLevelTokens)> {
+        let token = Token {
+            configuration: HashedCacheableRef::new(StoreSerialized(configuration)),
+            key_value_state: Default::default(),
+            circulating_supply: Default::default(),
+        };
+
+        let (token_index, tokens) = self.tokens.insert_value(loader, token)?;
+
+        Ok((token_index, ProtocolLevelTokens { tokens }))
+    }
+
+    pub fn set_token_key_value_state(
+        self,
+        loader: &impl BlobStoreLoad,
+        token_index: TokenIndex,
+        token_key_value_state: SimplisticTokenKeyValueState,
+    ) -> BlockStateResult<ProtocolLevelTokens> {
+        Ok(ProtocolLevelTokens {
+            tokens: self
+                .tokens
+                .update_value(loader, token_index, |token| {
+                    Ok(Token {
+                        key_value_state: StoreSerialized(token_key_value_state),
+                        ..token.into_owned()
+                    })
+                })
+                .ok_or_else(|| {
+                    BlockStateError::Invariant(format!(
+                        "token not found by index: {:?}",
+                        token_index
+                    ))
+                })??,
+        })
+    }
+}
+
+impl Storable for ProtocolLevelTokens {
+    fn store_to_buffer(&self, mut buffer: impl Buffer, storer: &mut impl BlobStoreStore) {
+        self.tokens.store_to_buffer(&mut buffer, storer);
+    }
+}
+
+impl Loadable for ProtocolLevelTokens {
+    fn load_from_buffer(mut buffer: impl Read) -> BlockStateResult<Self> {
+        let tokens = Loadable::load_from_buffer(&mut buffer)?;
+
+        Ok(Self { tokens })
+    }
+}
+
+impl Cacheable for ProtocolLevelTokens {
+    fn cache_reference_values(&self, loader: &impl BlobStoreLoad) -> BlockStateResult<()> {
+        self.tokens.cache_reference_values(loader)
+    }
+}
+
+impl Hashable for ProtocolLevelTokens {
+    fn hash(&self, loader: &impl BlobStoreLoad) -> BlockStateResult<Hash> {
+        self.tokens.hash(loader)
+    }
+}
+
+impl LFMBTreeKey for TokenIndex {
+    fn to_u64(self) -> u64 {
+        self.0
+    }
+
+    fn from_u64(key: u64) -> Self {
+        Self(key)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Token {
+    configuration: HashedCacheableRef<StoreSerialized<TokenConfiguration>>,
+    key_value_state: StoreSerialized<SimplisticTokenKeyValueState>,
+    circulating_supply: StoreSerialized<RawTokenAmount>,
+}
+
+impl Storable for Token {
+    fn store_to_buffer(&self, mut buffer: impl Buffer, storer: &mut impl BlobStoreStore) {
+        self.configuration.store_to_buffer(&mut buffer, storer);
+        self.key_value_state.store_to_buffer(&mut buffer, storer);
+        self.circulating_supply.store_to_buffer(&mut buffer, storer);
+    }
+}
+
+impl Loadable for Token {
+    fn load_from_buffer(mut buffer: impl Read) -> BlockStateResult<Self> {
+        let configuration = Loadable::load_from_buffer(&mut buffer)?;
+        let key_value_state = Loadable::load_from_buffer(&mut buffer)?;
+        let circulating_supply = Loadable::load_from_buffer(&mut buffer)?;
+
+        Ok(Self {
+            configuration,
+            key_value_state,
+            circulating_supply,
+        })
+    }
+}
+
+impl Cacheable for Token {
+    fn cache_reference_values(&self, loader: &impl BlobStoreLoad) -> BlockStateResult<()> {
+        self.configuration.cache_reference_values(loader)
+    }
+}
+
+impl Hashable for Token {
+    fn hash(&self, loader: &impl BlobStoreLoad) -> BlockStateResult<Hash> {
+        let config = self.configuration.hash(loader)?;
+        let key_value_state = self.key_value_state.hash(loader)?;
+        let circulating_supply = self.circulating_supply.hash(loader)?;
+
+        Ok(hash::hash_of_hashes(
+            config,
+            hash::hash_of_hashes(key_value_state, circulating_supply),
+        ))
+    }
+}
+
+// todo do real implementation of key-value store as part of https://linear.app/concordium/issue/PSR-11/port-the-plt-block-state-to-rust
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct SimplisticTokenKeyValueState {
+    state: BTreeMap<TokenStateKey, TokenStateValue>,
+}
+
+impl SimplisticTokenKeyValueState {
+    pub fn lookup_value(&self, key: &TokenStateKey) -> Option<TokenStateValue> {
+        self.state.get(key).cloned()
+    }
+
+    pub fn update_value(&mut self, key: &TokenStateKey, value: Option<TokenStateValue>) {
+        if let Some(value) = value {
+            self.state.insert(key.clone(), value);
+        } else {
+            self.state.remove(key);
+        }
+    }
+}
+
+impl SimplisticTokenKeyValueState {
+    pub fn iter_prefix(
+        &self,
+        prefix: TokenStateKey,
+    ) -> impl Iterator<Item = (&TokenStateKey, &TokenStateValue)> {
+        // This is just a temporary implementation and will not scale.
+        // However implementation should be trivial once using the actual trie.
+        let mut out = Vec::new();
+        for (key, value) in self.state.iter() {
+            if key.starts_with(prefix.as_slice()) {
+                out.push((key, value));
+            }
+        }
+        out.into_iter()
+    }
+}

--- a/plt/plt-block-state/src/block_state/types.rs
+++ b/plt/plt-block-state/src/block_state/types.rs
@@ -1,42 +1,8 @@
 //! Types used specifically in the block state.
 
-use concordium_base::common::Serialize;
+pub mod protocol_level_tokens;
+
 use concordium_base::contracts_common::AccountAddress;
-use concordium_base::protocol_level_tokens::{TokenId, TokenModuleRef};
-use plt_scheduler_types::types::tokens::RawTokenAmount;
-
-/// Index of the protocol-level token in the block state map of tokens.
-///
-/// Corresponding Haskell type: `Concordium.GlobalState.Persistent.BlockState.ProtocolLevelTokens.TokenIndex`
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
-pub struct TokenIndex(pub u64);
-
-/// Static configuration for a protocol-level token.
-///
-/// Corresponding Haskell type: `Concordium.GlobalState.Persistent.BlockState.ProtocolLevelTokens.PLTConfiguration`
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize)]
-pub struct TokenConfiguration {
-    /// The token ID in its canonical form. Token IDs are case-insensitive when compared,
-    /// but the canonical token ID preserves the original casing specified when
-    /// the token was created.
-    pub token_id: TokenId,
-    /// The token module reference.
-    pub module_ref: TokenModuleRef,
-    /// The number of decimal places used in the representation of the token.
-    pub decimals: u8,
-}
-
-/// Token account state at block state level.
-///
-/// Corresponding Haskell type: `Concordium.GlobalState.Persistent.Account.ProtocolLevelTokens.TokenAccountState`
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize)]
-pub struct TokenAccountState {
-    /// Balance of the account
-    pub balance: RawTokenAmount,
-}
-
-pub type TokenStateKey = Vec<u8>;
-pub type TokenStateValue = Vec<u8>;
 
 /// Account representing (read-only) account state.
 ///
@@ -48,44 +14,4 @@ pub struct AccountWithCanonicalAddress<Account> {
     /// The canonical account address of the account, i.e. the address used as part of the
     /// credential deployment and not an alias.
     pub canonical_account_address: AccountAddress,
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use concordium_base::common;
-    use concordium_base::protocol_level_tokens::TokenModuleRef;
-
-    #[test]
-    fn test_token_configuration_serial() {
-        let token_configuration = TokenConfiguration {
-            token_id: "tokenid1".parse().unwrap(),
-            module_ref: TokenModuleRef::from([5; 32]),
-            decimals: 4,
-        };
-
-        let bytes = common::to_bytes(&token_configuration);
-        assert_eq!(
-            hex::encode(&bytes),
-            "08746f6b656e696431050505050505050505050505050505050505050505050505050505050505050504"
-        );
-
-        let token_configuration_deserialized: TokenConfiguration =
-            common::from_bytes_complete(bytes.as_slice()).unwrap();
-        assert_eq!(token_configuration_deserialized, token_configuration);
-    }
-
-    #[test]
-    fn test_token_account_state_serial() {
-        let state = TokenAccountState {
-            balance: RawTokenAmount(10),
-        };
-
-        let bytes = common::to_bytes(&state);
-        assert_eq!(hex::encode(&bytes), "0a");
-
-        let state_deserialized: TokenAccountState =
-            common::from_bytes_complete(bytes.as_slice()).unwrap();
-        assert_eq!(state_deserialized, state);
-    }
 }

--- a/plt/plt-block-state/src/block_state/types/protocol_level_tokens.rs
+++ b/plt/plt-block-state/src/block_state/types/protocol_level_tokens.rs
@@ -1,0 +1,79 @@
+//! Protocol-level token types used in the block state.
+
+use concordium_base::common::Serialize;
+use concordium_base::protocol_level_tokens::{TokenId, TokenModuleRef};
+use plt_scheduler_types::types::tokens::RawTokenAmount;
+
+/// Index of the protocol-level token in the block state map of tokens.
+///
+/// Corresponding Haskell type: `Concordium.GlobalState.Persistent.BlockState.ProtocolLevelTokens.TokenIndex`
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+pub struct TokenIndex(pub u64);
+
+pub type TokenStateKey = Vec<u8>;
+pub type TokenStateValue = Vec<u8>;
+
+/// Static configuration for a protocol-level token.
+///
+/// Corresponding Haskell type: `Concordium.GlobalState.Persistent.BlockState.ProtocolLevelTokens.PLTConfiguration`
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize)]
+pub struct TokenConfiguration {
+    /// The token ID in its canonical form. Token IDs are case-insensitive when compared,
+    /// but the canonical token ID preserves the original casing specified when
+    /// the token was created.
+    pub token_id: TokenId,
+    /// The token module reference.
+    pub module_ref: TokenModuleRef,
+    /// The number of decimal places used in the representation of the token.
+    pub decimals: u8,
+}
+
+/// Token account state at block state level.
+///
+/// Corresponding Haskell type: `Concordium.GlobalState.Persistent.Account.ProtocolLevelTokens.TokenAccountState`
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize)]
+pub struct TokenAccountState {
+    /// Balance of the account
+    pub balance: RawTokenAmount,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use concordium_base::common;
+    use concordium_base::protocol_level_tokens::TokenModuleRef;
+    use plt_scheduler_types::types::tokens::RawTokenAmount;
+
+    #[test]
+    fn test_token_configuration_serial() {
+        let token_configuration = TokenConfiguration {
+            token_id: "tokenid1".parse().unwrap(),
+            module_ref: TokenModuleRef::from([5; 32]),
+            decimals: 4,
+        };
+
+        let bytes = common::to_bytes(&token_configuration);
+        assert_eq!(
+            hex::encode(&bytes),
+            "08746f6b656e696431050505050505050505050505050505050505050505050505050505050505050504"
+        );
+
+        let token_configuration_deserialized: TokenConfiguration =
+            common::from_bytes_complete(bytes.as_slice()).unwrap();
+        assert_eq!(token_configuration_deserialized, token_configuration);
+    }
+
+    #[test]
+    fn test_token_account_state_serial() {
+        let state = TokenAccountState {
+            balance: RawTokenAmount(10),
+        };
+
+        let bytes = common::to_bytes(&state);
+        assert_eq!(hex::encode(&bytes), "0a");
+
+        let state_deserialized: TokenAccountState =
+            common::from_bytes_complete(bytes.as_slice()).unwrap();
+        assert_eq!(state_deserialized, state);
+    }
+}

--- a/plt/plt-block-state/src/block_state_interface.rs
+++ b/plt/plt-block-state/src/block_state_interface.rs
@@ -1,8 +1,7 @@
-use crate::block_state::types::{
-    AccountWithCanonicalAddress, TokenAccountState, TokenConfiguration, TokenStateKey,
-    TokenStateValue,
+use crate::block_state::types::AccountWithCanonicalAddress;
+use crate::block_state::types::protocol_level_tokens::{
+    TokenAccountState, TokenConfiguration, TokenStateKey, TokenStateValue,
 };
-use crate::block_state::{AccountNotFoundByAddressError, AccountNotFoundByIndexError};
 use concordium_base::base::{AccountIndex, ProtocolVersion};
 use concordium_base::contracts_common::AccountAddress;
 use concordium_base::protocol_level_tokens::TokenId;
@@ -24,6 +23,16 @@ pub enum RawTokenAmountDelta {
 #[derive(Debug, thiserror::Error)]
 #[error("Token with id {0} does not exist")]
 pub struct TokenNotFoundByIdError(pub TokenId);
+
+/// Account with given address does not exist
+#[derive(Debug, thiserror::Error)]
+#[error("Account with address {0} does not exist")]
+pub struct AccountNotFoundByAddressError(pub AccountAddress);
+
+/// Account with given index does not exist
+#[derive(Debug, thiserror::Error)]
+#[error("Account with index {0} does not exist")]
+pub struct AccountNotFoundByIndexError(pub AccountIndex);
 
 /// Unrecoverable error accessing the block state. This is generally an error that
 /// should never happen and is unrecoverable.

--- a/plt/plt-block-state/src/ffi/block_state.rs
+++ b/plt/plt-block-state/src/ffi/block_state.rs
@@ -3,7 +3,9 @@
 //! It is only available if the `ffi` feature is enabled.
 
 use crate::block_state::blob_reference::BlobStoreLocation;
-use crate::block_state::{PltBlockStateSavepoint, blob_store};
+use crate::block_state::cacheable::Cacheable;
+use crate::block_state::hash::Hashable;
+use crate::block_state::{BlockState, blob_store};
 use crate::ffi::blob_store_callbacks::{LoadCallback, StoreCallback};
 
 /// Allocate a new empty PLT block state and returns it.
@@ -11,8 +13,8 @@ use crate::ffi::blob_store_callbacks::{LoadCallback, StoreCallback};
 /// The returned pointer is to a uniquely owned instance.
 /// It must be freed by calling [`ffi_free_plt_block_state`].
 #[unsafe(no_mangle)]
-extern "C" fn ffi_empty_plt_block_state() -> *mut PltBlockStateSavepoint {
-    let block_state = PltBlockStateSavepoint::empty();
+extern "C" fn ffi_empty_plt_block_state() -> *mut BlockState {
+    let block_state = BlockState::empty();
     Box::into_raw(Box::new(block_state))
 }
 
@@ -24,11 +26,11 @@ extern "C" fn ffi_empty_plt_block_state() -> *mut PltBlockStateSavepoint {
 ///
 /// # Safety
 ///
-/// - Argument `block_state` must be unique, non-null pointer to well-formed [`PltBlockStateSavepoint`].
+/// - Argument `block_state` must be unique, non-null pointer to well-formed [`BlockState`].
 ///   No other pointers to the block state must exist.
 /// - Freeing is only ever done once.
 #[unsafe(no_mangle)]
-extern "C" fn ffi_free_plt_block_state(block_state: *mut PltBlockStateSavepoint) {
+extern "C" fn ffi_free_plt_block_state(block_state: *mut BlockState) {
     assert!(!block_state.is_null(), "block_state is a null pointer.");
     let state = unsafe { Box::from_raw(block_state) };
     drop(state);
@@ -45,19 +47,20 @@ extern "C" fn ffi_free_plt_block_state(block_state: *mut PltBlockStateSavepoint)
 /// # Safety
 ///
 /// - Argument `load_callback` must be a valid function pointer to a function with a signature matching [`LoadCallback`].
-/// - Argument `block_state` must be a non-null pointer to well-formed [`crate::block_state::PltBlockStateSavepoint`].
+/// - Argument `block_state` must be a non-null pointer to well-formed [`crate::block_state::BlockState`].
 ///   The pointer is to a shared instance, hence only valid for reading (writing only allowed through interior mutability).
 /// - Argument `destination` must be non-null and valid for writes of 32 bytes.
 #[unsafe(no_mangle)]
 extern "C" fn ffi_hash_plt_block_state(
-    mut load_callback: LoadCallback,
-    block_state: *const PltBlockStateSavepoint,
+    load_callback: LoadCallback,
+    block_state: *const BlockState,
     destination: *mut u8,
 ) {
     assert!(!block_state.is_null(), "block_state is a null pointer.");
     assert!(!destination.is_null(), "destination is a null pointer.");
     let block_state = unsafe { &*block_state };
-    let hash = block_state.hash(&mut load_callback);
+    // todo implement error handling for unrecoverable errors (instead of unwrap) in https://linear.app/concordium/issue/PSR-39/decide-and-implement-strategy-for-handling-panics-in-the-rust-code
+    let hash = block_state.hash(&load_callback).unwrap();
     unsafe {
         std::ptr::copy_nonoverlapping(hash.as_ptr(), destination, hash.len());
     }
@@ -80,7 +83,7 @@ extern "C" fn ffi_hash_plt_block_state(
 extern "C" fn ffi_load_plt_block_state(
     load_callback: LoadCallback,
     blob_ref: BlobStoreLocation,
-) -> *mut PltBlockStateSavepoint {
+) -> *mut BlockState {
     // todo implement error handling for unrecoverable errors (instead of unwrap) in https://linear.app/concordium/issue/PSR-39/decide-and-implement-strategy-for-handling-panics-in-the-rust-code
     let block_state = blob_store::load_from_store(&load_callback, blob_ref).unwrap();
     Box::into_raw(Box::new(block_state))
@@ -97,16 +100,16 @@ extern "C" fn ffi_load_plt_block_state(
 /// # Safety
 ///
 /// - Argument `load_callback` must be a valid function pointer to a function with a signature matching [`LoadCallback`].
-/// - Argument `block_state` must be a non-null pointer to well-formed [`crate::block_state::PltBlockStateSavepoint`].
+/// - Argument `block_state` must be a non-null pointer to well-formed [`crate::block_state::BlockState`].
 ///   The pointer is to a shared instance, hence only valid for reading (writing only allowed through interior mutability).
 #[unsafe(no_mangle)]
 extern "C" fn ffi_store_plt_block_state(
     mut store_callback: StoreCallback,
-    block_state: *const PltBlockStateSavepoint,
+    block_state: *const BlockState,
 ) -> BlobStoreLocation {
     assert!(!block_state.is_null(), "block_state is a null pointer.");
     let block_state = unsafe { &*block_state };
-    block_state.store_update(&mut store_callback)
+    blob_store::store_to_store(&mut store_callback, block_state)
 }
 
 /// Migrate the PLT block state from one blob store to another and return the migrated state.
@@ -125,17 +128,17 @@ extern "C" fn ffi_store_plt_block_state(
 ///
 /// - Argument `load_callback` must be a valid function pointer to a function with a signature matching [`LoadCallback`].
 /// - Argument `store_callback` must be a valid function pointer to a function with a signature matching [`StoreCallback`].
-/// - Argument `block_state` must be a non-null pointer to well-formed [`crate::block_state::PltBlockStateSavepoint`].
+/// - Argument `block_state` must be a non-null pointer to well-formed [`crate::block_state::BlockState`].
 ///   The pointer is to a shared instance, hence only valid for reading (writing only allowed through interior mutability).
 #[unsafe(no_mangle)]
 extern "C" fn ffi_migrate_plt_block_state(
-    mut load_callback: LoadCallback,
-    mut store_callback: StoreCallback,
-    block_state: *const PltBlockStateSavepoint,
-) -> *mut PltBlockStateSavepoint {
+    load_callback: LoadCallback,
+    store_callback: StoreCallback,
+    block_state: *const BlockState,
+) -> *mut BlockState {
     assert!(!block_state.is_null(), "block_state is a null pointer.");
     let block_state = unsafe { &*block_state };
-    let new_block_state = block_state.migrate(&mut load_callback, &mut store_callback);
+    let new_block_state = block_state.migrate(load_callback, store_callback);
     Box::into_raw(Box::new(new_block_state))
 }
 
@@ -149,14 +152,15 @@ extern "C" fn ffi_migrate_plt_block_state(
 /// # Safety
 ///
 /// - Argument `load_callback` must be a valid function pointer to a function with a signature matching [`LoadCallback`].
-/// - Argument `block_state` must be a non-null pointer to well-formed [`crate::block_state::PltBlockStateSavepoint`].
+/// - Argument `block_state` must be a non-null pointer to well-formed [`crate::block_state::BlockState`].
 ///   The pointer is to a shared instance, hence only valid for reading (writing only allowed through interior mutability).
 #[unsafe(no_mangle)]
 extern "C" fn ffi_cache_plt_block_state(
-    mut load_callback: LoadCallback,
-    block_state: *const PltBlockStateSavepoint,
+    load_callback: LoadCallback,
+    block_state: *const BlockState,
 ) {
     assert!(!block_state.is_null(), "block_state is a null pointer.");
     let block_state = unsafe { &*block_state };
-    block_state.cache(&mut load_callback)
+    // todo implement error handling for unrecoverable errors in https://linear.app/concordium/issue/PSR-39/decide-and-implement-strategy-for-handling-panics-in-the-rust-code
+    block_state.cache_reference_values(&load_callback).unwrap();
 }

--- a/plt/plt-block-state/src/ffi/block_state_callbacks.rs
+++ b/plt/plt-block-state/src/ffi/block_state_callbacks.rs
@@ -1,7 +1,8 @@
 use crate::block_state::external::{ExternalBlockStateOperations, ExternalBlockStateQuery};
-use crate::block_state::types::{TokenAccountState, TokenIndex};
-use crate::block_state::{AccountNotFoundByAddressError, AccountNotFoundByIndexError};
-use crate::block_state_interface::{OverflowError, RawTokenAmountDelta};
+use crate::block_state::types::protocol_level_tokens::{TokenAccountState, TokenIndex};
+use crate::block_state_interface::{
+    AccountNotFoundByAddressError, AccountNotFoundByIndexError, OverflowError, RawTokenAmountDelta,
+};
 use concordium_base::base::AccountIndex;
 use concordium_base::common;
 use concordium_base::contracts_common::AccountAddress;

--- a/plt/plt-block-state/tests/block_state.rs
+++ b/plt/plt-block-state/tests/block_state.rs
@@ -2,7 +2,7 @@
 
 use crate::block_state_no_external::BlockStateWithNoExternalState;
 use concordium_base::protocol_level_tokens::{TokenId, TokenModuleRef};
-use plt_block_state::block_state::types::TokenConfiguration;
+use plt_block_state::block_state::types::protocol_level_tokens::TokenConfiguration;
 use plt_block_state::block_state_interface::{BlockStateOperations, BlockStateQuery};
 use plt_scheduler_types::types::tokens::RawTokenAmount;
 

--- a/plt/plt-block-state/tests/block_state_no_external.rs
+++ b/plt/plt-block-state/tests/block_state_no_external.rs
@@ -19,14 +19,11 @@ use plt_block_state::block_state::blob_store::BlobStoreLoad;
 use plt_block_state::block_state::external::{
     ExternalBlockStateOperations, ExternalBlockStateQuery,
 };
-use plt_block_state::block_state::types::{TokenAccountState, TokenConfiguration, TokenIndex};
-use plt_block_state::block_state::{
-    AccountNotFoundByAddressError, AccountNotFoundByIndexError, ExecutionTimePltBlockState,
-    PltBlockState, PltBlockStateSavepoint,
-};
+use plt_block_state::block_state::types::protocol_level_tokens::{TokenAccountState, TokenIndex};
+use plt_block_state::block_state::{BlockState, ExecutionTimeBlockState, MutableBlockState};
 use plt_block_state::block_state_interface::{
-    BlockStateOperations, BlockStateQuery, OverflowError, RawTokenAmountDelta,
-    TokenNotFoundByIdError,
+    AccountNotFoundByAddressError, AccountNotFoundByIndexError, BlockStateOperations,
+    BlockStateQuery, OverflowError, RawTokenAmountDelta, TokenNotFoundByIdError,
 };
 use plt_scheduler_types::types::execution::TransactionOutcome;
 use plt_scheduler_types::types::tokens::RawTokenAmount;
@@ -42,15 +39,15 @@ impl BlobStoreLoad for BlobStoreLoadStub {
     }
 }
 
-type ExecutionTimePltBlockStateWithNoExternalState =
-    ExecutionTimePltBlockState<PltBlockState, BlobStoreLoadStub, NoExternalBlockStateStub>;
-type Token = <ExecutionTimePltBlockStateWithNoExternalState as BlockStateQuery>::Token;
+type ExecutionTimeBlockStateWithNoExternalState =
+    ExecutionTimeBlockState<MutableBlockState, BlobStoreLoadStub, NoExternalBlockStateStub>;
+type Token = <ExecutionTimeBlockStateWithNoExternalState as BlockStateQuery>::Token;
 
 /// Block state where external interactions with the Haskell maintained block
 /// state is not possible.
 #[derive(Debug)]
 pub struct BlockStateWithNoExternalState {
-    block_state: ExecutionTimePltBlockStateWithNoExternalState,
+    block_state: ExecutionTimeBlockStateWithNoExternalState,
 }
 
 /// Non-accessible block state representing the Haskell maintained part of the block state.
@@ -61,12 +58,12 @@ impl BlockStateWithNoExternalState {
     /// Create block state stub
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
-        let inner_block_state = PltBlockStateSavepoint::empty().mutable_state();
+        let inner_block_state = BlockState::empty().into_mutable();
 
-        let block_state = ExecutionTimePltBlockState {
+        let block_state = ExecutionTimeBlockState {
             protocol_version: ProtocolVersion::P10,
             internal_block_state: inner_block_state,
-            backing_store_load: BlobStoreLoadStub,
+            blob_store_load: BlobStoreLoadStub,
             external_block_state: NoExternalBlockStateStub,
         };
 
@@ -74,12 +71,12 @@ impl BlockStateWithNoExternalState {
     }
 
     /// Access to the underlying block state.
-    pub fn state(&self) -> &ExecutionTimePltBlockStateWithNoExternalState {
+    pub fn state(&self) -> &ExecutionTimeBlockStateWithNoExternalState {
         &self.block_state
     }
 
     /// Mutable access to the underlying block state.
-    pub fn state_mut(&mut self) -> &mut ExecutionTimePltBlockStateWithNoExternalState {
+    pub fn state_mut(&mut self) -> &mut ExecutionTimeBlockStateWithNoExternalState {
         &mut self.block_state
     }
 }

--- a/plt/plt-scheduler-interface/Cargo.toml
+++ b/plt/plt-scheduler-interface/Cargo.toml
@@ -4,9 +4,12 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+# Workspace dependencies
 plt-scheduler-types.workspace = true
 plt-block-state.workspace = true
 
+# Concordium dependencies
 concordium_base.workspace = true
 
+# Third party dependencies
 thiserror.workspace = true

--- a/plt/plt-scheduler-interface/src/token_kernel_interface.rs
+++ b/plt/plt-scheduler-interface/src/token_kernel_interface.rs
@@ -6,10 +6,11 @@ use concordium_base::base::{AccountIndex, ProtocolVersion};
 use concordium_base::contracts_common::AccountAddress;
 use concordium_base::protocol_level_tokens::{RawCbor, TokenModuleCborTypeDiscriminator};
 use concordium_base::transactions::Memo;
-use plt_block_state::block_state::types::{
-    AccountWithCanonicalAddress, TokenStateKey, TokenStateValue,
+use plt_block_state::block_state::types::AccountWithCanonicalAddress;
+use plt_block_state::block_state::types::protocol_level_tokens::{TokenStateKey, TokenStateValue};
+use plt_block_state::block_state_interface::{
+    AccountNotFoundByAddressError, AccountNotFoundByIndexError,
 };
-use plt_block_state::block_state::{AccountNotFoundByAddressError, AccountNotFoundByIndexError};
 use plt_scheduler_types::types::tokens::RawTokenAmount;
 
 /// The account has insufficient balance.

--- a/plt/plt-scheduler-types/Cargo.toml
+++ b/plt/plt-scheduler-types/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+# Concordium dependencies
 concordium_base.workspace = true
 
 [dev-dependencies]

--- a/plt/plt-scheduler/Cargo.toml
+++ b/plt/plt-scheduler/Cargo.toml
@@ -8,12 +8,16 @@ default = ["ffi"]
 ffi = ["dep:libc"]
 
 [dependencies]
+# Workspace dependencies
 plt-block-state.workspace = true
 plt-scheduler-types.workspace = true
 plt-scheduler-interface.workspace = true
 plt-token-module.workspace = true
 
+# Concordium dependencies
 concordium_base.workspace = true
+
+# Third party dependencies
 thiserror.workspace = true
 libc = { workspace = true, optional = true }
 

--- a/plt/plt-scheduler/src/ffi/queries.rs
+++ b/plt/plt-scheduler/src/ffi/queries.rs
@@ -7,7 +7,7 @@ use crate::queries::QueryTokenInfoError;
 use concordium_base::base::{AccountIndex, ProtocolVersion};
 use concordium_base::common;
 use libc::size_t;
-use plt_block_state::block_state::{ExecutionTimePltBlockState, PltBlockStateSavepoint};
+use plt_block_state::block_state::{BlockState, ExecutionTimeBlockState};
 use plt_block_state::ffi::blob_store_callbacks::LoadCallback;
 use plt_block_state::ffi::block_state_callbacks::{
     ExternalBlockStateQueryCallbacks, GetAccountIndexByAddressCallback,
@@ -51,7 +51,7 @@ extern "C" fn ffi_query_plt_list(
     get_account_index_by_address_callback: GetAccountIndexByAddressCallback,
     get_account_address_by_index_callback: GetCanonicalAddressByAccountIndexCallback,
     get_token_account_states_callback: GetTokenAccountStatesCallback,
-    block_state: *const PltBlockStateSavepoint,
+    block_state: *const BlockState,
     protocol_version: u64,
     return_data_out: *mut *mut u8,
     return_data_len_out: *mut size_t,
@@ -76,10 +76,10 @@ extern "C" fn ffi_query_plt_list(
     let protocol_version =
         ProtocolVersion::try_from(protocol_version).expect("Unknown protocol version");
     let internal_block_state = unsafe { &*block_state };
-    let block_state = ExecutionTimePltBlockState {
+    let block_state = ExecutionTimeBlockState {
         protocol_version,
         internal_block_state,
-        backing_store_load: load_callback,
+        blob_store_load: load_callback,
         external_block_state: external_callbacks,
     };
 
@@ -137,7 +137,7 @@ extern "C" fn ffi_query_token_info(
     get_account_index_by_address_callback: GetAccountIndexByAddressCallback,
     get_account_address_by_index_callback: GetCanonicalAddressByAccountIndexCallback,
     get_token_account_states_callback: GetTokenAccountStatesCallback,
-    block_state: *const PltBlockStateSavepoint,
+    block_state: *const BlockState,
     protocol_version: u64,
     token_id: *const u8,
     token_id_len: size_t,
@@ -164,10 +164,10 @@ extern "C" fn ffi_query_token_info(
     let protocol_version =
         ProtocolVersion::try_from(protocol_version).expect("Unknown protocol version");
     let internal_block_state = unsafe { &*block_state };
-    let block_state = ExecutionTimePltBlockState {
+    let block_state = ExecutionTimeBlockState {
         protocol_version,
         internal_block_state,
-        backing_store_load: load_callback,
+        blob_store_load: load_callback,
         external_block_state: external_callbacks,
     };
 
@@ -238,7 +238,7 @@ extern "C" fn ffi_query_token_authorizations(
     get_account_index_by_address_callback: GetAccountIndexByAddressCallback,
     get_account_address_by_index_callback: GetCanonicalAddressByAccountIndexCallback,
     get_token_account_states_callback: GetTokenAccountStatesCallback,
-    block_state: *const PltBlockStateSavepoint,
+    block_state: *const BlockState,
     protocol_version: u64,
     token_id: *const u8,
     token_id_len: size_t,
@@ -265,10 +265,10 @@ extern "C" fn ffi_query_token_authorizations(
     let protocol_version =
         ProtocolVersion::try_from(protocol_version).expect("Unknown protocol version");
     let internal_block_state = unsafe { &*block_state };
-    let block_state = ExecutionTimePltBlockState {
+    let block_state = ExecutionTimeBlockState {
         protocol_version,
         internal_block_state,
-        backing_store_load: load_callback,
+        blob_store_load: load_callback,
         external_block_state: external_callbacks,
     };
 
@@ -335,7 +335,7 @@ extern "C" fn ffi_query_token_account_infos(
     get_account_index_by_address_callback: GetAccountIndexByAddressCallback,
     get_account_address_by_index_callback: GetCanonicalAddressByAccountIndexCallback,
     get_token_account_states_callback: GetTokenAccountStatesCallback,
-    block_state: *const PltBlockStateSavepoint,
+    block_state: *const BlockState,
     protocol_version: u64,
     account_index: u64,
     return_data_out: *mut *mut u8,
@@ -361,10 +361,10 @@ extern "C" fn ffi_query_token_account_infos(
     let protocol_version =
         ProtocolVersion::try_from(protocol_version).expect("Unknown protocol version");
     let internal_block_state = unsafe { &*block_state };
-    let block_state = ExecutionTimePltBlockState {
+    let block_state = ExecutionTimeBlockState {
         protocol_version,
         internal_block_state,
-        backing_store_load: load_callback,
+        blob_store_load: load_callback,
         external_block_state: external_callbacks,
     };
 

--- a/plt/plt-scheduler/src/ffi/scheduler.rs
+++ b/plt/plt-scheduler/src/ffi/scheduler.rs
@@ -9,7 +9,7 @@ use concordium_base::transactions::Payload;
 use concordium_base::updates::UpdatePayload;
 use concordium_base::{common, contracts_common};
 use libc::size_t;
-use plt_block_state::block_state::{ExecutionTimePltBlockState, PltBlockStateSavepoint};
+use plt_block_state::block_state::{BlockState, ExecutionTimeBlockState};
 use plt_block_state::ffi::blob_store_callbacks::LoadCallback;
 use plt_block_state::ffi::block_state_callbacks::{
     ExternalBlockStateOperationCallbacks, ExternalBlockStateQueryCallbacks,
@@ -59,7 +59,7 @@ use plt_scheduler_types::types::execution::{ChainUpdateOutcome, TransactionOutco
 ///
 /// - All callback arguments must be a valid function pointers to functions with a signature matching the
 ///   signature of Rust type of the function pointer.
-/// - Argument `block_state` must be a non-null pointer to well-formed [`PltBlockStateSavepoint`].
+/// - Argument `block_state` must be a non-null pointer to well-formed [`BlockState`].
 ///   The pointer is to a shared instance, hence only valid for reading (writing only allowed through interior mutability).
 /// - Argument `payload` must be non-null and valid for reads for `payload_len` many bytes.
 /// - Argument `sender_account_address` must be non-null and valid for reads for 32 bytes.
@@ -77,14 +77,14 @@ extern "C" fn ffi_execute_transaction(
     get_account_index_by_address_callback: GetAccountIndexByAddressCallback,
     get_account_address_by_index_callback: GetCanonicalAddressByAccountIndexCallback,
     get_token_account_states_callback: GetTokenAccountStatesCallback,
-    block_state: *const PltBlockStateSavepoint,
+    block_state: *const BlockState,
     protocol_version: u64,
     payload: *const u8,
     payload_len: size_t,
     sender_account_index: u64,
     sender_account_address: *const u8,
     remaining_energy: u64,
-    block_state_out: *mut *mut PltBlockStateSavepoint,
+    block_state_out: *mut *mut BlockState,
     used_energy_out: *mut u64,
     return_data_out: *mut *mut u8,
     return_data_len_out: *mut size_t,
@@ -126,11 +126,11 @@ extern "C" fn ffi_execute_transaction(
 
     let protocol_version =
         ProtocolVersion::try_from(protocol_version).expect("Unknown protocol version");
-    let internal_block_state = unsafe { (*block_state).mutable_state() };
-    let mut block_state = ExecutionTimePltBlockState {
+    let internal_block_state = unsafe { (*block_state).clone().into_mutable() };
+    let mut block_state = ExecutionTimeBlockState {
         protocol_version,
         internal_block_state,
-        backing_store_load: load_callback,
+        blob_store_load: load_callback,
         external_block_state: external_callbacks,
     };
 
@@ -172,7 +172,7 @@ extern "C" fn ffi_execute_transaction(
         TransactionOutcome::Success(events) => {
             unsafe {
                 *block_state_out =
-                    Box::into_raw(Box::new(block_state.internal_block_state.savepoint()));
+                    Box::into_raw(Box::new(block_state.internal_block_state.into_immutable()));
             }
             (0, common::to_bytes(&events))
         }
@@ -239,11 +239,11 @@ extern "C" fn ffi_execute_chain_update(
     get_account_index_by_address_callback: GetAccountIndexByAddressCallback,
     get_account_address_by_index_callback: GetCanonicalAddressByAccountIndexCallback,
     get_token_account_states_callback: GetTokenAccountStatesCallback,
-    block_state: *const PltBlockStateSavepoint,
+    block_state: *const BlockState,
     protocol_version: u64,
     payload: *const u8,
     payload_len: size_t,
-    block_state_out: *mut *mut PltBlockStateSavepoint,
+    block_state_out: *mut *mut BlockState,
     return_data_out: *mut *mut u8,
     return_data_len_out: *mut size_t,
 ) -> u8 {
@@ -276,11 +276,11 @@ extern "C" fn ffi_execute_chain_update(
 
     let protocol_version =
         ProtocolVersion::try_from(protocol_version).expect("Unknown protocol version");
-    let internal_block_state = unsafe { (*block_state).mutable_state() };
-    let mut block_state = ExecutionTimePltBlockState {
+    let internal_block_state = unsafe { (*block_state).clone().into_mutable() };
+    let mut block_state = ExecutionTimeBlockState {
         protocol_version,
         internal_block_state,
-        backing_store_load: load_callback,
+        blob_store_load: load_callback,
         external_block_state: external_callbacks,
     };
 
@@ -297,7 +297,7 @@ extern "C" fn ffi_execute_chain_update(
         ChainUpdateOutcome::Success(events) => {
             unsafe {
                 *block_state_out =
-                    Box::into_raw(Box::new(block_state.internal_block_state.savepoint()));
+                    Box::into_raw(Box::new(block_state.internal_block_state.into_immutable()));
             }
             (0, common::to_bytes(&events))
         }

--- a/plt/plt-scheduler/src/scheduler/plt_scheduler.rs
+++ b/plt/plt-scheduler/src/scheduler/plt_scheduler.rs
@@ -6,7 +6,7 @@ use crate::token_kernel::TokenKernelOperationsImpl;
 use concordium_base::protocol_level_tokens::TokenOperationsPayload;
 use concordium_base::transactions;
 use concordium_base::updates::CreatePlt;
-use plt_block_state::block_state::types::TokenConfiguration;
+use plt_block_state::block_state::types::protocol_level_tokens::TokenConfiguration;
 use plt_block_state::block_state_interface::{BlockStateOperations, TokenNotFoundByIdError};
 use plt_scheduler_interface::transaction_execution_interface::{
     OutOfEnergyError, TransactionExecution,

--- a/plt/plt-scheduler/src/token_kernel.rs
+++ b/plt/plt-scheduler/src/token_kernel.rs
@@ -4,12 +4,13 @@ use concordium_base::base::{AccountIndex, ProtocolVersion};
 use concordium_base::contracts_common::AccountAddress;
 use concordium_base::protocol_level_tokens::{RawCbor, TokenModuleCborTypeDiscriminator};
 use concordium_base::transactions::Memo;
-use plt_block_state::block_state::types::{
-    AccountWithCanonicalAddress, TokenConfiguration, TokenStateKey, TokenStateValue,
+use plt_block_state::block_state::types::AccountWithCanonicalAddress;
+use plt_block_state::block_state::types::protocol_level_tokens::{
+    TokenConfiguration, TokenStateKey, TokenStateValue,
 };
-use plt_block_state::block_state::{AccountNotFoundByAddressError, AccountNotFoundByIndexError};
 use plt_block_state::block_state_interface::{
-    BlockStateOperations, BlockStateQuery, OverflowError, RawTokenAmountDelta,
+    AccountNotFoundByAddressError, AccountNotFoundByIndexError, BlockStateOperations,
+    BlockStateQuery, OverflowError, RawTokenAmountDelta,
 };
 use plt_scheduler_interface::token_kernel_interface::{
     InsufficientBalanceError, MintWouldOverflowError, TokenBurnError, TokenKernelOperations,

--- a/plt/plt-scheduler/tests/block_state_external_stubbed.rs
+++ b/plt/plt-scheduler/tests/block_state_external_stubbed.rs
@@ -19,14 +19,11 @@ use plt_block_state::block_state::blob_store::BlobStoreLoad;
 use plt_block_state::block_state::external::{
     ExternalBlockStateOperations, ExternalBlockStateQuery,
 };
-use plt_block_state::block_state::types::{TokenAccountState, TokenConfiguration, TokenIndex};
-use plt_block_state::block_state::{
-    AccountNotFoundByAddressError, AccountNotFoundByIndexError, ExecutionTimePltBlockState,
-    PltBlockState, PltBlockStateSavepoint,
-};
+use plt_block_state::block_state::types::protocol_level_tokens::{TokenAccountState, TokenIndex};
+use plt_block_state::block_state::{BlockState, ExecutionTimeBlockState, MutableBlockState};
 use plt_block_state::block_state_interface::{
-    BlockStateOperations, BlockStateQuery, OverflowError, RawTokenAmountDelta,
-    TokenNotFoundByIdError,
+    AccountNotFoundByAddressError, AccountNotFoundByIndexError, BlockStateOperations,
+    BlockStateQuery, OverflowError, RawTokenAmountDelta, TokenNotFoundByIdError,
 };
 use plt_scheduler::{queries, scheduler};
 use plt_scheduler_types::types::execution::TransactionOutcome;
@@ -45,7 +42,7 @@ impl BlobStoreLoad for BlobStoreLoadStub {
 }
 
 type ExecutionTimePltBlockStateWithExternalStateStubbed =
-    ExecutionTimePltBlockState<PltBlockState, BlobStoreLoadStub, ExternalBlockStateStub>;
+    ExecutionTimeBlockState<MutableBlockState, BlobStoreLoadStub, ExternalBlockStateStub>;
 type Token = <ExecutionTimePltBlockStateWithExternalStateStubbed as BlockStateQuery>::Token;
 
 /// Block state where external interactions with the Haskell maintained block
@@ -86,17 +83,17 @@ impl BlockStateWithExternalStateStubbed {
     /// Create block state stub
     #[allow(clippy::new_without_default)]
     pub fn new(protocol_version: ProtocolVersion) -> Self {
-        let inner_block_state = PltBlockStateSavepoint::empty().mutable_state();
+        let inner_block_state = BlockState::empty().into_mutable();
 
         let external_block_state = ExternalBlockStateStub {
             accounts: Default::default(),
             plt_update_instruction_sequence_number: 0,
         };
 
-        let block_state = ExecutionTimePltBlockState {
+        let block_state = ExecutionTimeBlockState {
             protocol_version,
             internal_block_state: inner_block_state,
-            backing_store_load: BlobStoreLoadStub,
+            blob_store_load: BlobStoreLoadStub,
             external_block_state,
         };
 

--- a/plt/plt-token-module/Cargo.toml
+++ b/plt/plt-token-module/Cargo.toml
@@ -4,11 +4,15 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+# Workspace dependencies
 plt-block-state.workspace = true
 plt-scheduler-types.workspace = true
 plt-scheduler-interface.workspace = true
 
+# Concordium dependencies
 concordium_base.workspace = true
+
+# Third party dependencies
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/plt/plt-token-module/src/key_value_state.rs
+++ b/plt/plt-token-module/src/key_value_state.rs
@@ -7,7 +7,7 @@ use concordium_base::protocol_level_tokens::{
     MetadataUrl, TokenAdminRole, TokenAuthorizations, TokenRoleAuthorizations,
 };
 use concordium_base::{base::AccountIndex, common::Serial};
-use plt_block_state::block_state::types::{TokenStateKey, TokenStateValue};
+use plt_block_state::block_state::types::protocol_level_tokens::{TokenStateKey, TokenStateValue};
 use plt_scheduler_interface::token_kernel_interface::{
     TokenKernelOperations, TokenKernelQueries, TokenStateInvariantError,
 };

--- a/plt/plt-token-module/src/roles.rs
+++ b/plt/plt-token-module/src/roles.rs
@@ -2,7 +2,7 @@
 
 use concordium_base::common;
 use concordium_base::protocol_level_tokens::TokenAdminRole;
-use plt_block_state::block_state::types::TokenStateValue;
+use plt_block_state::block_state::types::protocol_level_tokens::TokenStateValue;
 
 /// List roles which are unaffected by which features are enabled.
 pub const UNIVERSAL_ROLES: &[TokenAdminRole] = &[

--- a/plt/plt-token-module/src/token_module/initialize.rs
+++ b/plt/plt-token-module/src/token_module/initialize.rs
@@ -9,7 +9,7 @@ use concordium_base::common::cbor::CborSerializationError;
 use concordium_base::protocol_level_tokens::{
     RawCbor, TokenAdminRole, TokenModuleInitializationParameters,
 };
-use plt_block_state::block_state::AccountNotFoundByAddressError;
+use plt_block_state::block_state_interface::AccountNotFoundByAddressError;
 use plt_scheduler_interface::token_kernel_interface::{
     MintWouldOverflowError, TokenKernelOperations, TokenMintError, TokenStateInvariantError,
 };

--- a/plt/plt-token-module/src/token_module/update.rs
+++ b/plt/plt-token-module/src/token_module/update.rs
@@ -13,7 +13,7 @@ use concordium_base::protocol_level_tokens::{
     TokenUpdateMetadataEventDetails, UnsupportedOperationRejectReason,
 };
 use concordium_base::transactions::Memo;
-use plt_block_state::block_state::AccountNotFoundByAddressError;
+use plt_block_state::block_state_interface::AccountNotFoundByAddressError;
 use plt_scheduler_interface::token_kernel_interface::{
     InsufficientBalanceError, MintWouldOverflowError, TokenBurnError, TokenKernelOperations,
     TokenKernelQueries, TokenMintError, TokenStateInvariantError, TokenTransferError,

--- a/plt/plt-token-module/tests/token_module_initialize.rs
+++ b/plt/plt-token-module/tests/token_module_initialize.rs
@@ -3,7 +3,7 @@ use concordium_base::common::cbor;
 use concordium_base::contracts_common::AccountAddress;
 use concordium_base::protocol_level_tokens::{CborHolderAccount, MetadataUrl, TokenModuleState};
 use concordium_base::protocol_level_tokens::{TokenAmount, TokenModuleInitializationParameters};
-use plt_block_state::block_state::AccountNotFoundByAddressError;
+use plt_block_state::block_state_interface::AccountNotFoundByAddressError;
 use plt_scheduler_interface::token_kernel_interface::TokenKernelQueries;
 use plt_scheduler_types::types::tokens::RawTokenAmount;
 use plt_token_module::token_module::{

--- a/plt/plt-token-module/tests/utils/kernel_stub.rs
+++ b/plt/plt-token-module/tests/utils/kernel_stub.rs
@@ -9,10 +9,11 @@ use concordium_base::protocol_level_tokens::{
     TokenModuleInitializationParameters,
 };
 use concordium_base::transactions::Memo;
-use plt_block_state::block_state::types::{
-    AccountWithCanonicalAddress, TokenStateKey, TokenStateValue,
+use plt_block_state::block_state::types::AccountWithCanonicalAddress;
+use plt_block_state::block_state::types::protocol_level_tokens::{TokenStateKey, TokenStateValue};
+use plt_block_state::block_state_interface::{
+    AccountNotFoundByAddressError, AccountNotFoundByIndexError,
 };
-use plt_block_state::block_state::{AccountNotFoundByAddressError, AccountNotFoundByIndexError};
 use plt_scheduler_interface::token_kernel_interface::{
     InsufficientBalanceError, MintWouldOverflowError, TokenBurnError, TokenKernelOperations,
     TokenKernelQueries, TokenMintError, TokenStateInvariantError, TokenTransferError,


### PR DESCRIPTION
## Purpose

Implementation of Rust block state. The state builds on types representing immutable values, with the top level type being `block_state::BlockState`. The only type representing mutability is `block_state::MutableBlockState`.

## Changes

* implement block state queries and operations for `block_state::BlockState`. The only type representing mutability is `block_state::MutableBlockState`
* implement PLT state in `block_state::state::protocol_level_tokens::ProtocolLevelTokens`

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
