### PR TITLE
Ar/psr 85 implement test of storage and hashing

### DIFF
--- a/concordium-consensus/tests/globalstate/GlobalStateTests/ProtocolLevelTokens.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/ProtocolLevelTokens.hs
@@ -21,8 +21,11 @@ import Concordium.GlobalState.Persistent.BlobStore
 import Concordium.GlobalState.Persistent.BlockState.ProtocolLevelTokens
 import Concordium.GlobalState.Persistent.BlockState.ProtocolLevelTokens.RustPLTBlockState
 import Control.Monad.IO.Class
-import qualified Data.FixedByteString as FBS
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base16.Lazy as B16
+import Data.Either
+import qualified Data.FixedByteString as FBS
+import Data.Maybe
 
 -- | Generate a 'TokenRawAmount' value.
 genTokenRawAmount :: Gen TokenRawAmount
@@ -197,6 +200,8 @@ testUpdateTokenState = runWithNewMemBlobStore $ do
 snapshotTestHashEmpty :: Assertion
 snapshotTestHashEmpty = runWithNewMemBlobStore $ do
     tokensState <- emptyPLTPV
+
+    -- Assert hash
     (hash1 :: ProtocolLevelTokensHash) <- uncond <$> getHashM tokensState
     liftIO $ show hash1 `shouldBe` "c423f9e91ee218b2b5303485dd87a3093a653ddb9bdb839d30aa1924de1dbf05"
 
@@ -204,6 +209,8 @@ snapshotTestHashEmpty = runWithNewMemBlobStore $ do
 snapshotTestHashSimple :: Assertion
 snapshotTestHashSimple = runWithNewMemBlobStore $ do
     tokensState1 <- emptyPLTPV
+
+    -- Create tokens
     let config1 =
             PLTConfiguration
                 { _pltTokenId = TokenId "token1",
@@ -223,9 +230,69 @@ snapshotTestHashSimple = runWithNewMemBlobStore $ do
                   _pltDecimals = 4
                 }
     (_tokenIndex2, tokensState5) <- createToken config2 tokensState4
-    
+
+    -- Assert hash
     (hash1 :: ProtocolLevelTokensHash) <- uncond <$> getHashM tokensState5
     liftIO $ show hash1 `shouldBe` "d202e9153fea3fdd22c594be21d471c07e9619abc0baad3faca5c81f0bb1504b"
