### PR TITLE
Rely on toolchain.toml for Rust version and use windows-mscv instead …

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -139,7 +139,6 @@ jobs:
     # but also before building the Haskell sources because the Haskell
     # build kicks of a Rust build.
     - name: Install Rust tools
-      working-directory: plt
       run: |
         rustup component add clippy llvm-tools
         rustup target add x86_64-pc-windows-gnu

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -241,7 +241,7 @@ jobs:
 
   node-windows:
     runs-on: windows-latest  
-    # environment: release # This step needs to use the release context to access credentials for code signing.
+    environment: release # This step needs to use the release context to access credentials for code signing.
     needs: [validate-preconditions]
     if: contains(fromJSON('["rc", "alpha", "node-windows"]'), needs.validate-preconditions.outputs.release_type)
     defaults:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -241,7 +241,7 @@ jobs:
 
   node-windows:
     runs-on: windows-latest  
-    environment: release # This step needs to use the release context to access credentials for code signing.
+    # environment: release # This step needs to use the release context to access credentials for code signing.
     needs: [validate-preconditions]
     if: contains(fromJSON('["rc", "alpha", "node-windows"]'), needs.validate-preconditions.outputs.release_type)
     defaults:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -309,6 +309,11 @@ jobs:
         run: |
           echo "RUST_VERSION=$(cargo --version | awk '{print $2}')" >> $GITHUB_OUTPUT
 
+      - name: Print Rust version
+        id: print-rust-version
+        run: |
+          echo "Rust version: ${{ steps.read-rust-version.outputs.RUST_VERSION }}"
+
       - name: Setup node folder
         run: |
           mkdir -p "C:/Program Files/node/include"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -307,7 +307,8 @@ jobs:
       - name: Read Rust version
         id: read-rust-version
         run: |
-          echo "RUST_VERSION=$(cargo --version | awk '{print $2}')" >> $GITHUB_OUTPUT
+          $rustVersion = (cargo --version).Split(" ")[1]
+          echo "RUST_VERSION=$rustVersion" >> $env:GITHUB_OUTPUT
 
       - name: Print Rust version
         id: print-rust-version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -304,6 +304,11 @@ jobs:
           smctl healthcheck --all
         shell: cmd
 
+      - name: Read Rust version
+        id: read-rust-version
+        run: |
+          echo "RUST_VERSION=$(cargo --version | awk '{print $2}')" >> $GITHUB_OUTPUT
+
       - name: Setup node folder
         run: |
           mkdir -p "C:/Program Files/node/include"
@@ -350,7 +355,7 @@ jobs:
           SM_CLIENT_CERT_PASSWORD: ${{ secrets.WINDOWS_SM_CLIENT_CERT_PASSWORD }}
           SM_ARGS: "--verbose --exit-non-zero-on-fail --failfast"
         run: |
