### PR TITLE
Add new getTokenAuthorizations query to the gRPC API

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -139,7 +139,6 @@ jobs:
     # but also before building the Haskell sources because the Haskell
     # build kicks of a Rust build.
     - name: Install Rust tools
-      working-directory: plt
       run: |
         rustup component add clippy llvm-tools
         rustup target add x86_64-pc-windows-gnu

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,6 @@ on:
 env:
   UBUNTU_VERSION: '22.04'
   STATIC_LIBRARIES_IMAGE_TAG: 'rust-1.94_ghc-9.10.2'
-  RUST_VERSION: '1.94'
   STACK_VERSION: '3.7.1'
   FLATBUFFERS_VERSION: '23.5.26'
   GHC_VERSION: '9.10.2'
@@ -119,7 +118,6 @@ jobs:
             ghc_version=${{ env.GHC_VERSION }}
             protoc_version=${{ env.PROTOC_VERSION }}
             flatbuffers_version=${{ env.FLATBUFFERS_VERSION }}
-            rust_toolchain_version=${{ env.RUST_VERSION }}
           labels: |
             ubuntu_version=${{ env.UBUNTU_VERSION }}
             static_libraries_image_tag=${{ env.STATIC_LIBRARIES_IMAGE_TAG }}
@@ -306,15 +304,16 @@ jobs:
           smctl healthcheck --all
         shell: cmd
 
-      - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: ${{ env.RUST_VERSION }}-x86_64-pc-windows-msvc
+      - name: Read Rust version
+        id: read-rust-version
+        run: |
+          $rustVersion = (cargo --version).Split(" ")[1]
+          echo "RUST_VERSION=$rustVersion" >> $env:GITHUB_OUTPUT
 
-      - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: ${{ env.RUST_VERSION }}-x86_64-pc-windows-gnu
+      - name: Print Rust version
+        id: print-rust-version
+        run: |
+          echo "Rust version: ${{ steps.read-rust-version.outputs.RUST_VERSION }}"
 
       - name: Setup node folder
         run: |
@@ -362,7 +361,7 @@ jobs:
           SM_CLIENT_CERT_PASSWORD: ${{ secrets.WINDOWS_SM_CLIENT_CERT_PASSWORD }}
           SM_ARGS: "--verbose --exit-non-zero-on-fail --failfast"
         run: |
-          ./scripts/distribution/windows/build-all.ps1 -nodeVersion ${{ needs.validate-preconditions.outputs.version }} -rustVersion ${{ env.RUST_VERSION }}
+          ./scripts/distribution/windows/build-all.ps1 -nodeVersion ${{ needs.validate-preconditions.outputs.version }} -rustVersion ${{ steps.read-rust-version.outputs.RUST_VERSION }}
 
       - name: Sign installer with smctl
         working-directory: ${{steps.build.outputs.bin_dir}}
@@ -434,10 +433,6 @@ jobs:
           security import $INSTALLER_CERTIFICATE_PATH -P "$BUILD_INSTALLER_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
           security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
           security list-keychain -d user -s $KEYCHAIN_PATH
