### PR TITLE
Add locks to simplistic block state

### DIFF
--- a/plt/plt-block-state/src/block_state.rs
+++ b/plt/plt-block-state/src/block_state.rs
@@ -3,8 +3,8 @@
 use crate::block_state::blob_store::{BackingStoreLoad, BackingStoreStore, DecodeError};
 use crate::block_state::external::{ExternalBlockStateOperations, ExternalBlockStateQuery};
 use crate::block_state::types::{
-    AccountWithCanonicalAddress, TokenAccountState, TokenConfiguration, TokenIndex, TokenStateKey,
-    TokenStateValue,
+    AccountWithCanonicalAddress, LockConfiguration, TokenAccountState, TokenConfiguration,
+    TokenIndex, TokenStateKey, TokenStateValue,
 };
 use crate::block_state_interface::{
     BlockStateOperations, BlockStateQuery, OverflowError, RawTokenAmountDelta,
@@ -15,8 +15,9 @@ use concordium_base::common;
 use concordium_base::common::Serialize;
 use concordium_base::constants::SHA256;
 use concordium_base::contracts_common::AccountAddress;
+use concordium_base::protocol_level_locks::LockId;
 use concordium_base::protocol_level_tokens::TokenId;
-use plt_scheduler_types::types::tokens::RawTokenAmount;
+use plt_scheduler_types::types::tokens::{RawTokenAmount, TokenAndAmount};
 use sha2::Digest;
 use std::collections::BTreeMap;
 
@@ -366,17 +367,38 @@ impl<Load: BackingStoreLoad, ExtState: ExternalBlockStateOperations> BlockStateO
 // todo do real implementation as part of https://linear.app/concordium/issue/PSR-11/port-the-plt-block-state-to-rust
 #[derive(Debug, Default, Clone, Serialize)]
 struct SimplisticPltBlockState {
+    /// The block state for protocol-level tokens.
     tokens: Vec<Token>,
+    /// The block state for protocol-level locks.
+    locks: BTreeMap<LockId, Lock>,
 }
 
+/// The block state for a single protocol-level token.
 #[derive(Debug, Clone, Serialize)]
 struct Token {
+    /// The key-value state associated with the token defined by its `configuration`.
     key_value_state: SimplisticTokenKeyValueState,
+    /// The configuration parameters for this token.
     configuration: TokenConfiguration,
+    /// The current circulating supply of this token.
     circulating_supply: RawTokenAmount,
 }
 
+/// A simplistic key-value store for token state, backed by a [`BTreeMap`].
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct SimplisticTokenKeyValueState {
+    /// The underlying map from state keys to state values.
     state: BTreeMap<TokenStateKey, TokenStateValue>,
+}
+
+/// The block state for a single protocol-level lock.
+#[derive(Debug, Clone, Serialize)]
+struct Lock {
+    /// The balances locked per account, mapping each account index to its
+    /// locked token and amount.
+    locked_balances: BTreeMap<AccountIndex, TokenAndAmount>,
+    /// The configuration parameters for the lock.
+    configuration: LockConfiguration,
+    /// The key-value state associated with the lock.
+    key_value_state: SimplisticTokenKeyValueState,
 }

--- a/plt/plt-block-state/src/block_state.rs
+++ b/plt/plt-block-state/src/block_state.rs
@@ -396,6 +396,7 @@ pub struct SimplisticTokenKeyValueState {
 struct Lock {
     /// The balances locked per account, mapping each account index to its
     /// locked token and amount.
+    #[map_size_length = 4]
     locked_balances: BTreeMap<AccountIndex, TokenAndAmount>,
     /// The configuration parameters for the lock.
     configuration: LockConfiguration,

--- a/plt/plt-block-state/src/block_state.rs
+++ b/plt/plt-block-state/src/block_state.rs
@@ -3,8 +3,8 @@
 use crate::block_state::blob_store::{BackingStoreLoad, BackingStoreStore, DecodeError};
 use crate::block_state::external::{ExternalBlockStateOperations, ExternalBlockStateQuery};
 use crate::block_state::types::{
-    AccountWithCanonicalAddress, LockConfiguration, TokenAccountState, TokenConfiguration,
-    TokenIndex, TokenStateKey, TokenStateValue,
+    AccountWithCanonicalAddress, LockConfiguration, TokenAccountState, TokenAndAmount,
+    TokenConfiguration, TokenIndex, TokenStateKey, TokenStateValue,
 };
 use crate::block_state_interface::{
     BlockStateOperations, BlockStateQuery, OverflowError, RawTokenAmountDelta,
@@ -17,7 +17,7 @@ use concordium_base::constants::SHA256;
 use concordium_base::contracts_common::AccountAddress;
 use concordium_base::protocol_level_locks::LockId;
 use concordium_base::protocol_level_tokens::TokenId;
-use plt_scheduler_types::types::tokens::{RawTokenAmount, TokenAndAmount};
+use plt_scheduler_types::types::tokens::RawTokenAmount;
 use sha2::Digest;
 use std::collections::BTreeMap;
 
@@ -400,6 +400,10 @@ struct Lock {
     locked_balances: BTreeMap<AccountIndex, TokenAndAmount>,
     /// The configuration parameters for the lock.
     configuration: LockConfiguration,
-    /// The key-value state associated with the lock.
-    key_value_state: SimplisticTokenKeyValueState,
+    /// The state associated with the lock.
+    state: LockState,
 }
+
+/// The state of a single protocol-level lock.
+#[derive(Debug, Clone, Serialize)]
+struct LockState {}

--- a/plt/plt-block-state/src/block_state/types.rs
+++ b/plt/plt-block-state/src/block_state/types.rs
@@ -53,6 +53,15 @@ pub struct LockConfiguration {
     pub controller: LockController,
 }
 
+/// A token amount and the associated token ID as a pair.
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize)]
+pub struct TokenAndAmount {
+    /// The token ID corresponding to the `amount`.
+    pub token_id: TokenIndex,
+    /// The amount of tokens as an unscaled integer value.
+    pub amount: RawTokenAmount,
+}
+
 /// Account representing (read-only) account state.
 ///
 /// The account is guaranteed to exist on chain, when holding an instance of this type.
@@ -160,5 +169,20 @@ mod test {
         let deserialized: LockConfiguration =
             common::from_bytes_complete(bytes.as_slice()).unwrap();
         assert_eq!(deserialized, lock_config);
+    }
+
+    #[test]
+    fn test_token_and_amount_serial() {
+        let token_and_amount = TokenAndAmount {
+            token_id: TokenIndex(2),
+            amount: RawTokenAmount(1000),
+        };
+
+        let bytes = common::to_bytes(&token_and_amount);
+        assert_eq!(hex::encode(&bytes), "00000000000000028768");
+
+        let token_and_amount_deserialized: TokenAndAmount =
+            common::from_bytes_complete(bytes.as_slice()).unwrap();
+        assert_eq!(token_and_amount_deserialized, token_and_amount);
     }
 }

--- a/plt/plt-block-state/src/block_state/types.rs
+++ b/plt/plt-block-state/src/block_state/types.rs
@@ -45,6 +45,7 @@ pub type TokenStateValue = Vec<u8>;
 #[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub struct LockConfiguration {
     /// Accounts that can receive funds from this lock.
+    #[size_length = 2]
     pub recipients: Vec<AccountIndex>,
     /// Expiry time of the lock (seconds since epoch).
     pub expiry: TransactionTime,
@@ -101,5 +102,63 @@ mod test {
         let state_deserialized: TokenAccountState =
             common::from_bytes_complete(bytes.as_slice()).unwrap();
         assert_eq!(state_deserialized, state);
+    }
+
+    #[test]
+    fn test_lock_configuration_serial() {
+        use concordium_base::common::types::TransactionTime;
+        use concordium_base::protocol_level_locks::LockControllerSimpleV0Capability;
+        use plt_scheduler_types::types::locks::{
+            LockControllerSimpleV0, LockControllerSimpleV0Grant,
+        };
+
+        let lock_config = LockConfiguration {
+            recipients: vec![AccountIndex::from(1u64), AccountIndex::from(2u64)],
+            expiry: TransactionTime::from(1000u64),
+            controller: LockController::SimpleV0(LockControllerSimpleV0 {
+                grants: vec![LockControllerSimpleV0Grant {
+                    account: AccountIndex::from(1u64),
+                    roles: vec![LockControllerSimpleV0Capability::Fund],
+                }],
+                tokens: vec!["token1".parse().unwrap()],
+                keep_alive: true,
+                memo: None,
+            }),
+        };
+
+        let bytes = common::to_bytes(&lock_config);
+        assert_eq!(
+            hex::encode(&bytes),
+            "00020000000000000001000000000000000200000000000003e800000100000000000000010100000106746f6b656e310100"
+        );
+
+        let deserialized: LockConfiguration =
+            common::from_bytes_complete(bytes.as_slice()).unwrap();
+        assert_eq!(deserialized, lock_config);
+    }
+
+    #[test]
+    fn test_lock_configuration_serial_empty_recipients() {
+        use concordium_base::common::types::TransactionTime;
+
+        let lock_config = LockConfiguration {
+            recipients: vec![],
+            expiry: TransactionTime::from(500u64),
+            controller: LockController::SimpleV0(
+                plt_scheduler_types::types::locks::LockControllerSimpleV0 {
+                    grants: vec![],
+                    tokens: vec![],
+                    keep_alive: false,
+                    memo: None,
+                },
+            ),
+        };
+
+        let bytes = common::to_bytes(&lock_config);
+        assert_eq!(hex::encode(&bytes), "000000000000000001f400000000000000");
+
+        let deserialized: LockConfiguration =
+            common::from_bytes_complete(bytes.as_slice()).unwrap();
+        assert_eq!(deserialized, lock_config);
     }
 }