-          ./scripts/distribution/windows/build-all.ps1 -nodeVersion ${{ needs.validate-preconditions.outputs.version }}
+          ./scripts/distribution/windows/build-all.ps1 -nodeVersion ${{ needs.validate-preconditions.outputs.version }} -rustVersion ${{ steps.read-rust-version.outputs.RUST_VERSION }}
 
       - name: Sign installer with smctl
         working-directory: ${{steps.build.outputs.bin_dir}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,6 @@ on:
 env:
   UBUNTU_VERSION: '22.04'
   STATIC_LIBRARIES_IMAGE_TAG: 'rust-1.94_ghc-9.10.2'
-  RUST_VERSION: '1.94'
   STACK_VERSION: '3.7.1'
   FLATBUFFERS_VERSION: '23.5.26'
   GHC_VERSION: '9.10.2'
@@ -119,7 +118,6 @@ jobs:
             ghc_version=${{ env.GHC_VERSION }}
             protoc_version=${{ env.PROTOC_VERSION }}
             flatbuffers_version=${{ env.FLATBUFFERS_VERSION }}
-            rust_toolchain_version=${{ env.RUST_VERSION }}
           labels: |
             ubuntu_version=${{ env.UBUNTU_VERSION }}
             static_libraries_image_tag=${{ env.STATIC_LIBRARIES_IMAGE_TAG }}
@@ -306,16 +304,6 @@ jobs:
           smctl healthcheck --all
         shell: cmd
 
-      - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: ${{ env.RUST_VERSION }}-x86_64-pc-windows-msvc
-
-      - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: ${{ env.RUST_VERSION }}-x86_64-pc-windows-gnu
-
       - name: Setup node folder
         run: |
           mkdir -p "C:/Program Files/node/include"
@@ -362,7 +350,7 @@ jobs:
           SM_CLIENT_CERT_PASSWORD: ${{ secrets.WINDOWS_SM_CLIENT_CERT_PASSWORD }}
           SM_ARGS: "--verbose --exit-non-zero-on-fail --failfast"
         run: |
-          ./scripts/distribution/windows/build-all.ps1 -nodeVersion ${{ needs.validate-preconditions.outputs.version }} -rustVersion ${{ env.RUST_VERSION }}
+          ./scripts/distribution/windows/build-all.ps1 -nodeVersion ${{ needs.validate-preconditions.outputs.version }}
 
       - name: Sign installer with smctl
         working-directory: ${{steps.build.outputs.bin_dir}}
@@ -434,10 +422,6 @@ jobs:
           security import $INSTALLER_CERTIFICATE_PATH -P "$BUILD_INSTALLER_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
           security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
           security list-keychain -d user -s $KEYCHAIN_PATH
-
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
 
       - uses: haskell-actions/setup@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ hie.yaml
 .DS_Store
 /concordium-node/*.log
 /stack.yaml.lock
+/stack.static.yaml.lock
 
 # MacOS distribution
 /scripts/distribution/macOS-package/tools

--- a/concordium-consensus/README.md
+++ b/concordium-consensus/README.md
@@ -25,7 +25,7 @@ This might happen if Rust is installed with the MSVC [ABI](https://en.wikipedia.
 You can check this by running `rustup show`.
 If Rust is using the MSVC toolchain you can switch to GNU instead by running
 ```
-rustup default stable-x86_64-pc-windows-gnu
+rustup override set 1.94-x86_64-pc-windows-gnu
 ```
 
 ### `user specified .o/.so/.DLL could not be loaded (addDLL: pthread or dependencies not loaded. (Win32 error 5)) whilst trying to load:  (dynamic) pthread`

--- a/concordium-consensus/Setup.hs
+++ b/concordium-consensus/Setup.hs
@@ -32,6 +32,7 @@ postConfHook args flags _ _ = do
 
     -- Build and copy/symlink PLT scheduler project
     nodeRustLibraryWorkspace <- canonicalizePath nodeRustLibraryWorkspaceRelative
+    withCurrentDirectory nodeRustLibraryWorkspace $ runCmd verbosity $ "rustup show active-toolchain"
     withCurrentDirectory nodeRustLibraryWorkspace $ runCmd verbosity $ "cargo build --release --locked -p node-rust-library"
     case buildOS of
         Windows -> do

--- a/concordium-node/README.md
+++ b/concordium-node/README.md
@@ -2,7 +2,7 @@
 
 ## Dependencies to build the project
 
-- Rust (stable 1.82 for using static libraries)
+- The Rust toolchain specified in [`rust-toolchain.toml`](../rust-toolchain.toml)
 - binutils >= 2.22
   - For macOS one should use the binutils provided by Xcode.
 - cmake >= 3.8.0
@@ -10,7 +10,7 @@
   v22.12.06 is what we currently use. Either build from the v22.12.06 tag of the repository using CMake and copy the `flatc` binary somewhere in your PATH, or download a released binary from <https://github.com/google/flatbuffers/releases/tag/v22.12.06> and place it somewhere in your PATH.
 - protobuf >= 3.15
 - LLVM and Clang >= 3.9
-- As noted in the [caveats](#caveats) section below, you need to build the [Concordium Consensus](../concordium-consensus/) project before building this project. 
+- As noted in the [Building the node](#building-the-node) section below, you need to build the [Concordium Consensus](../concordium-consensus/) project before building this project. 
   So you also need the [dependencies listed in the README for Concordium Consensus](https://github.com/Concordium/concordium-node/tree/main/concordium-consensus#build-requirements).
 
 ### Optional dependencies

--- a/plt/node-rust-library/Cargo.toml
+++ b/plt/node-rust-library/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [lib]
-crate-type = ["cdylib", "staticlib"]
+crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
 # Include the Rust scheduler and the smart contract engine/wasm chain integration in the library

--- a/plt/node-rust-library/Cargo.toml
+++ b/plt/node-rust-library/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [lib]
-crate-type = ["cdylib", "staticlib", "rlib"]
+crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
 # Include the Rust scheduler and the smart contract engine/wasm chain integration in the library

--- a/scripts/distribution/windows/build-all.ps1
+++ b/scripts/distribution/windows/build-all.ps1
@@ -1,9 +1,12 @@
-param ([string] $nodeVersion)
+param ([string] $rustVersion, [string] $nodeVersion)
 
 Write-Output "stack version: $(stack --version)"
 Write-Output "cargo version: $(cargo --version)"
 Write-Output "flatc version: $(flatc --version)"
 Write-Output "protoc version: $(protoc --version)"
+
+# Override the rust toolchain so that consensus rust dependencies use it.
+rustup override set $rustVersion-x86_64-pc-windows-gnu
 
 Write-Output "Building consensus..."
 stack build
@@ -14,7 +17,7 @@ stack exec -- cargo build --manifest-path concordium-node\Cargo.toml --release -
 if ($LASTEXITCODE -ne 0) { throw "Failed building node" }
 
 Write-Output "Building the collector..."
-cargo build --manifest-path collector\Cargo.toml --release --locked
+cargo +$rustVersion-x86_64-pc-windows-msvc build --manifest-path collector\Cargo.toml --release --locked
 if ($LASTEXITCODE -ne 0) { throw "Failed building the collector" }
 
 Write-Output "Building node runner service..."
@@ -23,7 +26,7 @@ Write-Output "Building node runner service..."
 # This ensures that the MSVC runtime is linked statically, and the output is produced
 # in the right target folder.
 Push-Location service\windows
-cargo build --release --locked
+cargo +$rustVersion-x86_64-pc-windows-msvc build --release --locked
 Pop-Location
 if ($LASTEXITCODE -ne 0) { throw "Failed building node runner service" }
 
@@ -81,4 +84,4 @@ finally {
 }
 
 # Build the installer
-service\windows\installer\build.ps1 -nodeVersion $nodeVersion
+service\windows\installer\build.ps1 -toolchain $rustVersion-x86_64-pc-windows-msvc -nodeVersion $nodeVersion

--- a/scripts/distribution/windows/build-all.ps1
+++ b/scripts/distribution/windows/build-all.ps1
@@ -8,6 +8,10 @@ Write-Output "protoc version: $(protoc --version)"
 # Override the rust toolchain so that consensus rust dependencies use it.
 rustup override set $rustVersion-x86_64-pc-windows-gnu
 
+Push-Location plt
+cargo build --release --locked -p node-rust-library
+Pop-Location
+
 Write-Output "Building consensus..."
 stack build
 if ($LASTEXITCODE -ne 0) { throw "Failed building consensus" }

--- a/scripts/distribution/windows/build-all.ps1
+++ b/scripts/distribution/windows/build-all.ps1
@@ -8,7 +8,11 @@ Write-Output "protoc version: $(protoc --version)"
 # Override the rust toolchain so that consensus rust dependencies use it.
 rustup override set $rustVersion-x86_64-pc-windows-gnu
 
+# Sometimes it causes errors to build the Rust library indirectly 
+# via the Haskell concordium-consensus. Hence, we start by building it directly.
+Write-Output "Prebuilding node Rust library..."
 Push-Location plt
+rustup show active-toolchain
 cargo build --release --locked -p node-rust-library
 Pop-Location
 

--- a/scripts/distribution/windows/build-all.ps1
+++ b/scripts/distribution/windows/build-all.ps1
@@ -1,12 +1,9 @@
-param ([string] $rustVersion = "1.73", [string] $nodeVersion)
+param ([string] $nodeVersion)
 
 Write-Output "stack version: $(stack --version)"
 Write-Output "cargo version: $(cargo --version)"
 Write-Output "flatc version: $(flatc --version)"
 Write-Output "protoc version: $(protoc --version)"
-
-# Set the default rust toolchain so that consensus rust dependencies use it.
-rustup default $rustVersion-x86_64-pc-windows-gnu
 
 Write-Output "Building consensus..."
 stack build
@@ -17,7 +14,7 @@ stack exec -- cargo build --manifest-path concordium-node\Cargo.toml --release -
 if ($LASTEXITCODE -ne 0) { throw "Failed building node" }
 
 Write-Output "Building the collector..."
-cargo +$rustVersion-x86_64-pc-windows-msvc build --manifest-path collector\Cargo.toml --release --locked
+cargo build --manifest-path collector\Cargo.toml --release --locked
 if ($LASTEXITCODE -ne 0) { throw "Failed building the collector" }
 
 Write-Output "Building node runner service..."
@@ -26,7 +23,7 @@ Write-Output "Building node runner service..."
 # This ensures that the MSVC runtime is linked statically, and the output is produced
 # in the right target folder.
 Push-Location service\windows
-cargo +$rustVersion-x86_64-pc-windows-msvc build --release --locked
+cargo build --release --locked
 Pop-Location
 if ($LASTEXITCODE -ne 0) { throw "Failed building node runner service" }
 
@@ -84,4 +81,4 @@ finally {
 }
 
 # Build the installer
-service\windows\installer\build.ps1 -toolchain $rustVersion-x86_64-pc-windows-msvc -nodeVersion $nodeVersion
+service\windows\installer\build.ps1 -nodeVersion $nodeVersion

--- a/scripts/distribution/windows/build-all.ps1
+++ b/scripts/distribution/windows/build-all.ps1
@@ -8,8 +8,11 @@ Write-Output "protoc version: $(protoc --version)"
 # Override the rust toolchain so that consensus rust dependencies use it.
 rustup override set $rustVersion-x86_64-pc-windows-gnu
 
-# Sometimes it causes errors to build the Rust library indirectly 
-# via the Haskell concordium-consensus. Hence, we start by building it directly.
+# The reason we "prebuild" the node Rust library dependency:
+# When Setup.hs is run (which invokes the cargo build), stack puts 
+# the LLVM version of dlltool on the path, which is not compatible with the gnu dlltool. 
+# It thus does not generate the expected import lib. By the rust upfront, when it is 
+# subsequently built in Setup.hs it will already be built and so does not get rebuilt.
 Write-Output "Prebuilding node Rust library..."
 Push-Location plt
 rustup show active-toolchain

--- a/scripts/distribution/windows/build-all.ps1
+++ b/scripts/distribution/windows/build-all.ps1
@@ -13,6 +13,7 @@ stack build
 if ($LASTEXITCODE -ne 0) { throw "Failed building consensus" }
 
 Write-Output "Building node..."
+stack exec -- rustup show active-toolchain
 stack exec -- cargo build --manifest-path concordium-node\Cargo.toml --release --locked
 if ($LASTEXITCODE -ne 0) { throw "Failed building node" }
 

--- a/scripts/static-binaries/build-on-ubuntu.sh
+++ b/scripts/static-binaries/build-on-ubuntu.sh
@@ -13,7 +13,7 @@ set -euxo pipefail
 
 extra_features=${EXTRA_FEATURES:-""}
 
-REQUIRED_PARAMETERS=("PROTOC_VERSION" "FLATBUFFERS_VERSION" "RUST_TOOLCHAIN_VERSION")
+REQUIRED_PARAMETERS=("PROTOC_VERSION" "FLATBUFFERS_VERSION")
 
 # Loop through the required variables and check if they are set
 for VAR in "${REQUIRED_PARAMETERS[@]}"; do
@@ -50,7 +50,6 @@ rm protoc.zip
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 source "$HOME/.cargo/env"
 rustup set profile minimal
-rustup default "$RUST_TOOLCHAIN_VERSION"
 
 ASSETS_URL="https://github.com/google/flatbuffers/releases/expanded_assets/v${FLATBUFFERS_VERSION}"
 GCC_VERSION=$(curl -s "$ASSETS_URL" | grep -oP 'Linux\.flatc\.binary\.g\+\+\-\K[0-9]+' | head -n 1)

--- a/scripts/static-binaries/static-binaries.Dockerfile
+++ b/scripts/static-binaries/static-binaries.Dockerfile
@@ -29,14 +29,12 @@ ARG build_version
 ARG extra_features
 ARG protoc_version
 ARG flatbuffers_version
-ARG rust_toolchain_version
 
 WORKDIR /build
 RUN BRANCH="${branch}" \
     EXTRA_FEATURES="${extra_features}" \
     PROTOC_VERSION="${protoc_version}" \
     FLATBUFFERS_VERSION="${flatbuffers_version}" \
-    RUST_TOOLCHAIN_VERSION="${rust_toolchain_version}" \
       /build-on-ubuntu.sh
 
 # The binaries are available in the

--- a/scripts/static-libraries/build-static-libraries.sh
+++ b/scripts/static-libraries/build-static-libraries.sh
@@ -8,7 +8,7 @@ set -ex
 mkdir -p /target/{profiling,vanilla}/{ghc,dependencies,concordium}
 mkdir -p /binaries/{lib,bin}
 
-LIB_DIR=$(stack --stack-yaml /build/concordium-consensus/stack.static.yaml ghc -- --print-libdir)
+LIB_DIR=$(stack --stack-yaml /build/stack.static.yaml ghc -- --print-libdir)
 
 find "$LIB_DIR" -type f -name "*_p.a" ! -name "*_debug_p.a" ! -name "*rts_p.a" ! -name "*ffi_p.a" -exec cp {} /target/profiling/ghc/ \;
 find "$LIB_DIR" -type f -name "*.a" ! -name "*_p.a" ! -name "*_l.a" ! -name "*_debug.a" ! -name "*rts.a" ! -name "*ffi.a" -exec cp {} /target/vanilla/ghc/ \;
@@ -16,27 +16,27 @@ find "$LIB_DIR" -type f -name "*.a" ! -name "*_p.a" ! -name "*_l.a" ! -name "*_d
 cd /build
 
 #############################################################################################################################
-## Build the project
+## Build the project and copy Haskell libraries
 
-stack build --profile --flag "concordium-consensus:-dynamic" --stack-yaml /build/concordium-consensus/stack.static.yaml
-find /build/concordium-consensus/.stack-work -type f -name "*.a" ! -name "*_p.a" -exec cp {} /target/vanilla/concordium/ \;
-find /build/concordium-consensus/.stack-work -type f -name "*_p.a" -exec cp {} /target/profiling/concordium/ \;
+stack build --profile --flag "concordium-consensus:-dynamic" --stack-yaml /build/stack.static.yaml
+find /build/.stack-work -type f -name "*.a" ! -name "*_p.a" -exec cp {} /target/vanilla/concordium/ \;
+find /build/.stack-work -type f -name "*_p.a" -exec cp {} /target/profiling/concordium/ \;
 
 #############################################################################################################################
-## Copy rust binaries
+## Copy Haskell binaries and their Rust dependencies
 
-LOCAL_INSTALL_ROOT=$(stack --stack-yaml /build/concordium-consensus/stack.static.yaml path --profile --local-install-root)
+LOCAL_INSTALL_ROOT=$(stack --stack-yaml /build/stack.static.yaml path --profile --local-install-root)
 cp "$LOCAL_INSTALL_ROOT"/bin/{generate-update-keys,genesis,database-exporter} /binaries/bin/
 cp /build/concordium-base/rust-src/target/release/*.so /binaries/lib/
 cp /build/concordium-consensus/lib/*.so /binaries/lib/
 
 #############################################################################################################################
-## Copy dependencies
+## Copy Haskell dependencies
 
 find ~/.stack/snapshots/x86_64-linux/ -type f -name "*.a" ! -name "*_p.a" -exec cp {} /target/vanilla/dependencies \;
 find ~/.stack/snapshots/x86_64-linux/ -type f -name "*_p.a" -exec cp {} /target/profiling/dependencies \;
 
-## Rust files - copy the static libraries to the target directory, and strip debug symbols from them to reduce their size, as 
+## Rust dependencies - copy the static libraries to the target directory, and strip debug symbols from them to reduce their size, as 
 ## they are not needed for the final binaries and can cause linking issues if they contain ruststd symbols
 mkdir -p /target/rust
 cp -r /build/concordium-base/rust-src/target/release/*.a /target/rust/

--- a/service/windows/installer/build.ps1
+++ b/service/windows/installer/build.ps1
@@ -1,4 +1,4 @@
-﻿param ([string] $nodeVersion)
+﻿param ([string] $toolchain="", [string] $nodeVersion)
 
 Write-Output "Building Windows node installer..."
 
@@ -10,7 +10,7 @@ try {
     # Build the custom actions DLL. This provides custom functionality used by the installer.
     Write-Output "Building custom-actions.dll..."
     Push-Location custom-actions
-    cargo build --release --locked
+    cargo +$toolchain build --release --locked
     Pop-Location
     if ($LASTEXITCODE -ne 0) { throw "Failed building custom-actions.dll" }
 

--- a/service/windows/installer/build.ps1
+++ b/service/windows/installer/build.ps1
@@ -1,4 +1,4 @@
-﻿param ([string] $toolchain="", [string] $nodeVersion)
+﻿param ([string] $nodeVersion)
 
 Write-Output "Building Windows node installer..."
 
@@ -10,7 +10,7 @@ try {
     # Build the custom actions DLL. This provides custom functionality used by the installer.
     Write-Output "Building custom-actions.dll..."
     Push-Location custom-actions
-    cargo +$toolchain build --release --locked
+    cargo build --release --locked
     Pop-Location
     if ($LASTEXITCODE -ne 0) { throw "Failed building custom-actions.dll" }
 

--- a/stack.static.yaml
+++ b/stack.static.yaml
@@ -1,15 +1,15 @@
 resolver: lts-24.0
 
 packages:
-- .
-- haskell-lmdb
-- ../concordium-base
+- ./concordium-base
+- ./concordium-consensus
+- ./concordium-consensus/haskell-lmdb
 
 extra-deps:
 
 extra-lib-dirs:
-- ../concordium-base/lib
-- ./lib
+- ./concordium-base/lib
+- ./concordium-consensus/lib
 
 ghc-options:
     # `simpl-tick-factor` parameter here is necessary due to a bug in the ghc: https://gitlab.haskell.org/ghc/ghc/-/issues/14637#note_413425


### PR DESCRIPTION
## Purpose

Fix windows and macos build: Remove usages of the action `actions-rust-lang/setup-rust-toolchain` since it turns rustc warnings in base into errors via the environment variables it magically sets. We have no reason to use it anymore, since rustup is already installed in the runner images.

## Changes

Additional changes:
* rely on toolchain.toml to specify Rust version instead of passing the Rust version around
* prebuild node Rust library in the windows release before building consensus (building it indirectly via consensus Setup.hs without prebuilding fails for some unknown reason https://github.com/Concordium/concordium-node/pull/1595#discussion_r2986447691)
* move stack.static.yaml up next to stack.yaml in the repo root (both includes base and consensus as sub-packages)

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