+
+-- | Load empty PLTs state from storage fixture, to make sure we stay compatible.
+fixtureTestLoadEmpty :: Assertion
+fixtureTestLoadEmpty = runWithNewMemBlobStore $ do
+    mbs1 <- liftIO $ newMemBlobStoreWithBytes $ fromRight undefined $ B16.decode "00000000000000080000000000000000"
+    flip
+        runMemBlobStoreT
+        mbs1
+        ( do
+            -- Load empty PLTs state
+            (emptyStateV0 :: ProtocolLevelTokens) <-
+                loadDirect $ BlobRef 0
+            emptyState <- ProtocolLevelTokensV0 <$> refMake emptyStateV0
+
+            -- Assert empty
+            pltList <- getPLTList emptyState
+            liftIO $ assertEqual "PLTList" (length pltList) 0
+        )
+
+-- | Load PLTs state with some simple PLTs from storage fixture, to make sure we stay compatible.
+fixtureTestLoadSimple :: Assertion
+fixtureTestLoadSimple = runWithNewMemBlobStore $ do
+    mbs1 <- liftIO $ newMemBlobStoreWithBytes $ fromRight undefined $ B16.decode "000000000000002806746f6b656e310505050505050505050505050505050505050505050505050505050505050505020000000000000025edbda48b85971b3a874334ca94f07e55e6a6e63eabca968d1257a3223e1b84e14002010100000000000000002503b0eab929105fd6df1ec793cbaf1b554a7a385520a9f7c902adf0219ace6dab4002000000000000000000003648b07111a93452374c7bcf66ee01959af6b4a52cb7cd299341e9ea77b378b0230300000201000000000000005d020000000000000030000000000000000901000000000000008a0000000000000011000000000000000000000000000000c86400000000000000090000000000000000d9000000000000002806746f6b656e3205050505050505050505050505050505050505050505050505050505050505050400000000000000010000000000000000110000000000000103000000000000013300000000000000000900000000000000013c0000000000000021000000000000000201000000000000000000000000000000f20000000000000155"
+    flip
+        runMemBlobStoreT
+        mbs1
+        ( do
+            -- Load simple PLTs state
+            (simpleStateV0 :: ProtocolLevelTokens) <-
+                loadDirect $ BlobRef 358
+            simpleState <- ProtocolLevelTokensV0 <$> refMake simpleStateV0
+
+            -- Assert token state
+            pltList <- getPLTList simpleState
+            liftIO $ assertEqual "PLTList" (length pltList) 2
+            let expectedConfig1 =
+                    PLTConfiguration
+                        { _pltTokenId = TokenId "token1",
+                          _pltModule = TokenModuleRef $ Hash $ FBS.pack (replicate 32 5),
+                          _pltDecimals = 2
+                        }
+            tokenIndex1 <- fromJust <$> getTokenIndex (TokenId "token1") simpleState
+            config1 <- getTokenConfiguration tokenIndex1 simpleState
+            liftIO $ assertEqual "config1" config1 expectedConfig1
+            keyValueState1 <- getMutableTokenState tokenIndex1 simpleState
+            value1 <- lookupTokenState (BS.pack [0, 1]) keyValueState1
+            liftIO $ assertEqual "value1" value1 (Just $ BS.pack [0, 0])
+            value2 <- lookupTokenState (BS.pack [0, 2]) keyValueState1
+            liftIO $ assertEqual "value1" value2 (Just $ BS.pack [1, 1])
+            let expectedConfig2 =
+                    PLTConfiguration
+                        { _pltTokenId = TokenId "token2",
+                          _pltModule = TokenModuleRef $ Hash $ FBS.pack (replicate 32 5),
+                          _pltDecimals = 4
+                        }
+            tokenIndex2 <- fromJust <$> getTokenIndex (TokenId "token2") simpleState
+            config2 <- getTokenConfiguration tokenIndex2 simpleState
+            liftIO $ assertEqual "config2" config2 expectedConfig2
+        )
 
 tests :: Spec
 tests = describe "GlobalStateTests.ProtocolLevelTokens" $ do
@@ -233,4 +300,6 @@ tests = describe "GlobalStateTests.ProtocolLevelTokens" $ do
     it "setTokenCirculatingSupply" testSetTokenCirculatingSupply
     it "updateTokenState" testUpdateTokenState
     it "snapshotHashEmpty" snapshotTestHashEmpty
-    it "snapshotHashSimple" snapshotTestHashSimple    
+    it "snapshotHashSimple" snapshotTestHashSimple
+    it "fixtureLoadEmpty" fixtureTestLoadEmpty
+    it "fixtureLoadSimple" fixtureTestLoadSimple

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/ProtocolLevelTokens.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/ProtocolLevelTokens.hs
@@ -16,17 +16,21 @@ import Concordium.Types.Conditionally
 import Concordium.Types.HashableTo
 import Concordium.Types.Tokens
 
+import Concordium.Crypto.SHA256
 import Concordium.GlobalState.Persistent.BlobStore
 import Concordium.GlobalState.Persistent.BlockState.ProtocolLevelTokens
 import Concordium.GlobalState.Persistent.BlockState.ProtocolLevelTokens.RustPLTBlockState
+import Control.Monad.IO.Class
+import qualified Data.FixedByteString as FBS
+import qualified Data.ByteString as BS
 
 -- | Generate a 'TokenRawAmount' value.
 genTokenRawAmount :: Gen TokenRawAmount
 genTokenRawAmount = TokenRawAmount <$> arbitrary
 
 -- | Run an action in the 'MemBlobStoreT' monad transformer from an empty store.
