### PR TITLE
Handle unrecoverable errors in blockstate FFI

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/ProtocolLevelTokens/RustPLTBlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/ProtocolLevelTokens/RustPLTBlockState.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- | Bindings to the Rust PLT block state implementation.
 --
@@ -20,6 +21,7 @@ import qualified Concordium.Crypto.SHA256 as SHA256
 import qualified Concordium.GlobalState.ContractStateFFIHelpers as FFI
 import qualified Concordium.GlobalState.Persistent.BlobStore as BlobStore
 import qualified Concordium.Types.HashableTo as Hashable
+import qualified Control.Monad as Monad
 import Control.Monad.Trans (lift, liftIO)
 import qualified Data.FixedByteString as FixedByteString
 
@@ -67,11 +69,17 @@ instance (BlobStore.MonadBlobStore m) => BlobStore.BlobStorable m ForeignPLTBloc
         pure $! do
             loadCallback <- fst <$> BlobStore.getCallbacks
             liftIO $! do
-                blockState <- ffiLoadPLTBlockState loadCallback blobRef
-                wrapFFIPtr blockState
+                FFI.alloca $ \blockStateDestPtr -> do
+                    status <- ffiLoadPLTBlockState loadCallback blobRef blockStateDestPtr
+                    Monad.unless (status == 0) $ error "Unexpected panic when loading a block state"
+                    blockState <- FFI.peek blockStateDestPtr
+                    wrapFFIPtr blockState
     storeUpdate pltBlockState = do
         storeCallback <- snd <$> BlobStore.getCallbacks
-        blobRef <- liftIO $ withPLTBlockState pltBlockState $ ffiStorePLTBlockState storeCallback
+        blobRef <- liftIO $ FFI.alloca $ \blobRefDestPtr -> do
+            status <- withPLTBlockState pltBlockState $ ffiStorePLTBlockState storeCallback blobRefDestPtr
+            Monad.unless (status == 0) $ error "Unexpected panic when storing a block state"
+            BlobStore.BlobRef @RustPLTBlockState <$> FFI.peek blobRefDestPtr
         return (S.put blobRef, pltBlockState)
 
 -- | Load PLT block state from the given disk reference.
@@ -83,8 +91,10 @@ foreign import ccall "ffi_load_plt_block_state"
         FFI.LoadCallback ->
         -- | Reference in the blob store.
         BlobStore.BlobRef RustPLTBlockState ->
-        -- | Pointer to the loaded block state.
-        IO (FFI.Ptr RustPLTBlockState)
+        -- | Destination pointer for the loaded block state.
+        FFI.Ptr (FFI.Ptr RustPLTBlockState) ->
+        -- | Status code
+        IO FFI.Word8
 
 -- | Write out the block state using the provided callback, and return a `BlobRef`.
 --
@@ -93,15 +103,18 @@ foreign import ccall "ffi_store_plt_block_state"
     ffiStorePLTBlockState ::
         -- | The provided closure is called to write data to blob store.
         FFI.StoreCallback ->
+        -- | Destination for the new reference in the blob store.
+        FFI.Ptr FFI.Word64 ->
         -- | Pointer to the block state to write.
         FFI.Ptr RustPLTBlockState ->
-        -- | New reference in the blob store.
-        IO (BlobStore.BlobRef RustPLTBlockState)
+        -- | Status code
+        IO FFI.Word8
 
 instance (BlobStore.MonadBlobStore m) => BlobStore.Cacheable m ForeignPLTBlockStatePtr where
     cache blockState = do
         loadCallback <- fst <$> BlobStore.getCallbacks
-        liftIO $! withPLTBlockState blockState (ffiCachePLTBlockState loadCallback)
+        status <- liftIO $! withPLTBlockState blockState (ffiCachePLTBlockState loadCallback)
+        Monad.unless (status == 0) $ error "Unexpected panic when caching a block state"
         return blockState
 
 -- | Cache block state into memory.
@@ -113,7 +126,7 @@ foreign import ccall "ffi_cache_plt_block_state"
         FFI.LoadCallback ->
         -- | Pointer to the block state to cache into memory.
         FFI.Ptr RustPLTBlockState ->
-        IO ()
+        IO FFI.Word8
 
 -- | The hash of protocol-levels tokens state.
 newtype ProtocolLevelTokensHash = ProtocolLevelTokensHash {theProtocolLevelTokensHash :: SHA256.Hash}
@@ -124,8 +137,10 @@ instance (BlobStore.MonadBlobStore m) => Hashable.MHashableTo m ProtocolLevelTok
         loadCallback <- fst <$> BlobStore.getCallbacks
         ((), hash) <-
             liftIO $
