### PR TITLE
Remove 7zip setup step as already installed in windows runners

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -340,8 +340,6 @@ jobs:
           enable-stack: true
           stack-version: ${{ env.STACK_VERSION }}
 
-      - uses: milliewalky/setup-7-zip@v1
-
       - name: Install GCC
         run: |
           curl -L -O https://github.com/brechtsanders/winlibs_mingw/releases/download/14.2.0posix-19.1.1-12.0.0-msvcrt-r2/winlibs-x86_64-posix-seh-gcc-14.2.0-llvm-19.1.1-mingw-w64msvcrt-12.0.0-r2.7z


### PR DESCRIPTION
## Purpose

[Fix issue](https://github.com/Concordium/concordium-node/actions/runs/24085163554/job/70255965182) in windows release pipeline

## Changes

- Remove 7zip setup step from windows release pipeline, since it should already be installed in the runner image.