-runBlobStore :: MemBlobStoreT IO a -> IO a
-runBlobStore a = do
+runWithNewMemBlobStore :: MemBlobStoreT IO a -> IO a
+runWithNewMemBlobStore a = do
     mbs <- newMemBlobStore
     runMemBlobStoreT a mbs
 
@@ -56,7 +60,7 @@ emptyPLTPV :: (MonadBlobStore m) => m (ProtocolLevelTokensForStateVersion 'PLTSt
 emptyPLTPV = emptyProtocolLevelTokensForStateVersion
 
 testCreateToken :: Assertion
-testCreateToken = runBlobStore $ do
+testCreateToken = runWithNewMemBlobStore $ do
     (idx, tokens) <- createToken configABC =<< emptyPLTPV
     checks0 idx tokens
     (idx', tokens') <- createToken configDEF tokens
@@ -90,7 +94,7 @@ testCreateToken = runBlobStore $ do
             =<< getTokenConfiguration idx' tokens'
 
 testSetTokenCirculatingSupply :: Assertion
-testSetTokenCirculatingSupply = runBlobStore $ do
+testSetTokenCirculatingSupply = runWithNewMemBlobStore $ do
     (idxABC, tokens0) <- createToken configABC =<< emptyPLTPV
     (idxDEF, tokens1) <- createToken configDEF tokens0
     tokens2 <- setTokenCirculatingSupply idxABC 100 tokens1
@@ -125,7 +129,7 @@ testSetTokenCirculatingSupply = runBlobStore $ do
     lift $ assertEqual "Hash of tokens3 and tokens6 should be the same" hash3 hash6
 
 testUpdateTokenState :: Assertion
-testUpdateTokenState = runBlobStore $ do
+testUpdateTokenState = runWithNewMemBlobStore $ do
     (idxABC, tokens0) <- createToken configABC =<< emptyPLTPV
     (idxDEF, tokens1) <- createToken configDEF tokens0
     mutableStateABC <- getMutableTokenState idxABC tokens1
@@ -189,8 +193,44 @@ testUpdateTokenState = runBlobStore $ do
     hash3 <- uncond <$> getHashM tokens3
     lift $ assertEqual "Hash of tokens2 and tokens3 should be the same" hash2 hash3
 
+-- | Asserts "shapshot" of hash of empty 'ProtocolLevelTokens' to make sure it does not change.
+snapshotTestHashEmpty :: Assertion
+snapshotTestHashEmpty = runWithNewMemBlobStore $ do
+    tokensState <- emptyPLTPV
+    (hash1 :: ProtocolLevelTokensHash) <- uncond <$> getHashM tokensState
+    liftIO $ show hash1 `shouldBe` "c423f9e91ee218b2b5303485dd87a3093a653ddb9bdb839d30aa1924de1dbf05"
+
+-- | Asserts "shapshot" of hash of 'ProtocolLevelTokens' with some simple PLTs to make sure it does not change.
+snapshotTestHashSimple :: Assertion
+snapshotTestHashSimple = runWithNewMemBlobStore $ do
+    tokensState1 <- emptyPLTPV
+    let config1 =
+            PLTConfiguration
+                { _pltTokenId = TokenId "token1",
+                  _pltModule = TokenModuleRef $ Hash $ FBS.pack (replicate 32 5),
+                  _pltDecimals = 2
+                }
+    (tokenIndex1, tokensState2) <- createToken config1 tokensState1
+    tokensState3 <- setTokenCirculatingSupply tokenIndex1 100 tokensState2
+    mutableKeyValueState1 <- getMutableTokenState tokenIndex1 tokensState3
+    _ <- updateTokenState (BS.pack [0, 1]) (Just (BS.pack [0, 0])) mutableKeyValueState1
+    _ <- updateTokenState (BS.pack [0, 2]) (Just (BS.pack [1, 1])) mutableKeyValueState1
+    tokensState4 <- setTokenState tokenIndex1 mutableKeyValueState1 tokensState3
+    let config2 =
+            PLTConfiguration
+                { _pltTokenId = TokenId "token2",
+                  _pltModule = TokenModuleRef $ Hash $ FBS.pack (replicate 32 5),
+                  _pltDecimals = 4
+                }
+    (_tokenIndex2, tokensState5) <- createToken config2 tokensState4
+    
+    (hash1 :: ProtocolLevelTokensHash) <- uncond <$> getHashM tokensState5
+    liftIO $ show hash1 `shouldBe` "d202e9153fea3fdd22c594be21d471c07e9619abc0baad3faca5c81f0bb1504b"
+
 tests :: Spec
 tests = describe "GlobalStateTests.ProtocolLevelTokens" $ do
     it "createToken" testCreateToken
     it "setTokenCirculatingSupply" testSetTokenCirculatingSupply
     it "updateTokenState" testUpdateTokenState
+    it "snapshotHashEmpty" snapshotTestHashEmpty
+    it "snapshotHashSimple" snapshotTestHashSimple    

--- a/plt/plt-block-state/src/block_state/state/protocol_level_tokens.rs
+++ b/plt/plt-block-state/src/block_state/state/protocol_level_tokens.rs
@@ -281,9 +281,6 @@ impl Hashable for Token {
         let key_value_state = self.key_value_state.hash(loader)?;
         let state = hash::hash_of_serialization((key_value_state, self.circulating_supply.0));
 
-        Ok(hash::hash_of_hashes(
-            config,
-            state,
-        ))
+        Ok(hash::hash_of_hashes(config, state))
     }
 }

