### PR TITLE
Remove the token kernel interface

### DIFF
--- a/plt/plt-scheduler/src/lib.rs
+++ b/plt/plt-scheduler/src/lib.rs
@@ -2,7 +2,7 @@
 mod ffi;
 pub mod queries;
 pub mod scheduler;
-mod token_kernel;
+mod token_context;
 mod token_module;
 mod transaction_execution;
 

--- a/plt/plt-scheduler/src/queries.rs
+++ b/plt/plt-scheduler/src/queries.rs
@@ -1,6 +1,6 @@
 //! Implementation of queries related to protocol-level tokens.
 
-use crate::token_kernel::TokenKernelQueriesImpl;
+use crate::token_kernel::TokenQueryContext;
 use crate::token_module;
 use concordium_base::protocol_level_tokens::TokenId;
 use plt_block_state::block_state_interface::{BlockStateQuery, TokenNotFoundByIdError};
@@ -40,7 +40,7 @@ pub fn query_token_info(
 
     let token_module_state = block_state.mutable_token_key_value_state(&token);
 
-    let kernel = TokenKernelQueriesImpl {
+    let kernel = TokenQueryContext {
         block_state,
         token_module_state: &token_module_state,
     };
@@ -78,7 +78,7 @@ where
 
             let token_module_state = block_state.mutable_token_key_value_state(&token);
 
-            let kernel = TokenKernelQueriesImpl {
+            let kernel = TokenQueryContext {
                 block_state,
                 token_module_state: &token_module_state,
             };
@@ -112,7 +112,7 @@ pub fn query_token_authorizations(
 ) -> Result<TokenAuthorizations, QueryTokenInfoError> {
     let token = block_state.token_by_id(token_id)?;
     let token_module_state = block_state.mutable_token_key_value_state(&token);
-    let kernel = TokenKernelQueriesImpl {
+    let kernel = TokenQueryContext {
         block_state,
         token_module_state: &token_module_state,
     };

--- a/plt/plt-scheduler/src/queries.rs
+++ b/plt/plt-scheduler/src/queries.rs
@@ -1,6 +1,6 @@
 //! Implementation of queries related to protocol-level tokens.
 
-use crate::token_kernel::TokenQueryContext;
+use crate::token_context::TokenQueryContext;
 use crate::token_module;
 use concordium_base::protocol_level_tokens::TokenId;
 use plt_block_state::block_state_interface::{BlockStateQuery, TokenNotFoundByIdError};
@@ -40,12 +40,12 @@ pub fn query_token_info(
 
     let token_module_state = block_state.mutable_token_key_value_state(&token);
 
-    let kernel = TokenQueryContext {
+    let context = TokenQueryContext {
         block_state,
         token_module_state: &token_module_state,
     };
 
-    let module_state = token_module::query_token_module_state(&kernel)?;
+    let module_state = token_module::query_token_module_state(&context)?;
 
     let token_state = TokenState {
         token_module_ref: token_configuration.module_ref,
@@ -78,12 +78,12 @@ where
 
             let token_module_state = block_state.mutable_token_key_value_state(&token);
 
-            let kernel = TokenQueryContext {
+            let context = TokenQueryContext {
                 block_state,
                 token_module_state: &token_module_state,
             };
             let module_state = token_module::query_token_module_account_state(
-                &kernel,
+                &context,
                 block_state.account_index(&account),
             );
 
@@ -112,11 +112,11 @@ pub fn query_token_authorizations(
 ) -> Result<TokenAuthorizations, QueryTokenInfoError> {
     let token = block_state.token_by_id(token_id)?;
     let token_module_state = block_state.mutable_token_key_value_state(&token);
-    let kernel = TokenQueryContext {
+    let context = TokenQueryContext {
         block_state,
         token_module_state: &token_module_state,
     };
-    let details = token_module::query_token_authorizations(&kernel)?;
+    let details = token_module::query_token_authorizations(&context)?;
     let token_configuration = block_state.token_configuration(&token);
     Ok(TokenAuthorizations {
         token_id: token_configuration.token_id,

--- a/plt/plt-scheduler/src/queries.rs
+++ b/plt/plt-scheduler/src/queries.rs
@@ -42,7 +42,6 @@ pub fn query_token_info(
 
     let kernel = TokenKernelQueriesImpl {
         block_state,
-        token: &token,
         token_module_state: &token_module_state,
     };
 
@@ -81,7 +80,6 @@ where
 
             let kernel = TokenKernelQueriesImpl {
                 block_state,
-                token: &token,
                 token_module_state: &token_module_state,
             };
             let module_state = token_module::query_token_module_account_state(
@@ -116,7 +114,6 @@ pub fn query_token_authorizations(
     let token_module_state = block_state.mutable_token_key_value_state(&token);
     let kernel = TokenKernelQueriesImpl {
         block_state,
-        token: &token,
         token_module_state: &token_module_state,
     };
     let details = token_module::query_token_authorizations(&kernel)?;

--- a/plt/plt-scheduler/src/scheduler/plt_scheduler.rs
+++ b/plt/plt-scheduler/src/scheduler/plt_scheduler.rs
@@ -2,7 +2,7 @@
 //! of transactions related to protocol-level tokens.
 
 use crate::scheduler::{ChainUpdateExecutionError, TransactionExecutionError};
-use crate::token_kernel::TokenKernelOperationsImpl;
+use crate::token_kernel::TokenOperationContext;
 use crate::token_module::{self, TOKEN_MODULE_REF, TokenInitializationError, TokenUpdateError};
 use crate::transaction_execution::{OutOfEnergyError, TransactionExecution};
 use concordium_base::protocol_level_tokens::{
@@ -68,7 +68,7 @@ pub fn execute_token_update_transaction<BSO: BlockStateOperations>(
     let mut events = Vec::new();
     let mut token_module_state = block_state.mutable_token_key_value_state(&token);
     let mut token_module_state_dirty = false;
-    let mut kernel = TokenKernelOperationsImpl {
+    let mut kernel = TokenOperationContext {
         block_state,
         token: &token,
         token_configuration: &token_configuration,
@@ -176,7 +176,7 @@ pub fn execute_meta_update_transaction<BSO: BlockStateOperations>(
                 let token_configuration = block_state.token_configuration(&token);
                 let mut token_module_state = block_state.mutable_token_key_value_state(&token);
                 let mut token_module_state_dirty = false;
-                let mut kernel = TokenKernelOperationsImpl {
+                let mut kernel = TokenOperationContext {
                     block_state,
                     token: &token,
                     token_configuration: &token_configuration,
@@ -273,7 +273,7 @@ pub fn execute_create_plt_chain_update<BSO: BlockStateOperations>(
 
     let mut token_module_state = block_state.mutable_token_key_value_state(&token);
     let mut token_module_state_dirty = false;
-    let mut kernel = TokenKernelOperationsImpl {
+    let mut kernel = TokenOperationContext {
         block_state,
         token: &token,
         token_configuration: &token_configuration,

--- a/plt/plt-scheduler/src/scheduler/plt_scheduler.rs
+++ b/plt/plt-scheduler/src/scheduler/plt_scheduler.rs
@@ -2,7 +2,7 @@
 //! of transactions related to protocol-level tokens.
 
 use crate::scheduler::{ChainUpdateExecutionError, TransactionExecutionError};
-use crate::token_kernel::TokenOperationContext;
+use crate::token_context::TokenOperationContext;
 use crate::token_module::{self, TOKEN_MODULE_REF, TokenInitializationError, TokenUpdateError};
 use crate::transaction_execution::{OutOfEnergyError, TransactionExecution};
 use concordium_base::protocol_level_tokens::{
@@ -273,7 +273,7 @@ pub fn execute_create_plt_chain_update<BSO: BlockStateOperations>(
 
     let mut token_module_state = block_state.mutable_token_key_value_state(&token);
     let mut token_module_state_dirty = false;
-    let mut kernel = TokenOperationContext {
+    let mut context = TokenOperationContext {
         block_state,
         token: &token,
         token_configuration: &token_configuration,
@@ -284,7 +284,7 @@ pub fn execute_create_plt_chain_update<BSO: BlockStateOperations>(
 
     // Initialize token in token module
     let token_initialize_result =
-        token_module::initialize_token(&mut kernel, payload.initialization_parameters);
+        token_module::initialize_token(&mut context, payload.initialization_parameters);
 
     match token_initialize_result {
         Ok(()) => {

--- a/plt/plt-scheduler/src/token_context.rs
+++ b/plt/plt-scheduler/src/token_context.rs
@@ -1,6 +1,6 @@
-//! Implementation of the protocol-level token kernel.
+//! Context for running queries and operations on protocol-level tokens.
 
-use crate::token_module::token_kernel_interface::{
+use crate::token_module::errors::{
     InsufficientBalanceError, MintWouldOverflowError, TokenBurnError, TokenMintError,
     TokenStateInvariantError, TokenTransferError,
 };
@@ -8,7 +8,7 @@ use concordium_base::base::ProtocolVersion;
 use concordium_base::contracts_common::AccountAddress;
 use concordium_base::protocol_level_tokens::{RawCbor, TokenModuleCborTypeDiscriminator};
 use concordium_base::transactions::Memo;
-use plt_block_state::block_state::types::TokenConfiguration;
+use plt_block_state::block_state::types::{TokenConfiguration, TokenStateKey, TokenStateValue};
 use plt_block_state::block_state_interface::{
     BlockStateOperations, BlockStateQuery, OverflowError, RawTokenAmountDelta,
 };
@@ -42,36 +42,6 @@ pub struct TokenOperationContext<'a, BSQ: BlockStateQuery> {
 }
 
 impl<BSO: BlockStateOperations> TokenOperationContext<'_, BSO> {
-    /// Read the token balance of an account for the token being invoked.
-    pub fn account_token_balance(&self, account: &BSO::Account) -> RawTokenAmount {
-        self.block_state.account_token_balance(account, self.token)
-    }
-
-    /// Read the decimals of the token being invoked.
-    pub fn decimals(&self) -> u8 {
-        self.token_configuration.decimals
-    }
-
-    /// Whether the protocol version of the block supports RBAC token feature.
-    pub fn support_rbac(&self) -> bool {
-        self.block_state.protocol_version() >= ProtocolVersion::P11
-    }
-
-    /// Whether the protocol version of the block supports updating the token metadata.
-    pub fn support_updating_metadata(&self) -> bool {
-        self.block_state.protocol_version() >= ProtocolVersion::P11
-    }
-
-    /// Initialize the balance of the given account to zero if it didn't have a balance before.
-    /// It has the observable effect that the token is then returned when querying the tokens
-    /// for an account. Should be called if the token module account state is set,
-    /// in order to make sure the token is returned when querying token account info.
-    ///
-    /// If the account already has a balance for the token in context, the operation has no effect.
-    pub fn touch_account(&mut self, account: &BSO::Account) {
-        self.block_state.touch_token_account(self.token, account);
-    }
-
     /// Mint a specified amount and deposit it in the account.
     ///
     /// # Events
@@ -150,7 +120,7 @@ impl<BSO: BlockStateOperations> TokenOperationContext<'_, BSO> {
                 RawTokenAmountDelta::Subtract(amount),
             )
             .map_err(|_err: OverflowError| InsufficientBalanceError {
-                available: self.account_token_balance(account),
+                available: self.block_state.account_token_balance(account, self.token),
                 required: amount,
             })?;
 
@@ -203,7 +173,7 @@ impl<BSO: BlockStateOperations> TokenOperationContext<'_, BSO> {
         self.block_state
             .update_token_account_balance(self.token, from, RawTokenAmountDelta::Subtract(amount))
             .map_err(|_err: OverflowError| InsufficientBalanceError {
-                available: self.account_token_balance(from),
+                available: self.block_state.account_token_balance(from, self.token),
                 required: amount,
             })?;
 
@@ -233,6 +203,13 @@ impl<BSO: BlockStateOperations> TokenOperationContext<'_, BSO> {
         Ok(())
     }
 
+    /// Set or clear a value in the token key-value state at the corresponding key.
+    pub fn update_token_state_value(&mut self, key: TokenStateKey, value: Option<TokenStateValue>) {
+        *self.token_module_state_dirty = true;
+        self.block_state
+            .update_token_state_value(self.token_module_state, &key, value);
+    }
+
     /// Log a token module event with the specified type and details.
     ///
     /// # Events
@@ -249,5 +226,15 @@ impl<BSO: BlockStateOperations> TokenOperationContext<'_, BSO> {
                 event_type,
                 details,
             }))
+    }
+
+    /// Whether the protocol version of the block supports RBAC token feature.
+    pub fn support_rbac(&self) -> bool {
+        self.block_state.protocol_version() >= ProtocolVersion::P11
+    }
+
+    /// Whether the protocol version of the block supports updating the token metadata.
+    pub fn support_updating_metadata(&self) -> bool {
+        self.block_state.protocol_version() >= ProtocolVersion::P11
     }
 }

--- a/plt/plt-scheduler/src/token_kernel.rs
+++ b/plt/plt-scheduler/src/token_kernel.rs
@@ -1,8 +1,8 @@
 //! Implementation of the protocol-level token kernel.
 
 use crate::token_module::token_kernel_interface::{
-    InsufficientBalanceError, MintWouldOverflowError, TokenBurnError, TokenKernelOperations,
-    TokenKernelQueries, TokenMintError, TokenStateInvariantError, TokenTransferError,
+    HasTokenState, InsufficientBalanceError, MintWouldOverflowError, TokenBurnError, TokenMintError,
+    TokenStateInvariantError, TokenTransferError,
 };
 use concordium_base::base::{AccountIndex, ProtocolVersion};
 use concordium_base::contracts_common::AccountAddress;
@@ -24,48 +24,23 @@ use plt_scheduler_types::types::tokens::{RawTokenAmount, TokenAmount, TokenHolde
 pub struct TokenKernelQueriesImpl<'a, BSQ: BlockStateQuery> {
     /// The block state
     pub block_state: &'a BSQ,
-    /// Token in context
-    pub token: &'a BSQ::Token,
     /// Token module state for the token in context
     pub token_module_state: &'a BSQ::TokenKeyValueState,
 }
 
-impl<BSQ: BlockStateQuery> TokenKernelQueries for TokenKernelQueriesImpl<'_, BSQ> {
-    type Account = BSQ::Account;
-
-    fn account_by_address(
-        &self,
-        address: &AccountAddress,
-    ) -> Result<Self::Account, AccountNotFoundByAddressError> {
-        self.block_state.account_by_address(address)
-    }
-
-    fn account_by_index(
+impl<BSQ: BlockStateQuery> TokenKernelQueriesImpl<'_, BSQ> {
+    pub fn account_by_index(
         &self,
         index: AccountIndex,
-    ) -> Result<AccountWithCanonicalAddress<Self::Account>, AccountNotFoundByIndexError> {
+    ) -> Result<AccountWithCanonicalAddress<BSQ::Account>, AccountNotFoundByIndexError> {
         self.block_state.account_by_index(index)
     }
+}
 
-    fn account_index(&self, account: &Self::Account) -> AccountIndex {
-        self.block_state.account_index(account)
-    }
-
-    fn account_token_balance(&self, account: &Self::Account) -> RawTokenAmount {
-        self.block_state.account_token_balance(account, self.token)
-    }
-
-    fn decimals(&self) -> u8 {
-        self.block_state.token_configuration(self.token).decimals
-    }
-
+impl<BSQ: BlockStateQuery> HasTokenState for TokenKernelQueriesImpl<'_, BSQ> {
     fn lookup_token_state_value(&self, key: TokenStateKey) -> Option<TokenStateValue> {
         self.block_state
             .lookup_token_state_value(self.token_module_state, &key)
-    }
-
-    fn protocol_version(&self) -> ProtocolVersion {
-        self.block_state.protocol_version()
     }
 
     fn iter_token_state_prefix(
@@ -93,14 +68,61 @@ pub struct TokenKernelOperationsImpl<'a, BSQ: BlockStateQuery> {
     pub events: &'a mut Vec<BlockItemEvent>,
 }
 
-impl<BSO: BlockStateOperations> TokenKernelOperations for TokenKernelOperationsImpl<'_, BSO> {
-    fn touch_account(&mut self, account: &Self::Account) {
+impl<BSO: BlockStateOperations> TokenKernelOperationsImpl<'_, BSO> {
+    pub fn account_by_address(
+        &self,
+        address: &AccountAddress,
+    ) -> Result<BSO::Account, AccountNotFoundByAddressError> {
+        self.block_state.account_by_address(address)
+    }
+
+    pub fn account_index(&self, account: &BSO::Account) -> AccountIndex {
+        self.block_state.account_index(account)
+    }
+
+    pub fn account_token_balance(&self, account: &BSO::Account) -> RawTokenAmount {
+        self.block_state.account_token_balance(account, self.token)
+    }
+
+    pub fn decimals(&self) -> u8 {
+        self.block_state.token_configuration(self.token).decimals
+    }
+
+    pub fn protocol_version(&self) -> ProtocolVersion {
+        self.block_state.protocol_version()
+    }
+
+    pub fn support_rbac(&self) -> bool {
+        self.protocol_version() >= ProtocolVersion::P11
+    }
+
+    pub fn support_updating_metadata(&self) -> bool {
+        self.protocol_version() >= ProtocolVersion::P11
+    }
+
+    /// Initialize the balance of the given account to zero if it didn't have a balance before.
+    /// It has the observable effect that the token is then returned when querying the tokens
+    /// for an account. Should be called if the token module account state is set,
+    /// in order to make sure the token is returned when querying token account info.
+    ///
+    /// If the account already has a balance for the token in context, the operation has no effect.
+    pub fn touch_account(&mut self, account: &BSO::Account) {
         self.block_state.touch_token_account(self.token, account);
     }
 
-    fn mint(
+    /// Mint a specified amount and deposit it in the account.
+    ///
+    /// # Events
+    ///
+    /// This will produce a `TokenMintEvent` in the logs.
+    ///
+    /// # Errors
+    ///
+    /// - [`TokenMintError::MintWouldOverflow`] The total supply would exceed the representable amount.
+    /// - [`TokenMintError::StateInvariantViolation`] If an internal token state invariant is broken.
+    pub fn mint(
         &mut self,
-        account: &Self::Account,
+        account: &BSO::Account,
         account_address: AccountAddress,
         amount: RawTokenAmount,
     ) -> Result<(), TokenMintError> {
@@ -142,9 +164,19 @@ impl<BSO: BlockStateOperations> TokenKernelOperations for TokenKernelOperationsI
         Ok(())
     }
 
-    fn burn(
+    /// Burn a specified amount from the account.
+    ///
+    /// # Events
+    ///
+    /// This will produce a `TokenBurnEvent` in the logs.
+    ///
+    /// # Errors
+    ///
+    /// - [`TokenBurnError::InsufficientBalance`] The sender has insufficient balance.
+    /// - [`TokenBurnError::StateInvariantViolation`] If an internal token state invariant is broken.
+    pub fn burn(
         &mut self,
-        account: &Self::Account,
+        account: &BSO::Account,
         account_address: AccountAddress,
         amount: RawTokenAmount,
     ) -> Result<(), TokenBurnError> {
@@ -186,11 +218,21 @@ impl<BSO: BlockStateOperations> TokenKernelOperations for TokenKernelOperationsI
         Ok(())
     }
 
-    fn transfer(
+    /// Transfer a token amount from one account to another, with an optional memo.
+    ///
+    /// # Events
+    ///
+    /// This will produce a `TokenTransferEvent` in the logs.
+    ///
+    /// # Errors
+    ///
+    /// - [`TokenTransferError::InsufficientBalance`] The sender has insufficient balance.
+    /// - [`TokenTransferError::StateInvariantViolation`] If an internal token state invariant is broken.
+    pub fn transfer(
         &mut self,
-        from: &Self::Account,
+        from: &BSO::Account,
         from_address: AccountAddress,
-        to: &Self::Account,
+        to: &BSO::Account,
         to_address: AccountAddress,
         amount: RawTokenAmount,
         memo: Option<Memo>,
@@ -229,13 +271,16 @@ impl<BSO: BlockStateOperations> TokenKernelOperations for TokenKernelOperationsI
         Ok(())
     }
 
-    fn set_token_state_value(&mut self, key: TokenStateKey, value: Option<TokenStateValue>) {
-        *self.token_module_state_dirty = true;
-        self.block_state
-            .update_token_state_value(self.token_module_state, &key, value);
-    }
-
-    fn log_token_event(&mut self, event_type: TokenModuleCborTypeDiscriminator, details: RawCbor) {
+    /// Log a token module event with the specified type and details.
+    ///
+    /// # Events
+    ///
+    /// This will produce a `TokenModuleEvent` in the logs.
+    pub fn log_token_event(
+        &mut self,
+        event_type: TokenModuleCborTypeDiscriminator,
+        details: RawCbor,
+    ) {
         self.events
             .push(BlockItemEvent::TokenModule(EncodedTokenModuleEvent {
                 token_id: self.token_configuration.token_id.clone(),
@@ -245,42 +290,10 @@ impl<BSO: BlockStateOperations> TokenKernelOperations for TokenKernelOperationsI
     }
 }
 
-impl<BSO: BlockStateOperations> TokenKernelQueries for TokenKernelOperationsImpl<'_, BSO> {
-    type Account = BSO::Account;
-
-    fn account_by_address(
-        &self,
-        address: &AccountAddress,
-    ) -> Result<Self::Account, AccountNotFoundByAddressError> {
-        self.block_state.account_by_address(address)
-    }
-
-    fn account_by_index(
-        &self,
-        index: AccountIndex,
-    ) -> Result<AccountWithCanonicalAddress<Self::Account>, AccountNotFoundByIndexError> {
-        self.block_state.account_by_index(index)
-    }
-
-    fn account_index(&self, account: &Self::Account) -> AccountIndex {
-        self.block_state.account_index(account)
-    }
-
-    fn account_token_balance(&self, account: &Self::Account) -> RawTokenAmount {
-        self.block_state.account_token_balance(account, self.token)
-    }
-
-    fn decimals(&self) -> u8 {
-        self.block_state.token_configuration(self.token).decimals
-    }
-
+impl<BSO: BlockStateOperations> HasTokenState for TokenKernelOperationsImpl<'_, BSO> {
     fn lookup_token_state_value(&self, key: TokenStateKey) -> Option<TokenStateValue> {
         self.block_state
             .lookup_token_state_value(self.token_module_state, &key)
-    }
-
-    fn protocol_version(&self) -> ProtocolVersion {
-        self.block_state.protocol_version()
     }
 
     fn iter_token_state_prefix(

--- a/plt/plt-scheduler/src/token_kernel.rs
+++ b/plt/plt-scheduler/src/token_kernel.rs
@@ -1,17 +1,14 @@
 //! Implementation of the protocol-level token kernel.
 
 use crate::token_module::token_kernel_interface::{
-    HasTokenState, InsufficientBalanceError, MintWouldOverflowError, TokenBurnError, TokenMintError,
-    TokenStateInvariantError, TokenTransferError,
+    HasTokenState, InsufficientBalanceError, MintWouldOverflowError, TokenBurnError,
+    TokenMintError, TokenStateInvariantError, TokenTransferError,
 };
-use concordium_base::base::{AccountIndex, ProtocolVersion};
+use concordium_base::base::ProtocolVersion;
 use concordium_base::contracts_common::AccountAddress;
 use concordium_base::protocol_level_tokens::{RawCbor, TokenModuleCborTypeDiscriminator};
 use concordium_base::transactions::Memo;
-use plt_block_state::block_state::types::{
-    AccountWithCanonicalAddress, TokenConfiguration, TokenStateKey, TokenStateValue,
-};
-use plt_block_state::block_state::{AccountNotFoundByAddressError, AccountNotFoundByIndexError};
+use plt_block_state::block_state::types::{TokenConfiguration, TokenStateKey, TokenStateValue};
 use plt_block_state::block_state_interface::{
     BlockStateOperations, BlockStateQuery, OverflowError, RawTokenAmountDelta,
 };
@@ -26,15 +23,6 @@ pub struct TokenKernelQueriesImpl<'a, BSQ: BlockStateQuery> {
     pub block_state: &'a BSQ,
     /// Token module state for the token in context
     pub token_module_state: &'a BSQ::TokenKeyValueState,
-}
-
-impl<BSQ: BlockStateQuery> TokenKernelQueriesImpl<'_, BSQ> {
-    pub fn account_by_index(
-        &self,
-        index: AccountIndex,
-    ) -> Result<AccountWithCanonicalAddress<BSQ::Account>, AccountNotFoundByIndexError> {
-        self.block_state.account_by_index(index)
-    }
 }
 
 impl<BSQ: BlockStateQuery> HasTokenState for TokenKernelQueriesImpl<'_, BSQ> {
@@ -69,17 +57,6 @@ pub struct TokenKernelOperationsImpl<'a, BSQ: BlockStateQuery> {
 }
 
 impl<BSO: BlockStateOperations> TokenKernelOperationsImpl<'_, BSO> {
-    pub fn account_by_address(
-        &self,
-        address: &AccountAddress,
-    ) -> Result<BSO::Account, AccountNotFoundByAddressError> {
-        self.block_state.account_by_address(address)
-    }
-
-    pub fn account_index(&self, account: &BSO::Account) -> AccountIndex {
-        self.block_state.account_index(account)
-    }
-
     pub fn account_token_balance(&self, account: &BSO::Account) -> RawTokenAmount {
         self.block_state.account_token_balance(account, self.token)
     }

--- a/plt/plt-scheduler/src/token_kernel.rs
+++ b/plt/plt-scheduler/src/token_kernel.rs
@@ -1,14 +1,14 @@
 //! Implementation of the protocol-level token kernel.
 
 use crate::token_module::token_kernel_interface::{
-    HasTokenState, InsufficientBalanceError, MintWouldOverflowError, TokenBurnError,
-    TokenMintError, TokenStateInvariantError, TokenTransferError,
+    InsufficientBalanceError, MintWouldOverflowError, TokenBurnError, TokenMintError,
+    TokenStateInvariantError, TokenTransferError,
 };
 use concordium_base::base::ProtocolVersion;
 use concordium_base::contracts_common::AccountAddress;
 use concordium_base::protocol_level_tokens::{RawCbor, TokenModuleCborTypeDiscriminator};
 use concordium_base::transactions::Memo;
-use plt_block_state::block_state::types::{TokenConfiguration, TokenStateKey, TokenStateValue};
+use plt_block_state::block_state::types::TokenConfiguration;
 use plt_block_state::block_state_interface::{
     BlockStateOperations, BlockStateQuery, OverflowError, RawTokenAmountDelta,
 };
@@ -17,31 +17,16 @@ use plt_scheduler_types::types::events::{
 };
 use plt_scheduler_types::types::tokens::{RawTokenAmount, TokenAmount, TokenHolder};
 
-/// Implementation of token kernel queries with a specific token in context.
-pub struct TokenKernelQueriesImpl<'a, BSQ: BlockStateQuery> {
+/// Context for running token queries with a specific token in context.
+pub struct TokenQueryContext<'a, BSQ: BlockStateQuery> {
     /// The block state
     pub block_state: &'a BSQ,
     /// Token module state for the token in context
     pub token_module_state: &'a BSQ::TokenKeyValueState,
 }
 
-impl<BSQ: BlockStateQuery> HasTokenState for TokenKernelQueriesImpl<'_, BSQ> {
-    fn lookup_token_state_value(&self, key: TokenStateKey) -> Option<TokenStateValue> {
-        self.block_state
-            .lookup_token_state_value(self.token_module_state, &key)
-    }
-
-    fn iter_token_state_prefix(
-        &self,
-        prefix: TokenStateKey,
-    ) -> impl Iterator<Item = (&TokenStateKey, &TokenStateValue)> {
-        self.block_state
-            .iter_token_state_prefix(self.token_module_state, prefix)
-    }
-}
-
-/// Implementation of token kernel operations with a specific token in context.
-pub struct TokenKernelOperationsImpl<'a, BSQ: BlockStateQuery> {
+/// Context for running token operations with a specific token in context.
+pub struct TokenOperationContext<'a, BSQ: BlockStateQuery> {
     /// The block state
     pub block_state: &'a mut BSQ,
     /// Token in context
@@ -56,25 +41,25 @@ pub struct TokenKernelOperationsImpl<'a, BSQ: BlockStateQuery> {
     pub events: &'a mut Vec<BlockItemEvent>,
 }
 
-impl<BSO: BlockStateOperations> TokenKernelOperationsImpl<'_, BSO> {
+impl<BSO: BlockStateOperations> TokenOperationContext<'_, BSO> {
+    /// Read the token balance of an account for the token being invoked.
     pub fn account_token_balance(&self, account: &BSO::Account) -> RawTokenAmount {
         self.block_state.account_token_balance(account, self.token)
     }
 
+    /// Read the decimals of the token being invoked.
     pub fn decimals(&self) -> u8 {
-        self.block_state.token_configuration(self.token).decimals
+        self.token_configuration.decimals
     }
 
-    pub fn protocol_version(&self) -> ProtocolVersion {
-        self.block_state.protocol_version()
-    }
-
+    /// Whether the protocol version of the block supports RBAC token feature.
     pub fn support_rbac(&self) -> bool {
-        self.protocol_version() >= ProtocolVersion::P11
+        self.block_state.protocol_version() >= ProtocolVersion::P11
     }
 
+    /// Whether the protocol version of the block supports updating the token metadata.
     pub fn support_updating_metadata(&self) -> bool {
-        self.protocol_version() >= ProtocolVersion::P11
+        self.block_state.protocol_version() >= ProtocolVersion::P11
     }
 
     /// Initialize the balance of the given account to zero if it didn't have a balance before.
@@ -264,20 +249,5 @@ impl<BSO: BlockStateOperations> TokenKernelOperationsImpl<'_, BSO> {
                 event_type,
                 details,
             }))
-    }
-}
-
-impl<BSO: BlockStateOperations> HasTokenState for TokenKernelOperationsImpl<'_, BSO> {
-    fn lookup_token_state_value(&self, key: TokenStateKey) -> Option<TokenStateValue> {
-        self.block_state
-            .lookup_token_state_value(self.token_module_state, &key)
-    }
-
-    fn iter_token_state_prefix(
-        &self,
-        prefix: TokenStateKey,
-    ) -> impl Iterator<Item = (&TokenStateKey, &TokenStateValue)> {
-        self.block_state
-            .iter_token_state_prefix(self.token_module_state, prefix)
     }
 }

--- a/plt/plt-scheduler/src/token_module/errors.rs
+++ b/plt/plt-scheduler/src/token_module/errors.rs
@@ -1,7 +1,16 @@
-//! Token kernel interface for protocol-level tokens. This is the interface seen
-//! by the token module. The kernel handles all operations affecting token
-//! balance and supply and manages the state and events related to balances and supply.
+//! Errors used in the token module.
+
 use plt_scheduler_types::types::tokens::RawTokenAmount;
+
+/// Token amount decimals mismatch
+#[derive(Debug, thiserror::Error)]
+#[error("Token amount decimals mismatch: expected {expected}, found {found}")]
+pub struct TokenAmountDecimalsMismatchError {
+    /// Expected decimals
+    pub expected: u8,
+    /// Actual decimals
+    pub found: u8,
+}
 
 /// The account has insufficient balance.
 #[derive(Debug, thiserror::Error)]

--- a/plt/plt-scheduler/src/token_module/key_value_state.rs
+++ b/plt/plt-scheduler/src/token_module/key_value_state.rs
@@ -36,7 +36,7 @@ const STATE_KEY_GOVERNANCE_ACCOUNT: &[u8] = b"governanceAccount";
 ///
 /// Allows defining functions which works for both [`TokenQueryContext`] and
 /// [`TokenOperationContext`].
-pub trait ReadTokenState {
+pub trait ReadTokenKeyValueState {
     /// Lookup a key in the token key-value state.
     fn lookup_token_state_value(&self, key: &TokenStateKey) -> Option<TokenStateValue>;
 
@@ -47,7 +47,7 @@ pub trait ReadTokenState {
     ) -> impl Iterator<Item = (&TokenStateKey, &TokenStateValue)>;
 }
 
-impl<'a, BSQ> ReadTokenState for TokenQueryContext<'a, BSQ>
+impl<'a, BSQ> ReadTokenKeyValueState for TokenQueryContext<'a, BSQ>
 where
     BSQ: BlockStateQuery,
 {
@@ -65,7 +65,7 @@ where
     }
 }
 
-impl<'a, BSO> ReadTokenState for TokenOperationContext<'a, BSO>
+impl<'a, BSO> ReadTokenKeyValueState for TokenOperationContext<'a, BSO>
 where
     BSO: BlockStateOperations,
 {
@@ -93,7 +93,7 @@ fn module_state_key(key: &[u8]) -> TokenStateKey {
 }
 
 /// Get value from the token module state at the given key.
-fn get_module_state(context: &impl ReadTokenState, key: &[u8]) -> Option<TokenStateValue> {
+fn get_module_state(context: &impl ReadTokenKeyValueState, key: &[u8]) -> Option<TokenStateValue> {
     context.lookup_token_state_value(&module_state_key(key))
 }
 
@@ -118,7 +118,7 @@ fn account_state_key(account_index: AccountIndex, key: &[u8]) -> TokenStateKey {
 
 /// Lookup a value from the account section of the token state.
 fn lookup_account_state(
-    context: &impl ReadTokenState,
+    context: &impl ReadTokenKeyValueState,
     account: AccountIndex,
     key: &[u8],
 ) -> Option<TokenStateValue> {
@@ -146,7 +146,7 @@ fn account_roles_state_key(account_index: AccountIndex) -> TokenStateKey {
 
 /// Lookup a value from the account roles section of the token state.
 fn get_account_roles_state(
-    context: &impl ReadTokenState,
+    context: &impl ReadTokenKeyValueState,
     account: AccountIndex,
 ) -> Result<Roles, TokenStateInvariantError> {
     Roles::try_from_state_value(context.lookup_token_state_value(&account_roles_state_key(account)))
@@ -169,12 +169,12 @@ fn update_account_roles_state<BSO: BlockStateOperations>(
 
 /// Get whether the balance-affecting operations on the token are currently
 /// paused.
-pub fn is_paused(context: &impl ReadTokenState) -> bool {
+pub fn is_paused(context: &impl ReadTokenKeyValueState) -> bool {
     get_module_state(context, STATE_KEY_PAUSED).is_some()
 }
 
 /// Get whether the token has allow lists enabled.
-pub fn has_allow_list(context: &impl ReadTokenState) -> bool {
+pub fn has_allow_list(context: &impl ReadTokenKeyValueState) -> bool {
     get_module_state(context, STATE_KEY_ALLOW_LIST).is_some()
 }
 
@@ -184,7 +184,7 @@ pub fn set_allow_list_enabled<BSO: BlockStateOperations>(context: &mut TokenOper
 }
 
 /// Get whether the token has deny lists enabled.
-pub fn has_deny_list(context: &impl ReadTokenState) -> bool {
+pub fn has_deny_list(context: &impl ReadTokenKeyValueState) -> bool {
     get_module_state(context, STATE_KEY_DENY_LIST).is_some()
 }
 
@@ -194,7 +194,7 @@ pub fn set_deny_list_enabled<BSO: BlockStateOperations>(context: &mut TokenOpera
 }
 
 /// Get whether the token allows minting.
-pub fn is_mintable(context: &impl ReadTokenState) -> bool {
+pub fn is_mintable(context: &impl ReadTokenKeyValueState) -> bool {
     get_module_state(context, STATE_KEY_MINTABLE).is_some()
 }
 
@@ -204,7 +204,7 @@ pub fn set_mintable_enabled<BSO: BlockStateOperations>(context: &mut TokenOperat
 }
 
 /// Get whether the token allows burning.
-pub fn is_burnable(context: &impl ReadTokenState) -> bool {
+pub fn is_burnable(context: &impl ReadTokenKeyValueState) -> bool {
     get_module_state(context, STATE_KEY_BURNABLE).is_some()
 }
 
@@ -234,7 +234,9 @@ pub fn set_token_name<BSO: BlockStateOperations>(
 }
 
 /// Get the name of the token.
-pub fn get_token_name(context: &impl ReadTokenState) -> Result<String, TokenStateInvariantError> {
+pub fn get_token_name(
+    context: &impl ReadTokenKeyValueState,
+) -> Result<String, TokenStateInvariantError> {
     get_module_state(context, STATE_KEY_NAME)
         .ok_or_else(|| TokenStateInvariantError("Name not present".to_string()))
         .and_then(|value| {
@@ -246,7 +248,7 @@ pub fn get_token_name(context: &impl ReadTokenState) -> Result<String, TokenStat
 
 /// Get the URL metadata of the token.
 pub fn get_metadata(
-    context: &impl ReadTokenState,
+    context: &impl ReadTokenKeyValueState,
 ) -> Result<MetadataUrl, TokenStateInvariantError> {
     let metadata_cbor = get_module_state(context, STATE_KEY_METADATA)
         .ok_or_else(|| TokenStateInvariantError("Metadata not present".to_string()))?;
@@ -267,7 +269,7 @@ pub fn set_metadata_url<BSO: BlockStateOperations>(
 
 /// Get the account index of the governance account for the token.
 pub fn get_governance_account_index(
-    context: &impl ReadTokenState,
+    context: &impl ReadTokenKeyValueState,
 ) -> Result<AccountIndex, TokenStateInvariantError> {
     let governance_account_index = AccountIndex::from(
         get_module_state(context, STATE_KEY_GOVERNANCE_ACCOUNT)
@@ -286,7 +288,7 @@ pub fn get_governance_account_index(
 
 /// Get the authorization roles for an account from state.
 pub fn get_account_roles(
-    context: &impl ReadTokenState,
+    context: &impl ReadTokenKeyValueState,
     account: AccountIndex,
 ) -> Result<Roles, TokenStateInvariantError> {
     get_account_roles_state(context, account)
@@ -398,7 +400,7 @@ pub fn set_paused<BSO: BlockStateOperations>(
 }
 
 /// Get the allow-list state for the account at the given account.
-pub fn get_allow_list_for(context: &impl ReadTokenState, account: AccountIndex) -> bool {
+pub fn get_allow_list_for(context: &impl ReadTokenKeyValueState, account: AccountIndex) -> bool {
     lookup_account_state(context, account, STATE_KEY_ALLOW_LIST).is_some()
 }
 
@@ -413,7 +415,7 @@ pub fn set_allow_list_for<BSO: BlockStateOperations>(
 }
 
 /// Get the deny-list state for the account at the given account.
-pub fn get_deny_list_for(context: &impl ReadTokenState, account: AccountIndex) -> bool {
+pub fn get_deny_list_for(context: &impl ReadTokenKeyValueState, account: AccountIndex) -> bool {
     lookup_account_state(context, account, STATE_KEY_DENY_LIST).is_some()
 }
 

--- a/plt/plt-scheduler/src/token_module/key_value_state.rs
+++ b/plt/plt-scheduler/src/token_module/key_value_state.rs
@@ -2,15 +2,15 @@
 
 use super::roles::Roles;
 use super::util;
-use crate::token_module::token_kernel_interface::{
-    TokenKernelOperations, TokenKernelQueries, TokenStateInvariantError,
-};
+use crate::token_kernel::{TokenKernelOperationsImpl, TokenKernelQueriesImpl};
+use crate::token_module::token_kernel_interface::{HasTokenState, TokenStateInvariantError};
 use concordium_base::common;
 use concordium_base::protocol_level_tokens::{
     MetadataUrl, TokenAdminRole, TokenAuthorizations, TokenRoleAuthorizations,
 };
 use concordium_base::{base::AccountIndex, common::Serial};
 use plt_block_state::block_state::types::{TokenStateKey, TokenStateValue};
+use plt_block_state::block_state_interface::{BlockStateOperations, BlockStateQuery};
 
 /// Little-endian prefix used to distinguish module state keys.
 const MODULE_STATE_PREFIX: [u8; 2] = 0u16.to_le_bytes();
@@ -32,33 +32,9 @@ pub const STATE_KEY_BURNABLE: &[u8] = b"burnable";
 pub const STATE_KEY_PAUSED: &[u8] = b"paused";
 pub const STATE_KEY_GOVERNANCE_ACCOUNT: &[u8] = b"governanceAccount";
 
-/// Extension trait for [`TokenKernelOperations`] to provide convenience wrappers for
-/// state updates.
-pub trait KernelOperationsExt: TokenKernelOperations {
-    /// Set or clear a value in the token module state at the corresponding key.
-    fn set_module_state(&mut self, key: &[u8], value: Option<TokenStateValue>) {
-        self.set_token_state_value(module_state_key(key), value);
-    }
-
-    fn set_account_state(
-        &mut self,
-        account: AccountIndex,
-        key: &[u8],
-        value: Option<TokenStateValue>,
-    ) {
-        self.set_token_state_value(account_state_key(account, key), value);
-    }
-
-    fn set_account_roles_state(&mut self, account: AccountIndex, value: Roles) {
-        self.set_token_state_value(account_roles_state_key(account), value.into_state_value());
-    }
-}
-
-impl<T: TokenKernelOperations> KernelOperationsExt for T {}
-
-/// Extension trait for [`TokenKernelQueries`] to provide convenience wrappers for
-/// state access.
-pub trait KernelQueriesExt: TokenKernelQueries {
+/// Extension trait for [`HasTokenState`] providing convenience read wrappers for token
+/// key-value state access.
+pub trait KernelQueriesExt: HasTokenState {
     /// Get value from the token module state at the given key.
     fn get_module_state(&self, key: &[u8]) -> Option<TokenStateValue> {
         self.lookup_token_state_value(module_state_key(key))
@@ -82,7 +58,40 @@ pub trait KernelQueriesExt: TokenKernelQueries {
     }
 }
 
-impl<T: TokenKernelQueries> KernelQueriesExt for T {}
+impl<T: HasTokenState> KernelQueriesExt for T {}
+
+/// Extension trait for [`TokenKernelOperationsImpl`] providing convenience wrappers for
+/// token key-value state updates.
+pub trait KernelOperationsExt: KernelQueriesExt {
+    /// Set or clear a value in the token key-value state at the corresponding key.
+    fn set_token_state_value(&mut self, key: TokenStateKey, value: Option<TokenStateValue>);
+
+    /// Set or clear a value in the token module state at the corresponding key.
+    fn set_module_state(&mut self, key: &[u8], value: Option<TokenStateValue>) {
+        self.set_token_state_value(module_state_key(key), value);
+    }
+
+    fn set_account_state(
+        &mut self,
+        account: AccountIndex,
+        key: &[u8],
+        value: Option<TokenStateValue>,
+    ) {
+        self.set_token_state_value(account_state_key(account, key), value);
+    }
+
+    fn set_account_roles_state(&mut self, account: AccountIndex, value: Roles) {
+        self.set_token_state_value(account_roles_state_key(account), value.into_state_value());
+    }
+}
+
+impl<BSO: BlockStateOperations> KernelOperationsExt for TokenKernelOperationsImpl<'_, BSO> {
+    fn set_token_state_value(&mut self, key: TokenStateKey, value: Option<TokenStateValue>) {
+        *self.token_module_state_dirty = true;
+        self.block_state
+            .update_token_state_value(self.token_module_state, &key, value);
+    }
+}
 
 /// Construct a [`TokenStateKey`] for a module key. This prefixes the key to
 /// distinguish it from other keys.
@@ -112,32 +121,32 @@ fn account_roles_state_key(account_index: AccountIndex) -> TokenStateKey {
 
 /// Get whether the balance-affecting operations on the token are currently
 /// paused.
-pub fn is_paused(kernel: &impl TokenKernelQueries) -> bool {
+pub fn is_paused(kernel: &impl KernelQueriesExt) -> bool {
     kernel.get_module_state(STATE_KEY_PAUSED).is_some()
 }
 
 /// Get whether the token has allow lists enabled.
-pub fn has_allow_list(kernel: &impl TokenKernelQueries) -> bool {
+pub fn has_allow_list(kernel: &impl KernelQueriesExt) -> bool {
     kernel.get_module_state(STATE_KEY_ALLOW_LIST).is_some()
 }
 
 /// Get whether the token has deny lists enabled.
-pub fn has_deny_list(kernel: &impl TokenKernelQueries) -> bool {
+pub fn has_deny_list(kernel: &impl KernelQueriesExt) -> bool {
     kernel.get_module_state(STATE_KEY_DENY_LIST).is_some()
 }
 
 /// Get whether the token allows minting.
-pub fn is_mintable(kernel: &impl TokenKernelQueries) -> bool {
+pub fn is_mintable(kernel: &impl KernelQueriesExt) -> bool {
     kernel.get_module_state(STATE_KEY_MINTABLE).is_some()
 }
 
 /// Get whether the token allows burning.
-pub fn is_burnable(kernel: &impl TokenKernelQueries) -> bool {
+pub fn is_burnable(kernel: &impl KernelQueriesExt) -> bool {
     kernel.get_module_state(STATE_KEY_BURNABLE).is_some()
 }
 
 /// Get the name of the token.
-pub fn get_name(kernel: &impl TokenKernelQueries) -> Result<String, TokenStateInvariantError> {
+pub fn get_name(kernel: &impl KernelQueriesExt) -> Result<String, TokenStateInvariantError> {
     kernel
         .get_module_state(STATE_KEY_NAME)
         .ok_or_else(|| TokenStateInvariantError("Name not present".to_string()))
@@ -150,7 +159,7 @@ pub fn get_name(kernel: &impl TokenKernelQueries) -> Result<String, TokenStateIn
 
 /// Get the URL metadata of the token.
 pub fn get_metadata(
-    kernel: &impl TokenKernelQueries,
+    kernel: &impl KernelQueriesExt,
 ) -> Result<MetadataUrl, TokenStateInvariantError> {
     let metadata_cbor = kernel
         .get_module_state(STATE_KEY_METADATA)
@@ -162,14 +171,14 @@ pub fn get_metadata(
 }
 
 /// Set the metadata URL.
-pub fn set_metadata_url<TK: TokenKernelOperations>(kernel: &mut TK, metadata: &MetadataUrl) {
+pub fn set_metadata_url<TK: KernelOperationsExt>(kernel: &mut TK, metadata: &MetadataUrl) {
     let encoded_metadata = common::cbor::cbor_encode(metadata);
     kernel.set_module_state(STATE_KEY_METADATA, Some(encoded_metadata));
 }
 
 /// Get the account index of the governance account for the token.
 pub fn get_governance_account_index(
-    kernel: &impl TokenKernelQueries,
+    kernel: &impl KernelQueriesExt,
 ) -> Result<AccountIndex, TokenStateInvariantError> {
     let governance_account_index = AccountIndex::from(
         kernel
@@ -189,7 +198,7 @@ pub fn get_governance_account_index(
 
 /// Get the authorization roles for an account from state.
 pub fn get_account_roles(
-    kernel: &impl TokenKernelQueries,
+    kernel: &impl KernelQueriesExt,
     account: AccountIndex,
 ) -> Result<Roles, TokenStateInvariantError> {
     kernel.get_account_roles_state(account)
@@ -197,7 +206,7 @@ pub fn get_account_roles(
 
 /// Assign roles to an account in the state.
 pub fn assign_account_roles(
-    kernel: &mut impl TokenKernelOperations,
+    kernel: &mut impl KernelOperationsExt,
     account: AccountIndex,
     assigned_roles: &[TokenAdminRole],
 ) -> Result<(), TokenStateInvariantError> {
@@ -211,7 +220,7 @@ pub fn assign_account_roles(
 
 /// Revoke roles of an account in the state.
 pub fn revoke_account_roles(
-    kernel: &mut impl TokenKernelOperations,
+    kernel: &mut impl KernelOperationsExt,
     account: AccountIndex,
     revoked_roles: &[TokenAdminRole],
 ) -> Result<(), TokenStateInvariantError> {
@@ -224,8 +233,11 @@ pub fn revoke_account_roles(
 }
 
 /// Get authorization roles and assigned accounts for the token.
-pub fn get_token_authorizations<TK: TokenKernelQueries>(
-    kernel: &TK,
+///
+/// Takes a concrete [`TokenKernelQueriesImpl`] because account index lookups are needed
+/// in addition to key-value state access.
+pub fn get_token_authorizations<BSQ: BlockStateQuery>(
+    kernel: &TokenKernelQueriesImpl<'_, BSQ>,
 ) -> Result<TokenAuthorizations, TokenStateInvariantError> {
     let mut update_admin_roles = TokenRoleAuthorizations::default();
     let mut mint = TokenRoleAuthorizations::default();
@@ -290,21 +302,21 @@ pub fn get_token_authorizations<TK: TokenKernelQueries>(
     })
 }
 
-/// Sets the puased state of the token module.
-pub fn set_paused<TK: TokenKernelOperations>(kernel: &mut TK, value: bool) {
+/// Sets the paused state of the token module.
+pub fn set_paused<TK: KernelOperationsExt>(kernel: &mut TK, value: bool) {
     let state_value = value.then_some(vec![]);
     kernel.set_module_state(STATE_KEY_PAUSED, state_value)
 }
 
 /// Get the allow-list state for the account at the given account.
-pub fn get_allow_list_for<TK: TokenKernelQueries>(kernel: &TK, account: AccountIndex) -> bool {
+pub fn get_allow_list_for<TK: KernelQueriesExt>(kernel: &TK, account: AccountIndex) -> bool {
     kernel
         .get_account_state(account, STATE_KEY_ALLOW_LIST)
         .is_some()
 }
 
 /// Set the allow-list state for the account at the given account.
-pub fn set_allow_list_for<TK: TokenKernelOperations>(
+pub fn set_allow_list_for<TK: KernelOperationsExt>(
     kernel: &mut TK,
     account: AccountIndex,
     value: bool,
@@ -314,14 +326,14 @@ pub fn set_allow_list_for<TK: TokenKernelOperations>(
 }
 
 /// Get the deny-list state for the account at the given account.
-pub fn get_deny_list_for<TK: TokenKernelQueries>(kernel: &TK, account: AccountIndex) -> bool {
+pub fn get_deny_list_for<TK: KernelQueriesExt>(kernel: &TK, account: AccountIndex) -> bool {
     kernel
         .get_account_state(account, STATE_KEY_DENY_LIST)
         .is_some()
 }
 
 /// Set the deny-list state for the account at the given account.
-pub fn set_deny_list_for<TK: TokenKernelOperations>(
+pub fn set_deny_list_for<TK: KernelOperationsExt>(
     kernel: &mut TK,
     account: AccountIndex,
     value: bool,

--- a/plt/plt-scheduler/src/token_module/key_value_state.rs
+++ b/plt/plt-scheduler/src/token_module/key_value_state.rs
@@ -263,6 +263,7 @@ pub fn get_token_authorizations<BSQ: BlockStateQuery>(
                 ))
             })?;
         let account = kernel
+            .block_state
             .account_by_index(account_index)
             .map_err(|err| {
                 TokenStateInvariantError(format!(

--- a/plt/plt-scheduler/src/token_module/key_value_state.rs
+++ b/plt/plt-scheduler/src/token_module/key_value_state.rs
@@ -2,8 +2,8 @@
 
 use super::roles::Roles;
 use super::util;
-use crate::token_kernel::{TokenKernelOperationsImpl, TokenKernelQueriesImpl};
-use crate::token_module::token_kernel_interface::{HasTokenState, TokenStateInvariantError};
+use crate::token_kernel::{TokenOperationContext, TokenQueryContext};
+use crate::token_module::token_kernel_interface::TokenStateInvariantError;
 use concordium_base::common;
 use concordium_base::protocol_level_tokens::{
     MetadataUrl, TokenAdminRole, TokenAuthorizations, TokenRoleAuthorizations,
@@ -23,70 +23,74 @@ const ACCOUNT_STATE_PREFIX: [u8; 2] = 40307u16.to_le_bytes();
 /// the prefix.
 const ACCOUNT_ROLES_STATE_PREFIX: [u8; 2] = 40308u16.to_le_bytes();
 
-pub const STATE_KEY_NAME: &[u8] = b"name";
-pub const STATE_KEY_METADATA: &[u8] = b"metadata";
-pub const STATE_KEY_ALLOW_LIST: &[u8] = b"allowList";
-pub const STATE_KEY_DENY_LIST: &[u8] = b"denyList";
-pub const STATE_KEY_MINTABLE: &[u8] = b"mintable";
-pub const STATE_KEY_BURNABLE: &[u8] = b"burnable";
-pub const STATE_KEY_PAUSED: &[u8] = b"paused";
-pub const STATE_KEY_GOVERNANCE_ACCOUNT: &[u8] = b"governanceAccount";
+const STATE_KEY_NAME: &[u8] = b"name";
+const STATE_KEY_METADATA: &[u8] = b"metadata";
+const STATE_KEY_ALLOW_LIST: &[u8] = b"allowList";
+const STATE_KEY_DENY_LIST: &[u8] = b"denyList";
+const STATE_KEY_MINTABLE: &[u8] = b"mintable";
+const STATE_KEY_BURNABLE: &[u8] = b"burnable";
+const STATE_KEY_PAUSED: &[u8] = b"paused";
+const STATE_KEY_GOVERNANCE_ACCOUNT: &[u8] = b"governanceAccount";
 
-/// Extension trait for [`HasTokenState`] providing convenience read wrappers for token
-/// key-value state access.
-pub trait KernelQueriesExt: HasTokenState {
-    /// Get value from the token module state at the given key.
-    fn get_module_state(&self, key: &[u8]) -> Option<TokenStateValue> {
-        self.lookup_token_state_value(module_state_key(key))
-    }
+/// Minimal read-only access to token key-value state.
+///
+/// Allows defining functions which are generic over the access to the token state.
+pub trait ReadTokenState {
+    /// Lookup a key in the token key-value state.
+    fn lookup_token_state_value(&self, key: &TokenStateKey) -> Option<TokenStateValue>;
 
-    fn get_account_state(&self, account: AccountIndex, key: &[u8]) -> Option<TokenStateValue> {
-        self.lookup_token_state_value(account_state_key(account, key))
-    }
-
-    fn get_account_roles_state(
+    /// Get an iterator over key-value pairs that share the given prefix.
+    fn iter_token_state_prefix(
         &self,
-        account: AccountIndex,
-    ) -> Result<Roles, TokenStateInvariantError> {
-        Roles::try_from_state_value(self.lookup_token_state_value(account_roles_state_key(account)))
-            .map_err(|err| {
-                TokenStateInvariantError(format!(
-                    "Stored account authorization roles cannot be decoded: {}",
-                    err
-                ))
-            })
+        prefix: TokenStateKey,
+    ) -> impl Iterator<Item = (&TokenStateKey, &TokenStateValue)>;
+}
+
+impl<'a, BSQ> ReadTokenState for TokenQueryContext<'a, BSQ>
+where
+    BSQ: BlockStateQuery,
+{
+    fn lookup_token_state_value(&self, key: &TokenStateKey) -> Option<TokenStateValue> {
+        self.block_state
+            .lookup_token_state_value(self.token_module_state, key)
+    }
+
+    fn iter_token_state_prefix(
+        &self,
+        prefix: TokenStateKey,
+    ) -> impl Iterator<Item = (&TokenStateKey, &TokenStateValue)> {
+        self.block_state
+            .iter_token_state_prefix(self.token_module_state, prefix)
     }
 }
 
-impl<T: HasTokenState> KernelQueriesExt for T {}
+impl<'a, BSO> ReadTokenState for TokenOperationContext<'a, BSO>
+where
+    BSO: BlockStateOperations,
+{
+    fn lookup_token_state_value(&self, key: &TokenStateKey) -> Option<TokenStateValue> {
+        self.block_state
+            .lookup_token_state_value(self.token_module_state, key)
+    }
+
+    fn iter_token_state_prefix(
+        &self,
+        prefix: TokenStateKey,
+    ) -> impl Iterator<Item = (&TokenStateKey, &TokenStateValue)> {
+        self.block_state
+            .iter_token_state_prefix(self.token_module_state, prefix)
+    }
+}
 
 /// Extension trait for [`TokenKernelOperationsImpl`] providing convenience wrappers for
 /// token key-value state updates.
-pub trait KernelOperationsExt: KernelQueriesExt {
+pub trait WriteTokenStateExt: ReadTokenState {
     /// Set or clear a value in the token key-value state at the corresponding key.
-    fn set_token_state_value(&mut self, key: TokenStateKey, value: Option<TokenStateValue>);
-
-    /// Set or clear a value in the token module state at the corresponding key.
-    fn set_module_state(&mut self, key: &[u8], value: Option<TokenStateValue>) {
-        self.set_token_state_value(module_state_key(key), value);
-    }
-
-    fn set_account_state(
-        &mut self,
-        account: AccountIndex,
-        key: &[u8],
-        value: Option<TokenStateValue>,
-    ) {
-        self.set_token_state_value(account_state_key(account, key), value);
-    }
-
-    fn set_account_roles_state(&mut self, account: AccountIndex, value: Roles) {
-        self.set_token_state_value(account_roles_state_key(account), value.into_state_value());
-    }
+    fn update_token_state_value(&mut self, key: TokenStateKey, value: Option<TokenStateValue>);
 }
 
-impl<BSO: BlockStateOperations> KernelOperationsExt for TokenKernelOperationsImpl<'_, BSO> {
-    fn set_token_state_value(&mut self, key: TokenStateKey, value: Option<TokenStateValue>) {
+impl<BSO: BlockStateOperations> WriteTokenStateExt for TokenOperationContext<'_, BSO> {
+    fn update_token_state_value(&mut self, key: TokenStateKey, value: Option<TokenStateValue>) {
         *self.token_module_state_dirty = true;
         self.block_state
             .update_token_state_value(self.token_module_state, &key, value);
@@ -102,6 +106,21 @@ fn module_state_key(key: &[u8]) -> TokenStateKey {
     module_key
 }
 
+/// Get value from the token module state at the given key.
+fn get_module_state(kernel: &impl ReadTokenState, key: &[u8]) -> Option<TokenStateValue> {
+    kernel.lookup_token_state_value(&module_state_key(key))
+}
+
+/// Set or clear a value in the token module state at the corresponding key.
+fn set_module_state<BSO: BlockStateOperations>(
+    kernel: &mut TokenOperationContext<'_, BSO>,
+    key: &[u8],
+    value: Option<TokenStateValue>,
+) {
+    kernel.update_token_state_value(module_state_key(key), value);
+}
+
+/// Construct a key for the account section of the token state.
 fn account_state_key(account_index: AccountIndex, key: &[u8]) -> TokenStateKey {
     let mut account_key =
         Vec::with_capacity(ACCOUNT_STATE_PREFIX.len() + size_of::<AccountIndex>() + key.len());
@@ -111,6 +130,26 @@ fn account_state_key(account_index: AccountIndex, key: &[u8]) -> TokenStateKey {
     account_key
 }
 
+/// Lookup a value from the account section of the token state.
+fn lookup_account_state(
+    kernel: &impl ReadTokenState,
+    account: AccountIndex,
+    key: &[u8],
+) -> Option<TokenStateValue> {
+    kernel.lookup_token_state_value(&account_state_key(account, key))
+}
+
+/// Update a value in the account section of the token state.
+fn update_account_state<BSO: BlockStateOperations>(
+    kernel: &mut TokenOperationContext<BSO>,
+    account: AccountIndex,
+    key: &[u8],
+    value: Option<TokenStateValue>,
+) {
+    kernel.update_token_state_value(account_state_key(account, key), value);
+}
+
+/// Construct a key for the account roles section of the token state.
 fn account_roles_state_key(account_index: AccountIndex) -> TokenStateKey {
     let mut account_key =
         Vec::with_capacity(ACCOUNT_ROLES_STATE_PREFIX.len() + size_of::<AccountIndex>());
@@ -119,36 +158,106 @@ fn account_roles_state_key(account_index: AccountIndex) -> TokenStateKey {
     account_key
 }
 
+/// Lookup a value from the account roles section of the token state.
+fn get_account_roles_state(
+    kernel: &impl ReadTokenState,
+    account: AccountIndex,
+) -> Result<Roles, TokenStateInvariantError> {
+    Roles::try_from_state_value(kernel.lookup_token_state_value(&account_roles_state_key(account)))
+        .map_err(|err| {
+            TokenStateInvariantError(format!(
+                "Stored account authorization roles cannot be decoded: {}",
+                err
+            ))
+        })
+}
+
+/// Update a value in the account section of the token state.
+fn update_account_roles_state<BSO: BlockStateOperations>(
+    kernel: &mut TokenOperationContext<BSO>,
+    account: AccountIndex,
+    value: Roles,
+) {
+    kernel.update_token_state_value(account_roles_state_key(account), value.into_state_value());
+}
+
 /// Get whether the balance-affecting operations on the token are currently
 /// paused.
-pub fn is_paused(kernel: &impl KernelQueriesExt) -> bool {
-    kernel.get_module_state(STATE_KEY_PAUSED).is_some()
+pub fn is_paused(kernel: &impl ReadTokenState) -> bool {
+    get_module_state(kernel, STATE_KEY_PAUSED).is_some()
 }
 
 /// Get whether the token has allow lists enabled.
-pub fn has_allow_list(kernel: &impl KernelQueriesExt) -> bool {
-    kernel.get_module_state(STATE_KEY_ALLOW_LIST).is_some()
+pub fn is_allow_list_enabled(kernel: &impl ReadTokenState) -> bool {
+    get_module_state(kernel, STATE_KEY_ALLOW_LIST).is_some()
+}
+
+/// Enabled 'allowList' feature for the token.
+pub fn set_allow_list_enabled<BSO: BlockStateOperations>(
+    kernel: &mut TokenOperationContext<BSO>,
+) {
+    set_module_state(kernel, STATE_KEY_ALLOW_LIST, Some(vec![]));
 }
 
 /// Get whether the token has deny lists enabled.
-pub fn has_deny_list(kernel: &impl KernelQueriesExt) -> bool {
-    kernel.get_module_state(STATE_KEY_DENY_LIST).is_some()
+pub fn has_deny_list(kernel: &impl ReadTokenState) -> bool {
+    get_module_state(kernel, STATE_KEY_DENY_LIST).is_some()
+}
+
+/// Enabled 'DenyList' feature for the token.
+pub fn set_deny_list_enabled<BSO: BlockStateOperations>(
+    kernel: &mut TokenOperationContext<BSO>,
+) {
+    set_module_state(kernel, STATE_KEY_DENY_LIST, Some(vec![]));
 }
 
 /// Get whether the token allows minting.
-pub fn is_mintable(kernel: &impl KernelQueriesExt) -> bool {
-    kernel.get_module_state(STATE_KEY_MINTABLE).is_some()
+pub fn is_mintable(kernel: &impl ReadTokenState) -> bool {
+    get_module_state(kernel, STATE_KEY_MINTABLE).is_some()
+}
+
+/// Enabled 'Mintable' feature for the token.
+pub fn set_mintable_enabled<BSO: BlockStateOperations>(
+    kernel: &mut TokenOperationContext<BSO>,
+) {
+    set_module_state(kernel, STATE_KEY_MINTABLE, Some(vec![]));
 }
 
 /// Get whether the token allows burning.
-pub fn is_burnable(kernel: &impl KernelQueriesExt) -> bool {
-    kernel.get_module_state(STATE_KEY_BURNABLE).is_some()
+pub fn is_burnable(kernel: &impl ReadTokenState) -> bool {
+    get_module_state(kernel, STATE_KEY_BURNABLE).is_some()
+}
+
+/// Enabled 'Burnable' feature for the token.
+pub fn set_burnable_enabled<BSO: BlockStateOperations>(
+    kernel: &mut TokenOperationContext<BSO>,
+) {
+    set_module_state(kernel, STATE_KEY_BURNABLE, Some(vec![]));
+}
+
+/// Set the token governance account in module state.
+pub fn set_governance_account<BSO: BlockStateOperations>(
+    kernel: &mut TokenOperationContext<BSO>,
+    account: AccountIndex,
+) {
+    set_module_state(
+        kernel,
+        STATE_KEY_GOVERNANCE_ACCOUNT,
+        Some(common::to_bytes(&account)),
+    );
+}
+
+/// Set the token governance account in module state.
+pub fn set_token_name<BSO: BlockStateOperations>(
+    kernel: &mut TokenOperationContext<BSO>,
+    name: String,
+) {
+    set_module_state(kernel, STATE_KEY_NAME, Some(name.into()));
 }
 
 /// Get the name of the token.
-pub fn get_name(kernel: &impl KernelQueriesExt) -> Result<String, TokenStateInvariantError> {
-    kernel
-        .get_module_state(STATE_KEY_NAME)
+pub fn get_token_name(kernel: &impl ReadTokenState) -> Result<String, TokenStateInvariantError> {
+    get_module_state(kernel, STATE_KEY_NAME)
         .ok_or_else(|| TokenStateInvariantError("Name not present".to_string()))
         .and_then(|value| {
             String::from_utf8(value).map_err(|err| {
@@ -158,11 +267,8 @@ pub fn get_name(kernel: &impl KernelQueriesExt) -> Result<String, TokenStateInva
 }
 
 /// Get the URL metadata of the token.
-pub fn get_metadata(
-    kernel: &impl KernelQueriesExt,
-) -> Result<MetadataUrl, TokenStateInvariantError> {
-    let metadata_cbor = kernel
-        .get_module_state(STATE_KEY_METADATA)
+pub fn get_metadata(kernel: &impl ReadTokenState) -> Result<MetadataUrl, TokenStateInvariantError> {
+    let metadata_cbor = get_module_state(kernel, STATE_KEY_METADATA)
         .ok_or_else(|| TokenStateInvariantError("Metadata not present".to_string()))?;
     let metadata: MetadataUrl = util::cbor_decode(metadata_cbor).map_err(|err| {
         TokenStateInvariantError(format!("Stored metadata CBOR not decodable: {}", err))
@@ -171,18 +277,20 @@ pub fn get_metadata(
 }
 
 /// Set the metadata URL.
-pub fn set_metadata_url<TK: KernelOperationsExt>(kernel: &mut TK, metadata: &MetadataUrl) {
+pub fn set_metadata_url<BSO: BlockStateOperations>(
+    kernel: &mut TokenOperationContext<BSO>,
+    metadata: &MetadataUrl,
+) {
     let encoded_metadata = common::cbor::cbor_encode(metadata);
-    kernel.set_module_state(STATE_KEY_METADATA, Some(encoded_metadata));
+    set_module_state(kernel, STATE_KEY_METADATA, Some(encoded_metadata));
 }
 
 /// Get the account index of the governance account for the token.
 pub fn get_governance_account_index(
-    kernel: &impl KernelQueriesExt,
+    kernel: &impl ReadTokenState,
 ) -> Result<AccountIndex, TokenStateInvariantError> {
     let governance_account_index = AccountIndex::from(
-        kernel
-            .get_module_state(STATE_KEY_GOVERNANCE_ACCOUNT)
+        get_module_state(kernel, STATE_KEY_GOVERNANCE_ACCOUNT)
             .ok_or_else(|| TokenStateInvariantError("Governance account not present".to_string()))
             .and_then(|value| {
                 common::from_bytes_complete::<u64>(&mut value.as_slice()).map_err(|err| {
@@ -198,37 +306,37 @@ pub fn get_governance_account_index(
 
 /// Get the authorization roles for an account from state.
 pub fn get_account_roles(
-    kernel: &impl KernelQueriesExt,
+    kernel: &impl ReadTokenState,
     account: AccountIndex,
 ) -> Result<Roles, TokenStateInvariantError> {
-    kernel.get_account_roles_state(account)
+    get_account_roles_state(kernel, account)
 }
 
 /// Assign roles to an account in the state.
-pub fn assign_account_roles(
-    kernel: &mut impl KernelOperationsExt,
+pub fn assign_account_roles<BSO: BlockStateOperations>(
+    kernel: &mut TokenOperationContext<BSO>,
     account: AccountIndex,
     assigned_roles: &[TokenAdminRole],
 ) -> Result<(), TokenStateInvariantError> {
-    let mut roles = kernel.get_account_roles_state(account)?;
+    let mut roles = get_account_roles_state(kernel, account)?;
     for role in assigned_roles {
         roles.assign(*role)
     }
-    kernel.set_account_roles_state(account, roles);
+    update_account_roles_state(kernel, account, roles);
     Ok(())
 }
 
 /// Revoke roles of an account in the state.
-pub fn revoke_account_roles(
-    kernel: &mut impl KernelOperationsExt,
+pub fn revoke_account_roles<BSO: BlockStateOperations>(
+    kernel: &mut TokenOperationContext<BSO>,
     account: AccountIndex,
     revoked_roles: &[TokenAdminRole],
 ) -> Result<(), TokenStateInvariantError> {
-    let mut roles = kernel.get_account_roles_state(account)?;
+    let mut roles = get_account_roles_state(kernel, account)?;
     for role in revoked_roles {
         roles.revoke(*role)
     }
-    kernel.set_account_roles_state(account, roles);
+    update_account_roles_state(kernel, account, roles);
     Ok(())
 }
 
@@ -237,7 +345,7 @@ pub fn revoke_account_roles(
 /// Takes a concrete [`TokenKernelQueriesImpl`] because account index lookups are needed
 /// in addition to key-value state access.
 pub fn get_token_authorizations<BSQ: BlockStateQuery>(
-    kernel: &TokenKernelQueriesImpl<'_, BSQ>,
+    kernel: &TokenQueryContext<'_, BSQ>,
 ) -> Result<TokenAuthorizations, TokenStateInvariantError> {
     let mut update_admin_roles = TokenRoleAuthorizations::default();
     let mut mint = TokenRoleAuthorizations::default();
@@ -296,7 +404,7 @@ pub fn get_token_authorizations<BSQ: BlockStateQuery>(
         update_admin_roles: Some(update_admin_roles),
         mint: is_mintable(kernel).then_some(mint),
         burn: is_burnable(kernel).then_some(burn),
-        update_allow_list: has_allow_list(kernel).then_some(update_allow_list),
+        update_allow_list: is_allow_list_enabled(kernel).then_some(update_allow_list),
         update_deny_list: has_deny_list(kernel).then_some(update_deny_list),
         pause: Some(pause),
         update_metadata: Some(update_metadata),
@@ -304,43 +412,42 @@ pub fn get_token_authorizations<BSQ: BlockStateQuery>(
 }
 
 /// Sets the paused state of the token module.
-pub fn set_paused<TK: KernelOperationsExt>(kernel: &mut TK, value: bool) {
+pub fn set_paused<BSO: BlockStateOperations>(
+    kernel: &mut TokenOperationContext<BSO>,
+    value: bool,
+) {
     let state_value = value.then_some(vec![]);
-    kernel.set_module_state(STATE_KEY_PAUSED, state_value)
+    set_module_state(kernel, STATE_KEY_PAUSED, state_value)
 }
 
 /// Get the allow-list state for the account at the given account.
-pub fn get_allow_list_for<TK: KernelQueriesExt>(kernel: &TK, account: AccountIndex) -> bool {
-    kernel
-        .get_account_state(account, STATE_KEY_ALLOW_LIST)
-        .is_some()
+pub fn get_allow_list_for(kernel: &impl ReadTokenState, account: AccountIndex) -> bool {
+    lookup_account_state(kernel, account, STATE_KEY_ALLOW_LIST).is_some()
 }
 
 /// Set the allow-list state for the account at the given account.
-pub fn set_allow_list_for<TK: KernelOperationsExt>(
-    kernel: &mut TK,
+pub fn set_allow_list_for<BSO: BlockStateOperations>(
+    kernel: &mut TokenOperationContext<BSO>,
     account: AccountIndex,
     value: bool,
 ) {
     let state_value = value.then_some(vec![]);
-    kernel.set_account_state(account, STATE_KEY_ALLOW_LIST, state_value)
+    update_account_state(kernel, account, STATE_KEY_ALLOW_LIST, state_value)
 }
 
 /// Get the deny-list state for the account at the given account.
-pub fn get_deny_list_for<TK: KernelQueriesExt>(kernel: &TK, account: AccountIndex) -> bool {
-    kernel
-        .get_account_state(account, STATE_KEY_DENY_LIST)
-        .is_some()
+pub fn get_deny_list_for(kernel: &impl ReadTokenState, account: AccountIndex) -> bool {
+    lookup_account_state(kernel, account, STATE_KEY_DENY_LIST).is_some()
 }
 
 /// Set the deny-list state for the account at the given account.
-pub fn set_deny_list_for<TK: KernelOperationsExt>(
-    kernel: &mut TK,
+pub fn set_deny_list_for<BSO: BlockStateOperations>(
+    kernel: &mut TokenOperationContext<BSO>,
     account: AccountIndex,
     value: bool,
 ) {
     let state_value = value.then_some(vec![]);
-    kernel.set_account_state(account, STATE_KEY_DENY_LIST, state_value)
+    update_account_state(kernel, account, STATE_KEY_DENY_LIST, state_value)
 }
 
 #[cfg(test)]

--- a/plt/plt-scheduler/src/token_module/key_value_state.rs
+++ b/plt/plt-scheduler/src/token_module/key_value_state.rs
@@ -2,8 +2,8 @@
 
 use super::roles::Roles;
 use super::util;
-use crate::token_kernel::{TokenOperationContext, TokenQueryContext};
-use crate::token_module::token_kernel_interface::TokenStateInvariantError;
+use crate::token_context::{TokenOperationContext, TokenQueryContext};
+use crate::token_module::errors::TokenStateInvariantError;
 use concordium_base::common;
 use concordium_base::protocol_level_tokens::{
     MetadataUrl, TokenAdminRole, TokenAuthorizations, TokenRoleAuthorizations,
@@ -34,7 +34,8 @@ const STATE_KEY_GOVERNANCE_ACCOUNT: &[u8] = b"governanceAccount";
 
 /// Minimal read-only access to token key-value state.
 ///
-/// Allows defining functions which are generic over the access to the token state.
+/// Allows defining functions which works for both [`TokenQueryContext`] and
+/// [`TokenOperationContext`].
 pub trait ReadTokenState {
     /// Lookup a key in the token key-value state.
     fn lookup_token_state_value(&self, key: &TokenStateKey) -> Option<TokenStateValue>;
@@ -82,21 +83,6 @@ where
     }
 }
 
-/// Extension trait for [`TokenKernelOperationsImpl`] providing convenience wrappers for
-/// token key-value state updates.
-pub trait WriteTokenStateExt: ReadTokenState {
-    /// Set or clear a value in the token key-value state at the corresponding key.
-    fn update_token_state_value(&mut self, key: TokenStateKey, value: Option<TokenStateValue>);
-}
-
-impl<BSO: BlockStateOperations> WriteTokenStateExt for TokenOperationContext<'_, BSO> {
-    fn update_token_state_value(&mut self, key: TokenStateKey, value: Option<TokenStateValue>) {
-        *self.token_module_state_dirty = true;
-        self.block_state
-            .update_token_state_value(self.token_module_state, &key, value);
-    }
-}
-
 /// Construct a [`TokenStateKey`] for a module key. This prefixes the key to
 /// distinguish it from other keys.
 fn module_state_key(key: &[u8]) -> TokenStateKey {
@@ -107,17 +93,17 @@ fn module_state_key(key: &[u8]) -> TokenStateKey {
 }
 
 /// Get value from the token module state at the given key.
-fn get_module_state(kernel: &impl ReadTokenState, key: &[u8]) -> Option<TokenStateValue> {
-    kernel.lookup_token_state_value(&module_state_key(key))
+fn get_module_state(context: &impl ReadTokenState, key: &[u8]) -> Option<TokenStateValue> {
+    context.lookup_token_state_value(&module_state_key(key))
 }
 
 /// Set or clear a value in the token module state at the corresponding key.
 fn set_module_state<BSO: BlockStateOperations>(
-    kernel: &mut TokenOperationContext<'_, BSO>,
+    context: &mut TokenOperationContext<'_, BSO>,
     key: &[u8],
     value: Option<TokenStateValue>,
 ) {
-    kernel.update_token_state_value(module_state_key(key), value);
+    context.update_token_state_value(module_state_key(key), value);
 }
 
 /// Construct a key for the account section of the token state.
@@ -132,21 +118,21 @@ fn account_state_key(account_index: AccountIndex, key: &[u8]) -> TokenStateKey {
 
 /// Lookup a value from the account section of the token state.
 fn lookup_account_state(
-    kernel: &impl ReadTokenState,
+    context: &impl ReadTokenState,
     account: AccountIndex,
     key: &[u8],
 ) -> Option<TokenStateValue> {
-    kernel.lookup_token_state_value(&account_state_key(account, key))
+    context.lookup_token_state_value(&account_state_key(account, key))
 }
 
 /// Update a value in the account section of the token state.
 fn update_account_state<BSO: BlockStateOperations>(
-    kernel: &mut TokenOperationContext<BSO>,
+    context: &mut TokenOperationContext<BSO>,
     account: AccountIndex,
     key: &[u8],
     value: Option<TokenStateValue>,
 ) {
-    kernel.update_token_state_value(account_state_key(account, key), value);
+    context.update_token_state_value(account_state_key(account, key), value);
 }
 
 /// Construct a key for the account roles section of the token state.
@@ -160,10 +146,10 @@ fn account_roles_state_key(account_index: AccountIndex) -> TokenStateKey {
 
 /// Lookup a value from the account roles section of the token state.
 fn get_account_roles_state(
-    kernel: &impl ReadTokenState,
+    context: &impl ReadTokenState,
     account: AccountIndex,
 ) -> Result<Roles, TokenStateInvariantError> {
-    Roles::try_from_state_value(kernel.lookup_token_state_value(&account_roles_state_key(account)))
+    Roles::try_from_state_value(context.lookup_token_state_value(&account_roles_state_key(account)))
         .map_err(|err| {
             TokenStateInvariantError(format!(
                 "Stored account authorization roles cannot be decoded: {}",
@@ -174,74 +160,66 @@ fn get_account_roles_state(
 
 /// Update a value in the account section of the token state.
 fn update_account_roles_state<BSO: BlockStateOperations>(
-    kernel: &mut TokenOperationContext<BSO>,
+    context: &mut TokenOperationContext<BSO>,
     account: AccountIndex,
     value: Roles,
 ) {
-    kernel.update_token_state_value(account_roles_state_key(account), value.into_state_value());
+    context.update_token_state_value(account_roles_state_key(account), value.into_state_value());
 }
 
 /// Get whether the balance-affecting operations on the token are currently
 /// paused.
-pub fn is_paused(kernel: &impl ReadTokenState) -> bool {
-    get_module_state(kernel, STATE_KEY_PAUSED).is_some()
+pub fn is_paused(context: &impl ReadTokenState) -> bool {
+    get_module_state(context, STATE_KEY_PAUSED).is_some()
 }
 
 /// Get whether the token has allow lists enabled.
-pub fn is_allow_list_enabled(kernel: &impl ReadTokenState) -> bool {
-    get_module_state(kernel, STATE_KEY_ALLOW_LIST).is_some()
+pub fn has_allow_list(context: &impl ReadTokenState) -> bool {
+    get_module_state(context, STATE_KEY_ALLOW_LIST).is_some()
 }
 
 /// Enabled 'allowList' feature for the token.
-pub fn set_allow_list_enabled<BSO: BlockStateOperations>(
-    kernel: &mut TokenOperationContext<BSO>,
-) {
-    set_module_state(kernel, STATE_KEY_ALLOW_LIST, Some(vec![]));
+pub fn set_allow_list_enabled<BSO: BlockStateOperations>(context: &mut TokenOperationContext<BSO>) {
+    set_module_state(context, STATE_KEY_ALLOW_LIST, Some(vec![]));
 }
 
 /// Get whether the token has deny lists enabled.
-pub fn has_deny_list(kernel: &impl ReadTokenState) -> bool {
-    get_module_state(kernel, STATE_KEY_DENY_LIST).is_some()
+pub fn has_deny_list(context: &impl ReadTokenState) -> bool {
+    get_module_state(context, STATE_KEY_DENY_LIST).is_some()
 }
 
 /// Enabled 'DenyList' feature for the token.
-pub fn set_deny_list_enabled<BSO: BlockStateOperations>(
-    kernel: &mut TokenOperationContext<BSO>,
-) {
-    set_module_state(kernel, STATE_KEY_DENY_LIST, Some(vec![]));
+pub fn set_deny_list_enabled<BSO: BlockStateOperations>(context: &mut TokenOperationContext<BSO>) {
+    set_module_state(context, STATE_KEY_DENY_LIST, Some(vec![]));
 }
 
 /// Get whether the token allows minting.
-pub fn is_mintable(kernel: &impl ReadTokenState) -> bool {
-    get_module_state(kernel, STATE_KEY_MINTABLE).is_some()
+pub fn is_mintable(context: &impl ReadTokenState) -> bool {
+    get_module_state(context, STATE_KEY_MINTABLE).is_some()
 }
 
 /// Enabled 'Mintable' feature for the token.
-pub fn set_mintable_enabled<BSO: BlockStateOperations>(
-    kernel: &mut TokenOperationContext<BSO>,
-) {
-    set_module_state(kernel, STATE_KEY_MINTABLE, Some(vec![]));
+pub fn set_mintable_enabled<BSO: BlockStateOperations>(context: &mut TokenOperationContext<BSO>) {
+    set_module_state(context, STATE_KEY_MINTABLE, Some(vec![]));
 }
 
 /// Get whether the token allows burning.
-pub fn is_burnable(kernel: &impl ReadTokenState) -> bool {
-    get_module_state(kernel, STATE_KEY_BURNABLE).is_some()
+pub fn is_burnable(context: &impl ReadTokenState) -> bool {
+    get_module_state(context, STATE_KEY_BURNABLE).is_some()
 }
 
 /// Enabled 'Burnable' feature for the token.
-pub fn set_burnable_enabled<BSO: BlockStateOperations>(
-    kernel: &mut TokenOperationContext<BSO>,
-) {
-    set_module_state(kernel, STATE_KEY_BURNABLE, Some(vec![]));
+pub fn set_burnable_enabled<BSO: BlockStateOperations>(context: &mut TokenOperationContext<BSO>) {
+    set_module_state(context, STATE_KEY_BURNABLE, Some(vec![]));
 }
 
 /// Set the token governance account in module state.
 pub fn set_governance_account<BSO: BlockStateOperations>(
-    kernel: &mut TokenOperationContext<BSO>,
+    context: &mut TokenOperationContext<BSO>,
     account: AccountIndex,
 ) {
     set_module_state(
-        kernel,
+        context,
         STATE_KEY_GOVERNANCE_ACCOUNT,
         Some(common::to_bytes(&account)),
     );
@@ -249,15 +227,15 @@ pub fn set_governance_account<BSO: BlockStateOperations>(
 
 /// Set the token governance account in module state.
 pub fn set_token_name<BSO: BlockStateOperations>(
-    kernel: &mut TokenOperationContext<BSO>,
+    context: &mut TokenOperationContext<BSO>,
     name: String,
 ) {
-    set_module_state(kernel, STATE_KEY_NAME, Some(name.into()));
+    set_module_state(context, STATE_KEY_NAME, Some(name.into()));
 }
 
 /// Get the name of the token.
-pub fn get_token_name(kernel: &impl ReadTokenState) -> Result<String, TokenStateInvariantError> {
-    get_module_state(kernel, STATE_KEY_NAME)
+pub fn get_token_name(context: &impl ReadTokenState) -> Result<String, TokenStateInvariantError> {
+    get_module_state(context, STATE_KEY_NAME)
         .ok_or_else(|| TokenStateInvariantError("Name not present".to_string()))
         .and_then(|value| {
             String::from_utf8(value).map_err(|err| {
@@ -267,8 +245,10 @@ pub fn get_token_name(kernel: &impl ReadTokenState) -> Result<String, TokenState
 }
 
 /// Get the URL metadata of the token.
-pub fn get_metadata(kernel: &impl ReadTokenState) -> Result<MetadataUrl, TokenStateInvariantError> {
-    let metadata_cbor = get_module_state(kernel, STATE_KEY_METADATA)
+pub fn get_metadata(
+    context: &impl ReadTokenState,
+) -> Result<MetadataUrl, TokenStateInvariantError> {
+    let metadata_cbor = get_module_state(context, STATE_KEY_METADATA)
         .ok_or_else(|| TokenStateInvariantError("Metadata not present".to_string()))?;
     let metadata: MetadataUrl = util::cbor_decode(metadata_cbor).map_err(|err| {
         TokenStateInvariantError(format!("Stored metadata CBOR not decodable: {}", err))
@@ -278,19 +258,19 @@ pub fn get_metadata(kernel: &impl ReadTokenState) -> Result<MetadataUrl, TokenSt
 
 /// Set the metadata URL.
 pub fn set_metadata_url<BSO: BlockStateOperations>(
-    kernel: &mut TokenOperationContext<BSO>,
+    context: &mut TokenOperationContext<BSO>,
     metadata: &MetadataUrl,
 ) {
     let encoded_metadata = common::cbor::cbor_encode(metadata);
-    set_module_state(kernel, STATE_KEY_METADATA, Some(encoded_metadata));
+    set_module_state(context, STATE_KEY_METADATA, Some(encoded_metadata));
 }
 
 /// Get the account index of the governance account for the token.
 pub fn get_governance_account_index(
-    kernel: &impl ReadTokenState,
+    context: &impl ReadTokenState,
 ) -> Result<AccountIndex, TokenStateInvariantError> {
     let governance_account_index = AccountIndex::from(
-        get_module_state(kernel, STATE_KEY_GOVERNANCE_ACCOUNT)
+        get_module_state(context, STATE_KEY_GOVERNANCE_ACCOUNT)
             .ok_or_else(|| TokenStateInvariantError("Governance account not present".to_string()))
             .and_then(|value| {
                 common::from_bytes_complete::<u64>(&mut value.as_slice()).map_err(|err| {
@@ -306,46 +286,43 @@ pub fn get_governance_account_index(
 
 /// Get the authorization roles for an account from state.
 pub fn get_account_roles(
-    kernel: &impl ReadTokenState,
+    context: &impl ReadTokenState,
     account: AccountIndex,
 ) -> Result<Roles, TokenStateInvariantError> {
-    get_account_roles_state(kernel, account)
+    get_account_roles_state(context, account)
 }
 
 /// Assign roles to an account in the state.
 pub fn assign_account_roles<BSO: BlockStateOperations>(
-    kernel: &mut TokenOperationContext<BSO>,
+    context: &mut TokenOperationContext<BSO>,
     account: AccountIndex,
     assigned_roles: &[TokenAdminRole],
 ) -> Result<(), TokenStateInvariantError> {
-    let mut roles = get_account_roles_state(kernel, account)?;
+    let mut roles = get_account_roles_state(context, account)?;
     for role in assigned_roles {
         roles.assign(*role)
     }
-    update_account_roles_state(kernel, account, roles);
+    update_account_roles_state(context, account, roles);
     Ok(())
 }
 
 /// Revoke roles of an account in the state.
 pub fn revoke_account_roles<BSO: BlockStateOperations>(
-    kernel: &mut TokenOperationContext<BSO>,
+    context: &mut TokenOperationContext<BSO>,
     account: AccountIndex,
     revoked_roles: &[TokenAdminRole],
 ) -> Result<(), TokenStateInvariantError> {
-    let mut roles = get_account_roles_state(kernel, account)?;
+    let mut roles = get_account_roles_state(context, account)?;
     for role in revoked_roles {
         roles.revoke(*role)
     }
-    update_account_roles_state(kernel, account, roles);
+    update_account_roles_state(context, account, roles);
     Ok(())
 }
 
 /// Get authorization roles and assigned accounts for the token.
-///
-/// Takes a concrete [`TokenKernelQueriesImpl`] because account index lookups are needed
-/// in addition to key-value state access.
 pub fn get_token_authorizations<BSQ: BlockStateQuery>(
-    kernel: &TokenQueryContext<'_, BSQ>,
+    context: &TokenQueryContext<'_, BSQ>,
 ) -> Result<TokenAuthorizations, TokenStateInvariantError> {
     let mut update_admin_roles = TokenRoleAuthorizations::default();
     let mut mint = TokenRoleAuthorizations::default();
@@ -355,7 +332,7 @@ pub fn get_token_authorizations<BSQ: BlockStateQuery>(
     let mut pause = TokenRoleAuthorizations::default();
     let mut update_metadata = TokenRoleAuthorizations::default();
 
-    for (key, roles) in kernel.iter_token_state_prefix(ACCOUNT_ROLES_STATE_PREFIX.into()) {
+    for (key, roles) in context.iter_token_state_prefix(ACCOUNT_ROLES_STATE_PREFIX.into()) {
         let account_index_bytes =
             key.strip_prefix(&ACCOUNT_ROLES_STATE_PREFIX)
                 .ok_or_else(|| {
@@ -370,7 +347,7 @@ pub fn get_token_authorizations<BSQ: BlockStateQuery>(
                     err
                 ))
             })?;
-        let account = kernel
+        let account = context
             .block_state
             .account_by_index(account_index)
             .map_err(|err| {
@@ -402,10 +379,10 @@ pub fn get_token_authorizations<BSQ: BlockStateQuery>(
     }
     Ok(TokenAuthorizations {
         update_admin_roles: Some(update_admin_roles),
-        mint: is_mintable(kernel).then_some(mint),
-        burn: is_burnable(kernel).then_some(burn),
-        update_allow_list: is_allow_list_enabled(kernel).then_some(update_allow_list),
-        update_deny_list: has_deny_list(kernel).then_some(update_deny_list),
+        mint: is_mintable(context).then_some(mint),
+        burn: is_burnable(context).then_some(burn),
+        update_allow_list: has_allow_list(context).then_some(update_allow_list),
+        update_deny_list: has_deny_list(context).then_some(update_deny_list),
         pause: Some(pause),
         update_metadata: Some(update_metadata),
     })
@@ -413,41 +390,41 @@ pub fn get_token_authorizations<BSQ: BlockStateQuery>(
 
 /// Sets the paused state of the token module.
 pub fn set_paused<BSO: BlockStateOperations>(
-    kernel: &mut TokenOperationContext<BSO>,
+    context: &mut TokenOperationContext<BSO>,
     value: bool,
 ) {
     let state_value = value.then_some(vec![]);
-    set_module_state(kernel, STATE_KEY_PAUSED, state_value)
+    set_module_state(context, STATE_KEY_PAUSED, state_value)
 }
 
 /// Get the allow-list state for the account at the given account.
-pub fn get_allow_list_for(kernel: &impl ReadTokenState, account: AccountIndex) -> bool {
-    lookup_account_state(kernel, account, STATE_KEY_ALLOW_LIST).is_some()
+pub fn get_allow_list_for(context: &impl ReadTokenState, account: AccountIndex) -> bool {
+    lookup_account_state(context, account, STATE_KEY_ALLOW_LIST).is_some()
 }
 
 /// Set the allow-list state for the account at the given account.
 pub fn set_allow_list_for<BSO: BlockStateOperations>(
-    kernel: &mut TokenOperationContext<BSO>,
+    context: &mut TokenOperationContext<BSO>,
     account: AccountIndex,
     value: bool,
 ) {
     let state_value = value.then_some(vec![]);
-    update_account_state(kernel, account, STATE_KEY_ALLOW_LIST, state_value)
+    update_account_state(context, account, STATE_KEY_ALLOW_LIST, state_value)
 }
 
 /// Get the deny-list state for the account at the given account.
-pub fn get_deny_list_for(kernel: &impl ReadTokenState, account: AccountIndex) -> bool {
-    lookup_account_state(kernel, account, STATE_KEY_DENY_LIST).is_some()
+pub fn get_deny_list_for(context: &impl ReadTokenState, account: AccountIndex) -> bool {
+    lookup_account_state(context, account, STATE_KEY_DENY_LIST).is_some()
 }
 
 /// Set the deny-list state for the account at the given account.
 pub fn set_deny_list_for<BSO: BlockStateOperations>(
-    kernel: &mut TokenOperationContext<BSO>,
+    context: &mut TokenOperationContext<BSO>,
     account: AccountIndex,
     value: bool,
 ) {
     let state_value = value.then_some(vec![]);
-    update_account_state(kernel, account, STATE_KEY_DENY_LIST, state_value)
+    update_account_state(context, account, STATE_KEY_DENY_LIST, state_value)
 }
 
 #[cfg(test)]

--- a/plt/plt-scheduler/src/token_module/mod.rs
+++ b/plt/plt-scheduler/src/token_module/mod.rs
@@ -1,9 +1,9 @@
 use concordium_base::protocol_level_tokens::TokenModuleRef;
 
+pub mod errors;
 mod key_value_state;
 mod module;
 mod roles;
-pub mod token_kernel_interface;
 mod util;
 
 pub use module::*;

--- a/plt/plt-scheduler/src/token_module/module/initialize.rs
+++ b/plt/plt-scheduler/src/token_module/module/initialize.rs
@@ -93,8 +93,10 @@ fn initialize_token_impl<BSO: BlockStateOperations>(
         enabled_roles.push(TokenAdminRole::Burn);
     }
 
-    let governance_account = kernel.account_by_address(&cbor_governance_account.address)?;
-    let governance_account_index = kernel.account_index(&governance_account);
+    let governance_account = kernel
+        .block_state
+        .account_by_address(&cbor_governance_account.address)?;
+    let governance_account_index = kernel.block_state.account_index(&governance_account);
     kernel.set_module_state(
         key_value_state::STATE_KEY_GOVERNANCE_ACCOUNT,
         Some(common::to_bytes(&governance_account_index.index)),

--- a/plt/plt-scheduler/src/token_module/module/initialize.rs
+++ b/plt/plt-scheduler/src/token_module/module/initialize.rs
@@ -1,11 +1,10 @@
-use crate::token_kernel::TokenKernelOperationsImpl;
-use crate::token_module::key_value_state::{self, KernelOperationsExt};
+use crate::token_kernel::TokenOperationContext;
+use crate::token_module::key_value_state;
 use crate::token_module::module::TokenAmountDecimalsMismatchError;
 use crate::token_module::token_kernel_interface::{
     MintWouldOverflowError, TokenMintError, TokenStateInvariantError,
 };
 use crate::token_module::{roles, util};
-use concordium_base::common;
 use concordium_base::common::cbor::CborSerializationError;
 use concordium_base::protocol_level_tokens::{
     RawCbor, TokenAdminRole, TokenModuleInitializationParameters,
@@ -42,7 +41,7 @@ impl From<TokenMintError> for TokenInitializationError {
 /// Initialize a PLT by recording the relevant configuration parameters in the state and
 /// (if necessary) minting the initial supply to the token governance account.
 pub fn initialize_token<BSO: BlockStateOperations>(
-    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
+    kernel: &mut TokenOperationContext<'_, BSO>,
     initialization_parameters_cbor: RawCbor,
 ) -> Result<(), TokenInitializationError> {
     let init_params: TokenModuleInitializationParameters =
@@ -51,7 +50,7 @@ pub fn initialize_token<BSO: BlockStateOperations>(
 }
 
 fn initialize_token_impl<BSO: BlockStateOperations>(
-    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
+    kernel: &mut TokenOperationContext<'_, BSO>,
     init_params: TokenModuleInitializationParameters,
 ) -> Result<(), TokenInitializationError> {
     let name = init_params.name.ok_or_else(|| {
@@ -69,7 +68,7 @@ fn initialize_token_impl<BSO: BlockStateOperations>(
             "Token governance account is missing".to_string(),
         )
     })?;
-    kernel.set_module_state(key_value_state::STATE_KEY_NAME, Some(name.into()));
+    key_value_state::set_token_name(kernel, name);
     key_value_state::set_metadata_url(kernel, &metadata);
 
     // The governance account should hold every role, except for disabled features, so we build a
@@ -77,19 +76,19 @@ fn initialize_token_impl<BSO: BlockStateOperations>(
     let mut enabled_roles = Vec::from(roles::UNIVERSAL_ROLES);
 
     if init_params.allow_list == Some(true) {
-        kernel.set_module_state(key_value_state::STATE_KEY_ALLOW_LIST, Some(vec![]));
+        key_value_state::set_allow_list_enabled(kernel);
         enabled_roles.push(TokenAdminRole::UpdateAllowList);
     }
     if init_params.deny_list == Some(true) {
-        kernel.set_module_state(key_value_state::STATE_KEY_DENY_LIST, Some(vec![]));
+        key_value_state::set_deny_list_enabled(kernel);
         enabled_roles.push(TokenAdminRole::UpdateDenyList);
     }
     if init_params.mintable == Some(true) {
-        kernel.set_module_state(key_value_state::STATE_KEY_MINTABLE, Some(vec![]));
+        key_value_state::set_mintable_enabled(kernel);
         enabled_roles.push(TokenAdminRole::Mint);
     }
     if init_params.burnable == Some(true) {
-        kernel.set_module_state(key_value_state::STATE_KEY_BURNABLE, Some(vec![]));
+        key_value_state::set_burnable_enabled(kernel);
         enabled_roles.push(TokenAdminRole::Burn);
     }
 
@@ -97,10 +96,7 @@ fn initialize_token_impl<BSO: BlockStateOperations>(
         .block_state
         .account_by_address(&cbor_governance_account.address)?;
     let governance_account_index = kernel.block_state.account_index(&governance_account);
-    kernel.set_module_state(
-        key_value_state::STATE_KEY_GOVERNANCE_ACCOUNT,
-        Some(common::to_bytes(&governance_account_index.index)),
-    );
+    key_value_state::set_governance_account(kernel, governance_account_index);
     if kernel.support_rbac() {
         key_value_state::assign_account_roles(kernel, governance_account_index, &enabled_roles)?;
     }

--- a/plt/plt-scheduler/src/token_module/module/initialize.rs
+++ b/plt/plt-scheduler/src/token_module/module/initialize.rs
@@ -1,7 +1,8 @@
+use crate::token_kernel::TokenKernelOperationsImpl;
 use crate::token_module::key_value_state::{self, KernelOperationsExt};
 use crate::token_module::module::TokenAmountDecimalsMismatchError;
 use crate::token_module::token_kernel_interface::{
-    MintWouldOverflowError, TokenKernelOperations, TokenMintError, TokenStateInvariantError,
+    MintWouldOverflowError, TokenMintError, TokenStateInvariantError,
 };
 use crate::token_module::{roles, util};
 use concordium_base::common;
@@ -10,6 +11,7 @@ use concordium_base::protocol_level_tokens::{
     RawCbor, TokenAdminRole, TokenModuleInitializationParameters,
 };
 use plt_block_state::block_state::AccountNotFoundByAddressError;
+use plt_block_state::block_state_interface::BlockStateOperations;
 
 /// Represents the reasons why [`initialize_token`] can fail.
 #[derive(Debug, thiserror::Error)]
@@ -39,8 +41,8 @@ impl From<TokenMintError> for TokenInitializationError {
 
 /// Initialize a PLT by recording the relevant configuration parameters in the state and
 /// (if necessary) minting the initial supply to the token governance account.
-pub fn initialize_token(
-    kernel: &mut impl TokenKernelOperations,
+pub fn initialize_token<BSO: BlockStateOperations>(
+    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
     initialization_parameters_cbor: RawCbor,
 ) -> Result<(), TokenInitializationError> {
     let init_params: TokenModuleInitializationParameters =
@@ -48,8 +50,8 @@ pub fn initialize_token(
     initialize_token_impl(kernel, init_params)
 }
 
-fn initialize_token_impl(
-    kernel: &mut impl TokenKernelOperations,
+fn initialize_token_impl<BSO: BlockStateOperations>(
+    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
     init_params: TokenModuleInitializationParameters,
 ) -> Result<(), TokenInitializationError> {
     let name = init_params.name.ok_or_else(|| {

--- a/plt/plt-scheduler/src/token_module/module/initialize.rs
+++ b/plt/plt-scheduler/src/token_module/module/initialize.rs
@@ -1,9 +1,9 @@
-use crate::token_kernel::TokenOperationContext;
-use crate::token_module::key_value_state;
-use crate::token_module::module::TokenAmountDecimalsMismatchError;
-use crate::token_module::token_kernel_interface::{
-    MintWouldOverflowError, TokenMintError, TokenStateInvariantError,
+use crate::token_context::TokenOperationContext;
+use crate::token_module::errors::{
+    MintWouldOverflowError, TokenAmountDecimalsMismatchError, TokenMintError,
+    TokenStateInvariantError,
 };
+use crate::token_module::key_value_state;
 use crate::token_module::{roles, util};
 use concordium_base::common::cbor::CborSerializationError;
 use concordium_base::protocol_level_tokens::{
@@ -41,16 +41,16 @@ impl From<TokenMintError> for TokenInitializationError {
 /// Initialize a PLT by recording the relevant configuration parameters in the state and
 /// (if necessary) minting the initial supply to the token governance account.
 pub fn initialize_token<BSO: BlockStateOperations>(
-    kernel: &mut TokenOperationContext<'_, BSO>,
+    context: &mut TokenOperationContext<'_, BSO>,
     initialization_parameters_cbor: RawCbor,
 ) -> Result<(), TokenInitializationError> {
     let init_params: TokenModuleInitializationParameters =
         util::cbor_decode(&initialization_parameters_cbor)?;
-    initialize_token_impl(kernel, init_params)
+    initialize_token_impl(context, init_params)
 }
 
 fn initialize_token_impl<BSO: BlockStateOperations>(
-    kernel: &mut TokenOperationContext<'_, BSO>,
+    context: &mut TokenOperationContext<'_, BSO>,
     init_params: TokenModuleInitializationParameters,
 ) -> Result<(), TokenInitializationError> {
     let name = init_params.name.ok_or_else(|| {
@@ -68,41 +68,42 @@ fn initialize_token_impl<BSO: BlockStateOperations>(
             "Token governance account is missing".to_string(),
         )
     })?;
-    key_value_state::set_token_name(kernel, name);
-    key_value_state::set_metadata_url(kernel, &metadata);
+    key_value_state::set_token_name(context, name);
+    key_value_state::set_metadata_url(context, &metadata);
 
     // The governance account should hold every role, except for disabled features, so we build a
     // list of every enabled role and the mandatory roles.
     let mut enabled_roles = Vec::from(roles::UNIVERSAL_ROLES);
 
     if init_params.allow_list == Some(true) {
-        key_value_state::set_allow_list_enabled(kernel);
+        key_value_state::set_allow_list_enabled(context);
         enabled_roles.push(TokenAdminRole::UpdateAllowList);
     }
     if init_params.deny_list == Some(true) {
-        key_value_state::set_deny_list_enabled(kernel);
+        key_value_state::set_deny_list_enabled(context);
         enabled_roles.push(TokenAdminRole::UpdateDenyList);
     }
     if init_params.mintable == Some(true) {
-        key_value_state::set_mintable_enabled(kernel);
+        key_value_state::set_mintable_enabled(context);
         enabled_roles.push(TokenAdminRole::Mint);
     }
     if init_params.burnable == Some(true) {
-        key_value_state::set_burnable_enabled(kernel);
+        key_value_state::set_burnable_enabled(context);
         enabled_roles.push(TokenAdminRole::Burn);
     }
 
-    let governance_account = kernel
+    let governance_account = context
         .block_state
         .account_by_address(&cbor_governance_account.address)?;
-    let governance_account_index = kernel.block_state.account_index(&governance_account);
-    key_value_state::set_governance_account(kernel, governance_account_index);
-    if kernel.support_rbac() {
-        key_value_state::assign_account_roles(kernel, governance_account_index, &enabled_roles)?;
+    let governance_account_index = context.block_state.account_index(&governance_account);
+    key_value_state::set_governance_account(context, governance_account_index);
+    if context.support_rbac() {
+        key_value_state::assign_account_roles(context, governance_account_index, &enabled_roles)?;
     }
     if let Some(initial_supply) = init_params.initial_supply {
-        let mint_amount = util::to_raw_token_amount(kernel, initial_supply)?;
-        kernel.mint(
+        let mint_amount = util::to_raw_token_amount(context.token_configuration, initial_supply)?;
+
+        context.mint(
             &governance_account,
             cbor_governance_account.address,
             mint_amount,

--- a/plt/plt-scheduler/src/token_module/module/mod.rs
+++ b/plt/plt-scheduler/src/token_module/module/mod.rs
@@ -1,10 +1,6 @@
 //! Implementation of the protocol-level token module. The token module implements
 //! execution of [token operations](concordium_base::protocol_level_tokens::TokenOperation).
 //!
-//! The capabilities of the token module are defined and limited by the token kernel through
-//! which all state modifications are performed,
-//! see [`TokenKernelOperations`](crate::token_kernel_interface::TokenKernelOperations).
-//!
 //! It is the responsibility of the token module to charge energy for execution via
 //! [`TransactionExecution`](crate::transaction_execution_interface::TransactionExecution),
 //! and release control (return an error) if the energy limit is reached.

--- a/plt/plt-scheduler/src/token_module/module/mod.rs
+++ b/plt/plt-scheduler/src/token_module/module/mod.rs
@@ -2,7 +2,7 @@
 //! execution of [token operations](concordium_base::protocol_level_tokens::TokenOperation).
 //!
 //! It is the responsibility of the token module to charge energy for execution via
-//! [`TransactionExecution`](crate::transaction_execution_interface::TransactionExecution),
+//! [`TransactionExecution`](crate::transaction_execution::TransactionExecution),
 //! and release control (return an error) if the energy limit is reached.
 mod initialize;
 mod queries;
@@ -11,10 +11,3 @@ mod update;
 pub use initialize::*;
 pub use queries::*;
 pub use update::*;
-
-#[derive(Debug, thiserror::Error)]
-#[error("Token amount decimals mismatch: expected {expected}, found {found}")]
-pub struct TokenAmountDecimalsMismatchError {
-    pub expected: u8,
-    pub found: u8,
-}

--- a/plt/plt-scheduler/src/token_module/module/queries.rs
+++ b/plt/plt-scheduler/src/token_module/module/queries.rs
@@ -1,5 +1,5 @@
-use crate::token_kernel::TokenKernelQueriesImpl;
-use crate::token_module::key_value_state::{self, KernelQueriesExt};
+use crate::token_kernel::TokenQueryContext;
+use crate::token_module::key_value_state;
 use crate::token_module::token_kernel_interface::TokenStateInvariantError;
 use concordium_base::base::AccountIndex;
 use concordium_base::common::cbor;
@@ -17,7 +17,7 @@ pub enum QueryTokenModuleError {
 
 /// Get the CBOR-encoded representation of the token module state.
 pub fn query_token_module_state<BSQ: BlockStateQuery>(
-    kernel: &TokenKernelQueriesImpl<'_, BSQ>,
+    kernel: &TokenQueryContext<'_, BSQ>,
 ) -> Result<RawCbor, QueryTokenModuleError> {
     let state = query_token_module_state_impl(kernel)?;
 
@@ -25,11 +25,11 @@ pub fn query_token_module_state<BSQ: BlockStateQuery>(
 }
 
 fn query_token_module_state_impl<BSQ: BlockStateQuery>(
-    kernel: &TokenKernelQueriesImpl<'_, BSQ>,
+    kernel: &TokenQueryContext<'_, BSQ>,
 ) -> Result<TokenModuleState, QueryTokenModuleError> {
-    let name = key_value_state::get_name(kernel)?;
+    let name = key_value_state::get_token_name(kernel)?;
     let metadata = key_value_state::get_metadata(kernel)?;
-    let allow_list = key_value_state::has_allow_list(kernel);
+    let allow_list = key_value_state::is_allow_list_enabled(kernel);
     let deny_list = key_value_state::has_deny_list(kernel);
     let mintable = key_value_state::is_mintable(kernel);
     let burnable = key_value_state::is_burnable(kernel);
@@ -63,19 +63,19 @@ fn query_token_module_state_impl<BSQ: BlockStateQuery>(
 }
 
 /// Get the CBOR-encoded representation of the token module account state.
-pub fn query_token_module_account_state<TK: KernelQueriesExt>(
-    kernel: &TK,
+pub fn query_token_module_account_state<BSQ: BlockStateQuery>(
+    kernel: &TokenQueryContext<'_, BSQ>,
     account: AccountIndex,
 ) -> RawCbor {
     let state = query_token_module_account_state_impl(kernel, account);
     RawCbor::from(cbor::cbor_encode(&state))
 }
 
-fn query_token_module_account_state_impl<TK: KernelQueriesExt>(
-    kernel: &TK,
+fn query_token_module_account_state_impl<BSQ: BlockStateQuery>(
+    kernel: &TokenQueryContext<'_, BSQ>,
     account: AccountIndex,
 ) -> TokenModuleAccountState {
-    let has_allow_list = key_value_state::has_allow_list(kernel);
+    let has_allow_list = key_value_state::is_allow_list_enabled(kernel);
     let allow_list = if has_allow_list {
         key_value_state::get_allow_list_for(kernel, account).into()
     } else {
@@ -96,7 +96,7 @@ fn query_token_module_account_state_impl<TK: KernelQueriesExt>(
 
 /// Get authorization roles and assigned accounts for the token.
 pub fn query_token_authorizations<BSQ: BlockStateQuery>(
-    kernel: &TokenKernelQueriesImpl<'_, BSQ>,
+    kernel: &TokenQueryContext<'_, BSQ>,
 ) -> Result<RawCbor, QueryTokenModuleError> {
     Ok(RawCbor::from(cbor::cbor_encode(
         &key_value_state::get_token_authorizations(kernel)?,

--- a/plt/plt-scheduler/src/token_module/module/queries.rs
+++ b/plt/plt-scheduler/src/token_module/module/queries.rs
@@ -37,6 +37,7 @@ fn query_token_module_state_impl<BSQ: BlockStateQuery>(
 
     let governance_account_index = key_value_state::get_governance_account_index(kernel)?;
     let governance_account = kernel
+        .block_state
         .account_by_index(governance_account_index)
         .map_err(|_| {
             TokenStateInvariantError(format!(

--- a/plt/plt-scheduler/src/token_module/module/queries.rs
+++ b/plt/plt-scheduler/src/token_module/module/queries.rs
@@ -1,6 +1,6 @@
-use crate::token_kernel::TokenQueryContext;
+use crate::token_context::TokenQueryContext;
+use crate::token_module::errors::TokenStateInvariantError;
 use crate::token_module::key_value_state;
-use crate::token_module::token_kernel_interface::TokenStateInvariantError;
 use concordium_base::base::AccountIndex;
 use concordium_base::common::cbor;
 use concordium_base::protocol_level_tokens::{
@@ -17,26 +17,26 @@ pub enum QueryTokenModuleError {
 
 /// Get the CBOR-encoded representation of the token module state.
 pub fn query_token_module_state<BSQ: BlockStateQuery>(
-    kernel: &TokenQueryContext<'_, BSQ>,
+    context: &TokenQueryContext<'_, BSQ>,
 ) -> Result<RawCbor, QueryTokenModuleError> {
-    let state = query_token_module_state_impl(kernel)?;
+    let state = query_token_module_state_impl(context)?;
 
     Ok(RawCbor::from(cbor::cbor_encode(&state)))
 }
 
 fn query_token_module_state_impl<BSQ: BlockStateQuery>(
-    kernel: &TokenQueryContext<'_, BSQ>,
+    context: &TokenQueryContext<'_, BSQ>,
 ) -> Result<TokenModuleState, QueryTokenModuleError> {
-    let name = key_value_state::get_token_name(kernel)?;
-    let metadata = key_value_state::get_metadata(kernel)?;
-    let allow_list = key_value_state::is_allow_list_enabled(kernel);
-    let deny_list = key_value_state::has_deny_list(kernel);
-    let mintable = key_value_state::is_mintable(kernel);
-    let burnable = key_value_state::is_burnable(kernel);
-    let paused = key_value_state::is_paused(kernel);
+    let name = key_value_state::get_token_name(context)?;
+    let metadata = key_value_state::get_metadata(context)?;
+    let allow_list = key_value_state::has_allow_list(context);
+    let deny_list = key_value_state::has_deny_list(context);
+    let mintable = key_value_state::is_mintable(context);
+    let burnable = key_value_state::is_burnable(context);
+    let paused = key_value_state::is_paused(context);
 
-    let governance_account_index = key_value_state::get_governance_account_index(kernel)?;
-    let governance_account = kernel
+    let governance_account_index = key_value_state::get_governance_account_index(context)?;
+    let governance_account = context
         .block_state
         .account_by_index(governance_account_index)
         .map_err(|_| {
@@ -64,26 +64,26 @@ fn query_token_module_state_impl<BSQ: BlockStateQuery>(
 
 /// Get the CBOR-encoded representation of the token module account state.
 pub fn query_token_module_account_state<BSQ: BlockStateQuery>(
-    kernel: &TokenQueryContext<'_, BSQ>,
+    context: &TokenQueryContext<'_, BSQ>,
     account: AccountIndex,
 ) -> RawCbor {
-    let state = query_token_module_account_state_impl(kernel, account);
+    let state = query_token_module_account_state_impl(context, account);
     RawCbor::from(cbor::cbor_encode(&state))
 }
 
 fn query_token_module_account_state_impl<BSQ: BlockStateQuery>(
-    kernel: &TokenQueryContext<'_, BSQ>,
+    context: &TokenQueryContext<'_, BSQ>,
     account: AccountIndex,
 ) -> TokenModuleAccountState {
-    let has_allow_list = key_value_state::is_allow_list_enabled(kernel);
+    let has_allow_list = key_value_state::has_allow_list(context);
     let allow_list = if has_allow_list {
-        key_value_state::get_allow_list_for(kernel, account).into()
+        key_value_state::get_allow_list_for(context, account).into()
     } else {
         None
     };
-    let has_deny_list = key_value_state::has_deny_list(kernel);
+    let has_deny_list = key_value_state::has_deny_list(context);
     let deny_list = if has_deny_list {
-        key_value_state::get_deny_list_for(kernel, account).into()
+        key_value_state::get_deny_list_for(context, account).into()
     } else {
         None
     };
@@ -96,9 +96,9 @@ fn query_token_module_account_state_impl<BSQ: BlockStateQuery>(
 
 /// Get authorization roles and assigned accounts for the token.
 pub fn query_token_authorizations<BSQ: BlockStateQuery>(
-    kernel: &TokenQueryContext<'_, BSQ>,
+    context: &TokenQueryContext<'_, BSQ>,
 ) -> Result<RawCbor, QueryTokenModuleError> {
     Ok(RawCbor::from(cbor::cbor_encode(
-        &key_value_state::get_token_authorizations(kernel)?,
+        &key_value_state::get_token_authorizations(context)?,
     )))
 }

--- a/plt/plt-scheduler/src/token_module/module/queries.rs
+++ b/plt/plt-scheduler/src/token_module/module/queries.rs
@@ -1,10 +1,12 @@
-use crate::token_module::key_value_state;
-use crate::token_module::token_kernel_interface::{TokenKernelQueries, TokenStateInvariantError};
+use crate::token_kernel::TokenKernelQueriesImpl;
+use crate::token_module::key_value_state::{self, KernelQueriesExt};
+use crate::token_module::token_kernel_interface::TokenStateInvariantError;
 use concordium_base::base::AccountIndex;
 use concordium_base::common::cbor;
 use concordium_base::protocol_level_tokens::{
     CborHolderAccount, RawCbor, TokenModuleAccountState, TokenModuleState,
 };
+use plt_block_state::block_state_interface::BlockStateQuery;
 
 /// Represents the reasons why a query to the token module can fail.
 #[derive(Debug, thiserror::Error)]
@@ -14,16 +16,16 @@ pub enum QueryTokenModuleError {
 }
 
 /// Get the CBOR-encoded representation of the token module state.
-pub fn query_token_module_state<TK: TokenKernelQueries>(
-    kernel: &TK,
+pub fn query_token_module_state<BSQ: BlockStateQuery>(
+    kernel: &TokenKernelQueriesImpl<'_, BSQ>,
 ) -> Result<RawCbor, QueryTokenModuleError> {
     let state = query_token_module_state_impl(kernel)?;
 
     Ok(RawCbor::from(cbor::cbor_encode(&state)))
 }
 
-fn query_token_module_state_impl<TK: TokenKernelQueries>(
-    kernel: &TK,
+fn query_token_module_state_impl<BSQ: BlockStateQuery>(
+    kernel: &TokenKernelQueriesImpl<'_, BSQ>,
 ) -> Result<TokenModuleState, QueryTokenModuleError> {
     let name = key_value_state::get_name(kernel)?;
     let metadata = key_value_state::get_metadata(kernel)?;
@@ -60,7 +62,7 @@ fn query_token_module_state_impl<TK: TokenKernelQueries>(
 }
 
 /// Get the CBOR-encoded representation of the token module account state.
-pub fn query_token_module_account_state<TK: TokenKernelQueries>(
+pub fn query_token_module_account_state<TK: KernelQueriesExt>(
     kernel: &TK,
     account: AccountIndex,
 ) -> RawCbor {
@@ -68,7 +70,7 @@ pub fn query_token_module_account_state<TK: TokenKernelQueries>(
     RawCbor::from(cbor::cbor_encode(&state))
 }
 
-fn query_token_module_account_state_impl<TK: TokenKernelQueries>(
+fn query_token_module_account_state_impl<TK: KernelQueriesExt>(
     kernel: &TK,
     account: AccountIndex,
 ) -> TokenModuleAccountState {
@@ -92,8 +94,8 @@ fn query_token_module_account_state_impl<TK: TokenKernelQueries>(
 }
 
 /// Get authorization roles and assigned accounts for the token.
-pub fn query_token_authorizations<TK: TokenKernelQueries>(
-    kernel: &TK,
+pub fn query_token_authorizations<BSQ: BlockStateQuery>(
+    kernel: &TokenKernelQueriesImpl<'_, BSQ>,
 ) -> Result<RawCbor, QueryTokenModuleError> {
     Ok(RawCbor::from(cbor::cbor_encode(
         &key_value_state::get_token_authorizations(kernel)?,

--- a/plt/plt-scheduler/src/token_module/module/update.rs
+++ b/plt/plt-scheduler/src/token_module/module/update.rs
@@ -442,7 +442,9 @@ fn check_authorized<BSO: BlockStateOperations>(
 ) -> Result<(), TokenUpdateErrorInternal> {
     if kernel.support_rbac() {
         // Ensure the sender holds the specified role.
-        let sender_index = kernel.account_index(transaction_execution.sender_account());
+        let sender_index = kernel
+            .block_state
+            .account_index(transaction_execution.sender_account());
         let account_roles = key_value_state::get_account_roles(kernel, sender_index)?;
         if !account_roles.has(required_role) {
             return Err(TokenUpdateErrorInternal::OperationNotPermitted {
@@ -452,7 +454,9 @@ fn check_authorized<BSO: BlockStateOperations>(
         }
     } else {
         // Ensure the sender is the governance account.
-        let sender_index = kernel.account_index(transaction_execution.sender_account());
+        let sender_index = kernel
+            .block_state
+            .account_index(transaction_execution.sender_account());
         let gov_index = key_value_state::get_governance_account_index(kernel)?;
         if gov_index != sender_index {
             return Err(TokenUpdateErrorInternal::OperationNotPermitted {
@@ -476,16 +480,19 @@ fn execute_token_transfer<BSO: BlockStateOperations>(
     check_not_paused(kernel)?;
     let sender = transaction_execution.sender_account();
     let sender_address = transaction_execution.sender_account_address();
-    let receiver = kernel.account_by_address(&transfer_operation.recipient.address)?;
+    let receiver = kernel
+        .block_state
+        .account_by_address(&transfer_operation.recipient.address)?;
 
     if key_value_state::has_allow_list(kernel) {
-        if !key_value_state::get_allow_list_for(kernel, kernel.account_index(sender)) {
+        if !key_value_state::get_allow_list_for(kernel, kernel.block_state.account_index(sender)) {
             return Err(TokenUpdateErrorInternal::OperationNotPermitted {
                 account_address: Some(sender_address),
                 reason: "sender not in allow list",
             });
         }
-        if !key_value_state::get_allow_list_for(kernel, kernel.account_index(&receiver)) {
+        if !key_value_state::get_allow_list_for(kernel, kernel.block_state.account_index(&receiver))
+        {
             return Err(TokenUpdateErrorInternal::OperationNotPermitted {
                 account_address: Some(transfer_operation.recipient.address),
                 reason: "recipient not in allow list",
@@ -494,13 +501,13 @@ fn execute_token_transfer<BSO: BlockStateOperations>(
     }
 
     if key_value_state::has_deny_list(kernel) {
-        if key_value_state::get_deny_list_for(kernel, kernel.account_index(sender)) {
+        if key_value_state::get_deny_list_for(kernel, kernel.block_state.account_index(sender)) {
             return Err(TokenUpdateErrorInternal::OperationNotPermitted {
                 account_address: Some(sender_address),
                 reason: "sender in deny list",
             });
         }
-        if key_value_state::get_deny_list_for(kernel, kernel.account_index(&receiver)) {
+        if key_value_state::get_deny_list_for(kernel, kernel.block_state.account_index(&receiver)) {
             return Err(TokenUpdateErrorInternal::OperationNotPermitted {
                 account_address: Some(transfer_operation.recipient.address),
                 reason: "recipient in deny list",
@@ -610,10 +617,12 @@ fn execute_add_allow_list<BSO: BlockStateOperations>(
         kernel,
         TokenAdminRole::UpdateAllowList,
     )?;
-    let account = kernel.account_by_address(&list_operation.target.address)?;
+    let account = kernel
+        .block_state
+        .account_by_address(&list_operation.target.address)?;
 
     kernel.touch_account(&account);
-    key_value_state::set_allow_list_for(kernel, kernel.account_index(&account), true);
+    key_value_state::set_allow_list_for(kernel, kernel.block_state.account_index(&account), true);
 
     let event_details = TokenListUpdateEventDetails {
         target: list_operation.target.clone(),
@@ -640,10 +649,12 @@ fn execute_add_deny_list<BSO: BlockStateOperations>(
         TokenAdminRole::UpdateDenyList,
     )?;
 
-    let account = kernel.account_by_address(&list_operation.target.address)?;
+    let account = kernel
+        .block_state
+        .account_by_address(&list_operation.target.address)?;
 
     kernel.touch_account(&account);
-    key_value_state::set_deny_list_for(kernel, kernel.account_index(&account), true);
+    key_value_state::set_deny_list_for(kernel, kernel.block_state.account_index(&account), true);
 
     let event_details = TokenListUpdateEventDetails {
         target: list_operation.target.clone(),
@@ -670,10 +681,12 @@ fn execute_remove_allow_list<BSO: BlockStateOperations>(
         TokenAdminRole::UpdateAllowList,
     )?;
 
-    let account = kernel.account_by_address(&list_operation.target.address)?;
+    let account = kernel
+        .block_state
+        .account_by_address(&list_operation.target.address)?;
 
     kernel.touch_account(&account);
-    key_value_state::set_allow_list_for(kernel, kernel.account_index(&account), false);
+    key_value_state::set_allow_list_for(kernel, kernel.block_state.account_index(&account), false);
 
     let event_details = TokenListUpdateEventDetails {
         target: list_operation.target.clone(),
@@ -700,10 +713,12 @@ fn execute_remove_deny_list<BSO: BlockStateOperations>(
         TokenAdminRole::UpdateDenyList,
     )?;
 
-    let account = kernel.account_by_address(&list_operation.target.address)?;
+    let account = kernel
+        .block_state
+        .account_by_address(&list_operation.target.address)?;
 
     kernel.touch_account(&account);
-    key_value_state::set_deny_list_for(kernel, kernel.account_index(&account), false);
+    key_value_state::set_deny_list_for(kernel, kernel.block_state.account_index(&account), false);
 
     let event_details = TokenListUpdateEventDetails {
         target: list_operation.target.clone(),
@@ -748,10 +763,12 @@ fn execute_assign_admin_roles<BSO: BlockStateOperations>(
         TokenAdminRole::UpdateAdminRoles,
     )?;
     check_roles_supported(kernel, &operation.roles)?;
-    let account = kernel.account_by_address(&operation.account.address)?;
+    let account = kernel
+        .block_state
+        .account_by_address(&operation.account.address)?;
     key_value_state::assign_account_roles(
         kernel,
-        kernel.account_index(&account),
+        kernel.block_state.account_index(&account),
         &operation.roles,
     )?;
     let event = TokenModuleEvent::AssignAdminRoles(TokenUpdateAdminRolesEventDetails {
@@ -774,9 +791,14 @@ fn execute_revoke_admin_roles<BSO: BlockStateOperations>(
         TokenAdminRole::UpdateAdminRoles,
     )?;
     check_roles_supported(kernel, &operation.roles)?;
-    let account = kernel.account_by_address(&operation.account.address)?;
-    let account_index = kernel.account_index(&account);
-    if account_index == kernel.account_index(transaction_execution.sender_account())
+    let account = kernel
+        .block_state
+        .account_by_address(&operation.account.address)?;
+    let account_index = kernel.block_state.account_index(&account);
+    if account_index
+        == kernel
+            .block_state
+            .account_index(transaction_execution.sender_account())
         && operation.roles.contains(&TokenAdminRole::UpdateAdminRoles)
     {
         return Err(TokenUpdateErrorInternal::OperationNotPermitted {

--- a/plt/plt-scheduler/src/token_module/module/update.rs
+++ b/plt/plt-scheduler/src/token_module/module/update.rs
@@ -1,8 +1,7 @@
-use crate::token_kernel::TokenOperationContext;
-use crate::token_module::module::TokenAmountDecimalsMismatchError;
-use crate::token_module::token_kernel_interface::{
-    InsufficientBalanceError, MintWouldOverflowError, TokenBurnError, TokenMintError,
-    TokenStateInvariantError, TokenTransferError,
+use crate::token_context::TokenOperationContext;
+use crate::token_module::errors::{
+    InsufficientBalanceError, MintWouldOverflowError, TokenAmountDecimalsMismatchError,
+    TokenBurnError, TokenMintError, TokenStateInvariantError, TokenTransferError,
 };
 use crate::token_module::{key_value_state, util};
 use crate::transaction_execution::{OutOfEnergyError, TransactionExecution};
@@ -42,7 +41,7 @@ pub enum TokenUpdateError {
     StateInvariantViolation(#[from] TokenStateInvariantError),
 }
 
-/// Execute a token update transaction using the token kernel to
+/// Execute a token update transaction using the token context to
 /// update state and produce events.
 ///
 /// The caller must ensure to rollback state changes in case of
@@ -58,7 +57,7 @@ pub enum TokenUpdateError {
 ///    - Check that the recipient is valid.
 ///    - Check allow and deny list restrictions.
 ///    - Transfer the amount from the sender to the recipient, if the sender's balance is
-///      sufficient (checked by the kernel).
+///      sufficient (checked by the context).
 ///
 /// - For each list update operation:
 ///
@@ -76,7 +75,7 @@ pub enum TokenUpdateError {
 ///    - Check that the module is not paused.
 ///    - Check that the module configuration allows minting.
 ///    - Mint the amount to the sender, if the resulting circulating supply is
-///      within representable range (checked by the kernel).
+///      within representable range (checked by the context).
 ///
 /// - For each burn operation:
 ///
@@ -86,7 +85,7 @@ pub enum TokenUpdateError {
 ///    - Check that the module is not paused.
 ///    - Check that the module configuration allows burning.
 ///    - Burn the amount from the sender, if the sender's balance is
-///      sufficient (checked by the kernel).
+///      sufficient (checked by the context).
 ///
 /// - For each pause/unpause operation:
 ///
@@ -99,7 +98,7 @@ pub enum TokenUpdateError {
 /// is returned. This is an unrecoverable error and should never happen.
 pub fn execute_token_update_transaction<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &mut TokenOperationContext<'_, BSO>,
+    context: &mut TokenOperationContext<'_, BSO>,
     token_operations: RawCbor,
 ) -> Result<(), TokenUpdateError> {
     let operations: Vec<TokenOperation> = util::cbor_decode(&token_operations).map_err(|err| {
@@ -111,12 +110,12 @@ pub fn execute_token_update_transaction<BSO: BlockStateOperations>(
     })?;
 
     for (index, operation) in operations.into_iter().enumerate() {
-        execute_token_update_operation_at_index(transaction_execution, kernel, index, &operation)?;
+        execute_token_update_operation_at_index(transaction_execution, context, index, &operation)?;
     }
     Ok(())
 }
 
-/// Execute a token update operation using the token kernel to
+/// Execute a token update operation using the token context to
 /// update state and produce events.
 ///
 /// The caller must ensure to rollback state changes in case of
@@ -132,7 +131,7 @@ pub fn execute_token_update_transaction<BSO: BlockStateOperations>(
 ///    - Check that the recipient is valid.
 ///    - Check allow and deny list restrictions.
 ///    - Transfer the amount from the sender to the recipient, if the sender's balance is
-///      sufficient (checked by the kernel).
+///      sufficient (checked by the context).
 ///
 /// - For a list update operation:
 ///
@@ -150,7 +149,7 @@ pub fn execute_token_update_transaction<BSO: BlockStateOperations>(
 ///    - Check that the module is not paused.
 ///    - Check that the module configuration allows minting.
 ///    - Mint the amount to the sender, if the resulting circulating supply is
-///      within representable range (checked by the kernel).
+///      within representable range (checked by the context).
 ///
 /// - For a burn operation:
 ///
@@ -160,7 +159,7 @@ pub fn execute_token_update_transaction<BSO: BlockStateOperations>(
 ///    - Check that the module is not paused.
 ///    - Check that the module configuration allows burning.
 ///    - Burn the amount from the sender, if the sender's balance is
-///      sufficient (checked by the kernel).
+///      sufficient (checked by the context).
 ///
 /// - For a pause/unpause operation:
 ///
@@ -176,17 +175,17 @@ pub fn execute_token_update_transaction<BSO: BlockStateOperations>(
 /// # Arguments
 ///
 /// - `transaction_execution`: the transaction execution context
-/// - `kernel`: the token kernel operations interface
+/// - `context`: the token context operations interface
 /// - `index`: the index of the operation in the transaction, used for error reporting
 /// - `operation`: the token operation to execute
 pub fn execute_token_update_operation_at_index<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &mut TokenOperationContext<'_, BSO>,
+    context: &mut TokenOperationContext<'_, BSO>,
     index: usize,
     operation: &TokenOperation,
 ) -> Result<(), TokenUpdateError> {
-    execute_token_update_operation(transaction_execution, kernel, operation).map_err(
-        |err| match err {
+    execute_token_update_operation(transaction_execution, context, operation).map_err(|err| {
+        match err {
             TokenUpdateErrorInternal::AccountDoesNotExist(err) => {
                 TokenUpdateError::TokenModuleReject(make_reject_reason(
                     TokenModuleRejectReason::AddressNotFound(AddressNotFoundRejectReason {
@@ -209,8 +208,14 @@ pub fn execute_token_update_operation_at_index<BSO: BlockStateOperations>(
                     TokenModuleRejectReason::TokenBalanceInsufficient(
                         TokenBalanceInsufficientRejectReason {
                             index: index as u64,
-                            available_balance: util::to_token_amount(kernel, err.available),
-                            required_balance: util::to_token_amount(kernel, err.required),
+                            available_balance: util::to_token_amount(
+                                context.token_configuration,
+                                err.available,
+                            ),
+                            required_balance: util::to_token_amount(
+                                context.token_configuration,
+                                err.required,
+                            ),
                         },
                     ),
                 ))
@@ -219,10 +224,16 @@ pub fn execute_token_update_operation_at_index<BSO: BlockStateOperations>(
                 TokenUpdateError::TokenModuleReject(make_reject_reason(
                     TokenModuleRejectReason::MintWouldOverflow(MintWouldOverflowRejectReason {
                         index: index as u64,
-                        requested_amount: util::to_token_amount(kernel, err.requested_amount),
-                        current_supply: util::to_token_amount(kernel, err.current_supply),
+                        requested_amount: util::to_token_amount(
+                            context.token_configuration,
+                            err.requested_amount,
+                        ),
+                        current_supply: util::to_token_amount(
+                            context.token_configuration,
+                            err.current_supply,
+                        ),
                         max_representable_amount: util::to_token_amount(
-                            kernel,
+                            context.token_configuration,
                             err.max_representable_amount,
                         ),
                     }),
@@ -264,8 +275,8 @@ pub fn execute_token_update_operation_at_index<BSO: BlockStateOperations>(
                     ),
                 ))
             }
-        },
-    )
+        }
+    })
 }
 
 fn operation_name(operation: &TokenOperation) -> &'static str {
@@ -349,7 +360,7 @@ impl From<TokenBurnError> for TokenUpdateErrorInternal {
 
 fn execute_token_update_operation<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &mut TokenOperationContext<'_, BSO>,
+    context: &mut TokenOperationContext<'_, BSO>,
     token_operation: &TokenOperation,
 ) -> Result<(), TokenUpdateErrorInternal> {
     // Charge energy
@@ -364,41 +375,41 @@ fn execute_token_update_operation<BSO: BlockStateOperations>(
     // Execute operation
     match token_operation {
         TokenOperation::Transfer(transfer) => {
-            execute_token_transfer(transaction_execution, kernel, transfer)
+            execute_token_transfer(transaction_execution, context, transfer)
         }
-        TokenOperation::Mint(mint) => execute_token_mint(transaction_execution, kernel, mint),
-        TokenOperation::Burn(burn) => execute_token_burn(transaction_execution, kernel, burn),
-        TokenOperation::Pause(_) => execute_token_pause(transaction_execution, kernel),
-        TokenOperation::Unpause(_) => execute_token_unpause(transaction_execution, kernel),
+        TokenOperation::Mint(mint) => execute_token_mint(transaction_execution, context, mint),
+        TokenOperation::Burn(burn) => execute_token_burn(transaction_execution, context, burn),
+        TokenOperation::Pause(_) => execute_token_pause(transaction_execution, context),
+        TokenOperation::Unpause(_) => execute_token_unpause(transaction_execution, context),
         TokenOperation::AddAllowList(list_operation) => {
-            execute_add_allow_list(transaction_execution, kernel, list_operation)
+            execute_add_allow_list(transaction_execution, context, list_operation)
         }
         TokenOperation::RemoveAllowList(list_operation) => {
-            execute_remove_allow_list(transaction_execution, kernel, list_operation)
+            execute_remove_allow_list(transaction_execution, context, list_operation)
         }
         TokenOperation::AddDenyList(list_operation) => {
-            execute_add_deny_list(transaction_execution, kernel, list_operation)
+            execute_add_deny_list(transaction_execution, context, list_operation)
         }
         TokenOperation::RemoveDenyList(list_operation) => {
-            execute_remove_deny_list(transaction_execution, kernel, list_operation)
+            execute_remove_deny_list(transaction_execution, context, list_operation)
         }
         TokenOperation::AssignAdminRoles(operation) => {
-            if kernel.support_rbac() {
-                execute_assign_admin_roles(transaction_execution, kernel, operation)
+            if context.support_rbac() {
+                execute_assign_admin_roles(transaction_execution, context, operation)
             } else {
                 Err(WRONG_PROTOCOL_ERROR)
             }
         }
         TokenOperation::RevokeAdminRoles(operation) => {
-            if kernel.support_rbac() {
-                execute_revoke_admin_roles(transaction_execution, kernel, operation)
+            if context.support_rbac() {
+                execute_revoke_admin_roles(transaction_execution, context, operation)
             } else {
                 Err(WRONG_PROTOCOL_ERROR)
             }
         }
         TokenOperation::UpdateMetadata(operation) => {
-            if kernel.support_updating_metadata() {
-                execute_update_metadata(transaction_execution, kernel, operation)
+            if context.support_updating_metadata() {
+                execute_update_metadata(transaction_execution, context, operation)
             } else {
                 Err(WRONG_PROTOCOL_ERROR)
             }
@@ -426,9 +437,9 @@ fn energy_cost(operation: &TokenOperation) -> Energy {
 }
 
 fn check_not_paused<BSO: BlockStateOperations>(
-    kernel: &TokenOperationContext<'_, BSO>,
+    context: &TokenOperationContext<'_, BSO>,
 ) -> Result<(), TokenUpdateErrorInternal> {
-    if key_value_state::is_paused(kernel) {
+    if key_value_state::is_paused(context) {
         return Err(TokenUpdateErrorInternal::Paused);
     }
     Ok(())
@@ -437,15 +448,15 @@ fn check_not_paused<BSO: BlockStateOperations>(
 /// Ensure the sender account from the transaction context is authorized to perform the operation.
 fn check_authorized<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &TokenOperationContext<'_, BSO>,
+    context: &TokenOperationContext<'_, BSO>,
     required_role: TokenAdminRole,
 ) -> Result<(), TokenUpdateErrorInternal> {
-    if kernel.support_rbac() {
+    if context.support_rbac() {
         // Ensure the sender holds the specified role.
-        let sender_index = kernel
+        let sender_index = context
             .block_state
             .account_index(transaction_execution.sender_account());
-        let account_roles = key_value_state::get_account_roles(kernel, sender_index)?;
+        let account_roles = key_value_state::get_account_roles(context, sender_index)?;
         if !account_roles.has(required_role) {
             return Err(TokenUpdateErrorInternal::OperationNotPermitted {
                 account_address: Some(transaction_execution.sender_account_address()),
@@ -454,10 +465,10 @@ fn check_authorized<BSO: BlockStateOperations>(
         }
     } else {
         // Ensure the sender is the governance account.
-        let sender_index = kernel
+        let sender_index = context
             .block_state
             .account_index(transaction_execution.sender_account());
-        let gov_index = key_value_state::get_governance_account_index(kernel)?;
+        let gov_index = key_value_state::get_governance_account_index(context)?;
         if gov_index != sender_index {
             return Err(TokenUpdateErrorInternal::OperationNotPermitted {
                 account_address: Some(transaction_execution.sender_account_address()),
@@ -470,29 +481,33 @@ fn check_authorized<BSO: BlockStateOperations>(
 
 fn execute_token_transfer<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &mut TokenOperationContext<'_, BSO>,
+    context: &mut TokenOperationContext<'_, BSO>,
     transfer_operation: &TokenTransfer,
 ) -> Result<(), TokenUpdateErrorInternal> {
     // preprocessing
-    let raw_amount = util::to_raw_token_amount(kernel, transfer_operation.amount)?;
+    let raw_amount =
+        util::to_raw_token_amount(context.token_configuration, transfer_operation.amount)?;
 
     // operation execution
-    check_not_paused(kernel)?;
+    check_not_paused(context)?;
     let sender = transaction_execution.sender_account();
     let sender_address = transaction_execution.sender_account_address();
-    let receiver = kernel
+    let receiver = context
         .block_state
         .account_by_address(&transfer_operation.recipient.address)?;
 
-    if key_value_state::is_allow_list_enabled(kernel) {
-        if !key_value_state::get_allow_list_for(kernel, kernel.block_state.account_index(sender)) {
+    if key_value_state::has_allow_list(context) {
+        if !key_value_state::get_allow_list_for(context, context.block_state.account_index(sender))
+        {
             return Err(TokenUpdateErrorInternal::OperationNotPermitted {
                 account_address: Some(sender_address),
                 reason: "sender not in allow list",
             });
         }
-        if !key_value_state::get_allow_list_for(kernel, kernel.block_state.account_index(&receiver))
-        {
+        if !key_value_state::get_allow_list_for(
+            context,
+            context.block_state.account_index(&receiver),
+        ) {
             return Err(TokenUpdateErrorInternal::OperationNotPermitted {
                 account_address: Some(transfer_operation.recipient.address),
                 reason: "recipient not in allow list",
@@ -500,14 +515,15 @@ fn execute_token_transfer<BSO: BlockStateOperations>(
         }
     }
 
-    if key_value_state::has_deny_list(kernel) {
-        if key_value_state::get_deny_list_for(kernel, kernel.block_state.account_index(sender)) {
+    if key_value_state::has_deny_list(context) {
+        if key_value_state::get_deny_list_for(context, context.block_state.account_index(sender)) {
             return Err(TokenUpdateErrorInternal::OperationNotPermitted {
                 account_address: Some(sender_address),
                 reason: "sender in deny list",
             });
         }
-        if key_value_state::get_deny_list_for(kernel, kernel.block_state.account_index(&receiver)) {
+        if key_value_state::get_deny_list_for(context, context.block_state.account_index(&receiver))
+        {
             return Err(TokenUpdateErrorInternal::OperationNotPermitted {
                 account_address: Some(transfer_operation.recipient.address),
                 reason: "recipient in deny list",
@@ -515,7 +531,7 @@ fn execute_token_transfer<BSO: BlockStateOperations>(
         }
     }
 
-    kernel.transfer(
+    context.transfer(
         sender,
         sender_address,
         &receiver,
@@ -528,22 +544,22 @@ fn execute_token_transfer<BSO: BlockStateOperations>(
 
 fn execute_token_mint<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &mut TokenOperationContext<'_, BSO>,
+    context: &mut TokenOperationContext<'_, BSO>,
     mint_operation: &TokenSupplyUpdateDetails,
 ) -> Result<(), TokenUpdateErrorInternal> {
     // preprocessing
-    let raw_amount = util::to_raw_token_amount(kernel, mint_operation.amount)?;
+    let raw_amount = util::to_raw_token_amount(context.token_configuration, mint_operation.amount)?;
 
     // operation execution
-    if !key_value_state::is_mintable(kernel) {
+    if !key_value_state::is_mintable(context) {
         return Err(TokenUpdateErrorInternal::UnsupportedOperation {
             reason: "feature not enabled",
         });
     };
-    check_authorized(transaction_execution, kernel, TokenAdminRole::Mint)?;
-    check_not_paused(kernel)?;
+    check_authorized(transaction_execution, context, TokenAdminRole::Mint)?;
+    check_not_paused(context)?;
 
-    kernel.mint(
+    context.mint(
         transaction_execution.sender_account(),
         transaction_execution.sender_account_address(),
         raw_amount,
@@ -553,22 +569,22 @@ fn execute_token_mint<BSO: BlockStateOperations>(
 
 fn execute_token_burn<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &mut TokenOperationContext<'_, BSO>,
+    context: &mut TokenOperationContext<'_, BSO>,
     burn_operation: &TokenSupplyUpdateDetails,
 ) -> Result<(), TokenUpdateErrorInternal> {
     // preprocessing
-    let raw_amount = util::to_raw_token_amount(kernel, burn_operation.amount)?;
+    let raw_amount = util::to_raw_token_amount(context.token_configuration, burn_operation.amount)?;
 
     // operation execution
-    if !key_value_state::is_burnable(kernel) {
+    if !key_value_state::is_burnable(context) {
         return Err(TokenUpdateErrorInternal::UnsupportedOperation {
             reason: "feature not enabled",
         });
     }
-    check_authorized(transaction_execution, kernel, TokenAdminRole::Burn)?;
-    check_not_paused(kernel)?;
+    check_authorized(transaction_execution, context, TokenAdminRole::Burn)?;
+    check_not_paused(context)?;
 
-    kernel.burn(
+    context.burn(
         transaction_execution.sender_account(),
         transaction_execution.sender_account_address(),
         raw_amount,
@@ -578,168 +594,180 @@ fn execute_token_burn<BSO: BlockStateOperations>(
 
 fn execute_token_pause<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &mut TokenOperationContext<'_, BSO>,
+    context: &mut TokenOperationContext<'_, BSO>,
 ) -> Result<(), TokenUpdateErrorInternal> {
-    check_authorized(transaction_execution, kernel, TokenAdminRole::Pause)?;
+    check_authorized(transaction_execution, context, TokenAdminRole::Pause)?;
 
-    key_value_state::set_paused(kernel, true);
+    key_value_state::set_paused(context, true);
 
     let (event_type, details) = TokenModuleEvent::Pause(TokenPauseEventDetails {}).encode_event();
-    kernel.log_token_event(event_type.to_type_discriminator(), details);
+    context.log_token_event(event_type.to_type_discriminator(), details);
     Ok(())
 }
 
 fn execute_token_unpause<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &mut TokenOperationContext<'_, BSO>,
+    context: &mut TokenOperationContext<'_, BSO>,
 ) -> Result<(), TokenUpdateErrorInternal> {
-    check_authorized(transaction_execution, kernel, TokenAdminRole::Pause)?;
+    check_authorized(transaction_execution, context, TokenAdminRole::Pause)?;
 
-    key_value_state::set_paused(kernel, false);
+    key_value_state::set_paused(context, false);
 
     let (event_type, details) = TokenModuleEvent::Unpause(TokenPauseEventDetails {}).encode_event();
-    kernel.log_token_event(event_type.to_type_discriminator(), details);
+    context.log_token_event(event_type.to_type_discriminator(), details);
     Ok(())
 }
 
 fn execute_add_allow_list<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &mut TokenOperationContext<'_, BSO>,
+    context: &mut TokenOperationContext<'_, BSO>,
     list_operation: &TokenListUpdateDetails,
 ) -> Result<(), TokenUpdateErrorInternal> {
-    if !key_value_state::is_allow_list_enabled(kernel) {
+    if !key_value_state::has_allow_list(context) {
         return Err(TokenUpdateErrorInternal::UnsupportedOperation {
             reason: "feature not enabled",
         });
     }
     check_authorized(
         transaction_execution,
-        kernel,
+        context,
         TokenAdminRole::UpdateAllowList,
     )?;
-    let account = kernel
+    let account = context
         .block_state
         .account_by_address(&list_operation.target.address)?;
 
-    kernel.touch_account(&account);
-    key_value_state::set_allow_list_for(kernel, kernel.block_state.account_index(&account), true);
+    context
+        .block_state
+        .touch_token_account(context.token, &account);
+    key_value_state::set_allow_list_for(context, context.block_state.account_index(&account), true);
 
     let event_details = TokenListUpdateEventDetails {
         target: list_operation.target.clone(),
     };
     let (event_type, details) = TokenModuleEvent::AddAllowList(event_details).encode_event();
-    kernel.log_token_event(event_type.to_type_discriminator(), details);
+    context.log_token_event(event_type.to_type_discriminator(), details);
 
     Ok(())
 }
 
 fn execute_add_deny_list<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &mut TokenOperationContext<'_, BSO>,
+    context: &mut TokenOperationContext<'_, BSO>,
     list_operation: &TokenListUpdateDetails,
 ) -> Result<(), TokenUpdateErrorInternal> {
-    if !key_value_state::has_deny_list(kernel) {
+    if !key_value_state::has_deny_list(context) {
         return Err(TokenUpdateErrorInternal::UnsupportedOperation {
             reason: "feature not enabled",
         });
     }
     check_authorized(
         transaction_execution,
-        kernel,
+        context,
         TokenAdminRole::UpdateDenyList,
     )?;
 
-    let account = kernel
+    let account = context
         .block_state
         .account_by_address(&list_operation.target.address)?;
 
-    kernel.touch_account(&account);
-    key_value_state::set_deny_list_for(kernel, kernel.block_state.account_index(&account), true);
+    context
+        .block_state
+        .touch_token_account(context.token, &account);
+    key_value_state::set_deny_list_for(context, context.block_state.account_index(&account), true);
 
     let event_details = TokenListUpdateEventDetails {
         target: list_operation.target.clone(),
     };
     let (event_type, details) = TokenModuleEvent::AddDenyList(event_details).encode_event();
-    kernel.log_token_event(event_type.to_type_discriminator(), details);
+    context.log_token_event(event_type.to_type_discriminator(), details);
 
     Ok(())
 }
 
 fn execute_remove_allow_list<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &mut TokenOperationContext<'_, BSO>,
+    context: &mut TokenOperationContext<'_, BSO>,
     list_operation: &TokenListUpdateDetails,
 ) -> Result<(), TokenUpdateErrorInternal> {
-    if !key_value_state::is_allow_list_enabled(kernel) {
+    if !key_value_state::has_allow_list(context) {
         return Err(TokenUpdateErrorInternal::UnsupportedOperation {
             reason: "feature not enabled",
         });
     }
     check_authorized(
         transaction_execution,
-        kernel,
+        context,
         TokenAdminRole::UpdateAllowList,
     )?;
 
-    let account = kernel
+    let account = context
         .block_state
         .account_by_address(&list_operation.target.address)?;
 
-    kernel.touch_account(&account);
-    key_value_state::set_allow_list_for(kernel, kernel.block_state.account_index(&account), false);
+    context
+        .block_state
+        .touch_token_account(context.token, &account);
+    key_value_state::set_allow_list_for(
+        context,
+        context.block_state.account_index(&account),
+        false,
+    );
 
     let event_details = TokenListUpdateEventDetails {
         target: list_operation.target.clone(),
     };
     let (event_type, details) = TokenModuleEvent::RemoveAllowList(event_details).encode_event();
-    kernel.log_token_event(event_type.to_type_discriminator(), details);
+    context.log_token_event(event_type.to_type_discriminator(), details);
 
     Ok(())
 }
 
 fn execute_remove_deny_list<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &mut TokenOperationContext<'_, BSO>,
+    context: &mut TokenOperationContext<'_, BSO>,
     list_operation: &TokenListUpdateDetails,
 ) -> Result<(), TokenUpdateErrorInternal> {
-    if !key_value_state::has_deny_list(kernel) {
+    if !key_value_state::has_deny_list(context) {
         return Err(TokenUpdateErrorInternal::UnsupportedOperation {
             reason: "feature not enabled",
         });
     }
     check_authorized(
         transaction_execution,
-        kernel,
+        context,
         TokenAdminRole::UpdateDenyList,
     )?;
 
-    let account = kernel
+    let account = context
         .block_state
         .account_by_address(&list_operation.target.address)?;
 
-    kernel.touch_account(&account);
-    key_value_state::set_deny_list_for(kernel, kernel.block_state.account_index(&account), false);
+    context
+        .block_state
+        .touch_token_account(context.token, &account);
+    key_value_state::set_deny_list_for(context, context.block_state.account_index(&account), false);
 
     let event_details = TokenListUpdateEventDetails {
         target: list_operation.target.clone(),
     };
     let (event_type, details) = TokenModuleEvent::RemoveDenyList(event_details).encode_event();
-    kernel.log_token_event(event_type.to_type_discriminator(), details);
+    context.log_token_event(event_type.to_type_discriminator(), details);
 
     Ok(())
 }
 
 fn check_roles_supported<BSO: BlockStateOperations>(
-    kernel: &TokenOperationContext<'_, BSO>,
+    context: &TokenOperationContext<'_, BSO>,
     roles: &[TokenAdminRole],
 ) -> Result<(), TokenUpdateErrorInternal> {
     for role in roles {
         let supported = match role {
             TokenAdminRole::UpdateAdminRoles => true,
-            TokenAdminRole::Mint => key_value_state::is_mintable(kernel),
-            TokenAdminRole::Burn => key_value_state::is_burnable(kernel),
-            TokenAdminRole::UpdateAllowList => key_value_state::is_allow_list_enabled(kernel),
-            TokenAdminRole::UpdateDenyList => key_value_state::has_deny_list(kernel),
+            TokenAdminRole::Mint => key_value_state::is_mintable(context),
+            TokenAdminRole::Burn => key_value_state::is_burnable(context),
+            TokenAdminRole::UpdateAllowList => key_value_state::has_allow_list(context),
+            TokenAdminRole::UpdateDenyList => key_value_state::has_deny_list(context),
             TokenAdminRole::Pause => true,
             TokenAdminRole::UpdateMetadata => true,
         };
@@ -754,21 +782,21 @@ fn check_roles_supported<BSO: BlockStateOperations>(
 
 fn execute_assign_admin_roles<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &mut TokenOperationContext<'_, BSO>,
+    context: &mut TokenOperationContext<'_, BSO>,
     operation: &TokenUpdateAdminRolesDetails,
 ) -> Result<(), TokenUpdateErrorInternal> {
     check_authorized(
         transaction_execution,
-        kernel,
+        context,
         TokenAdminRole::UpdateAdminRoles,
     )?;
-    check_roles_supported(kernel, &operation.roles)?;
-    let account = kernel
+    check_roles_supported(context, &operation.roles)?;
+    let account = context
         .block_state
         .account_by_address(&operation.account.address)?;
     key_value_state::assign_account_roles(
-        kernel,
-        kernel.block_state.account_index(&account),
+        context,
+        context.block_state.account_index(&account),
         &operation.roles,
     )?;
     let event = TokenModuleEvent::AssignAdminRoles(TokenUpdateAdminRolesEventDetails {
@@ -776,27 +804,27 @@ fn execute_assign_admin_roles<BSO: BlockStateOperations>(
         account: operation.account.clone(),
     });
     let (event_type, details) = event.encode_event();
-    kernel.log_token_event(event_type.to_type_discriminator(), details);
+    context.log_token_event(event_type.to_type_discriminator(), details);
     Ok(())
 }
 
 fn execute_revoke_admin_roles<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &mut TokenOperationContext<'_, BSO>,
+    context: &mut TokenOperationContext<'_, BSO>,
     operation: &TokenUpdateAdminRolesDetails,
 ) -> Result<(), TokenUpdateErrorInternal> {
     check_authorized(
         transaction_execution,
-        kernel,
+        context,
         TokenAdminRole::UpdateAdminRoles,
     )?;
-    check_roles_supported(kernel, &operation.roles)?;
-    let account = kernel
+    check_roles_supported(context, &operation.roles)?;
+    let account = context
         .block_state
         .account_by_address(&operation.account.address)?;
-    let account_index = kernel.block_state.account_index(&account);
+    let account_index = context.block_state.account_index(&account);
     if account_index
-        == kernel
+        == context
             .block_state
             .account_index(transaction_execution.sender_account())
         && operation.roles.contains(&TokenAdminRole::UpdateAdminRoles)
@@ -806,19 +834,19 @@ fn execute_revoke_admin_roles<BSO: BlockStateOperations>(
             reason: "Sender not allowed to remove own update-admin-role role",
         });
     }
-    key_value_state::revoke_account_roles(kernel, account_index, &operation.roles)?;
+    key_value_state::revoke_account_roles(context, account_index, &operation.roles)?;
     let event = TokenModuleEvent::RevokeAdminRoles(TokenUpdateAdminRolesEventDetails {
         roles: operation.roles.clone(),
         account: operation.account.clone(),
     });
     let (event_type, details) = event.encode_event();
-    kernel.log_token_event(event_type.to_type_discriminator(), details);
+    context.log_token_event(event_type.to_type_discriminator(), details);
     Ok(())
 }
 
 fn execute_update_metadata<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &mut TokenOperationContext<'_, BSO>,
+    context: &mut TokenOperationContext<'_, BSO>,
     metadata_url: &MetadataUrl,
 ) -> Result<(), TokenUpdateErrorInternal> {
     if !metadata_url.additional.is_empty() {
@@ -828,14 +856,14 @@ fn execute_update_metadata<BSO: BlockStateOperations>(
     }
     check_authorized(
         transaction_execution,
-        kernel,
+        context,
         TokenAdminRole::UpdateMetadata,
     )?;
-    key_value_state::set_metadata_url(kernel, metadata_url);
+    key_value_state::set_metadata_url(context, metadata_url);
     let event = TokenModuleEvent::UpdateMetadata(TokenUpdateMetadataEventDetails {
         metadata_url: metadata_url.clone(),
     });
     let (event_type, details) = event.encode_event();
-    kernel.log_token_event(event_type.to_type_discriminator(), details);
+    context.log_token_event(event_type.to_type_discriminator(), details);
     Ok(())
 }

--- a/plt/plt-scheduler/src/token_module/module/update.rs
+++ b/plt/plt-scheduler/src/token_module/module/update.rs
@@ -1,4 +1,4 @@
-use crate::token_kernel::TokenKernelOperationsImpl;
+use crate::token_kernel::TokenOperationContext;
 use crate::token_module::module::TokenAmountDecimalsMismatchError;
 use crate::token_module::token_kernel_interface::{
     InsufficientBalanceError, MintWouldOverflowError, TokenBurnError, TokenMintError,
@@ -99,7 +99,7 @@ pub enum TokenUpdateError {
 /// is returned. This is an unrecoverable error and should never happen.
 pub fn execute_token_update_transaction<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
+    kernel: &mut TokenOperationContext<'_, BSO>,
     token_operations: RawCbor,
 ) -> Result<(), TokenUpdateError> {
     let operations: Vec<TokenOperation> = util::cbor_decode(&token_operations).map_err(|err| {
@@ -181,7 +181,7 @@ pub fn execute_token_update_transaction<BSO: BlockStateOperations>(
 /// - `operation`: the token operation to execute
 pub fn execute_token_update_operation_at_index<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
+    kernel: &mut TokenOperationContext<'_, BSO>,
     index: usize,
     operation: &TokenOperation,
 ) -> Result<(), TokenUpdateError> {
@@ -349,7 +349,7 @@ impl From<TokenBurnError> for TokenUpdateErrorInternal {
 
 fn execute_token_update_operation<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
+    kernel: &mut TokenOperationContext<'_, BSO>,
     token_operation: &TokenOperation,
 ) -> Result<(), TokenUpdateErrorInternal> {
     // Charge energy
@@ -426,7 +426,7 @@ fn energy_cost(operation: &TokenOperation) -> Energy {
 }
 
 fn check_not_paused<BSO: BlockStateOperations>(
-    kernel: &TokenKernelOperationsImpl<'_, BSO>,
+    kernel: &TokenOperationContext<'_, BSO>,
 ) -> Result<(), TokenUpdateErrorInternal> {
     if key_value_state::is_paused(kernel) {
         return Err(TokenUpdateErrorInternal::Paused);
@@ -437,7 +437,7 @@ fn check_not_paused<BSO: BlockStateOperations>(
 /// Ensure the sender account from the transaction context is authorized to perform the operation.
 fn check_authorized<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &TokenKernelOperationsImpl<'_, BSO>,
+    kernel: &TokenOperationContext<'_, BSO>,
     required_role: TokenAdminRole,
 ) -> Result<(), TokenUpdateErrorInternal> {
     if kernel.support_rbac() {
@@ -470,7 +470,7 @@ fn check_authorized<BSO: BlockStateOperations>(
 
 fn execute_token_transfer<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
+    kernel: &mut TokenOperationContext<'_, BSO>,
     transfer_operation: &TokenTransfer,
 ) -> Result<(), TokenUpdateErrorInternal> {
     // preprocessing
@@ -484,7 +484,7 @@ fn execute_token_transfer<BSO: BlockStateOperations>(
         .block_state
         .account_by_address(&transfer_operation.recipient.address)?;
 
-    if key_value_state::has_allow_list(kernel) {
+    if key_value_state::is_allow_list_enabled(kernel) {
         if !key_value_state::get_allow_list_for(kernel, kernel.block_state.account_index(sender)) {
             return Err(TokenUpdateErrorInternal::OperationNotPermitted {
                 account_address: Some(sender_address),
@@ -528,7 +528,7 @@ fn execute_token_transfer<BSO: BlockStateOperations>(
 
 fn execute_token_mint<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
+    kernel: &mut TokenOperationContext<'_, BSO>,
     mint_operation: &TokenSupplyUpdateDetails,
 ) -> Result<(), TokenUpdateErrorInternal> {
     // preprocessing
@@ -553,7 +553,7 @@ fn execute_token_mint<BSO: BlockStateOperations>(
 
 fn execute_token_burn<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
+    kernel: &mut TokenOperationContext<'_, BSO>,
     burn_operation: &TokenSupplyUpdateDetails,
 ) -> Result<(), TokenUpdateErrorInternal> {
     // preprocessing
@@ -578,7 +578,7 @@ fn execute_token_burn<BSO: BlockStateOperations>(
 
 fn execute_token_pause<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
+    kernel: &mut TokenOperationContext<'_, BSO>,
 ) -> Result<(), TokenUpdateErrorInternal> {
     check_authorized(transaction_execution, kernel, TokenAdminRole::Pause)?;
 
@@ -591,7 +591,7 @@ fn execute_token_pause<BSO: BlockStateOperations>(
 
 fn execute_token_unpause<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
+    kernel: &mut TokenOperationContext<'_, BSO>,
 ) -> Result<(), TokenUpdateErrorInternal> {
     check_authorized(transaction_execution, kernel, TokenAdminRole::Pause)?;
 
@@ -604,10 +604,10 @@ fn execute_token_unpause<BSO: BlockStateOperations>(
 
 fn execute_add_allow_list<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
+    kernel: &mut TokenOperationContext<'_, BSO>,
     list_operation: &TokenListUpdateDetails,
 ) -> Result<(), TokenUpdateErrorInternal> {
-    if !key_value_state::has_allow_list(kernel) {
+    if !key_value_state::is_allow_list_enabled(kernel) {
         return Err(TokenUpdateErrorInternal::UnsupportedOperation {
             reason: "feature not enabled",
         });
@@ -635,7 +635,7 @@ fn execute_add_allow_list<BSO: BlockStateOperations>(
 
 fn execute_add_deny_list<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
+    kernel: &mut TokenOperationContext<'_, BSO>,
     list_operation: &TokenListUpdateDetails,
 ) -> Result<(), TokenUpdateErrorInternal> {
     if !key_value_state::has_deny_list(kernel) {
@@ -667,10 +667,10 @@ fn execute_add_deny_list<BSO: BlockStateOperations>(
 
 fn execute_remove_allow_list<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
+    kernel: &mut TokenOperationContext<'_, BSO>,
     list_operation: &TokenListUpdateDetails,
 ) -> Result<(), TokenUpdateErrorInternal> {
-    if !key_value_state::has_allow_list(kernel) {
+    if !key_value_state::is_allow_list_enabled(kernel) {
         return Err(TokenUpdateErrorInternal::UnsupportedOperation {
             reason: "feature not enabled",
         });
@@ -699,7 +699,7 @@ fn execute_remove_allow_list<BSO: BlockStateOperations>(
 
 fn execute_remove_deny_list<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
+    kernel: &mut TokenOperationContext<'_, BSO>,
     list_operation: &TokenListUpdateDetails,
 ) -> Result<(), TokenUpdateErrorInternal> {
     if !key_value_state::has_deny_list(kernel) {
@@ -730,7 +730,7 @@ fn execute_remove_deny_list<BSO: BlockStateOperations>(
 }
 
 fn check_roles_supported<BSO: BlockStateOperations>(
-    kernel: &TokenKernelOperationsImpl<'_, BSO>,
+    kernel: &TokenOperationContext<'_, BSO>,
     roles: &[TokenAdminRole],
 ) -> Result<(), TokenUpdateErrorInternal> {
     for role in roles {
@@ -738,7 +738,7 @@ fn check_roles_supported<BSO: BlockStateOperations>(
             TokenAdminRole::UpdateAdminRoles => true,
             TokenAdminRole::Mint => key_value_state::is_mintable(kernel),
             TokenAdminRole::Burn => key_value_state::is_burnable(kernel),
-            TokenAdminRole::UpdateAllowList => key_value_state::has_allow_list(kernel),
+            TokenAdminRole::UpdateAllowList => key_value_state::is_allow_list_enabled(kernel),
             TokenAdminRole::UpdateDenyList => key_value_state::has_deny_list(kernel),
             TokenAdminRole::Pause => true,
             TokenAdminRole::UpdateMetadata => true,
@@ -754,7 +754,7 @@ fn check_roles_supported<BSO: BlockStateOperations>(
 
 fn execute_assign_admin_roles<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
+    kernel: &mut TokenOperationContext<'_, BSO>,
     operation: &TokenUpdateAdminRolesDetails,
 ) -> Result<(), TokenUpdateErrorInternal> {
     check_authorized(
@@ -782,7 +782,7 @@ fn execute_assign_admin_roles<BSO: BlockStateOperations>(
 
 fn execute_revoke_admin_roles<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
+    kernel: &mut TokenOperationContext<'_, BSO>,
     operation: &TokenUpdateAdminRolesDetails,
 ) -> Result<(), TokenUpdateErrorInternal> {
     check_authorized(
@@ -818,7 +818,7 @@ fn execute_revoke_admin_roles<BSO: BlockStateOperations>(
 
 fn execute_update_metadata<BSO: BlockStateOperations>(
     transaction_execution: &mut TransactionExecution<BSO::Account>,
-    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
+    kernel: &mut TokenOperationContext<'_, BSO>,
     metadata_url: &MetadataUrl,
 ) -> Result<(), TokenUpdateErrorInternal> {
     if !metadata_url.additional.is_empty() {

--- a/plt/plt-scheduler/src/token_module/module/update.rs
+++ b/plt/plt-scheduler/src/token_module/module/update.rs
@@ -1,7 +1,8 @@
+use crate::token_kernel::TokenKernelOperationsImpl;
 use crate::token_module::module::TokenAmountDecimalsMismatchError;
 use crate::token_module::token_kernel_interface::{
-    InsufficientBalanceError, MintWouldOverflowError, TokenBurnError, TokenKernelOperations,
-    TokenKernelQueries, TokenMintError, TokenStateInvariantError, TokenTransferError,
+    InsufficientBalanceError, MintWouldOverflowError, TokenBurnError, TokenMintError,
+    TokenStateInvariantError, TokenTransferError,
 };
 use crate::token_module::{key_value_state, util};
 use crate::transaction_execution::{OutOfEnergyError, TransactionExecution};
@@ -18,6 +19,7 @@ use concordium_base::protocol_level_tokens::{
 };
 use concordium_base::transactions::Memo;
 use plt_block_state::block_state::AccountNotFoundByAddressError;
+use plt_block_state::block_state_interface::BlockStateOperations;
 
 /// Details provided by the token module in the event of rejecting a
 /// transaction.
@@ -40,7 +42,7 @@ pub enum TokenUpdateError {
     StateInvariantViolation(#[from] TokenStateInvariantError),
 }
 
-/// Execute a token update transaction using the [`TokenKernelOperations`] to
+/// Execute a token update transaction using the token kernel to
 /// update state and produce events.
 ///
 /// The caller must ensure to rollback state changes in case of
@@ -95,9 +97,9 @@ pub enum TokenUpdateError {
 /// If the state stored in the token module contains data that breaks the invariants
 /// maintained by the token module, the special error [`TokenUpdateError::StateInvariantViolation`]
 /// is returned. This is an unrecoverable error and should never happen.
-pub fn execute_token_update_transaction<TK: TokenKernelOperations>(
-    transaction_execution: &mut TransactionExecution<TK::Account>,
-    kernel: &mut TK,
+pub fn execute_token_update_transaction<BSO: BlockStateOperations>(
+    transaction_execution: &mut TransactionExecution<BSO::Account>,
+    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
     token_operations: RawCbor,
 ) -> Result<(), TokenUpdateError> {
     let operations: Vec<TokenOperation> = util::cbor_decode(&token_operations).map_err(|err| {
@@ -114,7 +116,7 @@ pub fn execute_token_update_transaction<TK: TokenKernelOperations>(
     Ok(())
 }
 
-/// Execute a token update operation using the [`TokenKernelOperations`] to
+/// Execute a token update operation using the token kernel to
 /// update state and produce events.
 ///
 /// The caller must ensure to rollback state changes in case of
@@ -177,9 +179,9 @@ pub fn execute_token_update_transaction<TK: TokenKernelOperations>(
 /// - `kernel`: the token kernel operations interface
 /// - `index`: the index of the operation in the transaction, used for error reporting
 /// - `operation`: the token operation to execute
-pub fn execute_token_update_operation_at_index<TK: TokenKernelOperations>(
-    transaction_execution: &mut TransactionExecution<TK::Account>,
-    kernel: &mut TK,
+pub fn execute_token_update_operation_at_index<BSO: BlockStateOperations>(
+    transaction_execution: &mut TransactionExecution<BSO::Account>,
+    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
     index: usize,
     operation: &TokenOperation,
 ) -> Result<(), TokenUpdateError> {
@@ -345,9 +347,9 @@ impl From<TokenBurnError> for TokenUpdateErrorInternal {
     }
 }
 
-fn execute_token_update_operation<TK: TokenKernelOperations>(
-    transaction_execution: &mut TransactionExecution<TK::Account>,
-    kernel: &mut TK,
+fn execute_token_update_operation<BSO: BlockStateOperations>(
+    transaction_execution: &mut TransactionExecution<BSO::Account>,
+    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
     token_operation: &TokenOperation,
 ) -> Result<(), TokenUpdateErrorInternal> {
     // Charge energy
@@ -423,8 +425,8 @@ fn energy_cost(operation: &TokenOperation) -> Energy {
     }
 }
 
-fn check_not_paused<TK: TokenKernelOperations>(
-    kernel: &TK,
+fn check_not_paused<BSO: BlockStateOperations>(
+    kernel: &TokenKernelOperationsImpl<'_, BSO>,
 ) -> Result<(), TokenUpdateErrorInternal> {
     if key_value_state::is_paused(kernel) {
         return Err(TokenUpdateErrorInternal::Paused);
@@ -433,9 +435,9 @@ fn check_not_paused<TK: TokenKernelOperations>(
 }
 
 /// Ensure the sender account from the transaction context is authorized to perform the operation.
-fn check_authorized<TK: TokenKernelQueries>(
-    transaction_execution: &mut TransactionExecution<TK::Account>,
-    kernel: &TK,
+fn check_authorized<BSO: BlockStateOperations>(
+    transaction_execution: &mut TransactionExecution<BSO::Account>,
+    kernel: &TokenKernelOperationsImpl<'_, BSO>,
     required_role: TokenAdminRole,
 ) -> Result<(), TokenUpdateErrorInternal> {
     if kernel.support_rbac() {
@@ -462,9 +464,9 @@ fn check_authorized<TK: TokenKernelQueries>(
     Ok(())
 }
 
-fn execute_token_transfer<TK: TokenKernelOperations>(
-    transaction_execution: &mut TransactionExecution<TK::Account>,
-    kernel: &mut TK,
+fn execute_token_transfer<BSO: BlockStateOperations>(
+    transaction_execution: &mut TransactionExecution<BSO::Account>,
+    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
     transfer_operation: &TokenTransfer,
 ) -> Result<(), TokenUpdateErrorInternal> {
     // preprocessing
@@ -517,9 +519,9 @@ fn execute_token_transfer<TK: TokenKernelOperations>(
     Ok(())
 }
 
-fn execute_token_mint<TK: TokenKernelOperations>(
-    transaction_execution: &mut TransactionExecution<TK::Account>,
-    kernel: &mut TK,
+fn execute_token_mint<BSO: BlockStateOperations>(
+    transaction_execution: &mut TransactionExecution<BSO::Account>,
+    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
     mint_operation: &TokenSupplyUpdateDetails,
 ) -> Result<(), TokenUpdateErrorInternal> {
     // preprocessing
@@ -542,9 +544,9 @@ fn execute_token_mint<TK: TokenKernelOperations>(
     Ok(())
 }
 
-fn execute_token_burn<TK: TokenKernelOperations>(
-    transaction_execution: &mut TransactionExecution<TK::Account>,
-    kernel: &mut TK,
+fn execute_token_burn<BSO: BlockStateOperations>(
+    transaction_execution: &mut TransactionExecution<BSO::Account>,
+    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
     burn_operation: &TokenSupplyUpdateDetails,
 ) -> Result<(), TokenUpdateErrorInternal> {
     // preprocessing
@@ -567,9 +569,9 @@ fn execute_token_burn<TK: TokenKernelOperations>(
     Ok(())
 }
 
-fn execute_token_pause<TK: TokenKernelOperations>(
-    transaction_execution: &mut TransactionExecution<TK::Account>,
-    kernel: &mut TK,
+fn execute_token_pause<BSO: BlockStateOperations>(
+    transaction_execution: &mut TransactionExecution<BSO::Account>,
+    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
 ) -> Result<(), TokenUpdateErrorInternal> {
     check_authorized(transaction_execution, kernel, TokenAdminRole::Pause)?;
 
@@ -580,9 +582,9 @@ fn execute_token_pause<TK: TokenKernelOperations>(
     Ok(())
 }
 
-fn execute_token_unpause<TK: TokenKernelOperations>(
-    transaction_execution: &mut TransactionExecution<TK::Account>,
-    kernel: &mut TK,
+fn execute_token_unpause<BSO: BlockStateOperations>(
+    transaction_execution: &mut TransactionExecution<BSO::Account>,
+    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
 ) -> Result<(), TokenUpdateErrorInternal> {
     check_authorized(transaction_execution, kernel, TokenAdminRole::Pause)?;
 
@@ -593,9 +595,9 @@ fn execute_token_unpause<TK: TokenKernelOperations>(
     Ok(())
 }
 
-fn execute_add_allow_list<TK: TokenKernelOperations>(
-    transaction_execution: &mut TransactionExecution<TK::Account>,
-    kernel: &mut TK,
+fn execute_add_allow_list<BSO: BlockStateOperations>(
+    transaction_execution: &mut TransactionExecution<BSO::Account>,
+    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
     list_operation: &TokenListUpdateDetails,
 ) -> Result<(), TokenUpdateErrorInternal> {
     if !key_value_state::has_allow_list(kernel) {
@@ -622,9 +624,9 @@ fn execute_add_allow_list<TK: TokenKernelOperations>(
     Ok(())
 }
 
-fn execute_add_deny_list<TK: TokenKernelOperations>(
-    transaction_execution: &mut TransactionExecution<TK::Account>,
-    kernel: &mut TK,
+fn execute_add_deny_list<BSO: BlockStateOperations>(
+    transaction_execution: &mut TransactionExecution<BSO::Account>,
+    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
     list_operation: &TokenListUpdateDetails,
 ) -> Result<(), TokenUpdateErrorInternal> {
     if !key_value_state::has_deny_list(kernel) {
@@ -652,9 +654,9 @@ fn execute_add_deny_list<TK: TokenKernelOperations>(
     Ok(())
 }
 
-fn execute_remove_allow_list<TK: TokenKernelOperations>(
-    transaction_execution: &mut TransactionExecution<TK::Account>,
-    kernel: &mut TK,
+fn execute_remove_allow_list<BSO: BlockStateOperations>(
+    transaction_execution: &mut TransactionExecution<BSO::Account>,
+    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
     list_operation: &TokenListUpdateDetails,
 ) -> Result<(), TokenUpdateErrorInternal> {
     if !key_value_state::has_allow_list(kernel) {
@@ -682,9 +684,9 @@ fn execute_remove_allow_list<TK: TokenKernelOperations>(
     Ok(())
 }
 
-fn execute_remove_deny_list<TK: TokenKernelOperations>(
-    transaction_execution: &mut TransactionExecution<TK::Account>,
-    kernel: &mut TK,
+fn execute_remove_deny_list<BSO: BlockStateOperations>(
+    transaction_execution: &mut TransactionExecution<BSO::Account>,
+    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
     list_operation: &TokenListUpdateDetails,
 ) -> Result<(), TokenUpdateErrorInternal> {
     if !key_value_state::has_deny_list(kernel) {
@@ -712,9 +714,8 @@ fn execute_remove_deny_list<TK: TokenKernelOperations>(
     Ok(())
 }
 
-/// Whether the roles are supported for the features enabled.
-fn check_roles_supported(
-    kernel: &impl TokenKernelQueries,
+fn check_roles_supported<BSO: BlockStateOperations>(
+    kernel: &TokenKernelOperationsImpl<'_, BSO>,
     roles: &[TokenAdminRole],
 ) -> Result<(), TokenUpdateErrorInternal> {
     for role in roles {
@@ -736,9 +737,9 @@ fn check_roles_supported(
     Ok(())
 }
 
-fn execute_assign_admin_roles<TK: TokenKernelOperations>(
-    transaction_execution: &mut TransactionExecution<TK::Account>,
-    kernel: &mut TK,
+fn execute_assign_admin_roles<BSO: BlockStateOperations>(
+    transaction_execution: &mut TransactionExecution<BSO::Account>,
+    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
     operation: &TokenUpdateAdminRolesDetails,
 ) -> Result<(), TokenUpdateErrorInternal> {
     check_authorized(
@@ -762,9 +763,9 @@ fn execute_assign_admin_roles<TK: TokenKernelOperations>(
     Ok(())
 }
 
-fn execute_revoke_admin_roles<TK: TokenKernelOperations>(
-    transaction_execution: &mut TransactionExecution<TK::Account>,
-    kernel: &mut TK,
+fn execute_revoke_admin_roles<BSO: BlockStateOperations>(
+    transaction_execution: &mut TransactionExecution<BSO::Account>,
+    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
     operation: &TokenUpdateAdminRolesDetails,
 ) -> Result<(), TokenUpdateErrorInternal> {
     check_authorized(
@@ -793,9 +794,9 @@ fn execute_revoke_admin_roles<TK: TokenKernelOperations>(
     Ok(())
 }
 
-fn execute_update_metadata<TK: TokenKernelOperations>(
-    transaction_execution: &mut TransactionExecution<TK::Account>,
-    kernel: &mut TK,
+fn execute_update_metadata<BSO: BlockStateOperations>(
+    transaction_execution: &mut TransactionExecution<BSO::Account>,
+    kernel: &mut TokenKernelOperationsImpl<'_, BSO>,
     metadata_url: &MetadataUrl,
 ) -> Result<(), TokenUpdateErrorInternal> {
     if !metadata_url.additional.is_empty() {

--- a/plt/plt-scheduler/src/token_module/token_kernel_interface.rs
+++ b/plt/plt-scheduler/src/token_module/token_kernel_interface.rs
@@ -1,8 +1,6 @@
 //! Token kernel interface for protocol-level tokens. This is the interface seen
 //! by the token module. The kernel handles all operations affecting token
 //! balance and supply and manages the state and events related to balances and supply.
-
-use plt_block_state::block_state::types::{TokenStateKey, TokenStateValue};
 use plt_scheduler_types::types::tokens::RawTokenAmount;
 
 /// The account has insufficient balance.
@@ -58,18 +56,4 @@ pub enum TokenBurnError {
     StateInvariantViolation(#[from] TokenStateInvariantError),
     #[error("Insufficient balance for burn: {0}")]
     InsufficientBalance(#[from] InsufficientBalanceError),
-}
-
-/// Minimal read-only access to token key-value state, used as an anchor for the
-/// extension traits [`KernelQueriesExt`](crate::token_module::key_value_state::KernelQueriesExt)
-/// and [`KernelOperationsExt`](crate::token_module::key_value_state::KernelOperationsExt).
-pub trait HasTokenState {
-    /// Lookup a key in the token key-value state.
-    fn lookup_token_state_value(&self, key: TokenStateKey) -> Option<TokenStateValue>;
-
-    /// Get an iterator over key-value pairs that share the given prefix.
-    fn iter_token_state_prefix(
-        &self,
-        prefix: TokenStateKey,
-    ) -> impl Iterator<Item = (&TokenStateKey, &TokenStateValue)>;
 }

--- a/plt/plt-scheduler/src/token_module/token_kernel_interface.rs
+++ b/plt/plt-scheduler/src/token_module/token_kernel_interface.rs
@@ -2,14 +2,7 @@
 //! by the token module. The kernel handles all operations affecting token
 //! balance and supply and manages the state and events related to balances and supply.
 
-use concordium_base::base::{AccountIndex, ProtocolVersion};
-use concordium_base::contracts_common::AccountAddress;
-use concordium_base::protocol_level_tokens::{RawCbor, TokenModuleCborTypeDiscriminator};
-use concordium_base::transactions::Memo;
-use plt_block_state::block_state::types::{
-    AccountWithCanonicalAddress, TokenStateKey, TokenStateValue,
-};
-use plt_block_state::block_state::{AccountNotFoundByAddressError, AccountNotFoundByIndexError};
+use plt_block_state::block_state::types::{TokenStateKey, TokenStateValue};
 use plt_scheduler_types::types::tokens::RawTokenAmount;
 
 /// The account has insufficient balance.
@@ -67,135 +60,16 @@ pub enum TokenBurnError {
     InsufficientBalance(#[from] InsufficientBalanceError),
 }
 
-/// Queries provided by the token kernel. All queries are in context of
-/// a specific token that the kernel is initialized with.
-pub trait TokenKernelQueries {
-    /// Opaque type that represents an account on chain.
-    /// The account is guaranteed to exist on chain, when holding an instance of this type.
-    type Account;
-
-    /// Lookup the account using an account address.
-    fn account_by_address(
-        &self,
-        address: &AccountAddress,
-    ) -> Result<Self::Account, AccountNotFoundByAddressError>;
-
-    /// Lookup the account using an account index.
-    /// Returns both the opaque account
-    //  representation and the account canonical address.
-    fn account_by_index(
-        &self,
-        index: AccountIndex,
-    ) -> Result<AccountWithCanonicalAddress<Self::Account>, AccountNotFoundByIndexError>;
-
-    /// Get the account index for the account.
-    fn account_index(&self, account: &Self::Account) -> AccountIndex;
-
-    /// Get the token balance of the account.
-    fn account_token_balance(&self, account: &Self::Account) -> RawTokenAmount;
-
-    /// The number of decimals used in the presentation of the token amount.
-    fn decimals(&self) -> u8;
-
-    /// Lookup a key in the token state.
+/// Minimal read-only access to token key-value state, used as an anchor for the
+/// extension traits [`KernelQueriesExt`](crate::token_module::key_value_state::KernelQueriesExt)
+/// and [`KernelOperationsExt`](crate::token_module::key_value_state::KernelOperationsExt).
+pub trait HasTokenState {
+    /// Lookup a key in the token key-value state.
     fn lookup_token_state_value(&self, key: TokenStateKey) -> Option<TokenStateValue>;
 
-    /// Get iterator over key-value pairs with a shared prefix.
+    /// Get an iterator over key-value pairs that share the given prefix.
     fn iter_token_state_prefix(
         &self,
         prefix: TokenStateKey,
     ) -> impl Iterator<Item = (&TokenStateKey, &TokenStateValue)>;
-
-    /// Query the protocol version for this block.
-    fn protocol_version(&self) -> ProtocolVersion;
-
-    /// Query whether to support RBAC operations.
-    fn support_rbac(&self) -> bool {
-        self.protocol_version() >= ProtocolVersion::P11
-    }
-
-    /// Query whether to support updating metadata operations.
-    fn support_updating_metadata(&self) -> bool {
-        self.protocol_version() >= ProtocolVersion::P11
-    }
-}
-
-/// Operations provided by the token kernel. All operations are in context of
-/// a specific token that the kernel is initialized with.
-///
-/// The operations do not only allow modifying
-/// token module state, but also indirectly affect the token state maintained by the token
-/// kernel.
-pub trait TokenKernelOperations: TokenKernelQueries {
-    /// Initialize the balance of the given account to zero if it didn't have a balance before.
-    /// It has the observable effect that the token is then returned when querying the tokens
-    /// for an account. Should be called if the token module account state is set,
-    /// in order to make sure the token is returned when querying token account info.
-    ///
-    /// If the account already has a balance for the token in context, the operation has no effect
-    fn touch_account(&mut self, account: &Self::Account);
-
-    /// Mint a specified amount and deposit it in the account.
-    ///
-    /// # Events
-    ///
-    /// This will produce a `TokenMintEvent` in the logs.
-    ///
-    /// # Errors
-    ///
-    /// - [`TokenMintError::MintWouldOverflow`] The total supply would exceed the representable amount.
-    /// - [`TokenMintError::StateInvariantViolation`] If an internal token state invariant is broken.
-    fn mint(
-        &mut self,
-        account: &Self::Account,
-        account_address: AccountAddress,
-        amount: RawTokenAmount,
-    ) -> Result<(), TokenMintError>;
-
-    /// Burn a specified amount from the account.
-    ///
-    /// # Events
-    ///
-    /// This will produce a `TokenBurnEvent` in the logs.
-    ///
-    /// # Errors
-    ///
-    /// - [`TokenBurnError::InsufficientBalance`] The sender has insufficient balance.
-    /// - [`TokenBurnError::StateInvariantViolation`] If an internal token state invariant is broken.
-    fn burn(
-        &mut self,
-        account: &Self::Account,
-        account_address: AccountAddress,
-        amount: RawTokenAmount,
-    ) -> Result<(), TokenBurnError>;
-
-    /// Transfer a token amount from one account to another, with an optional memo.
-    ///
-    /// # Events
-    ///
-    /// This will produce a `TokenTransferEvent` in the logs.
-    ///
-    /// # Errors
-    ///
-    /// - [`TokenTransferError::InsufficientBalance`] The sender has insufficient balance.
-    /// - [`TokenTransferError::StateInvariantViolation`] If an internal token state invariant is broken.
-    fn transfer(
-        &mut self,
-        from: &Self::Account,
-        from_address: AccountAddress,
-        to: &Self::Account,
-        to_address: AccountAddress,
-        amount: RawTokenAmount,
-        memo: Option<Memo>,
-    ) -> Result<(), TokenTransferError>;
-
-    /// Set or clear a value in the token state at the corresponding key.
-    fn set_token_state_value(&mut self, key: TokenStateKey, value: Option<TokenStateValue>);
-
-    /// Log a token module event with the specified type and details.
-    ///
-    /// # Events
-    ///
-    /// This will produce a `TokenModuleEvent` in the logs.
-    fn log_token_event(&mut self, event_type: TokenModuleCborTypeDiscriminator, details: RawCbor);
 }

--- a/plt/plt-scheduler/src/token_module/util.rs
+++ b/plt/plt-scheduler/src/token_module/util.rs
@@ -1,6 +1,6 @@
 //! Internal utilities for the token module implementation.
 
-use crate::token_kernel::TokenKernelOperationsImpl;
+use crate::token_kernel::TokenOperationContext;
 use crate::token_module::module::TokenAmountDecimalsMismatchError;
 use concordium_base::common::cbor;
 use concordium_base::common::cbor::{
@@ -13,7 +13,7 @@ use plt_scheduler_types::types::tokens::RawTokenAmount;
 /// Checks that token amount has the right number of decimals and converts it to a plain
 /// integer and return [`RawTokenAmount`]
 pub fn to_raw_token_amount<BSO: BlockStateOperations>(
-    kernel: &TokenKernelOperationsImpl<'_, BSO>,
+    kernel: &TokenOperationContext<'_, BSO>,
     amount: TokenAmount,
 ) -> Result<RawTokenAmount, TokenAmountDecimalsMismatchError> {
     let kernel_decimals = kernel.decimals();
@@ -28,7 +28,7 @@ pub fn to_raw_token_amount<BSO: BlockStateOperations>(
 }
 
 pub fn to_token_amount<BSO: BlockStateOperations>(
-    kernel: &TokenKernelOperationsImpl<'_, BSO>,
+    kernel: &TokenOperationContext<'_, BSO>,
     amount: RawTokenAmount,
 ) -> TokenAmount {
     TokenAmount::from_raw(amount.0, kernel.decimals())

--- a/plt/plt-scheduler/src/token_module/util.rs
+++ b/plt/plt-scheduler/src/token_module/util.rs
@@ -1,22 +1,21 @@
 //! Internal utilities for the token module implementation.
 
-use crate::token_kernel::TokenOperationContext;
-use crate::token_module::module::TokenAmountDecimalsMismatchError;
+use crate::token_module::errors::TokenAmountDecimalsMismatchError;
 use concordium_base::common::cbor;
 use concordium_base::common::cbor::{
     CborDeserialize, CborSerializationResult, SerializationOptions, UnknownMapKeys,
 };
 use concordium_base::protocol_level_tokens::TokenAmount;
-use plt_block_state::block_state_interface::BlockStateOperations;
+use plt_block_state::block_state::types::TokenConfiguration;
 use plt_scheduler_types::types::tokens::RawTokenAmount;
 
 /// Checks that token amount has the right number of decimals and converts it to a plain
 /// integer and return [`RawTokenAmount`]
-pub fn to_raw_token_amount<BSO: BlockStateOperations>(
-    kernel: &TokenOperationContext<'_, BSO>,
+pub fn to_raw_token_amount(
+    token_configuration: &TokenConfiguration,
     amount: TokenAmount,
 ) -> Result<RawTokenAmount, TokenAmountDecimalsMismatchError> {
-    let kernel_decimals = kernel.decimals();
+    let kernel_decimals = token_configuration.decimals;
     if amount.decimals() != kernel_decimals {
         Err(TokenAmountDecimalsMismatchError {
             expected: kernel_decimals,
@@ -27,11 +26,11 @@ pub fn to_raw_token_amount<BSO: BlockStateOperations>(
     }
 }
 
-pub fn to_token_amount<BSO: BlockStateOperations>(
-    kernel: &TokenOperationContext<'_, BSO>,
+pub fn to_token_amount(
+    token_configuration: &TokenConfiguration,
     amount: RawTokenAmount,
 ) -> TokenAmount {
-    TokenAmount::from_raw(amount.0, kernel.decimals())
+    TokenAmount::from_raw(amount.0, token_configuration.decimals)
 }
 
 /// Decode given CBOR using decode options set to suit the token module. The decode options

--- a/plt/plt-scheduler/src/token_module/util.rs
+++ b/plt/plt-scheduler/src/token_module/util.rs
@@ -1,18 +1,19 @@
 //! Internal utilities for the token module implementation.
 
+use crate::token_kernel::TokenKernelOperationsImpl;
 use crate::token_module::module::TokenAmountDecimalsMismatchError;
-use crate::token_module::token_kernel_interface::TokenKernelQueries;
 use concordium_base::common::cbor;
 use concordium_base::common::cbor::{
     CborDeserialize, CborSerializationResult, SerializationOptions, UnknownMapKeys,
 };
 use concordium_base::protocol_level_tokens::TokenAmount;
+use plt_block_state::block_state_interface::BlockStateOperations;
 use plt_scheduler_types::types::tokens::RawTokenAmount;
 
 /// Checks that token amount has the right number of decimals and converts it to a plain
 /// integer and return [`RawTokenAmount`]
-pub fn to_raw_token_amount(
-    kernel: &impl TokenKernelQueries,
+pub fn to_raw_token_amount<BSO: BlockStateOperations>(
+    kernel: &TokenKernelOperationsImpl<'_, BSO>,
     amount: TokenAmount,
 ) -> Result<RawTokenAmount, TokenAmountDecimalsMismatchError> {
     let kernel_decimals = kernel.decimals();
@@ -26,7 +27,10 @@ pub fn to_raw_token_amount(
     }
 }
 
-pub fn to_token_amount(kernel: &impl TokenKernelQueries, amount: RawTokenAmount) -> TokenAmount {
+pub fn to_token_amount<BSO: BlockStateOperations>(
+    kernel: &TokenKernelOperationsImpl<'_, BSO>,
+    amount: RawTokenAmount,
+) -> TokenAmount {
     TokenAmount::from_raw(amount.0, kernel.decimals())
 }
 

--- a/plt/plt-scheduler/src/transaction_execution.rs
+++ b/plt/plt-scheduler/src/transaction_execution.rs
@@ -10,7 +10,7 @@ pub struct OutOfEnergyError;
 
 /// Tracks the energy remaining and some context during the execution.
 pub struct TransactionExecution<Account> {
-    /// Limit for how much energy the execution can use. An [`OutOfEnergy`] error is
+    /// Limit for how much energy the execution can use. An [`OutOfEnergyError`] error is
     /// returned if the limit is reached.
     energy_limit: Energy,
     /// Energy used so far by execution. Energy is always charged in advance for each step executed.


### PR DESCRIPTION
## Purpose

Removes the token kernel abstraction, closing [COR-2347](https://linear.app/concordium/issue/COR-2347/remove-the-token-kernel-abstraction).

## Changes

- Rename `TokenKernelQueriesImpl` and `TokenKernelOperationsImpl` to `TokenQueryContext` and `TokenOperationContext` respectively.
- Remove trait `TokenKernelQueries` and `TokenKernelOperations` in favor of concrete types `TokenQueryContext` and `TokenOperationContext`.
- Introduce a small trait in key_value_states.rs to allow functions to be defined for both of the contexts above.
- Moved token_module error types into a `errors.rs` file.
