### PR TITLE
Expose unrecoverable errors from rust scheduler to Haskell 

### DIFF
--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/RustPLTScheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/RustPLTScheduler.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -23,6 +24,7 @@ import Data.Functor
 import qualified Data.IORef as IORef
 import qualified Data.Map.Strict as Map
 import qualified Data.Serialize as S
+import qualified Data.Text.Encoding as Text
 import qualified Data.Word as Word
 import qualified Foreign as FFI
 import qualified Foreign.C.Types as FFI
@@ -42,6 +44,7 @@ import qualified Concordium.GlobalState.Types as BS
 import qualified Concordium.Scheduler.Environment as EI
 import Concordium.Scheduler.ProtocolLevelTokens.RustPLTScheduler.BlockStateCallbacks
 import qualified Concordium.Scheduler.ProtocolLevelTokens.RustPLTScheduler.Memory as Memory
+import qualified Concordium.Scheduler.ProtocolLevelTokens.RustPLTScheduler.Status as Status
 
 -- | Execute a transaction payload in the 'SchedulerMonad' modifying the block state accordingly. The transaction
 -- is executed via the Rust PLT Scheduler library. Only 'TokenUpdate' transaction payloads are currently supported.
@@ -217,8 +220,8 @@ executeTransaction depositContext tokenUpdate =
                                     returnDataPtr
                                     (fromIntegral returnDataLen)
                                     (Memory.rs_free_array_len_2 returnDataPtr (fromIntegral returnDataLen))
-                            oucome <- case statusCode of
-                                0 -> do
+                            oucome <- case Status.parseStatusCode statusCode of
+                                Just Status.FSCSuccess -> do
                                     updatedBlockState <- FFI.peek resultingBlockStateOutPtr >>= PLTBlockState.wrapFFIPtr
                                     let getEvents = S.isolate (BS.length returnData) $ CS.getListOf $ Types.getEvent spv
                                     let events =
@@ -232,7 +235,7 @@ executeTransaction depositContext tokenUpdate =
                                                 { tesUpdatedBlockState = updatedBlockState,
                                                   tesEvents = events
                                                 }
-                                1 -> do
+                                Just Status.FSCFailed -> do
                                     let getRejectReason = S.isolate (BS.length returnData) S.get
                                     let rejectReason =
                                             either
@@ -244,7 +247,12 @@ executeTransaction depositContext tokenUpdate =
                                             TransactionExecutionReject
                                                 { terRejectReason = rejectReason
                                                 }