--- a/plt/plt-block-state/src/block_state/types.rs
+++ b/plt/plt-block-state/src/block_state/types.rs
@@ -1,8 +1,11 @@
 //! Types used specifically in the block state.
 
+use concordium_base::base::AccountIndex;
 use concordium_base::common::Serialize;
+use concordium_base::common::types::TransactionTime;
 use concordium_base::contracts_common::AccountAddress;
 use concordium_base::protocol_level_tokens::{TokenId, TokenModuleRef};
+use plt_scheduler_types::types::locks::LockController;
 use plt_scheduler_types::types::tokens::RawTokenAmount;
 
 /// Index of the protocol-level token in the block state map of tokens.
@@ -37,6 +40,17 @@ pub struct TokenAccountState {
 
 pub type TokenStateKey = Vec<u8>;
 pub type TokenStateValue = Vec<u8>;
+
+/// Lock configuration at the block state level.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct LockConfiguration {
+    /// Accounts that can receive funds from this lock.
+    pub recipients: Vec<AccountIndex>,
+    /// Expiry time of the lock (seconds since epoch).
+    pub expiry: TransactionTime,
+    /// Controller configuration for the lock.
+    pub controller: LockController,
+}
 
 /// Account representing (read-only) account state.
 ///

--- a/plt/plt-scheduler-types/src/types.rs
+++ b/plt/plt-scheduler-types/src/types.rs
@@ -2,6 +2,7 @@
 
 pub mod events;
 pub mod execution;
