### PR TITLE
fix: copy plt rust libraries and strip out tokens

### DIFF
--- a/concordium-node/build.rs
+++ b/concordium-node/build.rs
@@ -884,7 +884,7 @@ fn link_static_libs() -> std::io::Result<()> {
                             );
                         }
                     }
-                    _ => panic!("Unable to link ghc libs"),
+                    _ => panic!("Unable tod link ghc libs"),
                 }
             }
         });
@@ -894,6 +894,8 @@ fn link_static_libs() -> std::io::Result<()> {
         out_dir
     );
     println!("cargo:rustc-link-lib=static=Rcrypto");
+    println!("cargo:rustc-link-lib=static=plt_scheduler");
+
     println!("cargo:rustc-link-lib=static=concordium_smart_contract_engine");
 
     println!("cargo:rustc-link-lib=dylib=gmp");
@@ -925,7 +927,7 @@ fn ghc_variant(stack_install_lib: &Path) -> std::io::Result<std::path::PathBuf> 
                 "No subdirectory in {:?} with prefix {}",
                 stack_install_lib, GHC_VARIANT
             );
-            Err(std::io::Error::new(
+            Err(std::io::Error::new(   
                 std::io::ErrorKind::NotFound,
                 "GHC_VARIANT directory not found",
             ))

--- a/concordium-node/build.rs
+++ b/concordium-node/build.rs
@@ -884,7 +884,7 @@ fn link_static_libs() -> std::io::Result<()> {
                             );
                         }
                     }
-                    _ => panic!("Unable tod link ghc libs"),
+                    _ => panic!("Unable to link ghc libs"),
                 }
             }
         });

--- a/concordium-node/build.rs
+++ b/concordium-node/build.rs
@@ -894,6 +894,7 @@ fn link_static_libs() -> std::io::Result<()> {
         out_dir
     );
     println!("cargo:rustc-link-lib=static=Rcrypto");
+    
     println!("cargo:rustc-link-lib=static=plt_scheduler");
 
     println!("cargo:rustc-link-lib=static=concordium_smart_contract_engine");

--- a/concordium-node/build.rs
+++ b/concordium-node/build.rs
@@ -894,7 +894,7 @@ fn link_static_libs() -> std::io::Result<()> {
         out_dir
     );
     println!("cargo:rustc-link-lib=static=Rcrypto");
-    
+
     println!("cargo:rustc-link-lib=static=plt_scheduler");
 
     println!("cargo:rustc-link-lib=static=concordium_smart_contract_engine");
@@ -928,7 +928,7 @@ fn ghc_variant(stack_install_lib: &Path) -> std::io::Result<std::path::PathBuf> 
                 "No subdirectory in {:?} with prefix {}",
                 stack_install_lib, GHC_VARIANT
             );
-            Err(std::io::Error::new(   
+            Err(std::io::Error::new(
                 std::io::ErrorKind::NotFound,
                 "GHC_VARIANT directory not found",
             ))

--- a/scripts/static-libraries/build-static-libraries.sh
+++ b/scripts/static-libraries/build-static-libraries.sh
@@ -36,8 +36,11 @@ cp /build/concordium-base/smart-contracts/wasm-chain-integration/target/release/
 find ~/.stack/snapshots/x86_64-linux/ -type f -name "*.a" ! -name "*_p.a" -exec cp {} /target/vanilla/dependencies \;
 find ~/.stack/snapshots/x86_64-linux/ -type f -name "*_p.a" -exec cp {} /target/profiling/dependencies \;
 
+## Rust files - copy the static libraries to the target directory, and strip debug symbols from them to reduce their size, as 
+## they are not needed for the final binaries and can cause linking issues if they contain ruststd symbols
 mkdir -p /target/rust
 cp -r /build/concordium-base/rust-src/target/release/*.a /target/rust/
+cp -r /build/plt/target/release/*.a /target/rust/
 
 find /target /binaries -type f -exec strip --strip-debug {} \;
 
@@ -47,6 +50,7 @@ find /target /binaries -type f -exec strip --strip-debug {} \;
 (
     cd /target/rust
 
+    ## takes every .a static file and unpacks them
     for i in $(ls)
     do
         ar x $i;
@@ -55,6 +59,7 @@ find /target /binaries -type f -exec strip --strip-debug {} \;
 
     set +e
 
+    ## delete rust specific runtime symbols from the .o files, as they are not needed and cause linking issues
     for file in $(find . -type f -name "*.o"); do
         if nm $file | grep "\(T __rust_alloc\)\|\(T __rdl_alloc\)\|\(T __clzsi2\)\|\(T rust_eh_personality\)" >> /dev/null; then
             echo "Removing file:";
@@ -65,9 +70,11 @@ find /target /binaries -type f -exec strip --strip-debug {} \;
 
     set -e
 
+    ## creates the librcrypto.a static library from the remaining .o files, which should now be free of ruststd symbols
     ar rcs libRcrypto.a *.o
     rm *.o
 
+    ## copy smart contract engine static library and repeat the process to remove ruststd symbols from it as well, as it is linked into the consensus node and must not contain ruststd symbols
     cp /build/concordium-base/smart-contracts/wasm-chain-integration/target/release/libconcordium_smart_contract_engine.a /target/rust/libconcordium_smart_contract_engine.a
 
     ar x libconcordium_smart_contract_engine.a
@@ -85,9 +92,30 @@ find /target /binaries -type f -exec strip --strip-debug {} \;
 
     set -e
 
-
     rm libconcordium_smart_contract_engine.a
     ar rcs libconcordium_smart_contract_engine.a *.o
+    rm *.o
+
+    #### PLT release handling - copy the static library, unpack it, remove ruststd symbols, and repack it as a static library again
+    cp /build/plt/target/release/libplt_scheduler.a /target/rust/libplt_scheduler.a
+
+    ar x libplt_scheduler.a
+
+    set +e
+
+    for file in $(find . -type f -name "*.o"); do
+        nm $file | grep "\(T __rust_alloc\)\|\(T __rdl_alloc\)\|\(T __clzsi2\)\|\(T rust_eh_personality\)" >> /dev/null;
+        if [ $? -eq 0 ]; then
+            echo "Removing file:"
+            echo $file
+            rm $file;
+        fi
+    done
+
+    set -e
+
+    rm libplt_scheduler.a
+    ar rcs libplt_scheduler.a *.o
     rm *.o
 )
 

--- a/scripts/static-libraries/build-static-libraries.sh
+++ b/scripts/static-libraries/build-static-libraries.sh
@@ -40,7 +40,6 @@ find ~/.stack/snapshots/x86_64-linux/ -type f -name "*_p.a" -exec cp {} /target/
 ## they are not needed for the final binaries and can cause linking issues if they contain ruststd symbols
 mkdir -p /target/rust
 cp -r /build/concordium-base/rust-src/target/release/*.a /target/rust/
-cp -r /build/plt/target/release/*.a /target/rust/
 
 find /target /binaries -type f -exec strip --strip-debug {} \;
 


### PR DESCRIPTION
## Purpose

Rust libraries handling for plt target

## Changes

copy rust plt libraries as part of build static libraries and perform removal of rust specific symbols for library linking

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