-                                _ -> error ("Unexpected status code from calling 'ffiExecuteTransaction': " ++ show statusCode)
+                                Just Status.FSCPanic -> do
+                                    let message = case Text.decodeUtf8' returnData of
+                                            Right decoded -> decoded
+                                            Left _ -> "<panic message was invalid UTF-8>"
+                                    error ("Call to 'ffiExecuteTransaction' resulted in panic with message: " ++ show message)
+                                Nothing -> error ("Unexpected status code from calling 'ffiExecuteTransaction': " ++ show statusCode)
                             return
                                 TransactionExecutionSummary
                                     { tesUsedEnergy = usedEnergy,
@@ -442,8 +450,8 @@ executeChainUpdate updateHeader createPLT =
                                     returnDataPtr
                                     (fromIntegral returnDataLen)
                                     (Memory.rs_free_array_len_2 returnDataPtr (fromIntegral returnDataLen))
-                            case statusCode of
-                                0 -> do
+                            case Status.parseStatusCode statusCode of
+                                Just Status.FSCSuccess -> do
                                     updatedBlockState <- FFI.peek resultingBlockStateOutPtr >>= PLTBlockState.wrapFFIPtr
                                     let getEvents = S.isolate (BS.length returnData) $ CS.getListOf $ Types.getEvent spv
                                     let events =
@@ -457,7 +465,7 @@ executeChainUpdate updateHeader createPLT =
                                                 { cuesUpdatedBlockState = updatedBlockState,
                                                   cuesEvents = events
                                                 }
-                                1 -> do
+                                Just Status.FSCFailed -> do
                                     let getFailureKind = S.isolate (BS.length returnData) S.get
                                     let failureKind =
                                             either
@@ -469,7 +477,12 @@ executeChainUpdate updateHeader createPLT =
                                             ChainUpdateExecutionFailed
                                                 { cuefFailureKind = failureKind
                                                 }
-                                _ -> error ("Unexpected status code from calling 'ffiExecuteChainUpdate': " ++ show statusCode)
+                                Just Status.FSCPanic -> do
+                                    let message = case Text.decodeUtf8' returnData of
+                                            Right decoded -> decoded
+                                            Left _ -> "<panic message was invalid UTF-8>"
+                                    error ("Call to 'ffiExecuteChainUpdate' resulted in panic with message: " ++ show message)
+                                Nothing -> error ("Unexpected status code from calling 'ffiExecuteChainUpdate': " ++ show statusCode)
 
 -- | C-binding for calling the Rust function `plt_scheduler::scheduler::execute_chain_update`.
 --

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/RustPLTScheduler/Queries.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/RustPLTScheduler/Queries.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -34,6 +35,8 @@ import qualified Concordium.GlobalState.Persistent.BlockState.ProtocolLevelToken
 import qualified Concordium.GlobalState.Types as BS
 import Concordium.Scheduler.ProtocolLevelTokens.RustPLTScheduler.BlockStateCallbacks
 import qualified Concordium.Scheduler.ProtocolLevelTokens.RustPLTScheduler.Memory as Memory
+import qualified Concordium.Scheduler.ProtocolLevelTokens.RustPLTScheduler.Status as Status
+import qualified Data.Text.Encoding as Text
 
 -- | Get the list of all tokens, for protocol version where the PLT state is managed in Rust.
 queryPLTList ::
@@ -100,8 +103,8 @@ queryPLTList bs = do
                                 returnDataPtr
                                 (fromIntegral returnDataLen)
                                 (Memory.rs_free_array_len_2 returnDataPtr (fromIntegral returnDataLen))
-                        case statusCode of
-                            0 -> do
+                        case Status.parseStatusCode statusCode of
+                            Just Status.FSCSuccess -> do
                                 let getTokenIdList = S.isolate (BS.length returnData) $ CS.getListOf S.get
                                 let tokenIdList =
                                         either
@@ -109,6 +112,11 @@ queryPLTList bs = do
                                             id
                                             $ S.runGet getTokenIdList returnData
                                 return tokenIdList
+                            Just Status.FSCPanic -> do
+                                let message = case Text.decodeUtf8' returnData of
+                                        Right decoded -> decoded
+                                        Left _ -> "<panic message was invalid UTF-8>"
+                                error ("Call to 'ffiQueryPLTList' resulted in panic with message: " ++ show message)
                             _ -> error ("Unexpected status code from calling 'ffiQueryPLTList': " ++ show statusCode)
 
 -- | C-binding for calling the Rust function `plt_scheduler::queries::query_plt_list`.
@@ -213,8 +221,8 @@ queryTokenInfo bs tokenId = do
                                 returnDataPtr
                                 (fromIntegral returnDataLen)
                                 (Memory.rs_free_array_len_2 returnDataPtr (fromIntegral returnDataLen))
-                        case statusCode of
-                            0 -> do
+                        case Status.parseStatusCode statusCode of
+                            Just Status.FSCSuccess -> do
                                 let getTokenInfo = S.isolate (BS.length returnData) S.get
                                 let tokenInfo =
                                         either
@@ -222,9 +230,14 @@ queryTokenInfo bs tokenId = do
                                             id
                                             $ S.runGet getTokenInfo returnData
                                 return $ Just tokenInfo
-                            1 -> do
+                            Just Status.FSCFailed -> do
                                 return Nothing
-                            _ -> error ("Unexpected status code from calling 'ffiQueryTokenInfo': " ++ show statusCode)
+                            Just Status.FSCPanic -> do
+                                let message = case Text.decodeUtf8' returnData of
+                                        Right decoded -> decoded
+                                        Left _ -> "<panic message was invalid UTF-8>"
+                                error ("Call to 'ffiQueryTokenInfo' resulted in panic with message: " ++ show message)
+                            Nothing -> error ("Unexpected status code from calling 'ffiQueryTokenInfo': " ++ show statusCode)
 
 -- | C-binding for calling the Rust function `plt_scheduler::queries::query_token_info`.
 --
@@ -335,8 +348,8 @@ queryTokenAuthorizations bs tokenId = do
                                 returnDataPtr
                                 (fromIntegral returnDataLen)
                                 (Memory.rs_free_array_len_2 returnDataPtr (fromIntegral returnDataLen))
-                        case statusCode of
-                            0 -> do
+                        case Status.parseStatusCode statusCode of
+                            Just Status.FSCSuccess -> do
                                 let getTokenAuthorizations = S.isolate (BS.length returnData) S.get
                                 let tokenAuthorizations =
                                         either
@@ -344,9 +357,14 @@ queryTokenAuthorizations bs tokenId = do
                                             id
                                             $ S.runGet getTokenAuthorizations returnData
                                 return $ Just tokenAuthorizations
-                            1 -> do
+                            Just Status.FSCFailed -> do
                                 return Nothing
-                            _ -> error ("Unexpected status code from calling 'ffiQueryTokenAuthorizations': " ++ show statusCode)
+                            Just Status.FSCPanic -> do
+                                let message = case Text.decodeUtf8' returnData of
+                                        Right decoded -> decoded
+                                        Left _ -> "<panic message was invalid UTF-8>"
+                                error ("Call to 'ffiQueryTokenAuthorizations' resulted in panic with message: " ++ show message)
+                            Nothing -> error ("Unexpected status code from calling 'ffiQueryTokenAuthorizations': " ++ show statusCode)
 
 -- | C-binding for calling the Rust function `plt_scheduler::queries::query_token_authorizations`.
 --
@@ -455,8 +473,8 @@ queryTokenAccountInfos bs accountIndex = do
                                 returnDataPtr
                                 (fromIntegral returnDataLen)
                                 (Memory.rs_free_array_len_2 returnDataPtr (fromIntegral returnDataLen))
-                        case statusCode of
-                            0 -> do
+                        case Status.parseStatusCode statusCode of
+                            Just Status.FSCSuccess -> do
                                 let getTokenAccountInfos = S.isolate (BS.length returnData) $ CS.getListOf S.get
                                 let tokenAccountInfos =
                                         either
@@ -464,6 +482,11 @@ queryTokenAccountInfos bs accountIndex = do
                                             id
                                             $ S.runGet getTokenAccountInfos returnData
                                 return tokenAccountInfos
+                            Just Status.FSCPanic -> do
+                                let message = case Text.decodeUtf8' returnData of
+                                        Right decoded -> decoded
+                                        Left _ -> "<panic message was invalid UTF-8>"
+                                error ("Call to 'ffiQueryTokenAccountInfos' resulted in panic with message: " ++ show message)
                             _ -> error ("Unexpected status code from calling 'ffiQueryTokenAccountInfos': " ++ show statusCode)
 
 -- | C-binding for calling the Rust function `plt_scheduler::queries::query_token_account_infos`.

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/RustPLTScheduler/Status.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/RustPLTScheduler/Status.hs
@@ -1,0 +1,22 @@
+module Concordium.Scheduler.ProtocolLevelTokens.RustPLTScheduler.Status (FFIStatusCode (..), parseStatusCode) where
+
+import qualified Data.Word as Word
+
+-- | Status code returned from the Rust scheduler library.
+--
+-- This must match the @FfiStatusCode@ type defined on the rust side.
+data FFIStatusCode
+    = -- | The call succeeded.
+      FSCSuccess
+    | -- | The call failed gracefully.
+      FSCFailed
+    | -- | The call resulted in a panic.
+      FSCPanic
+
+-- | Parse the word8 encoding of the @FfiStatusCode@ type found in the Rust library.
+parseStatusCode :: Word.Word8 -> Maybe FFIStatusCode
+parseStatusCode code = case code of
+    0 -> Just FSCSuccess
+    1 -> Just FSCFailed
+    2 -> Just FSCPanic
+    _ -> Nothing

--- a/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
@@ -61,6 +61,7 @@ import qualified Concordium.Scheduler.Runner as SchedTest
 import qualified Concordium.Scheduler.Types as Types
 import Concordium.TimeMonad
 import Concordium.Types (SProtocolVersion)
+import qualified Control.Monad.Catch as Catch
 
 getResults :: [(a, Types.TransactionSummary tov)] -> [(a, Types.ValidResult)]
 getResults = map (\(x, r) -> (x, Types.tsResult r))
@@ -99,7 +100,9 @@ newtype PersistentBSM pv a = PersistentBSM
           Functor,
           Monad,
           BlockStateTypes,
-          MonadIO
+          MonadIO,
+          Catch.MonadThrow,
+          Catch.MonadCatch
         )
 
 deriving instance (Types.IsProtocolVersion pv) => BS.AccountOperations (PersistentBSM pv)