--- a/plt/plt-block-state/src/block_state/state/protocol_level_tokens.rs
+++ b/plt/plt-block-state/src/block_state/state/protocol_level_tokens.rs
@@ -279,11 +279,11 @@ impl Hashable for Token {
     fn hash(&self, loader: &impl BlobStoreLoad) -> BlockStateResult<Hash> {
         let config = self.configuration.hash(loader)?;
         let key_value_state = self.key_value_state.hash(loader)?;
-        let circulating_supply = self.circulating_supply.hash(loader)?;
+        let state = hash::hash_of_serialization((key_value_state, self.circulating_supply.0));
 
         Ok(hash::hash_of_hashes(
             config,
-            hash::hash_of_hashes(key_value_state, circulating_supply),
+            state,
         ))
     }
 }

--- a/plt/plt-block-state/tests/block_state.rs
+++ b/plt/plt-block-state/tests/block_state.rs
@@ -248,8 +248,6 @@ fn test_key_value_state_prefix_iter() {
 }
 
 /// Store state with PLTs to blob store and load it again.
-///
-/// todo extend this test with a blob store fixture that matches the haskell side part of https://linear.app/concordium/issue/PSR-85/implement-test-of-storage-and-hashing
 #[test]
 fn test_store_and_load_plts() {
     let mut block_state = block_state_no_external::new_mutable_block_state(ProtocolVersion::P11);
@@ -320,11 +318,9 @@ fn test_store_and_load_plts() {
 
 /// Assert that hash of an empty block state matches a fixed/snapshot hash. The hash
 /// must remain stable.
-///
-/// todo extend this test on the haskell side as part of https://linear.app/concordium/issue/PSR-85/implement-test-of-storage-and-hashing
 #[test]
-fn snapshot_test_hash_empty() {
-    let block_state = block_state_no_external::new_mutable_block_state(ProtocolVersion::P11);
+fn snapshot_test_hash_empty_p10() {
+    let block_state = block_state_no_external::new_mutable_block_state(ProtocolVersion::P10);
 
     // Assert hash
     let immutable_state = block_state.internal_block_state.into_immutable();
@@ -339,11 +335,9 @@ fn snapshot_test_hash_empty() {
 
 /// Assert that hash of block state with some simple PLTs matches a fixed/snapshot hash. The hash
 /// must remain stable.
-///
-/// todo extend this test on the haskell side as part of https://linear.app/concordium/issue/PSR-85/implement-test-of-storage-and-hashing
 #[test]
-fn snapshot_test_hash_simple_plts() {
-    let mut block_state = block_state_no_external::new_mutable_block_state(ProtocolVersion::P11);
+fn snapshot_test_hash_simple_plts_p10() {
+    let mut block_state = block_state_no_external::new_mutable_block_state(ProtocolVersion::P10);
 
     // Create tokens
     let configuration1 = TokenConfiguration {
@@ -386,14 +380,14 @@ fn snapshot_test_hash_simple_plts() {
 /// Load empty block state from storage bytes fixture.
 /// The fixture bytes must not change and must be compatible with Haskell PLT state implementation.
 #[test]
-fn fixture_test_storage_empty() {
+fn fixture_test_storage_empty_p10() {
     let store = BlobStoreStub(hex::decode("00000000000000080000000000000000").unwrap());
 
     // Load block state
     let immutable_state = blob_store::load_from_store::<BlockState>(&store, BlobStoreLocation(0))
         .expect("load block state");
     let block_state =
-        block_state_no_external::with_block_state(ProtocolVersion::P11, store, &immutable_state);
+        block_state_no_external::with_block_state(ProtocolVersion::P10, store, &immutable_state);
 
     // Assert loaded state
     assert_eq!(block_state.plt_list().len(), 0);
@@ -402,14 +396,14 @@ fn fixture_test_storage_empty() {
 /// Load block state with some simple PLTs from storage bytes fixture.
 /// The fixture bytes must not change and must be compatible with Haskell PLT state implementation.
 #[test]
-fn fixture_test_storage_simple_plts() {
+fn fixture_test_storage_simple_plts_p10() {
     let store = BlobStoreStub(hex::decode("000000000000002806746f6b656e310505050505050505050505050505050505050505050505050505050505050505020000000000000025edbda48b85971b3a874334ca94f07e55e6a6e63eabca968d1257a3223e1b84e14002010100000000000000002503b0eab929105fd6df1ec793cbaf1b554a7a385520a9f7c902adf0219ace6dab4002000000000000000000003648b07111a93452374c7bcf66ee01959af6b4a52cb7cd299341e9ea77b378b0230300000201000000000000005d020000000000000030000000000000000901000000000000008a0000000000000011000000000000000000000000000000c86400000000000000090000000000000000d9000000000000002806746f6b656e3205050505050505050505050505050505050505050505050505050505050505050400000000000000010000000000000000110000000000000103000000000000013300000000000000000900000000000000013c0000000000000021000000000000000201000000000000000000000000000000f20000000000000155").unwrap());
 
     // Load block state
     let immutable_state = blob_store::load_from_store::<BlockState>(&store, BlobStoreLocation(358))
         .expect("load block state");
     let block_state =
-        block_state_no_external::with_block_state(ProtocolVersion::P11, store, &immutable_state);
+        block_state_no_external::with_block_state(ProtocolVersion::P10, store, &immutable_state);
 
     // Assert loaded state
     assert_eq!(block_state.plt_list().len(), 2);

--- a/plt/plt-block-state/tests/block_state.rs
+++ b/plt/plt-block-state/tests/block_state.rs
@@ -379,7 +379,7 @@ fn snapshot_test_hash_simple_plts() {
         .expect("hash");
     assert_eq!(
         format!("{}", hash),
-        "231140c20455e597dd5e9a6f09f0bdb718d68e400a241a10a98cda35e77baa05"
+        "d202e9153fea3fdd22c594be21d471c07e9619abc0baad3faca5c81f0bb1504b"
     );
 }
 


### PR DESCRIPTION
## Purpose

Tests snapshots/fixtures for hashing and storage of PLT block state.

## Changes

Implemented tests on both Rust and Haskell side, with same hash snapshots and storage fixtures (using P9/P10).

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