-                withPLTBlockState blockState $
-                    FixedByteString.createWith . ffiHashPLTBlockState loadCallback
+                withPLTBlockState blockState $ \blockStatePtr ->
+                    FixedByteString.createWith $ \hashDestPtr -> do
+                        status <- ffiHashPLTBlockState loadCallback blockStatePtr hashDestPtr
+                        Monad.unless (status == 0) $ error "Unexpected panic when hashing a block state"
         return $ ProtocolLevelTokensHash (SHA256.Hash hash)
 
 -- | Compute the hash of the block state.
@@ -139,7 +154,8 @@ foreign import ccall "ffi_hash_plt_block_state"
         FFI.Ptr RustPLTBlockState ->
         -- | Pointer to write destination of the hash
         FFI.Ptr FFI.Word8 ->
-        IO ()
+        -- | Status code
+        IO FFI.Word8
 
 -- | Run migration during a protocol update.
 migrate ::
@@ -151,8 +167,11 @@ migrate ::
 migrate currentState = do
     loadCallback <- fst <$> lift BlobStore.getCallbacks
     storeCallback <- snd <$> BlobStore.getCallbacks
-    newState <- liftIO $ withPLTBlockState currentState $ ffiMigratePLTBlockState loadCallback storeCallback
-    liftIO $ wrapFFIPtr newState
+    liftIO $ FFI.alloca $ \newStateDestPtr -> do
+        status <- withPLTBlockState currentState $ ffiMigratePLTBlockState loadCallback storeCallback newStateDestPtr
+        Monad.unless (status == 0) $ error "Unexpected panic when migrating a block state"
+        newState <- FFI.peek newStateDestPtr
+        wrapFFIPtr newState
 
 -- | Migrate PLT block state from one blob store to another.
 --
@@ -163,7 +182,9 @@ foreign import ccall "ffi_migrate_plt_block_state"
         FFI.LoadCallback ->
         -- | Called to write data to the new blob store.
         FFI.StoreCallback ->
+        -- | Pointer to the new block state.
+        FFI.Ptr (FFI.Ptr RustPLTBlockState) ->
         -- | Pointer to the old block state.
         FFI.Ptr RustPLTBlockState ->
-        -- | Pointer to the new block state.
-        IO (FFI.Ptr RustPLTBlockState)
+        -- | Status code
+        IO FFI.Word8

--- a/plt/plt-block-state/src/ffi.rs
+++ b/plt/plt-block-state/src/ffi.rs
@@ -6,3 +6,4 @@ pub mod blob_store_callbacks;
 mod block_state;
 pub mod block_state_callbacks;
 pub mod memory;
+pub mod status;

--- a/plt/plt-block-state/src/ffi/block_state.rs
+++ b/plt/plt-block-state/src/ffi/block_state.rs
@@ -2,8 +2,10 @@
 //!
 //! It is only available if the `ffi` feature is enabled.
 
+use super::status;
 use crate::block_state::{PltBlockStateSavepoint, blob_store};
 use crate::ffi::blob_store_callbacks::{LoadCallback, StoreCallback};
+use crate::ffi::status::FfiStatusCode;
 
 /// Allocate a new empty PLT block state and returns it.
 ///