--- a/concordium-consensus/tests/scheduler/SchedulerTests/RustScheduler.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/RustScheduler.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module SchedulerTests.RustScheduler where
+
+import qualified Concordium.GlobalState.BlockState as BlockState
+import qualified Concordium.Scheduler.Environment as EI
+import qualified Concordium.Scheduler.ProtocolLevelTokens.RustPLTScheduler as RustPLTScheduler
+import qualified Concordium.Types as Types
+import qualified Concordium.Types.Execution as Execution
+import qualified Control.Exception as Exception
+import qualified Control.Monad.Catch as Catch
+import qualified Data.ByteString.Short as ByteString
+import qualified SchedulerTests.Helpers as Helpers
+import Test.HUnit
+import Test.Hspec
+
+testExecuteTransaction :: Spec
+testExecuteTransaction = describe "executeTransaction" $ do
+    it "throws when called with a non-supported payload type" $ do
+        assertions <- Helpers.runTestBlockState @'Types.P11 $ do
+            account0 <- Helpers.makeTestAccountFromSeed 2_000_000 0
+            blockStateBefore <- Helpers.createTestBlockStateWithAccounts [account0]
+            blockStateBeforeThawed <- BlockState.thawBlockState blockStateBefore
+            let schedulerState = EI.makeInitialSchedulerState @(Helpers.PersistentBSM 'Types.P11) blockStateBeforeThawed
+            let depositContext :: EI.WithDepositContext (Helpers.PersistentBSM 'Types.P11) =
+                    EI.WithDepositContext
+                        { _wtcSenderAccount = (0, account0),
+                          _wtcPayerAccount = (0, account0),
+                          _wtcTransactionType = Execution.TTRegisterData,
+                          _wtcTransactionHash = read "0000000000000000000000000000000000000000000000000000000000000000",
+                          _wtcSenderAddress = Helpers.accountAddressFromSeed 0,
+                          _wtcSponsorAddress = Nothing,
+                          _wtcEnergyAmount = 500_000,
+                          _wtcTransactionCheckHeaderCost = 1_000,
+                          _wtcCurrentlyUsedBlockEnergy = 0,
+                          _wtcTransactionIndex = 0
+                        }
+            let schedulerComputation =
+                    RustPLTScheduler.executeTransaction
+                        @(Helpers.PersistentBSM 'Types.P11)
+                        depositContext
+                        (Execution.RegisterData $ Types.RegisteredData ByteString.empty)
+            let contextState =
+                    EI.ContextState
+                        { _chainMetadata =
+                            Types.ChainMetadata
+                                { slotTime = 500
+                                },
+                          _maxBlockEnergy = 500_000_000,
+                          _accountCreationLimit = 500
+                        }
+            errorMessage <-
+                Catch.catch
+                    @_
+                    @Exception.ErrorCall
+                    (EI.runSchedulerT schedulerComputation contextState schedulerState >> return Nothing)
+                    (\message -> return $ Just message)
+            return $ do
+                case errorMessage of
+                    Nothing -> assertFailure "Expected an exception to be thrown"
+                    Just (Exception.ErrorCall message) -> assertEqual "Expected error message" "Call to 'ffiExecuteTransaction' resulted in panic with message: \"Unexpected failure during transaction execution: UnexpectedPayload\"" message
+        assertions
+
+tests :: Spec
+tests = describe "RustScheduler" $ do
+    testExecuteTransaction

--- a/concordium-consensus/tests/scheduler/Spec.hs
+++ b/concordium-consensus/tests/scheduler/Spec.hs
@@ -17,6 +17,7 @@ import qualified SchedulerTests.RandomBakerTransactions (tests)
 import qualified SchedulerTests.ReceiveContextTest (tests)
 import qualified SchedulerTests.RejectReasons (tests)
 import qualified SchedulerTests.RejectReasonsRustContract (tests)
+import qualified SchedulerTests.RustScheduler (tests)
 import qualified SchedulerTests.SimpleTransferSpec (tests)
 import qualified SchedulerTests.SimpleTransfersTest (tests)
 import qualified SchedulerTests.SponsoredTransactions (tests)
@@ -120,3 +121,4 @@ main = hspec $ do
     SchedulerTests.TokenModule.tests
     SchedulerTests.TokenCreation.tests
     SchedulerTests.TokenHolderTransactions.tests
+    SchedulerTests.RustScheduler.tests

--- a/plt/plt-block-state/src/ffi/blob_store_callbacks.rs
+++ b/plt/plt-block-state/src/ffi/blob_store_callbacks.rs
@@ -27,3 +27,14 @@ impl BackingStoreLoad for LoadCallback {
         *unsafe { Box::from_raw(self(location)) }
     }
 }
+
+pub mod tests_helpers {
+    use super::*;
+
+    pub const UNIMPLEMENTED_LOAD_CALLBACK: LoadCallback = {
+        extern "C" fn fun(_: blob_store::Reference) -> *mut Vec<u8> {
+            unimplemented!()
+        }
+        fun
+    };
+}

--- a/plt/plt-block-state/src/ffi/block_state_callbacks.rs
+++ b/plt/plt-block-state/src/ffi/block_state_callbacks.rs
@@ -249,3 +249,58 @@ pub type GetAccountIndexByAddressCallback =
 /// - `account_index` The index of the account to update a token balance for. Must be a valid
 ///   account index of an existing account.
 pub type GetTokenAccountStatesCallback = extern "C" fn(account_index: u64) -> *mut Vec<u8>;
+
+pub mod tests_helpers {
+    use super::*;
+
+    pub const UNIMPLEMENTED_UPDATE_TOKEN_ACCOUNT_BALANCE: UpdateTokenAccountBalanceCallback = {
+        extern "C" fn fun(_: u64, _: u64, _: u64, _: u8) -> u8 {
+            unimplemented!()
+        }
+        fun
+    };
+
+    pub const UNIMPLEMENTED_TOUCH_TOKEN_ACCOUNT: TouchTokenAccountCallback = {
+        extern "C" fn fun(_: u64, _: u64) {
+            unimplemented!()
+        }
+        fun
+    };
+
+    pub const UNIMPLEMENTED_READ_TOKEN_ACCOUNT_BALANCE: ReadTokenAccountBalanceCallback = {
+        extern "C" fn fun(_: u64, _: u64) -> u64 {
+            unimplemented!()
+        }
+        fun
+    };
+
+    pub const UNIMPLEMENTED_INCREMENT_PLT_UPDATE_SEQUENCE_NUMBER:
+        IncrementPltUpdateSequenceNumberCallback = {
+        extern "C" fn fun() {
+            unimplemented!()
+        }
+        fun
+    };
+
+    pub const UNIMPLEMENTED_GET_CANONICAL_ADDRESS_BY_ACCOUNT_INDEX:
+        GetCanonicalAddressByAccountIndexCallback = {
+        extern "C" fn fun(_: u64, _: *mut u8) -> u8 {
+            unimplemented!()
+        }
+        fun
+    };
+
+    pub const UNIMPLEMENTED_GET_ACCOUNT_INDEX_BY_ADDRESS: GetAccountIndexByAddressCallback = {
+        extern "C" fn fun(_: *const u8, _: *mut u64) -> u8 {
+            unimplemented!()
+        }
+        fun
+    };
+
+    pub const UNIMPLEMENTED_GET_TOKEN_ACCOUNT_STATES: GetTokenAccountStatesCallback = {
+        extern "C" fn fun(_: u64) -> *mut Vec<u8> {
+            unimplemented!()
+        }
+        fun
+    };
+}

--- a/plt/plt-scheduler/src/ffi.rs
+++ b/plt/plt-scheduler/src/ffi.rs
@@ -4,3 +4,4 @@
 
 mod queries;
 mod scheduler;
+mod status;

--- a/plt/plt-scheduler/src/ffi/queries.rs
+++ b/plt/plt-scheduler/src/ffi/queries.rs
@@ -2,6 +2,7 @@
 //!
 //! It is only available if the `ffi` feature is enabled.
 
+use crate::ffi::status;
 use crate::queries;
 use crate::queries::QueryTokenInfoError;
 use concordium_base::base::{AccountIndex, ProtocolVersion};
@@ -55,46 +56,42 @@ extern "C" fn ffi_query_plt_list(
     protocol_version: u64,
     return_data_out: *mut *mut u8,
     return_data_len_out: *mut size_t,
-) -> u8 {
-    assert!(!block_state.is_null(), "block_state is a null pointer.");
-    assert!(
-        !return_data_len_out.is_null(),
-        "return_data_len_out is a null pointer."
-    );
-    assert!(
-        !return_data_out.is_null(),
-        "return_data_out is a null pointer."
-    );
-
-    let external_callbacks = ExternalBlockStateQueryCallbacks {
-        read_token_account_balance_ptr: read_token_account_balance_callback,
-        get_account_address_by_index_ptr: get_account_address_by_index_callback,
-        get_account_index_by_address_ptr: get_account_index_by_address_callback,
-        get_token_account_states_ptr: get_token_account_states_callback,
-    };
-
-    let protocol_version =
-        ProtocolVersion::try_from(protocol_version).expect("Unknown protocol version");
-    let internal_block_state = unsafe { &*block_state };
-    let block_state = ExecutionTimePltBlockState {
-        protocol_version,
-        internal_block_state,
-        backing_store_load: load_callback,
-        external_block_state: external_callbacks,
-    };
-
-    let token_ids = queries::query_plt_list(&block_state);
-
-    let return_data = common::to_bytes(&token_ids);
-
+) -> status::FfiStatusCode {
+    let (return_status, return_data) = status::catch_unwind(|| {
+        assert!(!block_state.is_null(), "block_state is a null pointer.");
+        assert!(
+            !return_data_len_out.is_null(),
+            "return_data_len_out is a null pointer."
+        );
+        assert!(
+            !return_data_out.is_null(),
+            "return_data_out is a null pointer."
+        );
+        let external_callbacks = ExternalBlockStateQueryCallbacks {
+            read_token_account_balance_ptr: read_token_account_balance_callback,
+            get_account_address_by_index_ptr: get_account_address_by_index_callback,
+            get_account_index_by_address_ptr: get_account_index_by_address_callback,
+            get_token_account_states_ptr: get_token_account_states_callback,
+        };
+        let protocol_version =
+            ProtocolVersion::try_from(protocol_version).expect("Unknown protocol version");
+        let internal_block_state = unsafe { &*block_state };
+        let block_state = ExecutionTimePltBlockState {
+            protocol_version,
+            internal_block_state,
+            backing_store_load: load_callback,
+            external_block_state: external_callbacks,
+        };
+        let token_ids = queries::query_plt_list(&block_state);
+        let return_data = common::to_bytes(&token_ids);
+        (status::FfiStatusCode::Success, return_data)
+    });
     let array = memory::alloc_array_from_vec(return_data);
     unsafe {
         *return_data_len_out = array.length;
         *return_data_out = array.array;
     }
-
-    // todo implement error handling for unrecoverable errors in https://linear.app/concordium/issue/PSR-39/decide-and-implement-strategy-for-handling-panics-in-the-rust-code
-    0
+    return_status
 }
 
 /// C-binding for calling [`queries::query_token_info`].
@@ -143,58 +140,56 @@ extern "C" fn ffi_query_token_info(
     token_id_len: size_t,
     return_data_out: *mut *mut u8,
     return_data_len_out: *mut size_t,
-) -> u8 {
-    assert!(!block_state.is_null(), "block_state is a null pointer.");
-    assert!(
-        !return_data_len_out.is_null(),
-        "return_data_len_out is a null pointer."
-    );
-    assert!(
-        !return_data_out.is_null(),
-        "return_data_out is a null pointer."
-    );
-
-    let external_callbacks = ExternalBlockStateQueryCallbacks {
-        read_token_account_balance_ptr: read_token_account_balance_callback,
-        get_account_address_by_index_ptr: get_account_address_by_index_callback,
-        get_account_index_by_address_ptr: get_account_index_by_address_callback,
-        get_token_account_states_ptr: get_token_account_states_callback,
-    };
-
-    let protocol_version =
-        ProtocolVersion::try_from(protocol_version).expect("Unknown protocol version");
-    let internal_block_state = unsafe { &*block_state };
-    let block_state = ExecutionTimePltBlockState {
-        protocol_version,
-        internal_block_state,
-        backing_store_load: load_callback,
-        external_block_state: external_callbacks,
-    };
-
-    let token_id_bytes = unsafe { std::slice::from_raw_parts(token_id, token_id_len) };
-    // todo implement error handling for unrecoverable errors in https://linear.app/concordium/issue/PSR-39/decide-and-implement-strategy-for-handling-panics-in-the-rust-code instead of calling unwrap
-    let token_id = String::from_utf8(token_id_bytes.to_vec())
-        .unwrap()
-        .try_into()
-        .unwrap();
-
-    let token_info = queries::query_token_info(&block_state, &token_id);
-
-    let (return_status, return_data) = match token_info {
-        Ok(token_info) => (0, common::to_bytes(&token_info)),
-        Err(QueryTokenInfoError::TokenDoesNotExist(_)) => (1, Vec::new()),
-        Err(_) => {
-            todo!()
-            // todo implement error handling for unrecoverable errors in https://linear.app/concordium/issue/PSR-39/decide-and-implement-strategy-for-handling-panics-in-the-rust-code
+) -> status::FfiStatusCode {
+    let (return_status, return_data) = status::catch_unwind(|| {
+        assert!(!block_state.is_null(), "block_state is a null pointer.");
+        assert!(
+            !return_data_len_out.is_null(),
+            "return_data_len_out is a null pointer."
+        );
+        assert!(
+            !return_data_out.is_null(),
+            "return_data_out is a null pointer."
+        );
+        let external_callbacks = ExternalBlockStateQueryCallbacks {
+            read_token_account_balance_ptr: read_token_account_balance_callback,
+            get_account_address_by_index_ptr: get_account_address_by_index_callback,
+            get_account_index_by_address_ptr: get_account_index_by_address_callback,
+            get_token_account_states_ptr: get_token_account_states_callback,
+        };
+        let protocol_version =
+            ProtocolVersion::try_from(protocol_version).expect("Unknown protocol version");
+        let internal_block_state = unsafe { &*block_state };
+        let block_state = ExecutionTimePltBlockState {
+            protocol_version,
+            internal_block_state,
+            backing_store_load: load_callback,
+            external_block_state: external_callbacks,
+        };
+        let token_id_bytes = unsafe { std::slice::from_raw_parts(token_id, token_id_len) };
+        let token_id = String::from_utf8(token_id_bytes.to_vec())
+            .expect("Bytes for the Token ID is not a valid UTF-8 encoding")
+            .try_into()
+            .expect("Invalid Token ID provided");
+        let token_info = queries::query_token_info(&block_state, &token_id);
+        match token_info {
+            Ok(token_info) => (
+                status::FfiStatusCode::Success,
+                common::to_bytes(&token_info),
+            ),
+            Err(QueryTokenInfoError::TokenDoesNotExist(_)) => {
+                (status::FfiStatusCode::Failed, Vec::new())
+            }
+            Err(QueryTokenInfoError::QueryTokenModule(err)) => {
+                (status::FfiStatusCode::Panic, err.to_string().into_bytes())
+            }
         }
-    };
-
+    });
     let array = memory::alloc_array_from_vec(return_data);
     unsafe {
         *return_data_len_out = array.length;
         *return_data_out = array.array;
     }
-
     return_status
 }
 
@@ -244,58 +239,56 @@ extern "C" fn ffi_query_token_authorizations(
     token_id_len: size_t,
     return_data_out: *mut *mut u8,
     return_data_len_out: *mut size_t,
-) -> u8 {
-    assert!(!block_state.is_null(), "block_state is a null pointer.");
-    assert!(
-        !return_data_len_out.is_null(),
-        "return_data_len_out is a null pointer."
-    );
-    assert!(
-        !return_data_out.is_null(),
-        "return_data_out is a null pointer."
-    );
-
-    let external_callbacks = ExternalBlockStateQueryCallbacks {
-        read_token_account_balance_ptr: read_token_account_balance_callback,
-        get_account_address_by_index_ptr: get_account_address_by_index_callback,
-        get_account_index_by_address_ptr: get_account_index_by_address_callback,
-        get_token_account_states_ptr: get_token_account_states_callback,
-    };
-
-    let protocol_version =
-        ProtocolVersion::try_from(protocol_version).expect("Unknown protocol version");
-    let internal_block_state = unsafe { &*block_state };
-    let block_state = ExecutionTimePltBlockState {
-        protocol_version,
-        internal_block_state,
-        backing_store_load: load_callback,
-        external_block_state: external_callbacks,
-    };
-
-    let token_id_bytes = unsafe { std::slice::from_raw_parts(token_id, token_id_len) };
-    // todo implement error handling for unrecoverable errors in https://linear.app/concordium/issue/PSR-39/decide-and-implement-strategy-for-handling-panics-in-the-rust-code instead of calling unwrap
-    let token_id = String::from_utf8(token_id_bytes.to_vec())
-        .unwrap()
-        .try_into()
-        .unwrap();
-
-    let token_info = queries::query_token_authorizations(&block_state, &token_id);
-
-    let (return_status, return_data) = match token_info {
-        Ok(token_info) => (0, common::to_bytes(&token_info)),
-        Err(QueryTokenInfoError::TokenDoesNotExist(_)) => (1, Vec::new()),
-        Err(_) => {
-            todo!()
-            // todo implement error handling for unrecoverable errors in https://linear.app/concordium/issue/PSR-39/decide-and-implement-strategy-for-handling-panics-in-the-rust-code
+) -> status::FfiStatusCode {
+    let (return_status, return_data) = status::catch_unwind(|| {
+        assert!(!block_state.is_null(), "block_state is a null pointer.");
+        assert!(
+            !return_data_len_out.is_null(),
+            "return_data_len_out is a null pointer."
+        );
+        assert!(
+            !return_data_out.is_null(),
+            "return_data_out is a null pointer."
+        );
+        let external_callbacks = ExternalBlockStateQueryCallbacks {
+            read_token_account_balance_ptr: read_token_account_balance_callback,
+            get_account_address_by_index_ptr: get_account_address_by_index_callback,
+            get_account_index_by_address_ptr: get_account_index_by_address_callback,
+            get_token_account_states_ptr: get_token_account_states_callback,
+        };
+        let protocol_version =
+            ProtocolVersion::try_from(protocol_version).expect("Unknown protocol version");
+        let internal_block_state = unsafe { &*block_state };
+        let block_state = ExecutionTimePltBlockState {
+            protocol_version,
+            internal_block_state,
+            backing_store_load: load_callback,
+            external_block_state: external_callbacks,
+        };
+        let token_id_bytes = unsafe { std::slice::from_raw_parts(token_id, token_id_len) };
+        let token_id = String::from_utf8(token_id_bytes.to_vec())
+            .expect("Bytes for the Token ID is not a valid UTF-8 encoding")
+            .try_into()
+            .expect("Invalid Token ID provided");
+        let token_info = queries::query_token_authorizations(&block_state, &token_id);
+        match token_info {
+            Ok(token_info) => (
+                status::FfiStatusCode::Success,
+                common::to_bytes(&token_info),
+            ),
+            Err(QueryTokenInfoError::TokenDoesNotExist(_)) => {
+                (status::FfiStatusCode::Failed, Vec::new())
+            }
+            Err(QueryTokenInfoError::QueryTokenModule(err)) => {
+                (status::FfiStatusCode::Panic, err.to_string().into_bytes())
+            }
         }
-    };
-
+    });
     let array = memory::alloc_array_from_vec(return_data);
     unsafe {
         *return_data_len_out = array.length;
         *return_data_out = array.array;
     }
-
     return_status
 }
 
@@ -340,45 +333,41 @@ extern "C" fn ffi_query_token_account_infos(
     account_index: u64,
     return_data_out: *mut *mut u8,
     return_data_len_out: *mut size_t,
-) -> u8 {
-    assert!(!block_state.is_null(), "block_state is a null pointer.");
-    assert!(
-        !return_data_len_out.is_null(),
-        "return_data_len_out is a null pointer."
-    );
-    assert!(
-        !return_data_out.is_null(),
-        "return_data_out is a null pointer."
-    );
-
-    let external_callbacks = ExternalBlockStateQueryCallbacks {
-        read_token_account_balance_ptr: read_token_account_balance_callback,
-        get_account_address_by_index_ptr: get_account_address_by_index_callback,
-        get_account_index_by_address_ptr: get_account_index_by_address_callback,
-        get_token_account_states_ptr: get_token_account_states_callback,
-    };
-
-    let protocol_version =
-        ProtocolVersion::try_from(protocol_version).expect("Unknown protocol version");
-    let internal_block_state = unsafe { &*block_state };
-    let block_state = ExecutionTimePltBlockState {
-        protocol_version,
-        internal_block_state,
-        backing_store_load: load_callback,
-        external_block_state: external_callbacks,
-    };
-
-    let token_account_infos =
-        queries::query_token_account_infos(&block_state, AccountIndex::from(account_index));
-
-    let return_data = common::to_bytes(&token_account_infos);
-
+) -> status::FfiStatusCode {
+    let (return_status, return_data) = status::catch_unwind(|| {
+        assert!(!block_state.is_null(), "block_state is a null pointer.");
+        assert!(
+            !return_data_len_out.is_null(),
+            "return_data_len_out is a null pointer."
+        );
+        assert!(
+            !return_data_out.is_null(),
+            "return_data_out is a null pointer."
+        );
+        let external_callbacks = ExternalBlockStateQueryCallbacks {
+            read_token_account_balance_ptr: read_token_account_balance_callback,
+            get_account_address_by_index_ptr: get_account_address_by_index_callback,
+            get_account_index_by_address_ptr: get_account_index_by_address_callback,
+            get_token_account_states_ptr: get_token_account_states_callback,
+        };
+        let protocol_version =
+            ProtocolVersion::try_from(protocol_version).expect("Unknown protocol version");
+        let internal_block_state = unsafe { &*block_state };
+        let block_state = ExecutionTimePltBlockState {
+            protocol_version,
+            internal_block_state,
+            backing_store_load: load_callback,
+            external_block_state: external_callbacks,
+        };
+        let token_account_infos =
+            queries::query_token_account_infos(&block_state, AccountIndex::from(account_index));
+        let return_data = common::to_bytes(&token_account_infos);
+        (status::FfiStatusCode::Success, return_data)
+    });
     let array = memory::alloc_array_from_vec(return_data);
     unsafe {
         *return_data_len_out = array.length;
         *return_data_out = array.array;
     }
-
-    // todo implement error handling for unrecoverable errors in https://linear.app/concordium/issue/PSR-39/decide-and-implement-strategy-for-handling-panics-in-the-rust-code
-    0
+    return_status
 }

--- a/plt/plt-scheduler/src/ffi/scheduler.rs
+++ b/plt/plt-scheduler/src/ffi/scheduler.rs
@@ -2,6 +2,7 @@
 //!
 //! It is only available if the `ffi` feature is enabled.
 
+use crate::ffi::status;
 use crate::scheduler;
 use concordium_base::base::{AccountIndex, Energy, ProtocolVersion};
 use concordium_base::contracts_common::AccountAddress;
@@ -88,103 +89,97 @@ extern "C" fn ffi_execute_transaction(
     used_energy_out: *mut u64,
     return_data_out: *mut *mut u8,
     return_data_len_out: *mut size_t,
-) -> u8 {
-    assert!(!block_state.is_null(), "block_state is a null pointer.");
-    assert!(!payload.is_null(), "payload is a null pointer.");
-    assert!(
-        !block_state_out.is_null(),
-        "block_state_out is a null pointer."
-    );
-    assert!(
-        !used_energy_out.is_null(),
-        "used_energy_out is a null pointer."
-    );
-    assert!(
-        !sender_account_address.is_null(),
-        "sender_account_address is a null pointer."
-    );
-    assert!(
-        !return_data_len_out.is_null(),
-        "return_data_len_out is a null pointer."
-    );
-    assert!(
-        !return_data_out.is_null(),
-        "return_data_out is a null pointer."
-    );
-
-    let external_callbacks = ExternalBlockStateOperationCallbacks {
-        queries: ExternalBlockStateQueryCallbacks {
-            read_token_account_balance_ptr: read_token_account_balance_callback,
-            get_account_address_by_index_ptr: get_account_address_by_index_callback,
-            get_account_index_by_address_ptr: get_account_index_by_address_callback,
-            get_token_account_states_ptr: get_token_account_states_callback,
-        },
-        update_token_account_balance_ptr: update_token_account_balance_callback,
-        touch_token_account_ptr: touch_token_account_callback,
-        increment_plt_update_sequence_number_ptr: increment_plt_update_sequence_number_callback,
-    };
-
-    let protocol_version =
-        ProtocolVersion::try_from(protocol_version).expect("Unknown protocol version");
-    let internal_block_state = unsafe { (*block_state).mutable_state() };
-    let mut block_state = ExecutionTimePltBlockState {
-        protocol_version,
-        internal_block_state,
-        backing_store_load: load_callback,
-        external_block_state: external_callbacks,
-    };
-
-    let sender_account_index = AccountIndex::from(sender_account_index);
-    let sender_account_address = {
-        let mut address_bytes = [0u8; contracts_common::ACCOUNT_ADDRESS_SIZE];
-        unsafe {
-            std::ptr::copy_nonoverlapping(
-                sender_account_address,
-                address_bytes.as_mut_ptr(),
-                contracts_common::ACCOUNT_ADDRESS_SIZE,
-            );
-        }
-        AccountAddress(address_bytes)
-    };
-
-    let payload_bytes = unsafe { std::slice::from_raw_parts(payload, payload_len) };
-    // todo implement error handling for unrecoverable errors in https://linear.app/concordium/issue/PSR-39/decide-and-implement-strategy-for-handling-panics-in-the-rust-code
-    let payload: Payload = common::from_bytes_complete(payload_bytes).unwrap();
-
-    let remaining_energy = Energy::from(remaining_energy);
-
-    let result = scheduler::execute_transaction(
-        sender_account_index,
-        sender_account_address,
-        &mut block_state,
-        payload,
-        remaining_energy,
-    );
-
-    // todo implement error handling for unrecoverable errors in https://linear.app/concordium/issue/PSR-39/decide-and-implement-strategy-for-handling-panics-in-the-rust-code
-    let summary = result.unwrap();
-
-    unsafe {
-        *used_energy_out = summary.energy_used.energy;
-    }
-
-    let (return_status, return_data) = match summary.outcome {
-        TransactionOutcome::Success(events) => {
+) -> status::FfiStatusCode {
+    let (return_status, data_out) = status::catch_unwind(|| {
+        assert!(!block_state.is_null(), "block_state is a null pointer.");
+        assert!(!payload.is_null(), "payload is a null pointer.");
+        assert!(
+            !block_state_out.is_null(),
+            "block_state_out is a null pointer."
+        );
+        assert!(
+            !used_energy_out.is_null(),
+            "used_energy_out is a null pointer."
+        );
+        assert!(
+            !sender_account_address.is_null(),
+            "sender_account_address is a null pointer."
+        );
+        assert!(
+            !return_data_len_out.is_null(),
+            "return_data_len_out is a null pointer."
+        );
+        assert!(
+            !return_data_out.is_null(),
+            "return_data_out is a null pointer."
+        );
+        let external_callbacks = ExternalBlockStateOperationCallbacks {
+            queries: ExternalBlockStateQueryCallbacks {
+                read_token_account_balance_ptr: read_token_account_balance_callback,
+                get_account_address_by_index_ptr: get_account_address_by_index_callback,
+                get_account_index_by_address_ptr: get_account_index_by_address_callback,
+                get_token_account_states_ptr: get_token_account_states_callback,
+            },
+            update_token_account_balance_ptr: update_token_account_balance_callback,
+            touch_token_account_ptr: touch_token_account_callback,
+            increment_plt_update_sequence_number_ptr: increment_plt_update_sequence_number_callback,
+        };
+        let protocol_version =
+            ProtocolVersion::try_from(protocol_version).expect("Unknown protocol version");
+        let internal_block_state = unsafe { (*block_state).mutable_state() };
+        let mut block_state = ExecutionTimePltBlockState {
+            protocol_version,
+            internal_block_state,
+            backing_store_load: load_callback,
+            external_block_state: external_callbacks,
+        };
+        let sender_account_index = AccountIndex::from(sender_account_index);
+        let sender_account_address = {
+            let mut address_bytes = [0u8; contracts_common::ACCOUNT_ADDRESS_SIZE];
             unsafe {
-                *block_state_out =
-                    Box::into_raw(Box::new(block_state.internal_block_state.savepoint()));
+                std::ptr::copy_nonoverlapping(
+                    sender_account_address,
+                    address_bytes.as_mut_ptr(),
+                    contracts_common::ACCOUNT_ADDRESS_SIZE,
+                );
             }
-            (0, common::to_bytes(&events))
+            AccountAddress(address_bytes)
+        };
+        let payload_bytes = unsafe { std::slice::from_raw_parts(payload, payload_len) };
+        let payload: Payload = common::from_bytes_complete(payload_bytes)
+            .expect("Failed decoding transaction payload");
+        let remaining_energy = Energy::from(remaining_energy);
+        let result = scheduler::execute_transaction(
+            sender_account_index,
+            sender_account_address,
+            &mut block_state,
+            payload,
+            remaining_energy,
+        );
+        let summary = result.expect("Unexpected failure during transaction execution");
+        unsafe {
+            *used_energy_out = summary.energy_used.energy;
         }
-        TransactionOutcome::Rejected(reject_reason) => (1, common::to_bytes(&reject_reason)),
-    };
+        match summary.outcome {
+            TransactionOutcome::Success(events) => {
+                unsafe {
+                    *block_state_out =
+                        Box::into_raw(Box::new(block_state.internal_block_state.savepoint()));
+                }
+                (status::FfiStatusCode::Success, common::to_bytes(&events))
+            }
+            TransactionOutcome::Rejected(reject_reason) => (
+                status::FfiStatusCode::Failed,
+                common::to_bytes(&reject_reason),
+            ),
+        }
+    });
 
-    let array = memory::alloc_array_from_vec(return_data);
+    let array = memory::alloc_array_from_vec(data_out);
     unsafe {
         *return_data_len_out = array.length;
         *return_data_out = array.array;
     }
-
     return_status
 }
 
@@ -246,69 +241,122 @@ extern "C" fn ffi_execute_chain_update(
     block_state_out: *mut *mut PltBlockStateSavepoint,
     return_data_out: *mut *mut u8,
     return_data_len_out: *mut size_t,
-) -> u8 {
-    assert!(!block_state.is_null(), "block_state is a null pointer.");
-    assert!(!payload.is_null(), "payload is a null pointer.");
-    assert!(
-        !block_state_out.is_null(),
-        "block_state_out is a null pointer."
-    );
-    assert!(
-        !return_data_len_out.is_null(),
-        "return_data_len_out is a null pointer."
-    );
-    assert!(
-        !return_data_out.is_null(),
-        "return_data_out is a null pointer."
-    );
+) -> status::FfiStatusCode {
+    let (return_status, return_data) = status::catch_unwind(|| {
+        assert!(!block_state.is_null(), "block_state is a null pointer.");
+        assert!(!payload.is_null(), "payload is a null pointer.");
+        assert!(
+            !block_state_out.is_null(),
+            "block_state_out is a null pointer."
+        );
+        assert!(
+            !return_data_len_out.is_null(),
+            "return_data_len_out is a null pointer."
+        );
+        assert!(
+            !return_data_out.is_null(),
+            "return_data_out is a null pointer."
+        );
 
-    let external_callbacks = ExternalBlockStateOperationCallbacks {
-        queries: ExternalBlockStateQueryCallbacks {
-            read_token_account_balance_ptr: read_token_account_balance_callback,
-            get_account_address_by_index_ptr: get_account_address_by_index_callback,
-            get_account_index_by_address_ptr: get_account_index_by_address_callback,
-            get_token_account_states_ptr: get_token_account_states_callback,
-        },
-        update_token_account_balance_ptr: update_token_account_balance_callback,
-        touch_token_account_ptr: touch_token_account_callback,
-        increment_plt_update_sequence_number_ptr: increment_plt_update_sequence_number_callback,
-    };
+        let external_callbacks = ExternalBlockStateOperationCallbacks {
+            queries: ExternalBlockStateQueryCallbacks {
+                read_token_account_balance_ptr: read_token_account_balance_callback,
+                get_account_address_by_index_ptr: get_account_address_by_index_callback,
+                get_account_index_by_address_ptr: get_account_index_by_address_callback,
+                get_token_account_states_ptr: get_token_account_states_callback,
+            },
+            update_token_account_balance_ptr: update_token_account_balance_callback,
+            touch_token_account_ptr: touch_token_account_callback,
+            increment_plt_update_sequence_number_ptr: increment_plt_update_sequence_number_callback,
+        };
 
-    let protocol_version =
-        ProtocolVersion::try_from(protocol_version).expect("Unknown protocol version");
-    let internal_block_state = unsafe { (*block_state).mutable_state() };
-    let mut block_state = ExecutionTimePltBlockState {
-        protocol_version,
-        internal_block_state,
-        backing_store_load: load_callback,
-        external_block_state: external_callbacks,
-    };
-
-    let payload_bytes = unsafe { std::slice::from_raw_parts(payload, payload_len) };
-    // todo implement error handling for unrecoverable errors in https://linear.app/concordium/issue/PSR-39/decide-and-implement-strategy-for-handling-panics-in-the-rust-code
-    let payload: UpdatePayload = common::from_bytes_complete(payload_bytes).unwrap();
-
-    let result = scheduler::execute_chain_update(&mut block_state, payload);
-
-    // todo implement error handling for unrecoverable errors in https://linear.app/concordium/issue/PSR-39/decide-and-implement-strategy-for-handling-panics-in-the-rust-code
-    let outcome = result.unwrap();
-
-    let (return_status, return_data) = match outcome {
-        ChainUpdateOutcome::Success(events) => {
-            unsafe {
-                *block_state_out =
-                    Box::into_raw(Box::new(block_state.internal_block_state.savepoint()));
+        let protocol_version =
+            ProtocolVersion::try_from(protocol_version).expect("Unknown protocol version");
+        let internal_block_state = unsafe { (*block_state).mutable_state() };
+        let mut block_state = ExecutionTimePltBlockState {
+            protocol_version,
+            internal_block_state,
+            backing_store_load: load_callback,
+            external_block_state: external_callbacks,
+        };
+        let payload_bytes = unsafe { std::slice::from_raw_parts(payload, payload_len) };
+        let payload: UpdatePayload = common::from_bytes_complete(payload_bytes)
+            .expect("Failed decoding chain update payload");
+        let result = scheduler::execute_chain_update(&mut block_state, payload);
+        let outcome = result.expect("Unexpected failure during chain update execution");
+        match outcome {
+            ChainUpdateOutcome::Success(events) => {
+                unsafe {
+                    *block_state_out =
+                        Box::into_raw(Box::new(block_state.internal_block_state.savepoint()));
+                }
+                (status::FfiStatusCode::Success, common::to_bytes(&events))
             }
-            (0, common::to_bytes(&events))
+            ChainUpdateOutcome::Failed(failure_kind) => (
+                status::FfiStatusCode::Failed,
+                common::to_bytes(&failure_kind),
+            ),
         }
-        ChainUpdateOutcome::Failed(failure_kind) => (1, common::to_bytes(&failure_kind)),
-    };
+    });
 
     let array = memory::alloc_array_from_vec(return_data);
     unsafe {
         *return_data_len_out = array.length;
         *return_data_out = array.array;
     }
-
     return_status
+}
+
+#[cfg(test)]
+mod tests {
+    use plt_block_state::ffi::blob_store_callbacks::tests_helpers::UNIMPLEMENTED_LOAD_CALLBACK;
+    use plt_block_state::ffi::block_state_callbacks::tests_helpers::{
+        UNIMPLEMENTED_GET_ACCOUNT_INDEX_BY_ADDRESS,
+        UNIMPLEMENTED_GET_CANONICAL_ADDRESS_BY_ACCOUNT_INDEX,
+        UNIMPLEMENTED_GET_TOKEN_ACCOUNT_STATES, UNIMPLEMENTED_INCREMENT_PLT_UPDATE_SEQUENCE_NUMBER,
+        UNIMPLEMENTED_READ_TOKEN_ACCOUNT_BALANCE, UNIMPLEMENTED_TOUCH_TOKEN_ACCOUNT,
+        UNIMPLEMENTED_UPDATE_TOKEN_ACCOUNT_BALANCE,
+    };
+
+    use super::*;
+    use std::ptr;
+
+    /// Test ensuring panics are caught and returned properly when providing invalid arguments to `ffi_execute_transaction`.
+    #[test]
+    fn test_execute_transaction_catches_panic() {
+        let data_out = Box::into_raw(Box::new(ptr::null_mut()));
+        let data_out_len = Box::into_raw(Box::new(0));
+
+        let status_code = ffi_execute_transaction(
+            UNIMPLEMENTED_LOAD_CALLBACK,
+            UNIMPLEMENTED_READ_TOKEN_ACCOUNT_BALANCE,
+            UNIMPLEMENTED_UPDATE_TOKEN_ACCOUNT_BALANCE,
+            UNIMPLEMENTED_TOUCH_TOKEN_ACCOUNT,
+            UNIMPLEMENTED_INCREMENT_PLT_UPDATE_SEQUENCE_NUMBER,
+            UNIMPLEMENTED_GET_ACCOUNT_INDEX_BY_ADDRESS,
+            UNIMPLEMENTED_GET_CANONICAL_ADDRESS_BY_ACCOUNT_INDEX,
+            UNIMPLEMENTED_GET_TOKEN_ACCOUNT_STATES,
+            ptr::null(),
+            8,
+            ptr::null(),
+            0,
+            0,
+            ptr::null(),
+            0,
+            ptr::null_mut(),
+            ptr::null_mut(),
+            data_out,
+            data_out_len,
+        );
+        assert_eq!(status_code, status::FfiStatusCode::Panic);
+        let data = unsafe {
+            let data_len = *data_out_len;
+            assert!(data_len > 0);
+            let data_ptr = *data_out;
+            assert!(!data_ptr.is_null());
+            std::slice::from_raw_parts(data_ptr, data_len)
+        };
+        let message = std::str::from_utf8(data).expect("Failed decoding panic message");
+        assert_eq!(message, "block_state is a null pointer.");
+    }
 }

--- a/plt/plt-scheduler/src/ffi/status.rs
+++ b/plt/plt-scheduler/src/ffi/status.rs
@@ -1,0 +1,57 @@
+/// Returned status code used in FFI calls into this library.
+///
+/// This must match the `FFIStatusCode` type defined on the haskell side.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum FfiStatusCode {
+    /// The call succeeded.
+    Success = 0,
+    /// The call failed gracefully.
+    Failed = 1,
+    /// The call resulted in a (caught) panic.
+    Panic = 2,
+}
+
+/// Helper function for wrapping calls with [`std::panic::catch_unwind`] then mapping a panic to the
+/// correct status code and extracting the panic message.
+///
+/// # Arguments
+///
+/// - `function` The closure which might panic
+pub fn catch_unwind<F: FnOnce() -> (FfiStatusCode, Vec<u8>) + std::panic::UnwindSafe>(
+    function: F,
+) -> (FfiStatusCode, Vec<u8>) {
+    std::panic::catch_unwind(function).unwrap_or_else(|err| {
+        let data_out = if let Some(message) = err.downcast_ref::<String>() {
+            message.clone().into_bytes()
+        } else if let Some(message) = err.downcast_ref::<&str>() {
+            message.to_string().into_bytes()
+        } else {
+            b"Unknown panic reason".to_vec()
+        };
+        (FfiStatusCode::Panic, data_out)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_catch_unwind_panics_str() {
+        let (status, message) = catch_unwind(|| {
+            panic!("my panic message");
+        });
+        assert_eq!(status, FfiStatusCode::Panic);
+        assert_eq!(String::from_utf8(message).unwrap(), "my panic message");
+    }
+
+    #[test]
+    fn test_catch_unwind_panics_string() {
+        let (status, message) = catch_unwind(|| {
+            panic!("my panic message {:?}", vec![5]);
+        });
+        assert_eq!(status, FfiStatusCode::Panic);
+        assert_eq!(String::from_utf8(message).unwrap(), "my panic message [5]");
+    }
+}


### PR DESCRIPTION
## Purpose

Closes PSR-39 [link](https://linear.app/concordium/issue/PSR-39/implement-strategy-for-handling-unrecoverable-errors-in-the-rust-code)

To ensure a panic on the rust scheduler implementation does not reach the haskell side, we use catch_unwind when exposed in the FFI to convert panics into a proper error code with panic message, allowing the haskell side to report this message as a proper error.

## Changes

- Introduce our own variant of `catch_unwind` which extracts the error message from panics.
- Added unit tests for ensuring panics with both `str` and `string` messages are extracted.
- Wrap each FFI call in the scheduler with `catch_unwind` and pass the panic message to haskell (note this does not include the blockstate FFI, to be discussed).
- Add unit test with panic in `ffi_execute_transaction`.
- Parsing of the panic status and error message on the haskell side.

