### PR TITLE
Run benchmarks on app protocol versions

### DIFF
--- a/concordium-consensus/benchmarks/transactions/SchedulerBench/Helpers.hs
+++ b/concordium-consensus/benchmarks/transactions/SchedulerBench/Helpers.hs
@@ -60,6 +60,27 @@ getResults = map $ Bifunctor.second Types.tsResult
 simpleTransferCost :: Types.Energy
 simpleTransferCost = Cost.baseCost (Types.transactionHeaderSize + 41) 1 + Cost.simpleTransferCost
 
+-- | Call a function for each protocol version, returning a list of results.
+--  Notice the return type for the function must be independent of the protocol version.
+--
+--  This is used to run a test against every protocol version.
+forEveryProtocolVersion ::
+    (forall pv. (Types.IsProtocolVersion pv) => Types.SProtocolVersion pv -> String -> a) ->
+    [a]
+forEveryProtocolVersion check =
+    [ check Types.SP1 "P1",
+      check Types.SP2 "P2",
+      check Types.SP3 "P3",
+      check Types.SP4 "P4",
+      check Types.SP5 "P5",
+      check Types.SP6 "P6",
+      check Types.SP7 "P7",
+      check Types.SP8 "P8",
+      check Types.SP9 "P9",
+      check Types.SP10 "P10",
+      check Types.SP11 "P11"
+    ]
+
 -- | Monad that implements the necessary constraints to be used for running the scheduler.
 newtype PersistentBSM pv a = PersistentBSM
     { _runPersistentBSM ::

--- a/concordium-consensus/benchmarks/transactions/TransactionsBench.hs
+++ b/concordium-consensus/benchmarks/transactions/TransactionsBench.hs
@@ -269,7 +269,7 @@ benchTransfer ::
     forall pv.
     (IsProtocolVersion pv, PVSupportsPLT pv) =>
     SProtocolVersion pv -> Benchmark
-benchTransfer spv = benchTransactionsAssertSuccess spv "transfer (CCD)" $ transactions operationScaleFactor
+benchTransfer spv = benchTransactionsAssertSuccess spv ("transfer (CCD) transaction x" ++ show operationScaleFactor) $ transactions operationScaleFactor
   where
     transactions :: Int -> [Runner.TransactionJSON]
     transactions txnCount =
@@ -287,7 +287,7 @@ benchPltTransfer ::
 benchPltTransfer spv =
     benchBlockItemsAssertSuccess
         spv
-        "PLT transfer"
+        ("PLT transfer operation x" ++ show operationScaleFactor ++ " in a single token update transaction")
         [ createPltBlockItem plt1 $ tokenInitializationParameters accountAddress0,
           Runner.AccountTx transaction
         ]
@@ -304,7 +304,7 @@ benchPltMint ::
 benchPltMint spv =
     benchBlockItemsAssertSuccess
         spv
-        "PLT mint"
+        ("PLT mint operation x" ++ show operationScaleFactor ++ " in a single token update transaction")
         [ createPltBlockItem plt1 $ tokenInitializationParameters accountAddress0,
           Runner.AccountTx transaction
         ]
@@ -321,7 +321,7 @@ benchPltBurn ::
 benchPltBurn spv =
     benchBlockItemsAssertSuccess
         spv
-        "PLT burn"
+        ("PLT burn operation x" ++ show operationScaleFactor ++ " in a single token update transaction")
         [ createPltBlockItem plt1 $ tokenInitializationParameters accountAddress0,
           Runner.AccountTx transaction
         ]
@@ -338,7 +338,7 @@ benchPltAddRemoveAllowList ::
 benchPltAddRemoveAllowList spv =
     benchBlockItemsAssertSuccess
         spv
-        "PLT add/remove allow list"
+        ("PLT add/remove allow list operation x" ++ show operationScaleFactor ++ " in a single token update transaction")
         [ createPltBlockItem plt1 (tokenInitializationParameters accountAddress0){CBOR.tipAllowList = Just True},
           Runner.AccountTx transaction
         ]
@@ -355,7 +355,7 @@ benchPltAddRemoveDenyList ::
 benchPltAddRemoveDenyList spv =
     benchBlockItemsAssertSuccess
         spv
-        "PLT add/remove deny list"
+        ("PLT add/remove deny list operation x" ++ show operationScaleFactor ++ " in a single token update transaction")
         [ createPltBlockItem plt1 $ (tokenInitializationParameters accountAddress0){CBOR.tipDenyList = Just True},
           Runner.AccountTx transaction
         ]
@@ -372,7 +372,7 @@ benchPltNoOperations ::
 benchPltNoOperations spv =
     benchBlockItemsAssertSuccess
         spv
-        "PLT no operations"
+        ("PLT token update transaction with no operations x" ++ show operationScaleFactor)
         ( createPltBlockItem plt1 (tokenInitializationParameters accountAddress0)
             : (Runner.AccountTx <$> transactions operationScaleFactor)
         )
@@ -394,7 +394,7 @@ benchPltTxnAndTransfer ::
 benchPltTxnAndTransfer spv =
     benchBlockItemsAssertSuccess
         spv
-        "PLT txn + PLT transfer"
+        ("PLT token update transaction with single PLT transfer operation x" ++ show operationScaleFactor)
         ( createPltBlockItem plt1 (tokenInitializationParameters accountAddress0)
             : (Runner.AccountTx <$> transactions operationScaleFactor)
         )
@@ -417,7 +417,7 @@ benchPltTxnCborDecodeError ::
 benchPltTxnCborDecodeError spv =
     benchBlockItems
         spv
-        "PLT cbor decode error"
+        ("PLT cbor decode error x" ++ show operationScaleFactor)
         False
         ( createPltBlockItem plt1 (tokenInitializationParameters accountAddress0)
             : (Runner.AccountTx <$> transactions operationScaleFactor)
@@ -445,7 +445,7 @@ benchNoTxns ::
     forall pv.
     (IsProtocolVersion pv, PVSupportsPLT pv) =>
     SProtocolVersion pv -> Benchmark
-benchNoTxns spv = benchBlockItemsAssertSuccess spv "no txns (overhead)" []
+benchNoTxns spv = benchBlockItemsAssertSuccess spv ("no txns (test overhead) x" ++ show operationScaleFactor) []
 
 main :: IO ()
 main =

--- a/concordium-consensus/benchmarks/transactions/TransactionsBench.hs
+++ b/concordium-consensus/benchmarks/transactions/TransactionsBench.hs
@@ -1,6 +1,10 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | Timing of various types of transaction
@@ -24,16 +28,20 @@ import Concordium.Types.ProtocolLevelTokens.CBOR (TokenUpdateTransaction (TokenU
 import qualified Concordium.Types.ProtocolLevelTokens.CBOR as CBOR
 import Concordium.Types.Tokens
 import Control.DeepSeq
+import Control.Monad
 import Criterion
 import Criterion.Main
+import Data.Bool.Singletons
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Short as BSS
 import qualified Data.Map as Map
+import Data.Maybe
 import qualified Data.Sequence as Seq
 import qualified SchedulerBench.Helpers as Helpers
 
 initialBlockState ::
-    Helpers.PersistentBSM 'Types.P9 (BS.HashedPersistentBlockState 'Types.P9)
+    (IsProtocolVersion pv) =>
+    Helpers.PersistentBSM pv (BS.HashedPersistentBlockState pv)
 initialBlockState =
     Helpers.createTestBlockStateWithAccountsM
         [ Helpers.makeTestAccountFromSeed 1_000_000_000 0,
@@ -43,19 +51,18 @@ initialBlockState =
 assertApplied :: Bool -> Int -> Helpers.SchedulerResult (TransactionOutcomesVersionFor pv) -> BS.PersistentBlockState pv -> Helpers.PersistentBSM pv ()
 assertApplied assertSuccess txnCount result _state = do
     let results = Helpers.getResults $ ftAdded (Helpers.srTransactions result)
-    if length results /= txnCount
-        then error ("expected " ++ show txnCount ++ " results, was " ++ show (length results))
-        else
-            seq
-                ( foldl'
-                    ( \_ item -> case snd item of
-                        Exec.TxReject _ | assertSuccess -> error ("failed transaction " ++ show item)
-                        _ -> ()
-                    )
-                    ()
-                    results
-                )
-                (return ())
+    seq
+        ( foldl'
+            ( \_ item -> case snd item of
+                Exec.TxReject _ | assertSuccess -> error ("failed transaction " ++ show item)
+                _ -> ()
+            )
+            ()
+            results
+        )
+        (return ())
+    when (length results /= txnCount) $
+        error ("expected " ++ show txnCount ++ " results, was " ++ show (length results))
 
 accountAddress0 :: Types.AccountAddress
 accountAddress0 = Helpers.accountAddressFromSeed 0
@@ -100,12 +107,12 @@ createPltBlockItem tokenId initializationParameters =
     toTokenParam = Types.TokenParameter . BSS.toShort . CBOR.tokenInitializationParametersToBytes
     createPlt =
         Types.CreatePLT
-            { _cpltTokenModule = TokenModuleRef dummyHash,
+            { _cpltTokenModule = tokenModuleV0Ref,
               _cpltTokenId = tokenId,
               _cpltInitializationParameters = toTokenParam initializationParameters,
               _cpltDecimals = 6
             }
-    dummyHash = Hash.hashShort BSS.empty
+    tokenModuleV0Ref = TokenModuleRef $ Hash.hash "TokenModuleV0"
 
 -- | CCD transfer transaction
 transferTxn :: SigScheme.KeyPair -> Nonce -> AccountAddress -> AccountAddress -> Amount -> Runner.TransactionJSON
@@ -215,17 +222,36 @@ operationScaleFactor :: Int
 operationScaleFactor = 1000
 
 -- | Run benchmark on given transactions
-benchTransactionsAssertSuccess :: String -> [Runner.TransactionJSON] -> Benchmark
-benchTransactionsAssertSuccess label transactions = benchBlockItemsAssertSuccess label (Runner.AccountTx <$> transactions)
+benchTransactionsAssertSuccess ::
+    forall pv.
+    (IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    [Runner.TransactionJSON] ->
+    Benchmark
+benchTransactionsAssertSuccess spv label transactions = benchBlockItemsAssertSuccess spv label (Runner.AccountTx <$> transactions)
 
 -- | Run benchmark on given block items
-benchBlockItemsAssertSuccess :: String -> [Runner.BlockItemDescription] -> Benchmark
-benchBlockItemsAssertSuccess label = benchBlockItems label True
+benchBlockItemsAssertSuccess ::
+    forall pv.
+    (IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    [Runner.BlockItemDescription] ->
+    Benchmark
+benchBlockItemsAssertSuccess spv label = benchBlockItems spv label True
 
 -- | Run benchmark on given block items
-benchBlockItems :: String -> Bool -> [Runner.BlockItemDescription] -> Benchmark
-benchBlockItems label assertSuccess blockItems =
-    env (pure initialBlockState) $ \ibs ->
+benchBlockItems ::
+    forall pv.
+    (IsProtocolVersion pv) =>
+    SProtocolVersion pv ->
+    String ->
+    Bool ->
+    [Runner.BlockItemDescription] ->
+    Benchmark
+benchBlockItems _spv label assertSuccess blockItems =
+    env (pure $ initialBlockState @pv) $ \ibs ->
         bench label $
             whnfAppIO
                 ( \bis -> do
@@ -239,8 +265,11 @@ benchBlockItems label assertSuccess blockItems =
                 blockItems
 
 -- | Benchmark `operationScaleFactor` number of CCD transfer transactions
-benchTransfer :: Benchmark
-benchTransfer = benchTransactionsAssertSuccess "transfer (CCD)" $ transactions operationScaleFactor
+benchTransfer ::
+    forall pv.
+    (IsProtocolVersion pv, PVSupportsPLT pv) =>
+    SProtocolVersion pv -> Benchmark
+benchTransfer spv = benchTransactionsAssertSuccess spv "transfer (CCD)" $ transactions operationScaleFactor
   where
     transactions :: Int -> [Runner.TransactionJSON]
     transactions txnCount =
@@ -251,9 +280,13 @@ benchTransfer = benchTransactionsAssertSuccess "transfer (CCD)" $ transactions o
             [1 .. txnCount]
 
 -- | Benchmark `operationScaleFactor` number of PLT transfer operations in a single transaction
-benchPltTransfer :: Benchmark
-benchPltTransfer =
+benchPltTransfer ::
+    forall pv.
+    (IsProtocolVersion pv, PVSupportsPLT pv) =>
+    SProtocolVersion pv -> Benchmark
+benchPltTransfer spv =
     benchBlockItemsAssertSuccess
+        spv
         "PLT transfer"
         [ createPltBlockItem plt1 $ tokenInitializationParameters accountAddress0,
           Runner.AccountTx transaction
@@ -264,9 +297,13 @@ benchPltTransfer =
     operations txnCount = replicate txnCount $ transferPltOp accountAddress1 1_000
 
 -- | Benchmark `operationScaleFactor` number of PLT mint operations in a single transaction
-benchPltMint :: Benchmark
-benchPltMint =
+benchPltMint ::
+    forall pv.
+    (IsProtocolVersion pv, PVSupportsPLT pv) =>
+    SProtocolVersion pv -> Benchmark
+benchPltMint spv =
     benchBlockItemsAssertSuccess
+        spv
         "PLT mint"
         [ createPltBlockItem plt1 $ tokenInitializationParameters accountAddress0,
           Runner.AccountTx transaction
@@ -277,9 +314,13 @@ benchPltMint =
     operations txnCount = replicate txnCount $ mintPltOp 1_000
 
 -- | Benchmark `operationScaleFactor` number of PLT burn operations in a single transaction
-benchPltBurn :: Benchmark
-benchPltBurn =
+benchPltBurn ::
+    forall pv.
+    (IsProtocolVersion pv, PVSupportsPLT pv) =>
+    SProtocolVersion pv -> Benchmark
+benchPltBurn spv =
     benchBlockItemsAssertSuccess
+        spv
         "PLT burn"
         [ createPltBlockItem plt1 $ tokenInitializationParameters accountAddress0,
           Runner.AccountTx transaction
@@ -290,9 +331,13 @@ benchPltBurn =
     operations txnCount = replicate txnCount $ burnPltOp 1_000
 
 -- | Benchmark `operationScaleFactor` total number of PLT add and remove from allow list operations in a single transaction
-benchPltAddRemoveAllowList :: Benchmark
-benchPltAddRemoveAllowList =
+benchPltAddRemoveAllowList ::
+    forall pv.
+    (IsProtocolVersion pv, PVSupportsPLT pv) =>
+    SProtocolVersion pv -> Benchmark
+benchPltAddRemoveAllowList spv =
     benchBlockItemsAssertSuccess
+        spv
         "PLT add/remove allow list"
         [ createPltBlockItem plt1 (tokenInitializationParameters accountAddress0){CBOR.tipAllowList = Just True},
           Runner.AccountTx transaction
@@ -303,9 +348,13 @@ benchPltAddRemoveAllowList =
     operations txnCount = take txnCount $ cycle [addAllowListPltOp accountAddress1, removeAllowListPltOp accountAddress1]
 
 -- | Benchmark `operationScaleFactor` total number of PLT add and remove from deny list operations in a single transaction
-benchPltAddRemoveDenyList :: Benchmark
-benchPltAddRemoveDenyList =
+benchPltAddRemoveDenyList ::
+    forall pv.
+    (IsProtocolVersion pv, PVSupportsPLT pv) =>
+    SProtocolVersion pv -> Benchmark
+benchPltAddRemoveDenyList spv =
     benchBlockItemsAssertSuccess
+        spv
         "PLT add/remove deny list"
         [ createPltBlockItem plt1 $ (tokenInitializationParameters accountAddress0){CBOR.tipDenyList = Just True},
           Runner.AccountTx transaction
@@ -316,9 +365,13 @@ benchPltAddRemoveDenyList =
     operations txnCount = take txnCount $ cycle [addDenyListPltOp accountAddress1, removeDenyListPltOp accountAddress1]
 
 -- | Benchmark `operationScaleFactor` number of PLT transactions with no operations
-benchPltNoOperations :: Benchmark
-benchPltNoOperations =
+benchPltNoOperations ::
+    forall pv.
+    (IsProtocolVersion pv, PVSupportsPLT pv) =>
+    SProtocolVersion pv -> Benchmark
+benchPltNoOperations spv =
     benchBlockItemsAssertSuccess
+        spv
         "PLT no operations"
         ( createPltBlockItem plt1 (tokenInitializationParameters accountAddress0)
             : (Runner.AccountTx <$> transactions operationScaleFactor)
@@ -334,9 +387,13 @@ benchPltNoOperations =
 
 -- | Benchmark `operationScaleFactor` number of PLT transaction each with a single PLT transfer operation. Benchmark should be equal
 -- to sum of PLT transaction with no operations plus PLT transfer operation
-benchPltTxnAndTransfer :: Benchmark
-benchPltTxnAndTransfer =
+benchPltTxnAndTransfer ::
+    forall pv.
+    (IsProtocolVersion pv, PVSupportsPLT pv) =>
+    SProtocolVersion pv -> Benchmark
+benchPltTxnAndTransfer spv =
     benchBlockItemsAssertSuccess
+        spv
         "PLT txn + PLT transfer"
         ( createPltBlockItem plt1 (tokenInitializationParameters accountAddress0)
             : (Runner.AccountTx <$> transactions operationScaleFactor)
@@ -353,9 +410,13 @@ benchPltTxnAndTransfer =
     operation = transferPltOp accountAddress1 1_000
 
 -- | Benchmark `operationScaleFactor` number of PLT transactions with invalid CBOR
-benchPltTxnCborDecodeError :: Benchmark
-benchPltTxnCborDecodeError =
+benchPltTxnCborDecodeError ::
+    forall pv.
+    (IsProtocolVersion pv, PVSupportsPLT pv) =>
+    SProtocolVersion pv -> Benchmark
+benchPltTxnCborDecodeError spv =
     benchBlockItems
+        spv
         "PLT cbor decode error"
         False
         ( createPltBlockItem plt1 (tokenInitializationParameters accountAddress0)
@@ -380,20 +441,34 @@ benchPltTxnCborDecodeError =
     operation = transferPltOp accountAddress1 1_000
 
 -- | Benchmark running no transactions (test framework overhead)
-benchNoTxns :: Benchmark
-benchNoTxns = benchBlockItemsAssertSuccess "no txns (overhead)" []
+benchNoTxns ::
+    forall pv.
+    (IsProtocolVersion pv, PVSupportsPLT pv) =>
+    SProtocolVersion pv -> Benchmark
+benchNoTxns spv = benchBlockItemsAssertSuccess spv "no txns (overhead)" []
 
 main :: IO ()
 main =
-    defaultMain
-        [ benchTransfer,
-          benchPltTransfer,
-          benchNoTxns,
-          benchPltMint,
-          benchPltBurn,
-          benchPltNoOperations,
-          benchPltAddRemoveAllowList,
-          benchPltAddRemoveDenyList,
-          benchPltTxnAndTransfer,
-          benchPltTxnCborDecodeError
-        ]
+    defaultMain $
+        catMaybes $
+            Helpers.forEveryProtocolVersion benches
+  where
+    benches :: forall pv. (IsProtocolVersion pv) => SProtocolVersion pv -> String -> Maybe Benchmark
+    benches spv pvString =
+        case sSupportsPLT (sAccountVersionFor spv) of
+            STrue ->
+                Just $
+                    bgroup
+                        pvString
+                        [ benchTransfer spv,
+                          benchPltTransfer spv,
+                          benchNoTxns spv,
+                          benchPltMint spv,
+                          benchPltBurn spv,
+                          benchPltNoOperations spv,
+                          benchPltAddRemoveAllowList spv,
+                          benchPltAddRemoveDenyList spv,
+                          benchPltTxnAndTransfer spv,
+                          benchPltTxnCborDecodeError spv
+                        ]
+            SFalse -> Nothing

--- a/plt/plt-block-state/tests/block_state.rs
+++ b/plt/plt-block-state/tests/block_state.rs
@@ -279,7 +279,7 @@ fn test_store_and_load_plts() {
         module_ref: TokenModuleRef::from([5; 32]),
         decimals: 4,
     };
-    let token2 = block_state.create_token(configuration2.clone());
+    let _token2 = block_state.create_token(configuration2.clone());
 
     // Store block state
     let blob_ref = blob_store::store_to_store(
@@ -324,7 +324,7 @@ fn test_store_and_load_plts() {
 /// todo extend this test on the haskell side as part of https://linear.app/concordium/issue/PSR-85/implement-test-of-storage-and-hashing
 #[test]
 fn snapshot_test_hash_empty() {
-    let mut block_state = block_state_no_external::new_mutable_block_state(ProtocolVersion::P11);
+    let block_state = block_state_no_external::new_mutable_block_state(ProtocolVersion::P11);
 
     // Assert hash
     let immutable_state = block_state.internal_block_state.into_immutable();


### PR DESCRIPTION
## Purpose

Benchmarks of PLT functionality across P9, P10, and P11.

Results on https://linear.app/concordium/issue/COR-2342/run-plt-scheduler-benchmarks-rust-vs-haskell
Results are that P11 is slightly faster than P9. Especially it is faster, the more of the transaction that is executed in Rust (e.g. executing a transaction with many PLT operations inside).

## Changes

Extended the existing benchmarks to run on P10 and P11 also.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