+pub mod locks;
 pub mod queries;
 pub mod reject_reasons;
 pub mod tokens;

--- a/plt/plt-scheduler-types/src/types/locks.rs
+++ b/plt/plt-scheduler-types/src/types/locks.rs
@@ -21,8 +21,10 @@ pub enum LockController {
 #[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub struct LockControllerSimpleV0 {
     /// Capability grants to accounts.
+    #[size_length = 2]
     pub grants: Vec<LockControllerSimpleV0Grant>,
     /// Tokens affected by this lock controller.
+    #[size_length = 2]
     pub tokens: Vec<TokenId>,
     /// Whether the lock should be kept alive after all funds are
     /// returned.
@@ -42,5 +44,95 @@ pub struct LockControllerSimpleV0Grant {
     /// The account receiving the grant.
     pub account: AccountIndex,
     /// The capabilities granted to the account.
+    #[size_length = 1]
     pub roles: Vec<LockControllerSimpleV0Capability>,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use concordium_base::common;
+    use concordium_base::transactions::Memo;
+
+    #[test]
+    fn test_lock_controller_simple_v0_grant_serial() {
+        let grant = LockControllerSimpleV0Grant {
+            account: AccountIndex::from(42u64),
+            roles: vec![
+                LockControllerSimpleV0Capability::Fund,
+                LockControllerSimpleV0Capability::Return,
+            ],
+        };
+
+        let bytes = common::to_bytes(&grant);
+        assert_eq!(hex::encode(&bytes), "000000000000002a020001");
+
+        let deserialized: LockControllerSimpleV0Grant =
+            common::from_bytes_complete(bytes.as_slice()).unwrap();
+        assert_eq!(deserialized, grant);
+    }
+
+    #[test]
+    fn test_lock_controller_simple_v0_serial() {
+        let controller = LockControllerSimpleV0 {
+            grants: vec![LockControllerSimpleV0Grant {
+                account: AccountIndex::from(1u64),
+                roles: vec![LockControllerSimpleV0Capability::Fund],
+            }],
+            tokens: vec!["token1".parse::<TokenId>().unwrap()],
+            keep_alive: true,
+            memo: Some(CborMemo::Raw(
+                Memo::try_from(vec![0x01, 0x02, 0x03]).unwrap(),
+            )),
+        };
+
+        let bytes = common::to_bytes(&controller);
+        assert_eq!(
+            hex::encode(&bytes),
+            "000100000000000000010100000106746f6b656e310101000003010203"
+        );
+
+        let deserialized: LockControllerSimpleV0 =
+            common::from_bytes_complete(bytes.as_slice()).unwrap();
+        assert_eq!(deserialized, controller);
+    }
+
+    #[test]
+    fn test_lock_controller_simple_v0_serial_minimal() {
+        let controller = LockControllerSimpleV0 {
+            grants: vec![],
+            tokens: vec![],
+            keep_alive: false,
+            memo: None,
+        };
+
+        let bytes = common::to_bytes(&controller);
+        assert_eq!(hex::encode(&bytes), "000000000000");
+
+        let deserialized: LockControllerSimpleV0 =
+            common::from_bytes_complete(bytes.as_slice()).unwrap();
+        assert_eq!(deserialized, controller);
+    }
+
+    #[test]
+    fn test_lock_controller_serial() {
+        let controller = LockController::SimpleV0(LockControllerSimpleV0 {
+            grants: vec![LockControllerSimpleV0Grant {
+                account: AccountIndex::from(1u64),
+                roles: vec![LockControllerSimpleV0Capability::Fund],
+            }],
+            tokens: vec!["token1".parse::<TokenId>().unwrap()],
+            keep_alive: true,
+            memo: None,
+        });
+
+        let bytes = common::to_bytes(&controller);
+        assert_eq!(
+            hex::encode(&bytes),
+            "00000100000000000000010100000106746f6b656e310100"
+        );
+
+        let deserialized: LockController = common::from_bytes_complete(bytes.as_slice()).unwrap();
+        assert_eq!(deserialized, controller);
+    }
 }

--- a/plt/plt-scheduler-types/src/types/locks.rs
+++ b/plt/plt-scheduler-types/src/types/locks.rs
@@ -1,0 +1,46 @@
+use concordium_base::{
+    base::AccountIndex,
+    common::Serialize,
+    protocol_level_locks::LockControllerSimpleV0Capability,
+    protocol_level_tokens::{CborMemo, TokenId},
+};
+
+/// Top-level lock controller type.
+///
+/// Each variant represents a different controller version.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub enum LockController {
+    /// SimpleV0 lock controller configuration.
+    SimpleV0(LockControllerSimpleV0),
+}
+
+/// Configuration for a SimpleV0 lock controller.
+///
+/// Contains the list of capability grants, which tokens are affected,
+/// a keep-alive flag, and an optional memo.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct LockControllerSimpleV0 {
+    /// Capability grants to accounts.
+    pub grants: Vec<LockControllerSimpleV0Grant>,
+    /// Tokens affected by this lock controller.
+    pub tokens: Vec<TokenId>,
+    /// Whether the lock should be kept alive after all funds are
+    /// returned.
+    pub keep_alive: bool,
+    /// Optional memo attached to the lock.
+    pub memo: Option<CborMemo>,
+}
+
+/// A grant of capabilities to a specific account for a SimpleV0 lock
+/// controller.
+///
+/// Each grant assigns one or more [`LockControllerSimpleV0Capability`] roles
+/// to the given account, authorizing it to perform the corresponding lock
+/// operations.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct LockControllerSimpleV0Grant {
+    /// The account receiving the grant.
+    pub account: AccountIndex,
+    /// The capabilities granted to the account.
+    pub roles: Vec<LockControllerSimpleV0Capability>,
+}

