### PR TITLE
Implement getTokenAuthorizations in rust token module

### DIFF
--- a/plt/plt-block-state/src/block_state.rs
+++ b/plt/plt-block-state/src/block_state.rs
@@ -313,13 +313,7 @@ impl<IntState: HasQueryableBlockState, Load: BackingStoreLoad, ExtState: Externa
         token_key_value_state: &Self::TokenKeyValueState,
         prefix: TokenStateKey,
     ) -> impl Iterator<Item = (TokenStateKey, TokenStateValue)> {
-        let mut out = Vec::new();
-        for (key, value) in token_key_value_state.state.iter() {
-            if let Some(rest) = key.strip_prefix(prefix.as_slice()) {
-                out.push((rest.to_vec(), value.clone()));
-            }
-        }
-        out.into_iter()
+        token_key_value_state.iter_prefix(prefix)
     }
 }
 
@@ -393,4 +387,21 @@ struct Token {
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct SimplisticTokenKeyValueState {
     state: BTreeMap<TokenStateKey, TokenStateValue>,
+}
+
+impl SimplisticTokenKeyValueState {
+    fn iter_prefix(
+        &self,
+        prefix: TokenStateKey,
+    ) -> impl Iterator<Item = (TokenStateKey, TokenStateValue)> {
+        // This is just a temporary implementation and will not scale.
+        // However implementation should be trivial once using the actual trie.
+        let mut out = Vec::new();
+        for (key, value) in self.state.iter() {
+            if let Some(rest) = key.strip_prefix(prefix.as_slice()) {
+                out.push((rest.to_vec(), value.clone()));
+            }
+        }
+        out.into_iter()
+    }
 }

--- a/plt/plt-block-state/src/block_state.rs
+++ b/plt/plt-block-state/src/block_state.rs
@@ -308,11 +308,11 @@ impl<IntState: HasQueryableBlockState, Load: BackingStoreLoad, ExtState: Externa
         self.protocol_version
     }
 
-    fn iter_token_state_prefix(
+    fn iter_token_state_prefix<'a>(
         &self,
-        token_key_value_state: &Self::TokenKeyValueState,
+        token_key_value_state: &'a Self::TokenKeyValueState,
         prefix: TokenStateKey,
-    ) -> impl Iterator<Item = (TokenStateKey, TokenStateValue)> {
+    ) -> impl Iterator<Item = (&'a TokenStateKey, &'a TokenStateValue)> {
         token_key_value_state.iter_prefix(prefix)
     }
 }