@@ -17,6 +19,9 @@ extern "C" fn ffi_empty_plt_block_state() -> *mut PltBlockStateSavepoint {
 
 /// Deallocate the PLT block state.
 ///
+/// This is called by the Haskell garbage collector, therefore we cannot handle
+/// a status code unlike other FFI functions in this module.
+///
 /// # Arguments
 ///
 /// - `block_state` Unique pointer to the PLT block state.
@@ -28,9 +33,14 @@ extern "C" fn ffi_empty_plt_block_state() -> *mut PltBlockStateSavepoint {
 /// - Freeing is only ever done once.
 #[unsafe(no_mangle)]
 extern "C" fn ffi_free_plt_block_state(block_state: *mut PltBlockStateSavepoint) {
-    assert!(!block_state.is_null(), "block_state is a null pointer.");
-    let state = unsafe { Box::from_raw(block_state) };
-    drop(state);
+    let panic_message = status::catch_unwind(move || {
+        assert!(!block_state.is_null(), "block_state is a null pointer.");
+        let state = unsafe { Box::from_raw(block_state) };
+        drop(state);
+    });
+    if let Some(message) = panic_message {
+        eprintln!("{}", message);
+    }
 }
 
 /// Compute the hash of the PLT block state.
@@ -52,13 +62,21 @@ extern "C" fn ffi_hash_plt_block_state(
     mut load_callback: LoadCallback,
     block_state: *const PltBlockStateSavepoint,
     destination: *mut u8,
-) {
-    assert!(!block_state.is_null(), "block_state is a null pointer.");
-    assert!(!destination.is_null(), "destination is a null pointer.");
-    let block_state = unsafe { &*block_state };
-    let hash = block_state.hash(&mut load_callback);
-    unsafe {
-        std::ptr::copy_nonoverlapping(hash.as_ptr(), destination, hash.len());
+) -> status::FfiStatusCode {
+    let panic_message = status::catch_unwind(move || {
+        assert!(!block_state.is_null(), "block_state is a null pointer.");
+        assert!(!destination.is_null(), "destination is a null pointer.");
+        let block_state = unsafe { &*block_state };
+        let hash = block_state.hash(&mut load_callback);
+        unsafe {
+            std::ptr::copy_nonoverlapping(hash.as_ptr(), destination, hash.len());
+        }
+    });
+    if let Some(message) = panic_message {
+        eprintln!("{}", message);
+        status::FfiStatusCode::Panic
+    } else {
+        status::FfiStatusCode::Success
     }
 }
 
@@ -79,11 +97,21 @@ extern "C" fn ffi_hash_plt_block_state(
 extern "C" fn ffi_load_plt_block_state(
     mut load_callback: LoadCallback,
     blob_ref: blob_store::Reference,
-) -> *mut PltBlockStateSavepoint {
-    // todo implement error handling for unrecoverable errors (instead of unwrap) in https://linear.app/concordium/issue/PSR-39/decide-and-implement-strategy-for-handling-panics-in-the-rust-code
-    let block_state =
-        blob_store::Loadable::load_from_location(&mut load_callback, blob_ref).unwrap();
-    Box::into_raw(Box::new(block_state))
+    destination: *mut *mut PltBlockStateSavepoint,
+) -> status::FfiStatusCode {
+    let panic_message = status::catch_unwind(move || {
+        let block_state = blob_store::Loadable::load_from_location(&mut load_callback, blob_ref)
+            .expect("Failed loading block state");
+        unsafe {
+            *destination = Box::into_raw(Box::new(block_state));
+        }
+    });
+    if let Some(message) = panic_message {
+        eprintln!("{}", message);
+        status::FfiStatusCode::Panic
+    } else {
+        status::FfiStatusCode::Success
+    }
 }
 
 /// Store a PLT block state in the blob store.
@@ -102,11 +130,23 @@ extern "C" fn ffi_load_plt_block_state(
 #[unsafe(no_mangle)]
 extern "C" fn ffi_store_plt_block_state(
     mut store_callback: StoreCallback,
+    destination: *mut blob_store::Reference,
     block_state: *const PltBlockStateSavepoint,
-) -> blob_store::Reference {
-    assert!(!block_state.is_null(), "block_state is a null pointer.");
-    let block_state = unsafe { &*block_state };
-    block_state.store_update(&mut store_callback)
+) -> status::FfiStatusCode {
+    let panic_message = status::catch_unwind(move || {
+        assert!(!block_state.is_null(), "block_state is a null pointer.");
+        let block_state = unsafe { &*block_state };
+        let reference = block_state.store_update(&mut store_callback);
+        unsafe {
+            *destination = reference;
+        }
+    });
+    if let Some(message) = panic_message {
+        eprintln!("{}", message);
+        status::FfiStatusCode::Panic
+    } else {
+        status::FfiStatusCode::Success
+    }
 }
 
 /// Migrate the PLT block state from one blob store to another and return the migrated state.
@@ -131,12 +171,23 @@ extern "C" fn ffi_store_plt_block_state(
 extern "C" fn ffi_migrate_plt_block_state(
     mut load_callback: LoadCallback,
     mut store_callback: StoreCallback,
+    destination: *mut *mut PltBlockStateSavepoint,
     block_state: *const PltBlockStateSavepoint,
-) -> *mut PltBlockStateSavepoint {
-    assert!(!block_state.is_null(), "block_state is a null pointer.");
-    let block_state = unsafe { &*block_state };
-    let new_block_state = block_state.migrate(&mut load_callback, &mut store_callback);
-    Box::into_raw(Box::new(new_block_state))
+) -> status::FfiStatusCode {
+    let panic_message = status::catch_unwind(move || {
+        assert!(!block_state.is_null(), "block_state is a null pointer.");
+        let block_state = unsafe { &*block_state };
+        let new_block_state = block_state.migrate(&mut load_callback, &mut store_callback);
+        unsafe {
+            *destination = Box::into_raw(Box::new(new_block_state));
+        }
+    });
+    if let Some(message) = panic_message {
+        eprintln!("{}", message);
+        status::FfiStatusCode::Panic
+    } else {
+        status::FfiStatusCode::Success
+    }
 }
 
 /// Cache the PLT block state into memory.
@@ -155,8 +206,16 @@ extern "C" fn ffi_migrate_plt_block_state(
 extern "C" fn ffi_cache_plt_block_state(
     mut load_callback: LoadCallback,
     block_state: *const PltBlockStateSavepoint,
-) {
-    assert!(!block_state.is_null(), "block_state is a null pointer.");
-    let block_state = unsafe { &*block_state };
-    block_state.cache(&mut load_callback)
+) -> FfiStatusCode {
+    let panic_message = status::catch_unwind(move || {
+        assert!(!block_state.is_null(), "block_state is a null pointer.");
+        let block_state = unsafe { &*block_state };
+        block_state.cache(&mut load_callback);
+    });
+    if let Some(message) = panic_message {
+        eprintln!("{}", message);
+        status::FfiStatusCode::Panic
+    } else {
+        status::FfiStatusCode::Success
+    }
 }

--- a/plt/plt-block-state/src/ffi/status.rs
+++ b/plt/plt-block-state/src/ffi/status.rs
@@ -1,0 +1,58 @@
+/// Returned status code used in FFI calls into this library.
+///
+/// This must match the `FFIStatusCode` type defined on the haskell side.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum FfiStatusCode {
+    /// The call succeeded.
+    Success = 0,
+    /// The call failed gracefully.
+    Failed = 1,
+    /// The call resulted in a (caught) panic.
+    Panic = 2,
+}
+
+/// Helper function for wrapping calls with [`std::panic::catch_unwind`] then mapping a panic to the
+/// correct status code and extracting the panic message.
+///
+/// # Arguments
+///
+/// - `function` The closure which might panic
+pub fn catch_unwind<F>(function: F) -> Option<String>
+where
+    F: std::panic::UnwindSafe + FnOnce(),
+{
+    if let Err(err) = std::panic::catch_unwind(function) {
+        let message = if let Some(message) = err.downcast_ref::<String>() {
+            message.clone()
+        } else if let Some(message) = err.downcast_ref::<&str>() {
+            message.to_string()
+        } else {
+            "Unknown panic reason".to_string()
+        };
+        Some(message)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_catch_unwind_panics_str() {
+        let message = catch_unwind(|| {
+            panic!("my panic message");
+        });
+        assert_eq!(message, Some("my panic message".to_string()));
+    }
+
+    #[test]
+    fn test_catch_unwind_panics_string() {
+        let message = catch_unwind(|| {
+            panic!("my panic message {:?}", vec![5]);
+        });
+        assert_eq!(message, Some("my panic message [5]".to_string()));
+    }
+}

--- a/plt/plt-scheduler/src/ffi/status.rs
+++ b/plt/plt-scheduler/src/ffi/status.rs
@@ -1,16 +1,4 @@
-/// Returned status code used in FFI calls into this library.
-///
-/// This must match the `FFIStatusCode` type defined on the haskell side.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(u8)]
-pub enum FfiStatusCode {
-    /// The call succeeded.
-    Success = 0,
-    /// The call failed gracefully.
-    Failed = 1,
-    /// The call resulted in a (caught) panic.
-    Panic = 2,
-}
+pub use plt_block_state::ffi::status::FfiStatusCode;
 
 /// Helper function for wrapping calls with [`std::panic::catch_unwind`] then mapping a panic to the
 /// correct status code and extracting the panic message.
@@ -18,9 +6,10 @@ pub enum FfiStatusCode {
 /// # Arguments
 ///
 /// - `function` The closure which might panic
-pub fn catch_unwind<F: FnOnce() -> (FfiStatusCode, Vec<u8>) + std::panic::UnwindSafe>(
-    function: F,
-) -> (FfiStatusCode, Vec<u8>) {
+pub fn catch_unwind<F>(function: F) -> (FfiStatusCode, Vec<u8>)
+where
+    F: FnOnce() -> (FfiStatusCode, Vec<u8>) + std::panic::UnwindSafe,
+{
     std::panic::catch_unwind(function).unwrap_or_else(|err| {
         let data_out = if let Some(message) = err.downcast_ref::<String>() {
             message.clone().into_bytes()


### PR DESCRIPTION
## Purpose

Closing PSR-86 ([link](https://linear.app/concordium/issue/PSR-86/handle-unrecoverable-errors-in-rust-blockstate-ffi))
Catch panic in the FFI related to operations on the block state.