--- a/plt/plt-scheduler-types/src/types/tokens.rs
+++ b/plt/plt-scheduler-types/src/types/tokens.rs
@@ -3,7 +3,6 @@ use concordium_base::common::{
     Buffer, Deserial, Get, ParseResult, Put, ReadBytesExt, Serial, Serialize,
 };
 use concordium_base::contracts_common::AccountAddress;
-use concordium_base::protocol_level_tokens::TokenId;
 
 /// Token amount without decimals specified. The token amount represented by
 /// this type must always be represented with the number of decimals
@@ -111,15 +110,6 @@ pub struct TokenAmount {
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize)]
 pub enum TokenHolder {
     Account(AccountAddress),
-}
-
-/// A token amount and the associated token ID as a pair.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize)]
-pub struct TokenAndAmount {
-    /// The token ID corresponding to the `amount`.
-    pub token_id: TokenId,
-    /// The amount of tokens as an unscaled integer value.
-    pub amount: RawTokenAmount,
 }
 
 #[cfg(test)]
@@ -307,24 +297,6 @@ mod test {
         let token_amount_deserialized: TokenAmount =
             common::from_bytes_complete(bytes.as_slice()).unwrap();
         assert_eq!(token_amount_deserialized, token_amount);
-    }
-
-    #[test]
-    fn test_token_and_amount_serial() {
-        use crate::types::tokens::TokenAndAmount;
-        use concordium_base::protocol_level_tokens::TokenId;
-
-        let token_and_amount = TokenAndAmount {
-            token_id: "token1".parse::<TokenId>().unwrap(),
-            amount: RawTokenAmount(1000),
-        };
-
-        let bytes = common::to_bytes(&token_and_amount);
-        assert_eq!(hex::encode(&bytes), "06746f6b656e318768");
-
-        let token_and_amount_deserialized: TokenAndAmount =
-            common::from_bytes_complete(bytes.as_slice()).unwrap();
-        assert_eq!(token_and_amount_deserialized, token_and_amount);
     }
 
     #[test]

