### PR TITLE
Prepare RBAC release for devnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,17 @@
 
 ## Unreleased changes
 
+# 11.1.0 (Devnet)
+
+- Support token operations:
+  - `assignAdminRoles` and `revokeAdminRoles` for managing admin roles for a protocol-level token.
+  - `updateMetadata` for setting the metadata URL and checksum of a protocol-level token.
+- Extend gRPC API with `getTokenAuthorizations` query for listing accounts holding roles for a given protocol-level token.
+
 # 11.0.0 (DevNet)
 
 - Protocol level tokens logic has been rewritten in Rust (no behavioral change from P9/P10)
- 
+
 # 10.0.7
 
 - Enhance node performance by limiting outbound queue saturation to peers that are slow in processing messages.
@@ -15,7 +22,7 @@
 
 - Prohibit peers from sending unsolicited PeerList messages
 - Enhance node performance by limiting inbound queue saturation from peers that send messages aggressively by using backpressure.
-- Introduce a background queue for processing messages that don't require the global block state lock. 
+- Introduce a background queue for processing messages that don't require the global block state lock.
 
 # 10.0.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 # 11.1.0 (Devnet)
 
-- Support token operations:
+- Support token operations in P11:
   - `assignAdminRoles` and `revokeAdminRoles` for managing admin roles for a protocol-level token.
   - `updateMetadata` for setting the metadata URL and checksum of a protocol-level token.
 - Extend gRPC API with `getTokenAuthorizations` query for listing accounts holding roles for a given protocol-level token.

--- a/concordium-node/Cargo.lock
+++ b/concordium-node/Cargo.lock
@@ -819,7 +819,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_node"
-version = "11.0.0"
+version = "11.1.0"
 dependencies = [
  "anyhow",
  "app_dirs2",

--- a/concordium-node/Cargo.toml
+++ b/concordium-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium_node"
-version = "11.0.0" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
+version = "11.1.0" # must be kept in sync with 'is_compatible_version' in 'src/configuration.rs'
 description = "Concordium Node"
 authors = ["Concordium <developers@concordium.com>"]
 exclude = [".gitignore", ".gitlab-ci.yml", "test/**/*","**/**/.gitignore","**/**/.gitlab-ci.yml"]


### PR DESCRIPTION
## Purpose

Prepare for devnet release with RBAC features.
The release tag of `11.1.0-0-alpha` will be added afterward.

## Changes

- Update changelog.
- Bump the version