-
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
 
       - uses: haskell-actions/setup@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ hie.yaml
 .DS_Store
 /concordium-node/*.log
 /stack.yaml.lock
+/stack.static.yaml.lock
 
 # MacOS distribution
 /scripts/distribution/macOS-package/tools

--- a/concordium-consensus/README.md
+++ b/concordium-consensus/README.md
@@ -25,7 +25,7 @@ This might happen if Rust is installed with the MSVC [ABI](https://en.wikipedia.
 You can check this by running `rustup show`.
 If Rust is using the MSVC toolchain you can switch to GNU instead by running
 ```
-rustup default stable-x86_64-pc-windows-gnu
+rustup override set 1.94-x86_64-pc-windows-gnu
 ```
 
 ### `user specified .o/.so/.DLL could not be loaded (addDLL: pthread or dependencies not loaded. (Win32 error 5)) whilst trying to load:  (dynamic) pthread`

--- a/concordium-consensus/Setup.hs
+++ b/concordium-consensus/Setup.hs
@@ -32,6 +32,7 @@ postConfHook args flags _ _ = do
 
     -- Build and copy/symlink PLT scheduler project
     nodeRustLibraryWorkspace <- canonicalizePath nodeRustLibraryWorkspaceRelative
+    withCurrentDirectory nodeRustLibraryWorkspace $ runCmd verbosity $ "rustup show active-toolchain"
     withCurrentDirectory nodeRustLibraryWorkspace $ runCmd verbosity $ "cargo build --release --locked -p node-rust-library"
     case buildOS of
         Windows -> do

--- a/concordium-consensus/lib.def
+++ b/concordium-consensus/lib.def
@@ -24,6 +24,7 @@ EXPORTS
 
  getAccountInfoV2
  getTokenInfoV2
+ getTokenAuthorizationsV2
  getAccountListV2
  getTokenListV2
  getModuleListV2

--- a/concordium-consensus/src-lib/Concordium/External/GRPC2.hs
+++ b/concordium-consensus/src-lib/Concordium/External/GRPC2.hs
@@ -42,7 +42,7 @@ import Concordium.Crypto.SHA256 (Hash (Hash))
 import Concordium.External.Helpers
 import Concordium.GlobalState.Parameters (CryptographicParameters)
 import Concordium.ID.Parameters (withGlobalContext)
-import Concordium.Scheduler.ProtocolLevelTokens.Queries (QueryTokenInfoError (..))
+import Concordium.Scheduler.ProtocolLevelTokens.Queries (QueryTokenModuleError (..))
 import qualified Concordium.Types.InvokeContract as InvokeContract
 import qualified Concordium.Wasm as Wasm
 
@@ -158,12 +158,49 @@ getTokenInfoV2 cptr blockType blockHashPtr tokenIdPtr tokenIdLen outHash outVec 
         Right tokenId -> do
             res <- runMVR (Q.getTokenInfo bhi tokenId) mvr
             case res of
-                Q.BQRBlock _ (Left QTIEUnknownToken) -> do
+                Q.BQRBlock _ (Left QTMEUnknownToken) -> do
                     copyHashTo outHash res
                     return $ queryResultCode QRNotFound
-                Q.BQRBlock _ (Left e@QTIEInternal{}) -> do
+                Q.BQRBlock _ (Left e@QTMEInternal{}) -> do
                     mvLog mvr Logger.External Logger.LLError $
                         "Internal error processing GetTokenInfo: " ++ show e
+                    return $ queryResultCode QRInternalError
+                Q.BQRBlock _ (Right r) ->
+                    returnMessageWithBlock (copier outVec) outHash (res $> r)
+                Q.BQRNoBlock ->
+                    return $ queryResultCode QRNotFound
+
+getTokenAuthorizationsV2 ::
+    StablePtr Ext.ConsensusRunner ->
+    -- | Block type.
+    Word8 ->
+    -- | Block hash.
+    Ptr Word8 ->
+    -- | Token ID.
+    Ptr Word8 ->
+    -- | Token ID length.
+    Word8 ->
+    -- | Out pointer for writing the block hash that was used.
+    Ptr Word8 ->
+    Ptr ReceiverVec ->
+    -- | Callback to output data.
+    FunPtr CopyToVecCallback ->
+    IO Int64
+getTokenAuthorizationsV2 cptr blockType blockHashPtr tokenIdPtr tokenIdLen outHash outVec copierCbk = do
+    Ext.ConsensusRunner mvr <- deRefStablePtr cptr
+    let copier = callCopyToVecCallback copierCbk
+    bhi <- decodeBlockHashInput blockType blockHashPtr
+    decodeTokenId tokenIdPtr tokenIdLen >>= \case
+        Left _ -> return $ queryResultCode QRInvalidArgument
+        Right tokenId -> do
+            res <- runMVR (Q.getTokenAuthorizations bhi tokenId) mvr
+            case res of
+                Q.BQRBlock _ (Left QTMEUnknownToken) -> do
+                    copyHashTo outHash res
+                    return $ queryResultCode QRNotFound
+                Q.BQRBlock _ (Left e@QTMEInternal{}) -> do
+                    mvLog mvr Logger.External Logger.LLError $
+                        "Internal error processing GetTokenAuthorizations: " ++ show e
                     return $ queryResultCode QRInternalError
                 Q.BQRBlock _ (Right r) ->
                     returnMessageWithBlock (copier outVec) outHash (res $> r)
@@ -1285,6 +1322,24 @@ foreign export ccall
 
 foreign export ccall
     getTokenInfoV2 ::
+        StablePtr Ext.ConsensusRunner ->
+        -- | Block type.
+        Word8 ->
+        -- | Block hash.
+        Ptr Word8 ->
+        -- | Token ID.
+        Ptr Word8 ->
+        -- | Token ID length.
+        Word8 ->
+        -- | Out pointer for writing the block hash that was used.
+        Ptr Word8 ->
+        Ptr ReceiverVec ->
+        -- | Callback to output data.
+        FunPtr CopyToVecCallback ->
+        IO Int64
+
+foreign export ccall
+    getTokenAuthorizationsV2 ::
         StablePtr Ext.ConsensusRunner ->
         -- | Block type.
         Word8 ->

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -89,7 +89,7 @@ import qualified Concordium.KonsensusV1.Types as SkovV1
 import Concordium.Kontrol
 import Concordium.Kontrol.BestBlock
 import Concordium.MultiVersion
-import Concordium.Scheduler.ProtocolLevelTokens.Queries (QueryTokenInfoError, queryAccountTokens, queryPLTList, queryTokenInfo)
+import Concordium.Scheduler.ProtocolLevelTokens.Queries (QueryTokenModuleError, queryAccountTokens, queryPLTList, queryTokenAuthorizations, queryTokenInfo)
 import Concordium.Skov as Skov (
     SkovQueryMonad (getBlocksAtHeight),
     evalSkovT,
@@ -1192,8 +1192,12 @@ getModuleList :: BlockHashInput -> MVR finconf (BHIQueryResponse [ModuleRef])
 getModuleList = liftSkovQueryStateBHI BS.getModuleList
 
 -- | Get the details of a token in the block state.
-getTokenInfo :: BlockHashInput -> TokenId -> MVR finconf (BHIQueryResponse (Either QueryTokenInfoError Tokens.TokenInfo))
+getTokenInfo :: BlockHashInput -> TokenId -> MVR finconf (BHIQueryResponse (Either QueryTokenModuleError Tokens.TokenInfo))
 getTokenInfo blockHashInput tokenId = liftSkovQueryStateBHI (queryTokenInfo tokenId) blockHashInput
+
+-- | Get the details of token authorizations in the block state.
+getTokenAuthorizations :: BlockHashInput -> TokenId -> MVR finconf (BHIQueryResponse (Either QueryTokenModuleError Tokens.TokenAuthorizations))
+getTokenAuthorizations blockHashInput tokenId = liftSkovQueryStateBHI (queryTokenAuthorizations tokenId) blockHashInput
 
 -- | Get the details of an account in the block state.
 --  The account can be given via an address, an account index or a credential registration id.

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Queries.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Queries.hs
@@ -5,10 +5,11 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Concordium.Scheduler.ProtocolLevelTokens.Queries (
-    QueryTokenInfoError (..),
+    QueryTokenModuleError (..),
     queryTokenInfo,
     queryAccountTokens,
     queryPLTList,
+    queryTokenAuthorizations,
 ) where
 
 import Control.Monad
@@ -97,17 +98,17 @@ instance (Monad m) => PLTKernelFail fail (QueryT fail ret m) where
     -- To abort, we simply drop the continuation and return the error.
     pltError err = QueryT $ ReaderT $ \_ -> ContT $ \_ -> return (Left err)
 
--- | An error that may occur as a result of 'queryTokenInfo'.
-data QueryTokenInfoError
+-- | An error that may occur as a result of 'queryTokenInfo' or 'queryTokenAuthorizations'.
+data QueryTokenModuleError
     = -- | The requested token does not exist in the block.
-      QTIEUnknownToken
+      QTMEUnknownToken
     | -- | An error occurred in the token module.
-      QTIEInternal !QueryTokenError
+      QTMEInternal !QueryTokenError
     deriving (Eq)
 
-instance Show QueryTokenInfoError where
-    show QTIEUnknownToken = "unknown token"
-    show (QTIEInternal e) = show e
+instance Show QueryTokenModuleError where
+    show QTMEUnknownToken = "unknown token"
+    show (QTMEInternal e) = show e
 
 -- | Get the 'TokenInfo' associated with a 'TokenId' in the given 'BlockState'.
 queryTokenInfo ::
@@ -115,20 +116,20 @@ queryTokenInfo ::
     (BS.BlockStateQuery m) =>
     TokenId ->
     BlockState m ->
-    m (Either QueryTokenInfoError TokenInfo)
+    m (Either QueryTokenModuleError TokenInfo)
 queryTokenInfo tokenId bs = case sPltStateVersionFor (protocolVersion @(MPV m)) of
-    SPLTStateNone -> return (Left QTIEUnknownToken)
+    SPLTStateNone -> return (Left QTMEUnknownToken)
     SPLTStateV0 -> do
         mTokenIx <- BS.getTokenIndex bs tokenId
         case mTokenIx of
-            Nothing -> return (Left QTIEUnknownToken)
+            Nothing -> return (Left QTMEUnknownToken)
             Just tokenIx -> do
                 PLTConfiguration{..} <- BS.getTokenConfiguration bs tokenIx
                 totalSupply <- BS.getTokenCirculatingSupply bs tokenIx
                 tokenState <- BS.getMutableTokenState bs tokenIx
                 let ctx = QueryContext{qcTokenIndex = tokenIx, qcBlockState = bs, qcTokenState = tokenState}
                 runQueryT queryTokenModuleState ctx >>= \case
-                    Left e -> return (Left (QTIEInternal e))
+                    Left e -> return (Left (QTMEInternal e))
                     Right tms -> do
                         let ts =
                                 TokenState
@@ -141,7 +142,22 @@ queryTokenInfo tokenId bs = case sPltStateVersionFor (protocolVersion @(MPV m)) 
     SPLTStateV1 ->
         RustQ.queryTokenInfo bs tokenId <&> \case
             Just tokenInfo -> Right tokenInfo
-            Nothing -> Left QTIEUnknownToken
+            Nothing -> Left QTMEUnknownToken
+
+-- | Get the 'TokenAuthorizations' associated with a 'TokenId' in the given 'BlockState'.
+queryTokenAuthorizations ::
+    forall m.
+    (BS.BlockStateQuery m) =>
+    TokenId ->
+    BlockState m ->
+    m (Either QueryTokenModuleError TokenAuthorizations)
+queryTokenAuthorizations tokenId bs = case sPltStateVersionFor (protocolVersion @(MPV m)) of
+    SPLTStateNone -> return (Left QTMEUnknownToken)
+    SPLTStateV0 -> return (Left QTMEUnknownToken)
+    SPLTStateV1 ->
+        RustQ.queryTokenAuthorizations bs tokenId <&> \case
+            Just out -> Right out
+            Nothing -> Left QTMEUnknownToken
 
 -- | Get the list of 'Token's on an account.
 queryAccountTokens ::

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/RustPLTScheduler/Queries.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/RustPLTScheduler/Queries.hs
@@ -9,6 +9,7 @@ module Concordium.Scheduler.ProtocolLevelTokens.RustPLTScheduler.Queries (
     queryPLTList,
     queryTokenInfo,
     queryTokenAccountInfos,
+    queryTokenAuthorizations,
 ) where
 
 import Control.Monad
@@ -235,6 +236,128 @@ queryTokenInfo bs tokenId = do
 -- See the exported function in the Rust code for documentation of safety.
 foreign import ccall "ffi_query_token_info"
     ffiQueryTokenInfo ::
+        -- | Called to read data from blob store.
+        FFI.LoadCallback ->
+        -- | Called to get the token account balance in the haskell-managed block state.
+        ReadTokenAccountBalanceCallbackPtr ->
+        -- | Called to get account index by account address.
+        GetAccountIndexByAddressCallbackPtr ->
+        -- | Called to get account address by account index.
+        GetAccountAddressByIndexCallbackPtr ->
+        -- | Called to get token account states for account.
+        GetTokenAccountStatesCallbackPtr ->
+        -- | Pointer to the input PLT block state.
+        FFI.Ptr PLTBlockState.RustPLTBlockState ->
+        -- | Protocol version of the block.
+        Word.Word64 ->
+        -- | Pointer to token id UTF-8 bytes.
+        FFI.Ptr Word.Word8 ->
+        -- | Byte length of token id UTF-8.
+        FFI.CSize ->
+        -- | Output location for array containing return data, which is the token info.
+        -- If the return value is `0`, the data is the serialized token info.
+        -- If the return value is `1`, the data is empty (zero bytes).
+        FFI.Ptr (FFI.Ptr Word.Word8) ->
+        -- | Output location for writing the length of the return data.
+        FFI.Ptr FFI.CSize ->
+        -- | Status code:
+        -- * `0`: the query was successful.
+        -- * `1`: token does not exist
+        IO Word.Word8
+
+-- | Get token authorizations for a given token, for protocol version where the PLT state is managed in Rust.
+queryTokenAuthorizations ::
+    forall m.
+    (Types.PVSupportsRustManagedPLT (Types.MPV m), BS.BlockStateQuery m) =>
+    -- | Block state to query.
+    BS.BlockState m ->
+    -- | Token to find token info for.
+    Types.TokenId ->
+    -- | The token info.
+    m (Maybe QueriesTypes.TokenAuthorizations)
+queryTokenAuthorizations bs tokenId = do
+    queryCallbacks <- unliftBlockStateQueryCallbacks bs
+    pltState <- BS.getRustPLTBlockState bs
+    let protocolVersion = Types.demoteProtocolVersion $ Types.protocolVersion @(Types.MPV m)
+    BS.liftBlobStore $ queryTokenAuthorizationsInBlobStoreMonad pltState queryCallbacks protocolVersion
+  where
+    -- Get token Authorizations for the given token in the given block state. The function is a wrapper around an FFI call
+    -- to the Rust PLT Scheduler library.
+    queryTokenAuthorizationsInBlobStoreMonad ::
+        (BlobStore.MonadBlobStore m') =>
+        -- Block state to query.
+        PLTBlockState.ForeignPLTBlockStatePtr ->
+        -- Callback need for queries.
+        BlockStateQueryCallbacks ->
+        -- The protocol version of the block.
+        Types.ProtocolVersion ->
+        -- The token info.
+        m' (Maybe QueriesTypes.TokenAuthorizations)
+    queryTokenAuthorizationsInBlobStoreMonad
+        pltBlockState
+        queryCallbacks
+        protocolVersion =
+            do
+                loadCallbackPtr <- fst <$> BlobStore.getCallbacks
+                liftIO $ FFI.alloca $ \returnDataPtrOutPtr -> FFI.alloca $ \returnDataLenOutPtr ->
+                    do
+                        readTokenAccountBalanceCallbackPtr <- wrapReadTokenAccountBalance $ readTokenAccountBalance queryCallbacks
+                        getAccountIndexByAddressCallbackPtr <- wrapGetAccountIndexByAddress $ getAccountIndexByAddress queryCallbacks
+                        getAccountAddressByIndexCallbackPtr <- wrapGetAccountAddressByIndex $ getAccountAddressByIndex queryCallbacks
+                        getTokenAccountStatesCallbackPtr <- wrapGetTokenAccountStates $ getTokenAccountStates queryCallbacks
+                        -- Invoke the ffi call
+                        statusCode <- PLTBlockState.withPLTBlockState pltBlockState $ \pltBlockStatePtr ->
+                            BSS.useAsCStringLen (Types.tokenId tokenId) $ \(tokenIdPtr, tokenIdLen) ->
+                                ffiQueryTokenAuthorizations
+                                    loadCallbackPtr
+                                    readTokenAccountBalanceCallbackPtr
+                                    getAccountIndexByAddressCallbackPtr
+                                    getAccountAddressByIndexCallbackPtr
+                                    getTokenAccountStatesCallbackPtr
+                                    pltBlockStatePtr
+                                    (Types.protocolVersionToWord64 protocolVersion)
+                                    (FFI.castPtr tokenIdPtr)
+                                    (fromIntegral tokenIdLen)
+                                    returnDataPtrOutPtr
+                                    returnDataLenOutPtr
+                        -- Free the function pointers we have just created
+                        -- (loadCallbackPtr is created in another context,
+                        -- so we should not free it)
+                        FFI.freeHaskellFunPtr readTokenAccountBalanceCallbackPtr
+                        FFI.freeHaskellFunPtr getAccountIndexByAddressCallbackPtr
+                        FFI.freeHaskellFunPtr getAccountAddressByIndexCallbackPtr
+                        FFI.freeHaskellFunPtr getTokenAccountStatesCallbackPtr
+                        -- Process the returned status and values returend via out pointers
+                        returnDataLen <- FFI.peek returnDataLenOutPtr
+                        returnDataPtr <- FFI.peek returnDataPtrOutPtr
+                        returnData <-
+                            BS.unsafePackCStringFinalizer
+                                returnDataPtr
+                                (fromIntegral returnDataLen)
+                                (Memory.rs_free_array_len_2 returnDataPtr (fromIntegral returnDataLen))
+                        case statusCode of
+                            0 -> do
+                                let getTokenAuthorizations = S.isolate (BS.length returnData) S.get
+                                let tokenInfo =
+                                        either
+                                            (\message -> error $ "Token authorizations from Rust PLT Scheduler could not be deserialized: " ++ message)
+                                            id
+                                            $ S.runGet getTokenAuthorizations returnData
+                                return $ Just tokenInfo
+                            1 -> do
+                                return Nothing
+                            _ -> error ("Unexpected status code from calling 'ffiQueryTokenAuthorizations': " ++ show statusCode)
+
+-- | C-binding for calling the Rust function `plt_scheduler::queries::query_token_authorizations`.
+--
+-- Returns a byte representing the result:
+--
+-- - `0`: The query was successful
+-- - `1`: The token does not exist
+--
+-- See the exported function in the Rust code for documentation of safety.
+foreign import ccall "ffi_query_token_authorizations"
+    ffiQueryTokenAuthorizations ::
         -- | Called to read data from blob store.
         FFI.LoadCallback ->
         -- | Called to get the token account balance in the haskell-managed block state.

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/RustPLTScheduler/Queries.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/RustPLTScheduler/Queries.hs
@@ -338,12 +338,12 @@ queryTokenAuthorizations bs tokenId = do
                         case statusCode of
                             0 -> do
                                 let getTokenAuthorizations = S.isolate (BS.length returnData) S.get
-                                let tokenInfo =
+                                let tokenAuthorizations =
                                         either
                                             (\message -> error $ "Token authorizations from Rust PLT Scheduler could not be deserialized: " ++ message)
                                             id
                                             $ S.runGet getTokenAuthorizations returnData
-                                return $ Just tokenInfo
+                                return $ Just tokenAuthorizations
                             1 -> do
                                 return Nothing
                             _ -> error ("Unexpected status code from calling 'ffiQueryTokenAuthorizations': " ++ show statusCode)
@@ -376,8 +376,8 @@ foreign import ccall "ffi_query_token_authorizations"
         FFI.Ptr Word.Word8 ->
         -- | Byte length of token id UTF-8.
         FFI.CSize ->
-        -- | Output location for array containing return data, which is the token info.
-        -- If the return value is `0`, the data is the serialized token info.
+        -- | Output location for array containing return data, which is the token authorizations.
+        -- If the return value is `0`, the data is the serialized token authorizations.
         -- If the return value is `1`, the data is empty (zero bytes).
         FFI.Ptr (FFI.Ptr Word.Word8) ->
         -- | Output location for writing the length of the return data.

--- a/concordium-consensus/tests/scheduler/SchedulerTests/TokenCreation.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/TokenCreation.hs
@@ -248,7 +248,7 @@ testCreatePLT _ pvString = describe pvString $ do
                                 pltList
                             assertEqual
                                 "Token info"
-                                (Left QTIEUnknownToken)
+                                (Left QTMEUnknownToken)
                                 tokenInfo
                     }
                 ]
@@ -294,7 +294,7 @@ testCreatePLT _ pvString = describe pvString $ do
                                 pltList
                             assertEqual
                                 "Token info"
-                                (Left QTIEUnknownToken)
+                                (Left QTMEUnknownToken)
                                 tokenInfo
                     }
                 ]
@@ -342,7 +342,7 @@ testCreatePLT _ pvString = describe pvString $ do
                                 pltList
                             assertEqual
                                 "Token info"
-                                (Left QTIEUnknownToken)
+                                (Left QTMEUnknownToken)
                                 tokenInfo
                     }
                 ]
@@ -567,7 +567,7 @@ testCreatePLT _ pvString = describe pvString $ do
                                 pltList
                             assertEqual
                                 "Token info"
-                                (Left QTIEUnknownToken)
+                                (Left QTMEUnknownToken)
                                 tokenInfo
                     }
                 ]

--- a/concordium-node/README.md
+++ b/concordium-node/README.md
@@ -2,7 +2,7 @@
 
 ## Dependencies to build the project
 
-- Rust (stable 1.82 for using static libraries)
+- The Rust toolchain specified in [`rust-toolchain.toml`](../rust-toolchain.toml)
 - binutils >= 2.22
   - For macOS one should use the binutils provided by Xcode.
 - cmake >= 3.8.0
@@ -10,7 +10,7 @@
   v22.12.06 is what we currently use. Either build from the v22.12.06 tag of the repository using CMake and copy the `flatc` binary somewhere in your PATH, or download a released binary from <https://github.com/google/flatbuffers/releases/tag/v22.12.06> and place it somewhere in your PATH.
 - protobuf >= 3.15
 - LLVM and Clang >= 3.9
-- As noted in the [caveats](#caveats) section below, you need to build the [Concordium Consensus](../concordium-consensus/) project before building this project. 
+- As noted in the [Building the node](#building-the-node) section below, you need to build the [Concordium Consensus](../concordium-consensus/) project before building this project. 
   So you also need the [dependencies listed in the README for Concordium Consensus](https://github.com/Concordium/concordium-node/tree/main/concordium-consensus#build-requirements).
 
 ### Optional dependencies

--- a/concordium-node/build.rs
+++ b/concordium-node/build.rs
@@ -220,6 +220,15 @@ fn build_grpc2(proto_root_input: &str) -> std::io::Result<()> {
         )
         .method(
             tonic_build::manual::Method::builder()
+                .name("get_token_authorizations")
+                .route_name("GetTokenAuthorizations")
+                .input_type("crate::grpc2::types::TokenAuthorizationsRequest")
+                .output_type("Vec<u8>")
+                .codec_path("crate::grpc2::RawCodec")
+                .build(),
+        )
+        .method(
+            tonic_build::manual::Method::builder()
                 .name("get_account_list")
                 .route_name("GetAccountList")
                 .input_type("crate::grpc2::types::BlockHashInput")

--- a/concordium-node/src/consensus_ffi/ffi.rs
+++ b/concordium-node/src/consensus_ffi/ffi.rs
@@ -562,6 +562,28 @@ extern "C" {
         copier: CopyToVecCallback,
     ) -> i64;
 
+    /// Get information about the token authorizations in a given block.
+    ///
+    /// * `consensus` - Pointer to the current consensus.
+    /// * `block_id_type` - Type of block identifier.
+    /// * `block_id` - Location with the block identifier. Length must match the
+    ///   corresponding type of block identifier.
+    /// * `token_id` - Pointer to the token identifier.
+    /// * `token_id_len` - Length of the token identifier.
+    /// * `out_hash` - Location to write the block hash used in the query.
+    /// * `out` - Location to write the output of the query.
+    /// * `copier` - Callback for writting the output.
+    pub fn getTokenAuthorizationsV2(
+        consensus: *mut consensus_runner,
+        block_id_type: u8,
+        block_id: *const u8,
+        token_id: *const u8,
+        token_id_len: u8,
+        out_hash: *mut u8,
+        out: *mut Vec<u8>,
+        copier: CopyToVecCallback,
+    ) -> i64;
+
     /// Get next account sequence number.
     ///
     /// * `consensus` - Pointer to the current consensus.
@@ -2398,6 +2420,42 @@ impl ConsensusContainer {
         let mut out_hash = [0u8; 32];
         let response: ConsensusQueryResponse = unsafe {
             getTokenInfoV2(
+                consensus,
+                block_id_type,
+                block_hash.as_ptr(),
+                token_id_ptr,
+                token_id_len,
+                out_hash.as_mut_ptr(),
+                &mut out_data,
+                copy_to_vec_callback,
+            )
+            .try_into()?
+        };
+        response.ensure_ok("tokenId or block")?;
+        Ok((out_hash, out_data))
+    }
+
+    pub fn get_token_authorizations_v2(
+        &self,
+        block_hash: &crate::grpc2::types::BlockHashInput,
+        token_id: &crate::grpc2::types::plt::TokenId,
+    ) -> Result<([u8; 32], Vec<u8>), tonic::Status> {
+        use crate::grpc2::Require;
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
+        let (block_id_type, block_hash) = bhi.to_ptr();
+        let token_id_len = token_id.value.len();
+        if token_id_len > 255 {
+            return Err(tonic::Status::invalid_argument(
+                "TokenId: length must be at most 255 bytes",
+            ));
+        }
+        let token_id_len = token_id_len as u8;
+        let token_id_ptr = token_id.value.as_ptr();
+        let consensus = self.consensus.load(Ordering::SeqCst);
+        let mut out_data: Vec<u8> = Vec::new();
+        let mut out_hash = [0u8; 32];
+        let response: ConsensusQueryResponse = unsafe {
+            getTokenAuthorizationsV2(
                 consensus,
                 block_id_type,
                 block_hash.as_ptr(),

--- a/concordium-node/src/consensus_ffi/ffi.rs
+++ b/concordium-node/src/consensus_ffi/ffi.rs
@@ -540,7 +540,7 @@ extern "C" {
         copier: CopyToVecCallback,
     ) -> i64;
 
-    /// Get information about a specific account in a given block.
+    /// Get information about a specific token in a given block.
     ///
     /// * `consensus` - Pointer to the current consensus.
     /// * `block_id_type` - Type of block identifier.
@@ -550,7 +550,7 @@ extern "C" {
     /// * `token_id_len` - Length of the token identifier.
     /// * `out_hash` - Location to write the block hash used in the query.
     /// * `out` - Location to write the output of the query.
-    /// * `copier` - Callback for writting the output.
+    /// * `copier` - Callback for writing the output.
     pub fn getTokenInfoV2(
         consensus: *mut consensus_runner,
         block_id_type: u8,
@@ -2435,6 +2435,12 @@ impl ConsensusContainer {
         Ok((out_hash, out_data))
     }
 
+    /// Get the authorizations for a protocol-level token in a block, introduced as part of P11.
+    /// The return value is a pair of the block hash which was used for the
+    /// query, and the protobuf serialized response.
+    ///
+    /// If the token cannot be found then a [tonic::Status::not_found] is
+    /// returned.
     pub fn get_token_authorizations_v2(
         &self,
         block_hash: &crate::grpc2::types::BlockHashInput,

--- a/concordium-node/src/grpc2.rs
+++ b/concordium-node/src/grpc2.rs
@@ -923,6 +923,8 @@ struct ServiceConfig {
     #[serde(default)]
     get_token_info: bool,
     #[serde(default)]
+    get_token_authorizations: bool,
+    #[serde(default)]
     get_module_list: bool,
     #[serde(default)]
     get_module_source: bool,
@@ -1050,6 +1052,7 @@ impl ServiceConfig {
             get_token_list: true,
             get_account_info: true,
             get_token_info: true,
+            get_token_authorizations: true,
             get_module_list: true,
             get_module_source: true,
             get_instance_list: true,
@@ -1817,6 +1820,29 @@ pub mod server {
                     let block_hash = request.block_hash.as_ref().require()?;
                     let token_identifier = request.token_id.as_ref().require()?;
                     consensus.get_token_info_v2(block_hash, token_identifier)
+                })
+                .await?;
+
+            let mut response = tonic::Response::new(response);
+            add_hash(&mut response, hash)?;
+            Ok(response)
+        }
+
+        async fn get_token_authorizations(
+            &self,
+            request: tonic::Request<crate::grpc2::types::TokenAuthorizationsRequest>,
+        ) -> Result<tonic::Response<Vec<u8>>, tonic::Status> {
+            if !self.service_config.get_token_authorizations {
+                return Err(tonic::Status::unimplemented(
+                    "`GetTokenAuthorizations` is not enabled.",
+                ));
+            }
+            let (hash, response) = self
+                .run_blocking(move |consensus| {
+                    let request = request.get_ref();
+                    let block_hash = request.block_hash.as_ref().require()?;
+                    let token_identifier = request.token_id.as_ref().require()?;
+                    consensus.get_token_authorizations_v2(block_hash, token_identifier)
                 })
                 .await?;
 

--- a/plt/plt-scheduler-types/src/types/queries.rs
+++ b/plt/plt-scheduler-types/src/types/queries.rs
@@ -53,6 +53,17 @@ pub struct TokenAccountInfo {
     pub account_state: TokenAccountState,
 }
 
+/// The token authorizations returned for a `TokenAuthorizationQuery`.
+///
+/// Corresponding Haskell type: `Concordium.Types.Queries.Tokens.TokenAuthorzations`
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+pub struct TokenAuthorizations {
+    /// The canonical identifier/symbol for the protocol level token.
+    pub token_id: TokenId,
+    /// The CBOR encoding of `token-authorizations` found in `concordium-base/cddl/cis-7.cddl`.
+    pub details: RawCbor,
+}
+
 #[cfg(test)]
 mod test {
     use concordium_base::{

--- a/plt/plt-scheduler/src/ffi/queries.rs
+++ b/plt/plt-scheduler/src/ffi/queries.rs
@@ -198,6 +198,107 @@ extern "C" fn ffi_query_token_info(
     return_status
 }
 
+/// C-binding for calling [`queries::query_token_authorizations`].
+///
+/// Returns a byte representing the result:
+///
+/// - `0`: Query succeeded
+/// - `1`: Token does not exist
+///
+/// # Arguments
+///
+/// - `load_callback` External function to call for loading bytes a reference from the blob store.
+/// - `read_token_account_balance_callback` External function to call reading the token balance of an account.
+/// - `get_account_address_by_index_callback` External function for getting account canonical address by account index.
+/// - `get_account_index_by_address_callback` External function for getting account index by account address.
+/// - `get_token_account_states_callback` External function for getting token account states.
+/// - `block_state` Shared pointer to a block state to use for queries.
+/// - `token_id` Shared pointer to token id UTF-8 bytes.
+/// - `token_id_len` Byte length of token id UTF-8 bytes.
+/// - `return_data_out` Location for writing pointer to array containing return data, which is the serialized token info.
+///   If the return value is `0`, the data is the token info.
+///   If the return value is `1`, the data is empty (zero bytes).
+///   The pointer written is to a uniquely owned array.
+///   The caller must free the written array using `free_array_len_2` when it is no longer used.
+/// - `return_data_len_out` Location for writing the length of the array whose pointer was written to `return_data_out`.
+///
+/// # Safety
+///
+/// - All callback arguments must be a valid function pointers to functions with a signature matching the
+///   signature of Rust type of the function pointer.
+/// - Argument `block_state` must be a non-null pointer to well-formed [`crate::block_state::PltBlockStateSavepoint`].
+///   The pointer is to a shared instance, hence only valid for reading (writing only allowed through interior mutability).
+/// - Argument `token_id` must be non-null and valid for reads for `token_id_len` many bytes.
+/// - Argument `return_data_out` must be a non-null and valid pointer for writing
+/// - Argument `return_data_len_out` must be a non-null and valid pointer for writing
+#[unsafe(no_mangle)]
+extern "C" fn ffi_query_token_authorizations(
+    load_callback: LoadCallback,
+    read_token_account_balance_callback: ReadTokenAccountBalanceCallback,
+    get_account_index_by_address_callback: GetAccountIndexByAddressCallback,
+    get_account_address_by_index_callback: GetCanonicalAddressByAccountIndexCallback,
+    get_token_account_states_callback: GetTokenAccountStatesCallback,
+    block_state: *const PltBlockStateSavepoint,
+    protocol_version: u64,
+    token_id: *const u8,
+    token_id_len: size_t,
+    return_data_out: *mut *mut u8,
+    return_data_len_out: *mut size_t,
+) -> u8 {
+    assert!(!block_state.is_null(), "block_state is a null pointer.");
+    assert!(
+        !return_data_len_out.is_null(),
+        "return_data_len_out is a null pointer."
+    );
+    assert!(
+        !return_data_out.is_null(),
+        "return_data_out is a null pointer."
+    );
+
+    let external_callbacks = ExternalBlockStateQueryCallbacks {
+        read_token_account_balance_ptr: read_token_account_balance_callback,
+        get_account_address_by_index_ptr: get_account_address_by_index_callback,
+        get_account_index_by_address_ptr: get_account_index_by_address_callback,
+        get_token_account_states_ptr: get_token_account_states_callback,
+    };
+
+    let protocol_version =
+        ProtocolVersion::try_from(protocol_version).expect("Unknown protocol version");
+    let internal_block_state = unsafe { &*block_state };
+    let block_state = ExecutionTimePltBlockState {
+        protocol_version,
+        internal_block_state,
+        backing_store_load: load_callback,
+        external_block_state: external_callbacks,
+    };
+
+    let token_id_bytes = unsafe { std::slice::from_raw_parts(token_id, token_id_len) };
+    // todo implement error handling for unrecoverable errors in https://linear.app/concordium/issue/PSR-39/decide-and-implement-strategy-for-handling-panics-in-the-rust-code instead of calling unwrap
+    let token_id = String::from_utf8(token_id_bytes.to_vec())
+        .unwrap()
+        .try_into()
+        .unwrap();
+
+    let token_info = queries::query_token_authorizations(&block_state, &token_id);
+
+    let (return_status, return_data) = match token_info {
+        Ok(token_info) => (0, common::to_bytes(&token_info)),
+        Err(QueryTokenInfoError::TokenDoesNotExist(_)) => (1, Vec::new()),
+        Err(_) => {
+            todo!()
+            // todo implement error handling for unrecoverable errors in https://linear.app/concordium/issue/PSR-39/decide-and-implement-strategy-for-handling-panics-in-the-rust-code
+        }
+    };
+
+    let array = memory::alloc_array_from_vec(return_data);
+    unsafe {
+        *return_data_len_out = array.length;
+        *return_data_out = array.array;
+    }
+
+    return_status
+}
+
 /// C-binding for calling [`queries::query_token_account_infos`].
 ///
 /// Returns a byte representing the result:

--- a/plt/plt-scheduler/src/queries.rs
+++ b/plt/plt-scheduler/src/queries.rs
@@ -121,8 +121,9 @@ pub fn query_token_authorizations(
         token_module_state: &token_module_state,
     };
     let details = token_module::query_token_authorizations(&kernel)?;
+    let token_configuration = block_state.token_configuration(&token);
     Ok(TokenAuthorizations {
-        token_id: token_id.clone(),
+        token_id: token_configuration.token_id,
         details,
     })
 }

--- a/plt/plt-scheduler/src/queries.rs
+++ b/plt/plt-scheduler/src/queries.rs
@@ -4,7 +4,7 @@ use crate::token_kernel::TokenKernelQueriesImpl;
 use concordium_base::protocol_level_tokens::TokenId;
 use plt_block_state::block_state_interface::{BlockStateQuery, TokenNotFoundByIdError};
 use plt_scheduler_types::types::queries::{
-    TokenAccountInfo, TokenAccountState, TokenInfo, TokenState,
+    TokenAccountInfo, TokenAccountState, TokenAuthorizations, TokenInfo, TokenState,
 };
 use plt_scheduler_types::types::tokens::TokenAmount;
 use plt_token_module::token_module;
@@ -106,4 +106,23 @@ where
             }
         })
         .collect()
+}
+
+/// Get the authorizations of a token.
+pub fn query_token_authorizations(
+    block_state: &impl BlockStateQuery,
+    token_id: &TokenId,
+) -> Result<TokenAuthorizations, QueryTokenInfoError> {
+    let token = block_state.token_by_id(token_id)?;
+    let token_module_state = block_state.mutable_token_key_value_state(&token);
+    let kernel = TokenKernelQueriesImpl {
+        block_state,
+        token: &token,
+        token_module_state: &token_module_state,
+    };
+    let details = token_module::query_token_authorizations(&kernel)?;
+    Ok(TokenAuthorizations {
+        token_id: token_id.clone(),
+        details,
+    })
 }

--- a/scripts/distribution/windows/build-all.ps1
+++ b/scripts/distribution/windows/build-all.ps1
@@ -1,18 +1,30 @@
-param ([string] $rustVersion = "1.73", [string] $nodeVersion)
+param ([string] $rustVersion, [string] $nodeVersion)
 
 Write-Output "stack version: $(stack --version)"
 Write-Output "cargo version: $(cargo --version)"
 Write-Output "flatc version: $(flatc --version)"
 Write-Output "protoc version: $(protoc --version)"
 
-# Set the default rust toolchain so that consensus rust dependencies use it.
-rustup default $rustVersion-x86_64-pc-windows-gnu
+# Override the rust toolchain so that consensus rust dependencies use it.
+rustup override set $rustVersion-x86_64-pc-windows-gnu
+
+# The reason we "prebuild" the node Rust library dependency:
+# When Setup.hs is run (which invokes the cargo build), stack puts 
+# the LLVM version of dlltool on the path, which is not compatible with the gnu dlltool. 
+# It thus does not generate the expected import lib. By the rust upfront, when it is 
+# subsequently built in Setup.hs it will already be built and so does not get rebuilt.
+Write-Output "Prebuilding node Rust library..."
+Push-Location plt
+rustup show active-toolchain
+cargo build --release --locked -p node-rust-library
+Pop-Location
 
 Write-Output "Building consensus..."
 stack build
 if ($LASTEXITCODE -ne 0) { throw "Failed building consensus" }
 
 Write-Output "Building node..."
+stack exec -- rustup show active-toolchain
 stack exec -- cargo build --manifest-path concordium-node\Cargo.toml --release --locked
 if ($LASTEXITCODE -ne 0) { throw "Failed building node" }
 

--- a/scripts/static-binaries/build-on-ubuntu.sh
+++ b/scripts/static-binaries/build-on-ubuntu.sh
@@ -13,7 +13,7 @@ set -euxo pipefail
 
 extra_features=${EXTRA_FEATURES:-""}
 
-REQUIRED_PARAMETERS=("PROTOC_VERSION" "FLATBUFFERS_VERSION" "RUST_TOOLCHAIN_VERSION")
+REQUIRED_PARAMETERS=("PROTOC_VERSION" "FLATBUFFERS_VERSION")
 
 # Loop through the required variables and check if they are set
 for VAR in "${REQUIRED_PARAMETERS[@]}"; do
@@ -50,7 +50,6 @@ rm protoc.zip
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 source "$HOME/.cargo/env"
 rustup set profile minimal
-rustup default "$RUST_TOOLCHAIN_VERSION"
 
 ASSETS_URL="https://github.com/google/flatbuffers/releases/expanded_assets/v${FLATBUFFERS_VERSION}"
 GCC_VERSION=$(curl -s "$ASSETS_URL" | grep -oP 'Linux\.flatc\.binary\.g\+\+\-\K[0-9]+' | head -n 1)

--- a/scripts/static-binaries/static-binaries.Dockerfile
+++ b/scripts/static-binaries/static-binaries.Dockerfile
@@ -29,14 +29,12 @@ ARG build_version
 ARG extra_features
 ARG protoc_version
 ARG flatbuffers_version
-ARG rust_toolchain_version
 
 WORKDIR /build
 RUN BRANCH="${branch}" \
     EXTRA_FEATURES="${extra_features}" \
     PROTOC_VERSION="${protoc_version}" \
     FLATBUFFERS_VERSION="${flatbuffers_version}" \
-    RUST_TOOLCHAIN_VERSION="${rust_toolchain_version}" \
       /build-on-ubuntu.sh
 
 # The binaries are available in the

--- a/scripts/static-libraries/build-static-libraries.sh
+++ b/scripts/static-libraries/build-static-libraries.sh
@@ -8,7 +8,7 @@ set -ex
 mkdir -p /target/{profiling,vanilla}/{ghc,dependencies,concordium}
 mkdir -p /binaries/{lib,bin}
 
-LIB_DIR=$(stack --stack-yaml /build/concordium-consensus/stack.static.yaml ghc -- --print-libdir)
+LIB_DIR=$(stack --stack-yaml /build/stack.static.yaml ghc -- --print-libdir)
 
 find "$LIB_DIR" -type f -name "*_p.a" ! -name "*_debug_p.a" ! -name "*rts_p.a" ! -name "*ffi_p.a" -exec cp {} /target/profiling/ghc/ \;
 find "$LIB_DIR" -type f -name "*.a" ! -name "*_p.a" ! -name "*_l.a" ! -name "*_debug.a" ! -name "*rts.a" ! -name "*ffi.a" -exec cp {} /target/vanilla/ghc/ \;
@@ -16,27 +16,27 @@ find "$LIB_DIR" -type f -name "*.a" ! -name "*_p.a" ! -name "*_l.a" ! -name "*_d
 cd /build
 
 #############################################################################################################################
-## Build the project
+## Build the project and copy Haskell libraries
 
-stack build --profile --flag "concordium-consensus:-dynamic" --stack-yaml /build/concordium-consensus/stack.static.yaml
-find /build/concordium-consensus/.stack-work -type f -name "*.a" ! -name "*_p.a" -exec cp {} /target/vanilla/concordium/ \;
-find /build/concordium-consensus/.stack-work -type f -name "*_p.a" -exec cp {} /target/profiling/concordium/ \;
+stack build --profile --flag "concordium-consensus:-dynamic" --stack-yaml /build/stack.static.yaml
+find /build/.stack-work -type f -name "*.a" ! -name "*_p.a" -exec cp {} /target/vanilla/concordium/ \;
+find /build/.stack-work -type f -name "*_p.a" -exec cp {} /target/profiling/concordium/ \;
 
 #############################################################################################################################
-## Copy rust binaries
+## Copy Haskell binaries and their Rust dependencies
 
-LOCAL_INSTALL_ROOT=$(stack --stack-yaml /build/concordium-consensus/stack.static.yaml path --profile --local-install-root)
+LOCAL_INSTALL_ROOT=$(stack --stack-yaml /build/stack.static.yaml path --profile --local-install-root)
 cp "$LOCAL_INSTALL_ROOT"/bin/{generate-update-keys,genesis,database-exporter} /binaries/bin/
 cp /build/concordium-base/rust-src/target/release/*.so /binaries/lib/
 cp /build/concordium-consensus/lib/*.so /binaries/lib/
 
 #############################################################################################################################
-## Copy dependencies
+## Copy Haskell dependencies
 
 find ~/.stack/snapshots/x86_64-linux/ -type f -name "*.a" ! -name "*_p.a" -exec cp {} /target/vanilla/dependencies \;
 find ~/.stack/snapshots/x86_64-linux/ -type f -name "*_p.a" -exec cp {} /target/profiling/dependencies \;
 
-## Rust files - copy the static libraries to the target directory, and strip debug symbols from them to reduce their size, as 
+## Rust dependencies - copy the static libraries to the target directory, and strip debug symbols from them to reduce their size, as 
 ## they are not needed for the final binaries and can cause linking issues if they contain ruststd symbols
 mkdir -p /target/rust
 cp -r /build/concordium-base/rust-src/target/release/*.a /target/rust/

--- a/stack.static.yaml
+++ b/stack.static.yaml
@@ -1,15 +1,15 @@
 resolver: lts-24.0
 
 packages:
-- .
-- haskell-lmdb
-- ../concordium-base
+- ./concordium-base
+- ./concordium-consensus
+- ./concordium-consensus/haskell-lmdb
 
 extra-deps:
 
 extra-lib-dirs:
-- ../concordium-base/lib
-- ./lib
+- ./concordium-base/lib
+- ./concordium-consensus/lib
 
 ghc-options:
     # `simpl-tick-factor` parameter here is necessary due to a bug in the ghc: https://gitlab.haskell.org/ghc/ghc/-/issues/14637#note_413425


### PR DESCRIPTION
## Purpose

Expose the new API endpoint for getting the token authorizations

Related [PR for base](https://github.com/Concordium/concordium-base/pull/917) 
Linear ticket [COR-2286](https://linear.app/concordium/issue/COR-2286/concordium-nodeconsensus-extend-grpc-queries-to-include-rbac-state)

## Changes

_Describe the changes that were needed.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