--- a/plt/plt-scheduler-types/src/types/tokens.rs
+++ b/plt/plt-scheduler-types/src/types/tokens.rs
@@ -310,6 +310,24 @@ mod test {
     }
 
     #[test]
+    fn test_token_and_amount_serial() {
+        use crate::types::tokens::TokenAndAmount;
+        use concordium_base::protocol_level_tokens::TokenId;
+
+        let token_and_amount = TokenAndAmount {
+            token_id: "token1".parse::<TokenId>().unwrap(),
+            amount: RawTokenAmount(1000),
+        };
+
+        let bytes = common::to_bytes(&token_and_amount);
+        assert_eq!(hex::encode(&bytes), "06746f6b656e318768");
+
+        let token_and_amount_deserialized: TokenAndAmount =
+            common::from_bytes_complete(bytes.as_slice()).unwrap();
+        assert_eq!(token_and_amount_deserialized, token_and_amount);
+    }
+
+    #[test]
     fn test_token_holder() {
         let token_holder = TokenHolder::Account(AccountAddress([5; 32]));
 

--- a/plt/plt-scheduler-types/src/types/tokens.rs
+++ b/plt/plt-scheduler-types/src/types/tokens.rs
@@ -3,6 +3,7 @@ use concordium_base::common::{
     Buffer, Deserial, Get, ParseResult, Put, ReadBytesExt, Serial, Serialize,
 };
 use concordium_base::contracts_common::AccountAddress;
+use concordium_base::protocol_level_tokens::TokenId;
 
 /// Token amount without decimals specified. The token amount represented by
 /// this type must always be represented with the number of decimals
@@ -110,6 +111,15 @@ pub struct TokenAmount {
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize)]
 pub enum TokenHolder {
     Account(AccountAddress),
+}
+
+/// A token amount and the associated token ID as a pair.
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize)]
+pub struct TokenAndAmount {
+    /// The token ID corresponding to the `amount`.
+    pub token_id: TokenId,
+    /// The amount of tokens as an unscaled integer value.
+    pub amount: RawTokenAmount,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Ref COR-2213
Depends on https://github.com/Concordium/concordium-base/pull/919 for some of the types.

## Purpose

Add the locks state model to the simplistic block state.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.