@@ -393,13 +393,13 @@ impl SimplisticTokenKeyValueState {
     fn iter_prefix(
         &self,
         prefix: TokenStateKey,
-    ) -> impl Iterator<Item = (TokenStateKey, TokenStateValue)> {
+    ) -> impl Iterator<Item = (&TokenStateKey, &TokenStateValue)> {
         // This is just a temporary implementation and will not scale.
         // However implementation should be trivial once using the actual trie.
         let mut out = Vec::new();
         for (key, value) in self.state.iter() {
-            if let Some(rest) = key.strip_prefix(prefix.as_slice()) {
-                out.push((rest.to_vec(), value.clone()));
+            if key.starts_with(prefix.as_slice()) {
+                out.push((key, value));
             }
         }
         out.into_iter()

--- a/plt/plt-block-state/src/block_state.rs
+++ b/plt/plt-block-state/src/block_state.rs
@@ -307,6 +307,20 @@ impl<IntState: HasQueryableBlockState, Load: BackingStoreLoad, ExtState: Externa
     fn protocol_version(&self) -> ProtocolVersion {
         self.protocol_version
     }
+
+    fn iter_token_state_prefix(
+        &self,
+        token_key_value_state: &Self::TokenKeyValueState,
+        prefix: TokenStateKey,
+    ) -> impl Iterator<Item = (TokenStateKey, TokenStateValue)> {
+        let mut out = Vec::new();
+        for (key, value) in token_key_value_state.state.iter() {
+            if let Some(rest) = key.strip_prefix(prefix.as_slice()) {
+                out.push((rest.to_vec(), value.clone()));
+            }
+        }
+        out.into_iter()
+    }
 }
 
 impl<Load: BackingStoreLoad, ExtState: ExternalBlockStateOperations> BlockStateOperations

--- a/plt/plt-block-state/src/block_state_interface.rs
+++ b/plt/plt-block-state/src/block_state_interface.rs
@@ -90,17 +90,16 @@ pub trait BlockStateQuery {
     ) -> Option<TokenStateValue>;
 
     /// Get iterator over key-value pairs with a shared prefix.
-    /// Returned keys have the prefix stripped.
     ///
     /// # Arguments
     ///
     /// - `token_key_value` The token module state to look up the value in.
     /// - `prefix` The token state key prefix to iterate over.
-    fn iter_token_state_prefix(
+    fn iter_token_state_prefix<'a>(
         &self,
-        token_key_value: &Self::TokenKeyValueState,
+        token_key_value: &'a Self::TokenKeyValueState,
         prefix: TokenStateKey,
-    ) -> impl Iterator<Item = (TokenStateKey, TokenStateValue)>;
+    ) -> impl Iterator<Item = (&'a TokenStateKey, &'a TokenStateValue)>;
 
     /// Update the value for the given key in the given token key-value state. If `None` is
     /// specified as value, the entry is removed.

--- a/plt/plt-block-state/src/block_state_interface.rs
+++ b/plt/plt-block-state/src/block_state_interface.rs
@@ -90,6 +90,7 @@ pub trait BlockStateQuery {
     ) -> Option<TokenStateValue>;
 
     /// Get iterator over key-value pairs with a shared prefix.
+    /// Returned keys have the prefix stripped.
     ///
     /// # Arguments
     ///

--- a/plt/plt-block-state/src/block_state_interface.rs
+++ b/plt/plt-block-state/src/block_state_interface.rs
@@ -81,7 +81,7 @@ pub trait BlockStateQuery {
     ///
     /// # Arguments
     ///
-    /// - `token_module_map` The token module state to look up the value in.
+    /// - `token_key_value` The token module state to look up the value in.
     /// - `key` The token state key.
     fn lookup_token_state_value(
         &self,
@@ -89,12 +89,24 @@ pub trait BlockStateQuery {
         key: &TokenStateKey,
     ) -> Option<TokenStateValue>;
 
+    /// Get iterator over key-value pairs with a shared prefix.
+    ///
+    /// # Arguments
+    ///
+    /// - `token_key_value` The token module state to look up the value in.
+    /// - `prefix` The token state key prefix to iterate over.
+    fn iter_token_state_prefix(
+        &self,
+        token_key_value: &Self::TokenKeyValueState,
+        prefix: TokenStateKey,
+    ) -> impl Iterator<Item = (TokenStateKey, TokenStateValue)>;
+
     /// Update the value for the given key in the given token key-value state. If `None` is
     /// specified as value, the entry is removed.
     ///
     /// # Arguments
     ///
-    /// - `token_module_map` The token module state to update the value in.
+    /// - `token_key_value` The token module state to update the value in.
     /// - `key` The token state key.
     /// - `value` The value to set. If `None`, the entry with the given key is removed.
     fn update_token_state_value(

--- a/plt/plt-scheduler-interface/src/token_kernel_interface.rs
+++ b/plt/plt-scheduler-interface/src/token_kernel_interface.rs
@@ -101,6 +101,7 @@ pub trait TokenKernelQueries {
     fn lookup_token_state_value(&self, key: TokenStateKey) -> Option<TokenStateValue>;
 
     /// Get iterator over key-value pairs with a shared prefix.
+    /// Returned keys have the prefix stripped.
     fn iter_token_state_prefix(
         &self,
         prefix: TokenStateKey,

--- a/plt/plt-scheduler-interface/src/token_kernel_interface.rs
+++ b/plt/plt-scheduler-interface/src/token_kernel_interface.rs
@@ -100,6 +100,12 @@ pub trait TokenKernelQueries {
     /// Lookup a key in the token state.
     fn lookup_token_state_value(&self, key: TokenStateKey) -> Option<TokenStateValue>;
 
+    /// Get iterator over key-value pairs with a shared prefix.
+    fn iter_token_state_prefix(
+        &self,
+        prefix: TokenStateKey,
+    ) -> impl Iterator<Item = (TokenStateKey, TokenStateValue)>;
+
     /// Query the protocol version for this block.
     fn protocol_version(&self) -> ProtocolVersion;
 

--- a/plt/plt-scheduler-interface/src/token_kernel_interface.rs
+++ b/plt/plt-scheduler-interface/src/token_kernel_interface.rs
@@ -101,11 +101,10 @@ pub trait TokenKernelQueries {
     fn lookup_token_state_value(&self, key: TokenStateKey) -> Option<TokenStateValue>;
 
     /// Get iterator over key-value pairs with a shared prefix.
-    /// Returned keys have the prefix stripped.
     fn iter_token_state_prefix(
         &self,
         prefix: TokenStateKey,
-    ) -> impl Iterator<Item = (TokenStateKey, TokenStateValue)>;
+    ) -> impl Iterator<Item = (&TokenStateKey, &TokenStateValue)>;
 
     /// Query the protocol version for this block.
     fn protocol_version(&self) -> ProtocolVersion;

--- a/plt/plt-scheduler/src/token_kernel.rs
+++ b/plt/plt-scheduler/src/token_kernel.rs
@@ -67,6 +67,14 @@ impl<BSQ: BlockStateQuery> TokenKernelQueries for TokenKernelQueriesImpl<'_, BSQ
     fn protocol_version(&self) -> ProtocolVersion {
         self.block_state.protocol_version()
     }
+
+    fn iter_token_state_prefix(
+        &self,
+        prefix: TokenStateKey,
+    ) -> impl Iterator<Item = (TokenStateKey, TokenStateValue)> {
+        self.block_state
+            .iter_token_state_prefix(self.token_module_state, prefix)
+    }
 }
 
 /// Implementation of token kernel operations with a specific token in context.
@@ -273,5 +281,13 @@ impl<BSO: BlockStateOperations> TokenKernelQueries for TokenKernelOperationsImpl
 
     fn protocol_version(&self) -> ProtocolVersion {
         self.block_state.protocol_version()
+    }
+
+    fn iter_token_state_prefix(
+        &self,
+        prefix: TokenStateKey,
+    ) -> impl Iterator<Item = (TokenStateKey, TokenStateValue)> {
+        self.block_state
+            .iter_token_state_prefix(self.token_module_state, prefix)
     }
 }

--- a/plt/plt-scheduler/src/token_kernel.rs
+++ b/plt/plt-scheduler/src/token_kernel.rs
@@ -71,7 +71,7 @@ impl<BSQ: BlockStateQuery> TokenKernelQueries for TokenKernelQueriesImpl<'_, BSQ
     fn iter_token_state_prefix(
         &self,
         prefix: TokenStateKey,
-    ) -> impl Iterator<Item = (TokenStateKey, TokenStateValue)> {
+    ) -> impl Iterator<Item = (&TokenStateKey, &TokenStateValue)> {
         self.block_state
             .iter_token_state_prefix(self.token_module_state, prefix)
     }
@@ -286,7 +286,7 @@ impl<BSO: BlockStateOperations> TokenKernelQueries for TokenKernelOperationsImpl
     fn iter_token_state_prefix(
         &self,
         prefix: TokenStateKey,
-    ) -> impl Iterator<Item = (TokenStateKey, TokenStateValue)> {
+    ) -> impl Iterator<Item = (&TokenStateKey, &TokenStateValue)> {
         self.block_state
             .iter_token_state_prefix(self.token_module_state, prefix)
     }

--- a/plt/plt-token-module/src/key_value_state.rs
+++ b/plt/plt-token-module/src/key_value_state.rs
@@ -3,7 +3,7 @@
 use crate::roles::Roles;
 use crate::util;
 use concordium_base::common;
-use concordium_base::protocol_level_tokens::{MetadataUrl, TokenAdminRole};
+use concordium_base::protocol_level_tokens::{MetadataUrl, TokenAdminRole, TokenAuthorizations};
 use concordium_base::{base::AccountIndex, common::Serial};
 use plt_block_state::block_state::types::{TokenStateKey, TokenStateValue};
 use plt_scheduler_interface::token_kernel_interface::{
@@ -219,6 +219,51 @@ pub fn revoke_account_roles(
     }
     kernel.set_account_roles_state(account, roles);
     Ok(())
+}
+
+/// Get authorization roles and assigned accounts for the token.
+pub fn get_token_authorizations<TK: TokenKernelQueries>(
+    kernel: &TK,
+) -> Result<TokenAuthorizations, TokenStateInvariantError> {
+    let mut authorizations = TokenAuthorizations::default();
+    for (account_index_bytes, roles) in
+        kernel.iter_token_state_prefix(ACCOUNT_ROLES_STATE_PREFIX.into())
+    {
+        let account_index: AccountIndex = common::from_bytes_complete(account_index_bytes)
+            .map_err(|err| {
+                TokenStateInvariantError(format!(
+                    "Stored account index in authorizations cannot be decoded: {}",
+                    err
+                ))
+            })?;
+        let account = kernel
+            .account_by_index(account_index)
+            .map_err(|err| {
+                TokenStateInvariantError(format!(
+                    "Stored account index in authorizations cannot be found: {}",
+                    err
+                ))
+            })?
+            .canonical_account_address;
+        let roles = Roles::try_from_state_value(Some(roles)).map_err(|err| {
+            TokenStateInvariantError(format!(
+                "Stored account authorization roles cannot be decoded: {}",
+                err
+            ))
+        })?;
+        for role in roles.iter_assigned() {
+            match role {
+                TokenAdminRole::UpdateAdminRoles => authorizations.update_admin_roles.push(account),
+                TokenAdminRole::Mint => authorizations.mint.push(account),
+                TokenAdminRole::Burn => authorizations.burn.push(account),
+                TokenAdminRole::UpdateAllowList => authorizations.update_allow_list.push(account),
+                TokenAdminRole::UpdateDenyList => authorizations.update_deny_list.push(account),
+                TokenAdminRole::Pause => authorizations.pause.push(account),
+                TokenAdminRole::UpdateMetadata => authorizations.update_metadata.push(account),
+            }
+        }
+    }
+    Ok(authorizations)
 }
 
 /// Sets the puased state of the token module.

--- a/plt/plt-token-module/src/key_value_state.rs
+++ b/plt/plt-token-module/src/key_value_state.rs
@@ -3,7 +3,9 @@
 use crate::roles::Roles;
 use crate::util;
 use concordium_base::common;
-use concordium_base::protocol_level_tokens::{MetadataUrl, TokenAdminRole, TokenAuthorizations};
+use concordium_base::protocol_level_tokens::{
+    MetadataUrl, TokenAdminRole, TokenAuthorizations, TokenRoleAuthorizations,
+};
 use concordium_base::{base::AccountIndex, common::Serial};
 use plt_block_state::block_state::types::{TokenStateKey, TokenStateValue};
 use plt_scheduler_interface::token_kernel_interface::{
@@ -225,7 +227,14 @@ pub fn revoke_account_roles(
 pub fn get_token_authorizations<TK: TokenKernelQueries>(
     kernel: &TK,
 ) -> Result<TokenAuthorizations, TokenStateInvariantError> {
-    let mut authorizations = TokenAuthorizations::default();
+    let mut update_admin_roles = TokenRoleAuthorizations::default();
+    let mut mint = TokenRoleAuthorizations::default();
+    let mut burn = TokenRoleAuthorizations::default();
+    let mut update_allow_list = TokenRoleAuthorizations::default();
+    let mut update_deny_list = TokenRoleAuthorizations::default();
+    let mut pause = TokenRoleAuthorizations::default();
+    let mut update_metadata = TokenRoleAuthorizations::default();
+
     for (account_index_bytes, roles) in
         kernel.iter_token_state_prefix(ACCOUNT_ROLES_STATE_PREFIX.into())
     {
@@ -253,17 +262,27 @@ pub fn get_token_authorizations<TK: TokenKernelQueries>(
         })?;
         for role in roles.iter_assigned() {
             match role {
-                TokenAdminRole::UpdateAdminRoles => authorizations.update_admin_roles.push(account),
-                TokenAdminRole::Mint => authorizations.mint.push(account),
-                TokenAdminRole::Burn => authorizations.burn.push(account),
-                TokenAdminRole::UpdateAllowList => authorizations.update_allow_list.push(account),
-                TokenAdminRole::UpdateDenyList => authorizations.update_deny_list.push(account),
-                TokenAdminRole::Pause => authorizations.pause.push(account),
-                TokenAdminRole::UpdateMetadata => authorizations.update_metadata.push(account),
+                TokenAdminRole::UpdateAdminRoles => {
+                    update_admin_roles.accounts.push(account.into())
+                }
+                TokenAdminRole::Mint => mint.accounts.push(account.into()),
+                TokenAdminRole::Burn => burn.accounts.push(account.into()),
+                TokenAdminRole::UpdateAllowList => update_allow_list.accounts.push(account.into()),
+                TokenAdminRole::UpdateDenyList => update_deny_list.accounts.push(account.into()),
+                TokenAdminRole::Pause => pause.accounts.push(account.into()),
+                TokenAdminRole::UpdateMetadata => update_metadata.accounts.push(account.into()),
             }
         }
     }
-    Ok(authorizations)
+    Ok(TokenAuthorizations {
+        update_admin_roles: Some(update_admin_roles),
+        mint: is_mintable(kernel).then_some(mint),
+        burn: is_burnable(kernel).then_some(burn),
+        update_allow_list: has_allow_list(kernel).then_some(update_allow_list),
+        update_deny_list: has_deny_list(kernel).then_some(update_deny_list),
+        pause: Some(pause),
+        update_metadata: Some(update_metadata),
+    })
 }
 
 /// Sets the puased state of the token module.

--- a/plt/plt-token-module/src/key_value_state.rs
+++ b/plt/plt-token-module/src/key_value_state.rs
@@ -235,9 +235,14 @@ pub fn get_token_authorizations<TK: TokenKernelQueries>(
     let mut pause = TokenRoleAuthorizations::default();
     let mut update_metadata = TokenRoleAuthorizations::default();
 
-    for (account_index_bytes, roles) in
-        kernel.iter_token_state_prefix(ACCOUNT_ROLES_STATE_PREFIX.into())
-    {
+    for (key, roles) in kernel.iter_token_state_prefix(ACCOUNT_ROLES_STATE_PREFIX.into()) {
+        let account_index_bytes =
+            key.strip_prefix(&ACCOUNT_ROLES_STATE_PREFIX)
+                .ok_or_else(|| {
+                    TokenStateInvariantError(
+                        "Iterator over account roles state produced invalid key".to_string(),
+                    )
+                })?;
         let account_index: AccountIndex = common::from_bytes_complete(account_index_bytes)
             .map_err(|err| {
                 TokenStateInvariantError(format!(
@@ -254,7 +259,7 @@ pub fn get_token_authorizations<TK: TokenKernelQueries>(
                 ))
             })?
             .canonical_account_address;
-        let roles = Roles::try_from_state_value(Some(roles)).map_err(|err| {
+        let roles = Roles::try_from_state_value(Some(roles.clone())).map_err(|err| {
             TokenStateInvariantError(format!(
                 "Stored account authorization roles cannot be decoded: {}",
                 err

--- a/plt/plt-token-module/src/roles.rs
+++ b/plt/plt-token-module/src/roles.rs
@@ -5,7 +5,7 @@ use concordium_base::protocol_level_tokens::TokenAdminRole;
 use plt_block_state::block_state::types::TokenStateValue;
 
 /// List roles which are unaffected by which features are enabled.
-pub const MANDATORY_ROLES: &[TokenAdminRole] = &[
+pub const UNIVERSAL_ROLES: &[TokenAdminRole] = &[
     TokenAdminRole::UpdateAdminRoles,
     TokenAdminRole::Pause,
     TokenAdminRole::UpdateMetadata,
@@ -14,8 +14,6 @@ pub const MANDATORY_ROLES: &[TokenAdminRole] = &[
 /// List all roles.
 const ALL_ROLES: &[TokenAdminRole] = &[
     TokenAdminRole::UpdateAdminRoles,
-    TokenAdminRole::Pause,
-    TokenAdminRole::UpdateMetadata,
     TokenAdminRole::Mint,
     TokenAdminRole::Burn,
     TokenAdminRole::UpdateAllowList,

--- a/plt/plt-token-module/src/roles.rs
+++ b/plt/plt-token-module/src/roles.rs
@@ -11,6 +11,19 @@ pub const MANDATORY_ROLES: &[TokenAdminRole] = &[
     TokenAdminRole::UpdateMetadata,
 ];
 
+/// List all roles.
+const ALL_ROLES: &[TokenAdminRole] = &[
+    TokenAdminRole::UpdateAdminRoles,
+    TokenAdminRole::Pause,
+    TokenAdminRole::UpdateMetadata,
+    TokenAdminRole::Mint,
+    TokenAdminRole::Burn,
+    TokenAdminRole::UpdateAllowList,
+    TokenAdminRole::UpdateDenyList,
+    TokenAdminRole::Pause,
+    TokenAdminRole::UpdateMetadata,
+];
+
 /// Convert a role into the bitmask with 1 in the position of the specific role and zero every else.
 const fn role_bitmask(role: TokenAdminRole) -> u16 {
     let bitshift = match role {
@@ -82,6 +95,11 @@ impl Roles {
             return Ok(Roles::none());
         };
         common::from_bytes_complete(value)
+    }
+
+    /// Iterate the roles assigned.
+    pub fn iter_assigned(&self) -> impl Iterator<Item = TokenAdminRole> {
+        ALL_ROLES.iter().filter(|&role| self.has(*role)).copied()
     }
 }
 

--- a/plt/plt-token-module/src/token_module/initialize.rs
+++ b/plt/plt-token-module/src/token_module/initialize.rs
@@ -75,7 +75,7 @@ fn initialize_token_impl(
 
     // The governance account should hold every role, except for disabled features, so we build a
     // list of every enabled role and the mandatory roles.
-    let mut enabled_roles = Vec::from(roles::MANDATORY_ROLES);
+    let mut enabled_roles = Vec::from(roles::UNIVERSAL_ROLES);
 
     if init_params.allow_list == Some(true) {
         kernel.set_module_state(STATE_KEY_ALLOW_LIST, Some(vec![]));

--- a/plt/plt-token-module/src/token_module/queries.rs
+++ b/plt/plt-token-module/src/token_module/queries.rs
@@ -92,3 +92,12 @@ fn query_token_module_account_state_impl<TK: TokenKernelQueries>(
         deny_list,
     }
 }
+
+/// Get authorization roles and assigned accounts for the token.
+pub fn query_token_authorizations<TK: TokenKernelQueries>(
+    kernel: &TK,
+) -> Result<RawCbor, QueryTokenModuleError> {
+    Ok(RawCbor::from(cbor::cbor_encode(
+        &key_value_state::get_token_authorizations(kernel)?,
+    )))
+}

--- a/plt/plt-token-module/tests/token_module_admin_role.rs
+++ b/plt/plt-token-module/tests/token_module_admin_role.rs
@@ -1,0 +1,508 @@
+use concordium_base::base::ProtocolVersion;
+use concordium_base::common::cbor;
+use concordium_base::protocol_level_tokens::{
+    CborHolderAccount, RawCbor, TokenAdminRole, TokenAuthorizations, TokenOperation,
+    TokenPauseDetails, TokenUpdateAdminRolesDetails,
+};
+use plt_token_module::token_module;
+use utils::kernel_stub::{KernelStub, TokenInitTestParams};
+
+mod utils;
+
+/// The governance account receives every role except for disabled features.
+#[test]
+fn test_rbac_initial_governance_account_have_every_role() {
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
+    let gov_account = stub.init_token(TokenInitTestParams::default().mintable().deny_list());
+
+    let auth = token_module::query_token_authorizations(&stub).unwrap();
+    let auth: TokenAuthorizations = cbor::cbor_decode(auth).unwrap();
+
+    let gov = stub.account_canonical_address(&gov_account);
+    assert!(auth.update_admin_roles.contains(&gov));
+    assert!(auth.mint.contains(&gov));
+    assert!(!auth.burn.contains(&gov));
+    assert!(!auth.update_allow_list.contains(&gov));
+    assert!(auth.update_deny_list.contains(&gov));
+    assert!(auth.pause.contains(&gov));
+    assert!(auth.update_metadata.contains(&gov));
+}
+
+/// Assign multiple roles to a new account succeeds.
+#[test]
+fn test_rbac_assign_roles() {
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
+    let gov_account = stub.init_token(TokenInitTestParams::default().mintable().burnable());
+    let account2 = stub.create_account();
+
+    // transaction: assign mint and burn to account2
+    let mut execution = stub.execution_with_sender(gov_account);
+    let operations = vec![TokenOperation::AssignAdminRoles(
+        TokenUpdateAdminRolesDetails {
+            roles: vec![TokenAdminRole::Mint, TokenAdminRole::Burn],
+            account: CborHolderAccount::from(stub.account_canonical_address(&account2)),
+        },
+    )];
+    token_module::execute_token_update_transaction(
+        &mut execution,
+        &mut stub,
+        RawCbor::from(cbor::cbor_encode(&operations)),
+    )
+    .expect("execute");
+
+    let auth = token_module::query_token_authorizations(&stub).unwrap();
+    let auth: TokenAuthorizations = cbor::cbor_decode(auth).unwrap();
+
+    let gov = stub.account_canonical_address(&gov_account);
+    assert!(auth.update_admin_roles.contains(&gov));
+    assert!(auth.mint.contains(&gov));
+    assert!(auth.burn.contains(&gov));
+    assert!(!auth.update_allow_list.contains(&gov)); // Not enabled.
+    assert!(!auth.update_deny_list.contains(&gov)); // Not enabled.
+    assert!(auth.pause.contains(&gov));
+    assert!(auth.update_metadata.contains(&gov));
+
+    let acc = stub.account_canonical_address(&account2);
+    assert!(!auth.update_admin_roles.contains(&acc));
+    assert!(auth.mint.contains(&acc));
+    assert!(auth.burn.contains(&acc));
+    assert!(!auth.update_allow_list.contains(&acc));
+    assert!(!auth.update_deny_list.contains(&acc));
+    assert!(!auth.pause.contains(&acc));
+    assert!(!auth.update_metadata.contains(&acc));
+}
+
+/// Assign the same role to the same account twice succeeds.
+#[test]
+fn test_rbac_assign_same_roles() {
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
+    let gov_account = stub.init_token(TokenInitTestParams::default().mintable().burnable());
+    let account2 = stub.create_account();
+
+    // transaction: assign mint and burn to account2
+    let mut execution = stub.execution_with_sender(gov_account);
+    let operations = vec![TokenOperation::AssignAdminRoles(
+        TokenUpdateAdminRolesDetails {
+            roles: vec![TokenAdminRole::Mint, TokenAdminRole::Burn],
+            account: CborHolderAccount::from(stub.account_canonical_address(&account2)),
+        },
+    )];
+    token_module::execute_token_update_transaction(
+        &mut execution,
+        &mut stub,
+        RawCbor::from(cbor::cbor_encode(&operations)),
+    )
+    .expect("execute");
+
+    // transaction: assign mint to account2 again
+    let mut execution = stub.execution_with_sender(gov_account);
+    let operations = vec![TokenOperation::AssignAdminRoles(
+        TokenUpdateAdminRolesDetails {
+            roles: vec![TokenAdminRole::Mint],
+            account: CborHolderAccount::from(stub.account_canonical_address(&account2)),
+        },
+    )];
+    token_module::execute_token_update_transaction(
+        &mut execution,
+        &mut stub,
+        RawCbor::from(cbor::cbor_encode(&operations)),
+    )
+    .expect("execute");
+
+    let auth = token_module::query_token_authorizations(&stub).unwrap();
+    let auth: TokenAuthorizations = cbor::cbor_decode(auth).unwrap();
+
+    let acc = stub.account_canonical_address(&account2);
+    assert!(!auth.update_admin_roles.contains(&acc));
+    assert!(auth.mint.contains(&acc));
+    assert!(auth.burn.contains(&acc));
+    assert!(!auth.update_allow_list.contains(&acc));
+    assert!(!auth.update_deny_list.contains(&acc));
+    assert!(!auth.pause.contains(&acc));
+    assert!(!auth.update_metadata.contains(&acc));
+}
+
+/// Assign rejects when not holding the admin role.
+#[test]
+fn test_rbac_assign_unauthorization_sender_rejects() {
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
+    stub.init_token(TokenInitTestParams::default().mintable().burnable());
+    let account2 = stub.create_account();
+
+    // transaction: assign mint and burn to account2
+    let mut execution = stub.execution_with_sender(account2);
+    let operations = vec![TokenOperation::AssignAdminRoles(
+        TokenUpdateAdminRolesDetails {
+            roles: vec![TokenAdminRole::Mint, TokenAdminRole::Burn],
+            account: CborHolderAccount::from(stub.account_canonical_address(&account2)),
+        },
+    )];
+    token_module::execute_token_update_transaction(
+        &mut execution,
+        &mut stub,
+        RawCbor::from(cbor::cbor_encode(&operations)),
+    )
+    .unwrap_err();
+}
+
+/// Assign fails on P10.
+#[test]
+fn test_rbac_assign_rejects_p10() {
+    let mut stub = KernelStub::with_decimals(2, ProtocolVersion::P10);
+    stub.init_token(TokenInitTestParams::default().mintable().burnable());
+    let account2 = stub.create_account();
+
+    // transaction: assign mint and burn to account2
+    let mut execution = stub.execution_with_sender(account2);
+    let operations = vec![TokenOperation::AssignAdminRoles(
+        TokenUpdateAdminRolesDetails {
+            roles: vec![TokenAdminRole::Mint, TokenAdminRole::Burn],
+            account: CborHolderAccount::from(stub.account_canonical_address(&account2)),
+        },
+    )];
+    token_module::execute_token_update_transaction(
+        &mut execution,
+        &mut stub,
+        RawCbor::from(cbor::cbor_encode(&operations)),
+    )
+    .unwrap_err();
+}
+
+/// Assign succeeds when paused.
+#[test]
+fn test_rbac_assign_role_works_when_paused() {
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
+    let gov_account = stub.init_token(TokenInitTestParams::default().mintable().burnable());
+    let account2 = stub.create_account();
+
+    // 1st transaction: pause the token
+    let mut execution = stub.execution_with_sender(gov_account);
+    let operations = vec![TokenOperation::Pause(TokenPauseDetails {})];
+    token_module::execute_token_update_transaction(
+        &mut execution,
+        &mut stub,
+        RawCbor::from(cbor::cbor_encode(&operations)),
+    )
+    .expect("execute");
+
+    // 2nd transaction: assign mint and burn to account2
+    let mut execution = stub.execution_with_sender(gov_account);
+    let operations = vec![TokenOperation::AssignAdminRoles(
+        TokenUpdateAdminRolesDetails {
+            roles: vec![TokenAdminRole::Mint, TokenAdminRole::Burn],
+            account: CborHolderAccount::from(stub.account_canonical_address(&account2)),
+        },
+    )];
+    token_module::execute_token_update_transaction(
+        &mut execution,
+        &mut stub,
+        RawCbor::from(cbor::cbor_encode(&operations)),
+    )
+    .expect("execute");
+
+    let auth = token_module::query_token_authorizations(&stub).unwrap();
+    let auth: TokenAuthorizations = cbor::cbor_decode(auth).unwrap();
+
+    let acc = stub.account_canonical_address(&account2);
+    assert!(!auth.update_admin_roles.contains(&acc));
+    assert!(auth.mint.contains(&acc));
+    assert!(auth.burn.contains(&acc));
+    assert!(!auth.update_allow_list.contains(&acc));
+    assert!(!auth.update_deny_list.contains(&acc));
+    assert!(!auth.pause.contains(&acc));
+    assert!(!auth.update_metadata.contains(&acc));
+}
+
+/// Assign rejects when using role for a feature which is not enabled.
+#[test]
+fn test_rbac_assign_rejects_for_unabled_burn() {
+    let mut stub = KernelStub::with_decimals(2, ProtocolVersion::P10);
+    stub.init_token(TokenInitTestParams::default().mintable());
+    let account2 = stub.create_account();
+
+    // transaction: assign mint and burn to account2
+    let mut execution = stub.execution_with_sender(account2);
+    let operations = vec![TokenOperation::AssignAdminRoles(
+        TokenUpdateAdminRolesDetails {
+            roles: vec![TokenAdminRole::Mint, TokenAdminRole::Burn],
+            account: CborHolderAccount::from(stub.account_canonical_address(&account2)),
+        },
+    )];
+    token_module::execute_token_update_transaction(
+        &mut execution,
+        &mut stub,
+        RawCbor::from(cbor::cbor_encode(&operations)),
+    )
+    .unwrap_err();
+}
+
+/// Revoke roles from the governance account.
+#[test]
+fn test_rbac_revoke_roles() {
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
+    let gov_account = stub.init_token(
+        TokenInitTestParams::default()
+            .mintable()
+            .burnable()
+            .allow_list(),
+    );
+
+    // transaction: Revoke mint and burn from gov_account
+    let mut execution = stub.execution_with_sender(gov_account);
+    let operations = vec![TokenOperation::RevokeAdminRoles(
+        TokenUpdateAdminRolesDetails {
+            roles: vec![TokenAdminRole::Mint, TokenAdminRole::Burn],
+            account: CborHolderAccount::from(stub.account_canonical_address(&gov_account)),
+        },
+    )];
+    token_module::execute_token_update_transaction(
+        &mut execution,
+        &mut stub,
+        RawCbor::from(cbor::cbor_encode(&operations)),
+    )
+    .expect("execute");
+
+    let auth = token_module::query_token_authorizations(&stub).unwrap();
+    let auth: TokenAuthorizations = cbor::cbor_decode(auth).unwrap();
+
+    let gov = stub.account_canonical_address(&gov_account);
+    assert!(auth.update_admin_roles.contains(&gov));
+    assert!(!auth.mint.contains(&gov));
+    assert!(!auth.burn.contains(&gov));
+    assert!(auth.update_allow_list.contains(&gov)); // Not enabled.
+    assert!(!auth.update_deny_list.contains(&gov)); // Not enabled.
+    assert!(auth.pause.contains(&gov));
+    assert!(auth.update_metadata.contains(&gov));
+}
+
+/// Revoke the same role from the same account twice succeeds.
+#[test]
+fn test_rbac_revoke_same_roles() {
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
+    let gov_account = stub.init_token(
+        TokenInitTestParams::default()
+            .mintable()
+            .burnable()
+            .allow_list(),
+    );
+
+    // transaction: Revoke mint and burn from gov_account
+    let mut execution = stub.execution_with_sender(gov_account);
+    let operations = vec![TokenOperation::RevokeAdminRoles(
+        TokenUpdateAdminRolesDetails {
+            roles: vec![TokenAdminRole::Mint, TokenAdminRole::Burn],
+            account: CborHolderAccount::from(stub.account_canonical_address(&gov_account)),
+        },
+    )];
+    token_module::execute_token_update_transaction(
+        &mut execution,
+        &mut stub,
+        RawCbor::from(cbor::cbor_encode(&operations)),
+    )
+    .expect("execute");
+
+    // transaction: Revoke mint from gov_account again
+    let mut execution = stub.execution_with_sender(gov_account);
+    let operations = vec![TokenOperation::RevokeAdminRoles(
+        TokenUpdateAdminRolesDetails {
+            roles: vec![TokenAdminRole::Mint],
+            account: CborHolderAccount::from(stub.account_canonical_address(&gov_account)),
+        },
+    )];
+    token_module::execute_token_update_transaction(
+        &mut execution,
+        &mut stub,
+        RawCbor::from(cbor::cbor_encode(&operations)),
+    )
+    .expect("execute");
+
+    let auth = token_module::query_token_authorizations(&stub).unwrap();
+    let auth: TokenAuthorizations = cbor::cbor_decode(auth).unwrap();
+
+    let gov = stub.account_canonical_address(&gov_account);
+    assert!(auth.update_admin_roles.contains(&gov));
+    assert!(!auth.mint.contains(&gov));
+    assert!(!auth.burn.contains(&gov));
+    assert!(auth.update_allow_list.contains(&gov));
+    assert!(!auth.update_deny_list.contains(&gov));
+    assert!(auth.pause.contains(&gov));
+    assert!(auth.update_metadata.contains(&gov));
+}
+
+/// Revoke rejects when not holding the admin role.
+#[test]
+fn test_rbac_revoke_rejects_without_admin_role() {
+    let mut stub = KernelStub::with_decimals(2, ProtocolVersion::P10);
+    let gov_account = stub.init_token(TokenInitTestParams::default().mintable().burnable());
+    let account2 = stub.create_account();
+
+    // transaction: revoke mint and burn from gov account
+    let mut execution = stub.execution_with_sender(account2);
+    let operations = vec![TokenOperation::RevokeAdminRoles(
+        TokenUpdateAdminRolesDetails {
+            roles: vec![TokenAdminRole::Mint, TokenAdminRole::Burn],
+            account: CborHolderAccount::from(stub.account_canonical_address(&gov_account)),
+        },
+    )];
+    token_module::execute_token_update_transaction(
+        &mut execution,
+        &mut stub,
+        RawCbor::from(cbor::cbor_encode(&operations)),
+    )
+    .unwrap_err();
+}
+
+/// Revoke fails on P10.
+#[test]
+fn test_rbac_revoke_rejects_p10() {
+    let mut stub = KernelStub::with_decimals(2, ProtocolVersion::P10);
+    let gov_account = stub.init_token(TokenInitTestParams::default().mintable().burnable());
+
+    // transaction: Revoke mint and burn from gov_account
+    let mut execution = stub.execution_with_sender(gov_account);
+    let operations = vec![TokenOperation::RevokeAdminRoles(
+        TokenUpdateAdminRolesDetails {
+            roles: vec![TokenAdminRole::Mint, TokenAdminRole::Burn],
+            account: CborHolderAccount::from(stub.account_canonical_address(&gov_account)),
+        },
+    )];
+    token_module::execute_token_update_transaction(
+        &mut execution,
+        &mut stub,
+        RawCbor::from(cbor::cbor_encode(&operations)),
+    )
+    .unwrap_err();
+}
+
+/// Revoke succeeds when paused.
+#[test]
+fn test_rbac_revoke_role_works_when_paused() {
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
+    let gov_account = stub.init_token(TokenInitTestParams::default().mintable().burnable());
+
+    // 1st transaction: pause the token
+    let mut execution = stub.execution_with_sender(gov_account);
+    let operations = vec![TokenOperation::Pause(TokenPauseDetails {})];
+    token_module::execute_token_update_transaction(
+        &mut execution,
+        &mut stub,
+        RawCbor::from(cbor::cbor_encode(&operations)),
+    )
+    .expect("execute");
+
+    // 2nd transaction: revoke mint and burn from gov account
+    let mut execution = stub.execution_with_sender(gov_account);
+    let operations = vec![TokenOperation::RevokeAdminRoles(
+        TokenUpdateAdminRolesDetails {
+            roles: vec![TokenAdminRole::Mint, TokenAdminRole::Burn],
+            account: CborHolderAccount::from(stub.account_canonical_address(&gov_account)),
+        },
+    )];
+    token_module::execute_token_update_transaction(
+        &mut execution,
+        &mut stub,
+        RawCbor::from(cbor::cbor_encode(&operations)),
+    )
+    .expect("execute");
+
+    let auth = token_module::query_token_authorizations(&stub).unwrap();
+    let auth: TokenAuthorizations = cbor::cbor_decode(auth).unwrap();
+
+    let acc = stub.account_canonical_address(&gov_account);
+    assert!(auth.update_admin_roles.contains(&acc));
+    assert!(!auth.mint.contains(&acc));
+    assert!(!auth.burn.contains(&acc));
+    assert!(!auth.update_allow_list.contains(&acc));
+    assert!(!auth.update_deny_list.contains(&acc));
+    assert!(auth.pause.contains(&acc));
+    assert!(auth.update_metadata.contains(&acc));
+}
+
+/// Revoke rejects when revoking admin role from sender.
+#[test]
+fn test_rbac_revoke_admin_role_from_sender_rejects() {
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
+    let gov_account = stub.init_token(TokenInitTestParams::default());
+
+    // transaction: Revoke updateAdminRole from gov_account
+    let mut execution = stub.execution_with_sender(gov_account);
+    let operations = vec![TokenOperation::RevokeAdminRoles(
+        TokenUpdateAdminRolesDetails {
+            roles: vec![TokenAdminRole::UpdateAdminRoles],
+            account: CborHolderAccount::from(stub.account_canonical_address(&gov_account)),
+        },
+    )];
+    token_module::execute_token_update_transaction(
+        &mut execution,
+        &mut stub,
+        RawCbor::from(cbor::cbor_encode(&operations)),
+    )
+    .unwrap_err();
+}
+
+/// Revoke rejects when using role for a feature which is not enabled.
+#[test]
+fn test_rbac_revoke_rejects_for_unabled_burn() {
+    let mut stub = KernelStub::with_decimals(2, ProtocolVersion::P10);
+    let gov_account = stub.init_token(TokenInitTestParams::default().mintable());
+
+    // transaction: Revoke mint and burn to from gov
+    let mut execution = stub.execution_with_sender(gov_account);
+    let operations = vec![TokenOperation::RevokeAdminRoles(
+        TokenUpdateAdminRolesDetails {
+            roles: vec![TokenAdminRole::Mint, TokenAdminRole::Burn],
+            account: CborHolderAccount::from(stub.account_canonical_address(&gov_account)),
+        },
+    )];
+    token_module::execute_token_update_transaction(
+        &mut execution,
+        &mut stub,
+        RawCbor::from(cbor::cbor_encode(&operations)),
+    )
+    .unwrap_err();
+}
+
+/// Revoke succeeds when revoking admin role from another account.
+#[test]
+fn test_rbac_admin_role_rotation_succeeds() {
+    let mut stub = KernelStub::with_decimals(2, utils::LATEST_PROTOCOL_VERSION);
+    let gov_account = stub.init_token(TokenInitTestParams::default().mintable().burnable());
+    let account2 = stub.create_account();
+
+    // 1st transaction: Assign account2 the updateAdminRole.
+    let mut execution = stub.execution_with_sender(gov_account);
+    let operations = vec![TokenOperation::AssignAdminRoles(
+        TokenUpdateAdminRolesDetails {
+            roles: vec![TokenAdminRole::UpdateAdminRoles],
+            account: CborHolderAccount::from(stub.account_canonical_address(&account2)),
+        },
+    )];
+    token_module::execute_token_update_transaction(
+        &mut execution,
+        &mut stub,
+        RawCbor::from(cbor::cbor_encode(&operations)),
+    )
+    .expect("execute");
+
+    // 2nd transaction: revoke updateAdminRole from gov_account
+    let mut execution = stub.execution_with_sender(account2);
+    let operations = vec![TokenOperation::RevokeAdminRoles(
+        TokenUpdateAdminRolesDetails {
+            roles: vec![TokenAdminRole::UpdateAdminRoles],
+            account: CborHolderAccount::from(stub.account_canonical_address(&gov_account)),
+        },
+    )];
+    token_module::execute_token_update_transaction(
+        &mut execution,
+        &mut stub,
+        RawCbor::from(cbor::cbor_encode(&operations)),
+    )
+    .expect("execute");
+
+    let auth = token_module::query_token_authorizations(&stub).unwrap();
+    let auth: TokenAuthorizations = cbor::cbor_decode(auth).unwrap();
+    let gov_acc = stub.account_canonical_address(&gov_account);
+    assert!(!auth.update_admin_roles.contains(&gov_acc));
+    let acc = stub.account_canonical_address(&account2);
+    assert!(auth.update_admin_roles.contains(&acc));
+}

--- a/plt/plt-token-module/tests/token_module_admin_role.rs
+++ b/plt/plt-token-module/tests/token_module_admin_role.rs
@@ -19,13 +19,23 @@ fn test_rbac_initial_governance_account_have_every_role() {
     let auth: TokenAuthorizations = cbor::cbor_decode(auth).unwrap();
 
     let gov = stub.account_canonical_address(&gov_account);
-    assert!(auth.update_admin_roles.contains(&gov));
-    assert!(auth.mint.contains(&gov));
-    assert!(!auth.burn.contains(&gov));
-    assert!(!auth.update_allow_list.contains(&gov));
-    assert!(auth.update_deny_list.contains(&gov));
-    assert!(auth.pause.contains(&gov));
-    assert!(auth.update_metadata.contains(&gov));
+    assert!(
+        auth.update_admin_roles
+            .unwrap()
+            .accounts
+            .contains(&gov.into())
+    );
+    assert!(auth.mint.unwrap().accounts.contains(&gov.into()));
+    assert!(auth.burn.is_none());
+    assert!(auth.update_allow_list.is_none());
+    assert!(
+        auth.update_deny_list
+            .unwrap()
+            .accounts
+            .contains(&gov.into())
+    );
+    assert!(auth.pause.unwrap().accounts.contains(&gov.into()));
+    assert!(auth.update_metadata.unwrap().accounts.contains(&gov.into()));
 }
 
 /// Assign multiple roles to a new account succeeds.
@@ -54,22 +64,49 @@ fn test_rbac_assign_roles() {
     let auth: TokenAuthorizations = cbor::cbor_decode(auth).unwrap();
 
     let gov = stub.account_canonical_address(&gov_account);
-    assert!(auth.update_admin_roles.contains(&gov));
-    assert!(auth.mint.contains(&gov));
-    assert!(auth.burn.contains(&gov));
-    assert!(!auth.update_allow_list.contains(&gov)); // Not enabled.
-    assert!(!auth.update_deny_list.contains(&gov)); // Not enabled.
-    assert!(auth.pause.contains(&gov));
-    assert!(auth.update_metadata.contains(&gov));
+    assert!(
+        auth.update_admin_roles
+            .as_ref()
+            .unwrap()
+            .accounts
+            .contains(&gov.into())
+    );
+    assert!(auth.mint.as_ref().unwrap().accounts.contains(&gov.into()));
+    assert!(auth.burn.as_ref().unwrap().accounts.contains(&gov.into()));
+    assert!(auth.update_allow_list.is_none());
+    assert!(auth.update_deny_list.is_none());
+    assert!(auth.pause.as_ref().unwrap().accounts.contains(&gov.into()));
+    assert!(
+        auth.update_metadata
+            .as_ref()
+            .unwrap()
+            .accounts
+            .contains(&gov.into())
+    );
 
-    let acc = stub.account_canonical_address(&account2);
-    assert!(!auth.update_admin_roles.contains(&acc));
-    assert!(auth.mint.contains(&acc));
-    assert!(auth.burn.contains(&acc));
-    assert!(!auth.update_allow_list.contains(&acc));
-    assert!(!auth.update_deny_list.contains(&acc));
-    assert!(!auth.pause.contains(&acc));
-    assert!(!auth.update_metadata.contains(&acc));
+    let acc = stub.account_canonical_address(&account2).into();
+    assert!(
+        !auth
+            .update_admin_roles
+            .as_ref()
+            .unwrap()
+            .accounts
+            .contains(&acc)
+    );
+    assert!(auth.mint.as_ref().unwrap().accounts.contains(&acc));
+    assert!(auth.burn.as_ref().unwrap().accounts.contains(&acc));
+    assert!(auth.update_allow_list.is_none());
+    assert!(auth.update_deny_list.is_none());
+    assert!(!auth.pause.as_ref().unwrap().accounts.contains(&acc));
+    assert!(
+        !auth
+            .update_metadata
+            .as_ref()
+            .as_ref()
+            .unwrap()
+            .accounts
+            .contains(&acc)
+    );
 }
 
 /// Assign the same role to the same account twice succeeds.
@@ -112,14 +149,26 @@ fn test_rbac_assign_same_roles() {
     let auth = token_module::query_token_authorizations(&stub).unwrap();
     let auth: TokenAuthorizations = cbor::cbor_decode(auth).unwrap();
 
-    let acc = stub.account_canonical_address(&account2);
-    assert!(!auth.update_admin_roles.contains(&acc));
-    assert!(auth.mint.contains(&acc));
-    assert!(auth.burn.contains(&acc));
-    assert!(!auth.update_allow_list.contains(&acc));
-    assert!(!auth.update_deny_list.contains(&acc));
-    assert!(!auth.pause.contains(&acc));
-    assert!(!auth.update_metadata.contains(&acc));
+    let acc = stub.account_canonical_address(&account2).into();
+    assert!(
+        !auth
+            .update_admin_roles
+            .as_ref()
+            .unwrap()
+            .accounts
+            .contains(&acc)
+    );
+    assert!(auth.mint.as_ref().unwrap().accounts.contains(&acc));
+    assert!(auth.burn.as_ref().unwrap().accounts.contains(&acc));
+    assert!(!auth.pause.as_ref().unwrap().accounts.contains(&acc));
+    assert!(
+        !auth
+            .update_metadata
+            .as_ref()
+            .unwrap()
+            .accounts
+            .contains(&acc)
+    );
 }
 
 /// Assign rejects when not holding the admin role.
@@ -203,14 +252,18 @@ fn test_rbac_assign_role_works_when_paused() {
     let auth = token_module::query_token_authorizations(&stub).unwrap();
     let auth: TokenAuthorizations = cbor::cbor_decode(auth).unwrap();
 
-    let acc = stub.account_canonical_address(&account2);
-    assert!(!auth.update_admin_roles.contains(&acc));
-    assert!(auth.mint.contains(&acc));
-    assert!(auth.burn.contains(&acc));
-    assert!(!auth.update_allow_list.contains(&acc));
-    assert!(!auth.update_deny_list.contains(&acc));
-    assert!(!auth.pause.contains(&acc));
-    assert!(!auth.update_metadata.contains(&acc));
+    let acc = stub.account_canonical_address(&account2).into();
+    assert!(
+        !auth
+            .update_admin_roles
+            .as_ref()
+            .unwrap()
+            .accounts
+            .contains(&acc)
+    );
+    assert!(auth.mint.as_ref().unwrap().accounts.contains(&acc));
+    assert!(auth.burn.as_ref().unwrap().accounts.contains(&acc));
+    assert!(!auth.pause.as_ref().unwrap().accounts.contains(&acc));
 }
 
 /// Assign rejects when using role for a feature which is not enabled.
@@ -265,14 +318,20 @@ fn test_rbac_revoke_roles() {
     let auth = token_module::query_token_authorizations(&stub).unwrap();
     let auth: TokenAuthorizations = cbor::cbor_decode(auth).unwrap();
 
-    let gov = stub.account_canonical_address(&gov_account);
-    assert!(auth.update_admin_roles.contains(&gov));
-    assert!(!auth.mint.contains(&gov));
-    assert!(!auth.burn.contains(&gov));
-    assert!(auth.update_allow_list.contains(&gov)); // Not enabled.
-    assert!(!auth.update_deny_list.contains(&gov)); // Not enabled.
-    assert!(auth.pause.contains(&gov));
-    assert!(auth.update_metadata.contains(&gov));
+    let gov = stub.account_canonical_address(&gov_account).into();
+    assert!(auth.update_admin_roles.unwrap().accounts.contains(&gov));
+    assert!(!auth.mint.as_ref().unwrap().accounts.contains(&gov));
+    assert!(!auth.burn.as_ref().unwrap().accounts.contains(&gov));
+    assert!(auth.update_allow_list.unwrap().accounts.contains(&gov));
+    assert!(auth.update_deny_list.is_none()); // Not enabled.
+    assert!(auth.pause.as_ref().unwrap().accounts.contains(&gov));
+    assert!(
+        auth.update_metadata
+            .as_ref()
+            .unwrap()
+            .accounts
+            .contains(&gov)
+    );
 }
 
 /// Revoke the same role from the same account twice succeeds.
@@ -319,14 +378,31 @@ fn test_rbac_revoke_same_roles() {
     let auth = token_module::query_token_authorizations(&stub).unwrap();
     let auth: TokenAuthorizations = cbor::cbor_decode(auth).unwrap();
 
-    let gov = stub.account_canonical_address(&gov_account);
-    assert!(auth.update_admin_roles.contains(&gov));
-    assert!(!auth.mint.contains(&gov));
-    assert!(!auth.burn.contains(&gov));
-    assert!(auth.update_allow_list.contains(&gov));
-    assert!(!auth.update_deny_list.contains(&gov));
-    assert!(auth.pause.contains(&gov));
-    assert!(auth.update_metadata.contains(&gov));
+    let gov = stub.account_canonical_address(&gov_account).into();
+    assert!(
+        auth.update_admin_roles
+            .as_ref()
+            .unwrap()
+            .accounts
+            .contains(&gov)
+    );
+    assert!(!auth.mint.as_ref().unwrap().accounts.contains(&gov));
+    assert!(!auth.burn.as_ref().unwrap().accounts.contains(&gov));
+    assert!(
+        auth.update_allow_list
+            .as_ref()
+            .unwrap()
+            .accounts
+            .contains(&gov)
+    );
+    assert!(auth.pause.as_ref().unwrap().accounts.contains(&gov));
+    assert!(
+        auth.update_metadata
+            .as_ref()
+            .unwrap()
+            .accounts
+            .contains(&gov)
+    );
 }
 
 /// Revoke rejects when not holding the admin role.
@@ -408,14 +484,24 @@ fn test_rbac_revoke_role_works_when_paused() {
     let auth = token_module::query_token_authorizations(&stub).unwrap();
     let auth: TokenAuthorizations = cbor::cbor_decode(auth).unwrap();
 
-    let acc = stub.account_canonical_address(&gov_account);
-    assert!(auth.update_admin_roles.contains(&acc));
-    assert!(!auth.mint.contains(&acc));
-    assert!(!auth.burn.contains(&acc));
-    assert!(!auth.update_allow_list.contains(&acc));
-    assert!(!auth.update_deny_list.contains(&acc));
-    assert!(auth.pause.contains(&acc));
-    assert!(auth.update_metadata.contains(&acc));
+    let acc = stub.account_canonical_address(&gov_account).into();
+    assert!(
+        auth.update_admin_roles
+            .as_ref()
+            .unwrap()
+            .accounts
+            .contains(&acc)
+    );
+    assert!(!auth.mint.as_ref().unwrap().accounts.contains(&acc));
+    assert!(!auth.burn.as_ref().unwrap().accounts.contains(&acc));
+    assert!(auth.pause.as_ref().unwrap().accounts.contains(&acc));
+    assert!(
+        auth.update_metadata
+            .as_ref()
+            .unwrap()
+            .accounts
+            .contains(&acc)
+    );
 }
 
 /// Revoke rejects when revoking admin role from sender.
@@ -501,8 +587,21 @@ fn test_rbac_admin_role_rotation_succeeds() {
 
     let auth = token_module::query_token_authorizations(&stub).unwrap();
     let auth: TokenAuthorizations = cbor::cbor_decode(auth).unwrap();
-    let gov_acc = stub.account_canonical_address(&gov_account);
-    assert!(!auth.update_admin_roles.contains(&gov_acc));
-    let acc = stub.account_canonical_address(&account2);
-    assert!(auth.update_admin_roles.contains(&acc));
+    let gov_acc = stub.account_canonical_address(&gov_account).into();
+    assert!(
+        !auth
+            .update_admin_roles
+            .as_ref()
+            .unwrap()
+            .accounts
+            .contains(&gov_acc)
+    );
+    let acc = stub.account_canonical_address(&account2).into();
+    assert!(
+        auth.update_admin_roles
+            .as_ref()
+            .unwrap()
+            .accounts
+            .contains(&acc)
+    );
 }

--- a/plt/plt-token-module/tests/utils/kernel_stub.rs
+++ b/plt/plt-token-module/tests/utils/kernel_stub.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, VecDeque};
+use std::iter::FilterMap;
 
 use concordium_base::base::{AccountIndex, Energy, InsufficientEnergy, ProtocolVersion};
 use concordium_base::common::{Serial, cbor};
@@ -320,6 +321,19 @@ impl TokenKernelQueries for KernelStub {
 
     fn protocol_version(&self) -> ProtocolVersion {
         self.protocol_version
+    }
+
+    fn iter_token_state_prefix(
+        &self,
+        prefix: TokenStateKey,
+    ) -> impl Iterator<Item = (TokenStateKey, TokenStateValue)> {
+        let mut out = Vec::new();
+        for (key, value) in self.state.iter() {
+            if let Some(rest) = key.strip_prefix(prefix.as_slice()) {
+                out.push((rest.to_vec(), value.clone()));
+            }
+        }
+        out.into_iter()
     }
 }
 

--- a/plt/plt-token-module/tests/utils/kernel_stub.rs
+++ b/plt/plt-token-module/tests/utils/kernel_stub.rs
@@ -326,11 +326,11 @@ impl TokenKernelQueries for KernelStub {
     fn iter_token_state_prefix(
         &self,
         prefix: TokenStateKey,
-    ) -> impl Iterator<Item = (TokenStateKey, TokenStateValue)> {
+    ) -> impl Iterator<Item = (&TokenStateKey, &TokenStateValue)> {
         let mut out = Vec::new();
         for (key, value) in self.state.iter() {
-            if let Some(rest) = key.strip_prefix(prefix.as_slice()) {
-                out.push((rest.to_vec(), value.clone()));
+            if key.starts_with(prefix.as_slice()) {
+                out.push((key, value));
             }
         }
         out.into_iter()


### PR DESCRIPTION
## Purpose

Closing [COR-2234](https://linear.app/concordium/issue/COR-2234/concordium-nodeplt-extend-token-module-with-rbac-functionality)

[Depends on PR for base](https://github.com/Concordium/concordium-base/pull/912) 

## Changes

- Extend token kernel interface with iterator for a state prefix.
- Extend token module with get_token_authorization query.
- Implement test suite for RBAC assign and revoke operations, now that the query is ready.
- Update base.

