### PR TITLE
Ar/psr 11 oncelock remove read closure from lfmb tree 2

### DIFF
--- a/plt/plt-block-state/benches/lfmb_tree.rs
+++ b/plt/plt-block-state/benches/lfmb_tree.rs
@@ -61,7 +61,7 @@ fn bench_lookup_value(bencher: Bencher, size: u64) {
     bencher
         .with_inputs(|| BenchKey(rand::random_range(0..size)))
         .bench_local_values(|key| {
-            tree.lookup_value(&UnreachableBlobStore, key, |v| Ok(*v))
+            tree.lookup_value(&UnreachableBlobStore, key)
                 .unwrap()
                 .unwrap()
         });

--- a/plt/plt-block-state/benches/lfmb_tree.rs
+++ b/plt/plt-block-state/benches/lfmb_tree.rs
@@ -91,8 +91,8 @@ fn bench_update_value(bencher: Bencher, size: u64) {
 fn bench_values(bencher: Bencher, size: u64) {
     let tree = divan::black_box(build_tree(size));
     bencher.bench_local(|| {
-        tree.values(&UnreachableBlobStore, |_k, v| Ok(v.0))
-            .map(|r| r.unwrap())
+        tree.values(&UnreachableBlobStore)
+            .map(|r| r.unwrap().1.0)
             .sum::<u64>()
     });
 }

--- a/plt/plt-block-state/src/block_state/blob_reference/hashed_cacheable_reference.rs
+++ b/plt/plt-block-state/src/block_state/blob_reference/hashed_cacheable_reference.rs
@@ -199,7 +199,7 @@ impl<V> HashedCacheableRefRepr<V> {
     }
 }
 
-impl<V: Loadable> Loadable for HashedCacheableRef<V> {
+impl<V> Loadable for HashedCacheableRef<V> {
     fn load_from_buffer(
         mut buffer: impl Read,
         _loader: &impl BlobStoreLoad,

--- a/plt/plt-block-state/src/block_state/lfmb_tree.rs
+++ b/plt/plt-block-state/src/block_state/lfmb_tree.rs
@@ -28,7 +28,7 @@ use std::{iter, vec};
 /// first.
 ///
 /// The operations supported for creating new trees are:
-/// * Create empty tree with [`LfmbTree::empty`]: Returns an new empty tree.
+/// * Create empty tree with [`LfmbTree::empty`]: Returns a new empty tree.
 /// * Insert new value with [`LfmbTree::insert_value`]: Inserts a new value, assigning the sequentially next unused key,
 ///   and returns new tree with the inserted value.
 /// * Update value with [`LfmbTree::update_value`]: Updates an existing value, keeping the same key, and returns
@@ -195,43 +195,38 @@ impl<K: LfmbTreeKey, V> LfmbTree<K, V> {
         }
     }
 
-    /// Access the value for the given `key` in the tree
-    /// using the `read` closure. Returns the value returned by the
-    /// closure if there is a value for the key in the tree, or `None` if there
+    /// Get the value for the given `key` in the tree or `None` if there
     /// is no value for the key.
     ///
     /// # Arguments
     ///
     /// - `loader`: Loader for the blob store the tree is stored in.
     /// - `key`: The key to access the value for.
-    /// - `read`: Closure that is given the value, either as owned or borrowed,
-    ///   and returns the value of type `T` that will be returned by `lookup_value`.
     ///
     /// # Errors
     ///
-    /// Returns [`BlockStateFailure`] if returned by `read`, or if decoding data from the
+    /// Returns [`BlockStateFailure`] if decoding data from the
     /// blob store fails, or if the tree does not fulfill
     /// the expected invariants (this can happen if the blob store is corrupted in some way).
-    pub fn lookup_value<T>(
+    pub fn lookup_value(
         &self,
         loader: &impl BlobStoreLoad,
         key: K,
-        read: impl FnOnce(OwnedOrBorrowed<'_, V>) -> BlockStateResult<T>,
-    ) -> Option<BlockStateResult<T>>
+    ) -> BlockStateResult<Option<OwnedOrBorrowed<'_, V>>>
     where
         V: Loadable,
     {
-        match &self.inner {
+        Ok(match &self.inner {
             LfmbTreeInner::Empty => None,
             LfmbTreeInner::NonEmpty(size, subtree) => {
                 let int_key = SubtreeKey(key.to_u64());
                 if int_key.0 < *size {
-                    Some(subtree.lookup_value(loader, int_key, read))
+                    Some(subtree.lookup_value(loader, int_key)?)
                 } else {
                     None
                 }
             }
-        }
+        })
     }
 
     /// Iterates all values in the tree in insertion order (which is also the order
@@ -416,19 +411,16 @@ const fn flip_nth_bit(nth: u64, key: SubtreeKey) -> SubtreeKey {
 }
 
 impl<V> Subtree<V> {
-    /// Access the value for the given `key` in the subtree.
+    /// Get the value for the given `key` in the subtree.
     ///
     /// # Arguments
     ///
     /// - `key`: The key to access the value for.
-    /// - `read`: Closure that is given the value, either as owned or borrowed,
-    ///   and returns the value of type `T` that will be returned by `lookup_value`.
-    fn lookup_value<T>(
+    fn lookup_value(
         &self,
         loader: &impl BlobStoreLoad,
         key: SubtreeKey,
-        read: impl FnOnce(OwnedOrBorrowed<'_, V>) -> BlockStateResult<T>,
-    ) -> BlockStateResult<T>
+    ) -> BlockStateResult<OwnedOrBorrowed<'_, V>>
     where
         V: Loadable,
     {
@@ -441,19 +433,31 @@ impl<V> Subtree<V> {
                         key
                     )));
                 }
-                read(val_ref.value(loader)?)
+                val_ref.value(loader)
             }
             Subtree::Node(height, left_ref, right_ref) => {
                 // The height'th bit in key decides if we should follow left `0`
                 // or right branch `1`. Additionally, when going right, we set the bit to 0.
                 // This allows us to check the invariant that the key must be identical to 0
                 // when we reach the leaf for the key.
-                if is_nth_bit_set(*height, key) {
-                    right_ref
-                        .value(loader)?
-                        .lookup_value(loader, flip_nth_bit(*height, key), read)
+                let (branch_ref, branch_key) = if is_nth_bit_set(*height, key) {
+                    (right_ref, flip_nth_bit(*height, key))
                 } else {
-                    left_ref.value(loader)?.lookup_value(loader, key, read)
+                    (left_ref, key)
+                };
+
+                match branch_ref.value(loader)? {
+                    OwnedOrBorrowed::Owned(branch) => {
+                        // Looking up the value in owned branch must return owned value due to the
+                        // lazy nature of the implementation Loadable for Subtree: The branch is
+                        // owned if it has just been loaded, and loading does not load any
+                        // blob references into memory.
+                        Ok(branch
+                            .lookup_value(loader, branch_key)?
+                            .new_lifetime_if_owned()
+                            .expect("Looking up the value in owned branch must return owned value"))
+                    }
+                    OwnedOrBorrowed::Borrowed(branch) => branch.lookup_value(loader, branch_key),
                 }
             }
         }
@@ -739,7 +743,7 @@ where
     }
 }
 
-impl<K, V: Loadable> Loadable for LfmbTree<K, V> {
+impl<K, V> Loadable for LfmbTree<K, V> {
     fn load_from_buffer(
         mut buffer: impl Read,
         loader: &impl BlobStoreLoad,
@@ -773,7 +777,7 @@ impl<K, V: Storable> Storable for LfmbTree<K, V> {
     }
 }
 
-impl<V: Loadable> Loadable for Subtree<V> {
+impl<V> Loadable for Subtree<V> {
     fn load_from_buffer(
         mut buffer: impl Read,
         loader: &impl BlobStoreLoad,
@@ -907,6 +911,14 @@ mod tests {
         tree
     }
 
+    fn store_value<T: Storable + Loadable, S: BlobStoreLoad + BlobStoreStore>(
+        store: &mut S,
+        value: &T,
+    ) -> T {
+        let blob_loc = blob_store::store_to_store(store, value);
+        blob_store::load_from_store(store, blob_loc).unwrap()
+    }
+
     /// Test [`LfmbTree::size`]
     #[test]
     fn prop_test_size() {
@@ -921,9 +933,9 @@ mod tests {
         }
     }
 
-    /// Test [`LfmbTree::lookup_value`]
+    /// Test [`LfmbTree::lookup_value`] for a tree that is in memory.
     #[test]
-    fn prop_test_with_value() {
+    fn prop_test_lookup_value_in_memory() {
         for i in 0..100 {
             let mut store = BlobStoreStub::default();
 
@@ -933,10 +945,8 @@ mod tests {
             // Lookup existing values
             for j in 0..i {
                 assert_eq!(
-                    tree.lookup_value(&store, TestKey(j), |val| Ok(*val))
-                        .transpose()
-                        .unwrap(),
-                    Some(StoreSerialized(j + 10)),
+                    tree.lookup_value(&store, TestKey(j)).unwrap().as_deref(),
+                    Some(&StoreSerialized(j + 10)),
                     "access value for key {:?} in tree of size {}",
                     TestKey(j),
                     i
@@ -945,18 +955,53 @@ mod tests {
 
             // Lookup non-existing values
             assert_eq!(
-                tree.lookup_value(&store, TestKey(i), |val| Ok(*val))
-                    .transpose()
-                    .unwrap(),
+                tree.lookup_value(&store, TestKey(i)).unwrap(),
                 None,
                 "access non-existing value for key {:?} in tree of size {}",
                 TestKey(i),
                 i
             );
             assert_eq!(
-                tree.lookup_value(&store, TestKey(i + 1), |val| Ok(*val))
-                    .transpose()
-                    .unwrap(),
+                tree.lookup_value(&store, TestKey(i + 1)).unwrap(),
+                None,
+                "access non-existing value for key {:?} in tree of size {}",
+                TestKey(i + 1),
+                i
+            );
+        }
+    }
+
+    /// Test [`LfmbTree::lookup_value`] for a tree that is in blob store.
+    #[test]
+    fn prop_test_lookup_value_stored() {
+        for i in 0..100 {
+            let mut store = BlobStoreStub::default();
+
+            // Append values to tree and store it
+            let tree = create_tree(&mut store, i);
+            let tree = store_value(&mut store, &tree);
+
+            // Lookup existing values
+            for j in 0..i {
+                assert_eq!(
+                    tree.lookup_value(&store, TestKey(j)).unwrap().as_deref(),
+                    Some(&StoreSerialized(j + 10)),
+                    "access value for key {:?} in tree of size {}",
+                    TestKey(j),
+                    i
+                );
+            }
+
+            // Lookup non-existing values
+            assert_eq!(
+                tree.lookup_value(&store, TestKey(i)).unwrap(),
+                None,
+                "access non-existing value for key {:?} in tree of size {}",
+                TestKey(i),
+                i
+            );
+            assert_eq!(
+                tree.lookup_value(&store, TestKey(i + 1)).unwrap(),
                 None,
                 "access non-existing value for key {:?} in tree of size {}",
                 TestKey(i + 1),
@@ -1004,6 +1049,8 @@ mod tests {
         }
     }
 
+    // todo ar fix iterator
+
     /// Test [`LfmbTree::update_value`]
     #[test]
     fn prop_test_update_value() {
@@ -1023,10 +1070,8 @@ mod tests {
 
                 // Lookup the value again
                 assert_eq!(
-                    tree.lookup_value(&store, TestKey(j), |val| Ok(*val))
-                        .transpose()
-                        .unwrap(),
-                    Some(StoreSerialized(j + 20)),
+                    tree.lookup_value(&store, TestKey(j)).unwrap().as_deref(),
+                    Some(&StoreSerialized(j + 20)),
                     "update value for key {:?} in tree of size {}",
                     TestKey(j),
                     i
@@ -1094,10 +1139,10 @@ mod tests {
             for j in 0..i {
                 assert_eq!(
                     tree2
-                        .lookup_value(&UnreachableBlobStore, TestKey(j), |val| Ok(*val))
-                        .transpose()
-                        .unwrap(),
-                    Some(StoreSerialized(j + 10)),
+                        .lookup_value(&UnreachableBlobStore, TestKey(j))
+                        .unwrap()
+                        .as_deref(),
+                    Some(&StoreSerialized(j + 10)),
                     "lookup value for key {:?} in cached tree of size {}",
                     TestKey(j),
                     i
@@ -1105,8 +1150,7 @@ mod tests {
             }
             assert_eq!(
                 tree2
-                    .lookup_value(&UnreachableBlobStore, TestKey(i), |val| Ok(*val))
-                    .transpose()
+                    .lookup_value(&UnreachableBlobStore, TestKey(i))
                     .unwrap(),
                 None,
                 "lookup non-existing value for key {:?} in cached tree of size {}",
@@ -1177,21 +1221,15 @@ mod tests {
             blob_store::load_from_store(&store, BlobStoreLocation(135)).expect("load tree");
         assert_eq!(tree.size(), 3);
         assert_eq!(
-            tree.lookup_value(&store, TestKey(0), |val| Ok(val.into_owned()))
-                .unwrap()
-                .unwrap(),
+            *tree.lookup_value(&store, TestKey(0)).unwrap().unwrap(),
             StoreSerialized("A".to_string())
         );
         assert_eq!(
-            tree.lookup_value(&store, TestKey(1), |val| Ok(val.into_owned()))
-                .unwrap()
-                .unwrap(),
+            *tree.lookup_value(&store, TestKey(1)).unwrap().unwrap(),
             StoreSerialized("B".to_string())
         );
         assert_eq!(
-            tree.lookup_value(&store, TestKey(2), |val| Ok(val.into_owned()))
-                .unwrap()
-                .unwrap(),
+            *tree.lookup_value(&store, TestKey(2)).unwrap().unwrap(),
             StoreSerialized("C".to_string())
         );
     }

--- a/plt/plt-block-state/src/block_state/lfmb_tree.rs
+++ b/plt/plt-block-state/src/block_state/lfmb_tree.rs
@@ -153,10 +153,19 @@ use std::{iter, vec};
 ///    [A] [B] [C] [D] [E] [F] [G] [H]
 ///    #0  #1  #2  #3  #4  #5  #6  #7
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct LfmbTree<K, V> {
     inner: LfmbTreeInner<V>,
     _key_type: PhantomData<K>,
+}
+
+impl<K, V> Clone for LfmbTree<K, V> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            _key_type: self._key_type,
+        }
+    }
 }
 
 impl<K: LfmbTreeKey, V> Default for LfmbTree<K, V> {
@@ -221,7 +230,7 @@ impl<K: LfmbTreeKey, V> LfmbTree<K, V> {
             LfmbTreeInner::NonEmpty(size, subtree) => {
                 let int_key = SubtreeKey(key.to_u64());
                 if int_key.0 < *size {
-                    Some(subtree.lookup_value(loader, int_key)?)
+                    Some(OwnedOrBorrowed::Borrowed(subtree).lookup_value(loader, int_key)?)
                 } else {
                     None
                 }
@@ -361,9 +370,9 @@ impl<K: LfmbTreeKey, V> LfmbTree<K, V> {
 struct SubtreeKey(u64);
 
 /// Internal representation of the tree.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 enum LfmbTreeInner<V> {
-    /// Emtpy Tree.
+    /// Empty Tree.
     Empty,
     /// Non-empty tree.
     ///
@@ -377,8 +386,19 @@ enum LfmbTreeInner<V> {
     ),
 }
 
+impl<V> Clone for LfmbTreeInner<V> {
+    fn clone(&self) -> Self {
+        match self {
+            LfmbTreeInner::Empty => LfmbTreeInner::Empty,
+            LfmbTreeInner::NonEmpty(size, subtree) => {
+                LfmbTreeInner::NonEmpty(*size, subtree.clone())
+            }
+        }
+    }
+}
+
 /// Non-empty subtree. The type is used recursively to represent branches.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 enum Subtree<V> {
     /// Leaf with value
     Leaf(HashedCacheableRef<V>),
@@ -397,6 +417,36 @@ enum Subtree<V> {
     ),
 }
 
+impl<V> Clone for Subtree<V> {
+    fn clone(&self) -> Self {
+        match self {
+            Subtree::Leaf(val_ref) => Subtree::Leaf(val_ref.clone()),
+            Subtree::Node(height, left_ref, right_ref) => {
+                Subtree::Node(*height, left_ref.clone(), right_ref.clone())
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+enum SubtreeWithReferencedValues<'b, V> {
+    /// Leaf with value
+    Leaf(OwnedOrBorrowed<'b, V>),
+    /// Node with two subtrees/branches.
+    ///
+    /// Invariant relating height `h` and branches:
+    /// * *size of left subtree* `== 2^h`
+    /// * `0 <` *size of right subtree* `<= 2^h`
+    Node(
+        /// Height of tree
+        u64,
+        /// Left branch
+        OwnedOrBorrowed<'b, Subtree<V>>,
+        /// Right branch
+        OwnedOrBorrowed<'b, Subtree<V>>,
+    ),
+}
+
 /// Check if `nth` bit is set in `key`.
 const fn is_nth_bit_set(nth: u64, key: SubtreeKey) -> bool {
     let bit = 1u64 << nth;
@@ -409,22 +459,60 @@ const fn flip_nth_bit(nth: u64, key: SubtreeKey) -> SubtreeKey {
     SubtreeKey(key.0 ^ bit)
 }
 
-impl<V> Subtree<V> {
+impl<'b, V> OwnedOrBorrowed<'b, Subtree<V>> {
+    /// Returns subtree where values in blob references have been fetched, both
+    /// the leaf values, and branch subtrees.
+    ///
+    /// Getting the referenced value in an owned subtree must return owned value due to the
+    /// lazy nature of the implementation Loadable for Subtree: The subtree is
+    /// owned if it has just been loaded, and loading does not load any
+    /// blob references into memory.
+    fn with_referenced_values(
+        self,
+        loader: &impl BlobStoreLoad,
+    ) -> BlockStateResult<SubtreeWithReferencedValues<'b, V>>
+    where
+        V: Loadable,
+    {
+        Ok(match self {
+            OwnedOrBorrowed::Borrowed(Subtree::Leaf(value_ref)) => {
+                SubtreeWithReferencedValues::Leaf(value_ref.value(loader)?)
+            }
+            OwnedOrBorrowed::Borrowed(Subtree::Node(height, left_ref, right_ref)) => {
+                SubtreeWithReferencedValues::Node(
+                    *height,
+                    left_ref.value(loader)?,
+                    right_ref.value(loader)?,
+                )
+            }
+            OwnedOrBorrowed::Owned(Subtree::Leaf(value_ref)) => SubtreeWithReferencedValues::Leaf(
+                value_ref.value(loader)?.new_lifetime_if_owned().expect("Loading value reference in owned subtree should return owned value"),
+            ),
+            OwnedOrBorrowed::Owned(Subtree::Node(height, left_ref, right_ref)) => {
+                SubtreeWithReferencedValues::Node(
+                    height,
+                    left_ref.value(loader)?.new_lifetime_if_owned().expect("Loading left branch reference in owned subtree should return owned subtree"),
+                    right_ref.value(loader)?.new_lifetime_if_owned().expect("Loading right branch reference in owned subtree should return owned subtree"),
+                )
+            }
+        })
+    }
+
     /// Get the value for the given `key` in the subtree.
     ///
     /// # Arguments
     ///
     /// - `key`: The key to access the value for.
     fn lookup_value(
-        &self,
+        self,
         loader: &impl BlobStoreLoad,
         key: SubtreeKey,
-    ) -> BlockStateResult<OwnedOrBorrowed<'_, V>>
+    ) -> BlockStateResult<OwnedOrBorrowed<'b, V>>
     where
         V: Loadable,
     {
-        match self {
-            Subtree::Leaf(val_ref) => {
+        match self.with_referenced_values(loader)? {
+            SubtreeWithReferencedValues::Leaf(val) => {
                 // When we reach the leaf for the key, the key must be 0.
                 if key != SubtreeKey(0) {
                     return Err(BlockStateFailure::Invariant(format!(
@@ -432,36 +520,24 @@ impl<V> Subtree<V> {
                         key
                     )));
                 }
-                val_ref.value(loader)
+                Ok(val)
             }
-            Subtree::Node(height, left_ref, right_ref) => {
+            SubtreeWithReferencedValues::Node(height, left, right) => {
                 // The height'th bit in key decides if we should follow left `0`
                 // or right branch `1`. Additionally, when going right, we set the bit to 0.
                 // This allows us to check the invariant that the key must be identical to 0
                 // when we reach the leaf for the key.
-                let (branch_ref, branch_key) = if is_nth_bit_set(*height, key) {
-                    (right_ref, flip_nth_bit(*height, key))
+                if is_nth_bit_set(height, key) {
+                    right.lookup_value(loader, flip_nth_bit(height, key))
                 } else {
-                    (left_ref, key)
-                };
-
-                match branch_ref.value(loader)? {
-                    OwnedOrBorrowed::Owned(branch) => {
-                        // Looking up the value in owned branch must return owned value due to the
-                        // lazy nature of the implementation Loadable for Subtree: The branch is
-                        // owned if it has just been loaded, and loading does not load any
-                        // blob references into memory.
-                        Ok(branch
-                            .lookup_value(loader, branch_key)?
-                            .new_lifetime_if_owned()
-                            .expect("Looking up the value in owned branch must return owned value"))
-                    }
-                    OwnedOrBorrowed::Borrowed(branch) => branch.lookup_value(loader, branch_key),
+                    left.lookup_value(loader, key)
                 }
             }
         }
     }
+}
 
+impl<V> Subtree<V> {
     /// Iterates all values in the subtree in insertion order.
     ///
     /// # Arguments
@@ -687,35 +763,11 @@ fn next_value_push_right_branches<'b, L: BlobStoreLoad, V: Loadable>(
     node: OwnedOrBorrowed<'b, Subtree<V>>,
     node_stack: &mut Vec<OwnedOrBorrowed<'b, Subtree<V>>>,
 ) -> BlockStateResult<OwnedOrBorrowed<'b, V>> {
-    Ok(match node {
-        OwnedOrBorrowed::Borrowed(node) => match node {
-            Subtree::Leaf(value) => value.value(loader)?,
-            Subtree::Node(_, left_ref, right_ref) => {
-                node_stack.push(right_ref.value(loader)?);
-                next_value_push_right_branches(loader, left_ref.value(loader)?, node_stack)?
-            }
-        },
-        OwnedOrBorrowed::Owned(node) => {
-            match node {
-                Subtree::Leaf(value) => value
-                    .value(loader)?
-                    .new_lifetime_if_owned()
-                    .expect("Looking up the value in owned node must return owned value"),
-                Subtree::Node(_, left_ref, right_ref) => {
-                    node_stack.push(
-                        right_ref.value(loader)?.new_lifetime_if_owned().expect(
-                            "Looking up the right ref in owned node must return owned value",
-                        ),
-                    );
-                    next_value_push_right_branches(
-                        loader,
-                        left_ref.value(loader)?.new_lifetime_if_owned().expect(
-                            "Looking up the left ref in owned node must return owned value",
-                        ),
-                        node_stack,
-                    )?
-                }
-            }
+    Ok(match node.with_referenced_values(loader)? {
+        SubtreeWithReferencedValues::Leaf(value) => value,
+        SubtreeWithReferencedValues::Node(_, left, right) => {
+            node_stack.push(right);
+            next_value_push_right_branches(loader, left, node_stack)?
         }
     })
 }

--- a/plt/plt-block-state/src/block_state/lfmb_tree.rs
+++ b/plt/plt-block-state/src/block_state/lfmb_tree.rs
@@ -718,20 +718,6 @@ fn next_value_push_right_branches<'b, L: BlobStoreLoad, V: Loadable>(
             }
         },
     })
-    // Ok(match node.value(loader)? {
-    //     OwnedOrBorrowed::Borrowed(Subtree::Leaf(value)) => value.value(loader)?,
-    //     OwnedOrBorrowed::Owned(Subtree::Leaf(value)) => {
-    //         value.value(loader)?.new_lifetime_if_owned().expect("")
-    //     }
-    //     OwnedOrBorrowed::Borrowed(Subtree::Node(_, left_ref, right_ref)) => {
-    //         node_stack.push(OwnedOrBorrowed::Borrowed(right_ref));
-    //         next_value_push_right_branches(loader, left_ref, node_stack)?
-    //     }
-    //     OwnedOrBorrowed::Owned(Subtree::Node(_, left_ref, right_ref)) => {
-    //         node_stack.push(OwnedOrBorrowed::Owned(right_ref));
-    //         next_value_push_right_branches(loader, left_ref, node_stack)?
-    //     }
-    // })
 }
 
 impl<K, V> Loadable for LfmbTree<K, V> {

--- a/plt/plt-block-state/src/block_state/lfmb_tree.rs
+++ b/plt/plt-block-state/src/block_state/lfmb_tree.rs
@@ -460,13 +460,21 @@ const fn flip_nth_bit(nth: u64, key: SubtreeKey) -> SubtreeKey {
 }
 
 impl<'b, V> OwnedOrBorrowed<'b, Subtree<V>> {
-    /// Returns subtree where values in blob references have been fetched, both
-    /// the leaf values, and branch subtrees.
+    /// Returns subtree where values in blob references have been fetched. Both
+    /// the referenced leaf values, and referenced branch subtrees are fetched.
     ///
-    /// Getting the referenced value in an owned subtree must return owned value due to the
-    /// lazy nature of the implementation Loadable for Subtree: The subtree is
-    /// owned if it has just been loaded, and loading does not load any
-    /// blob references into memory.
+    /// Precondition/invariant: If the given subtree is owned,
+    /// it is a precondition/invariant that the referenced values (leaf values and branch subtrees)
+    /// are not be in-memory. The invariant will be fulfilled in the returned subtrees.
+    /// If the given subtree is borrowed, there is no precondition for using the function.
+    ///
+    /// Notice that the precondition for owned subtrees is also true for a subtree that has just
+    /// been loaded with the implementation of `Loadable` for `Subtree` due to its lazy behaviour
+    /// of not loading referenced values.
+    ///
+    /// # Panic
+    ///
+    /// Panics if the precondition described above is not fulfilled for the subtree.
     fn with_referenced_values(
         self,
         loader: &impl BlobStoreLoad,
@@ -503,6 +511,10 @@ impl<'b, V> OwnedOrBorrowed<'b, Subtree<V>> {
     /// # Arguments
     ///
     /// - `key`: The key to access the value for.
+    ///
+    /// # Panic
+    ///
+    /// Panics if the precondition described on `[Self::with_referenced_values`] is not fulfilled for the subtree.
     fn lookup_value(
         self,
         loader: &impl BlobStoreLoad,
@@ -702,6 +714,8 @@ struct ValuesIterator<'a, 'b, L, V> {
     /// Blob store loader reference
     loader: &'a L,
     /// Stack of next nodes to visit.
+    /// All nodes in the stack must fulfill the precondition described on
+    /// [`OwnedOrBorrowed<Subtree>::with_referenced_values`].
     node_stack: Vec<OwnedOrBorrowed<'b, Subtree<V>>>,
     /// Size of the full tree (constant).
     tree_size: u64,
@@ -758,12 +772,17 @@ impl<'a, 'b, L: BlobStoreLoad, V: Loadable> Iterator for ValuesIterator<'a, 'b, 
 
 /// Follow left branches to reach next value while pushing all right branches to the
 /// node stack.
+///
+/// # Panic
+///
+/// Panics if the precondition described on [`OwnedOrBorrowed<Subtree>::with_referenced_values`] is
+/// not fulfilled for the subtree.
 fn next_value_push_right_branches<'b, L: BlobStoreLoad, V: Loadable>(
     loader: &L,
-    node: OwnedOrBorrowed<'b, Subtree<V>>,
+    subtree: OwnedOrBorrowed<'b, Subtree<V>>,
     node_stack: &mut Vec<OwnedOrBorrowed<'b, Subtree<V>>>,
 ) -> BlockStateResult<OwnedOrBorrowed<'b, V>> {
-    Ok(match node.with_referenced_values(loader)? {
+    Ok(match subtree.with_referenced_values(loader)? {
         SubtreeWithReferencedValues::Leaf(value) => value,
         SubtreeWithReferencedValues::Node(_, left, right) => {
             node_stack.push(right);

--- a/plt/plt-block-state/src/block_state/lfmb_tree.rs
+++ b/plt/plt-block-state/src/block_state/lfmb_tree.rs
@@ -244,22 +244,21 @@ impl<K: LfmbTreeKey, V> LfmbTree<K, V> {
     /// The iterator returns [`BlockStateFailure`] if returned by `read`, or if decoding data from the
     /// blob store fails, or if the tree does not fulfill the expected invariants (this can happen
     /// if the blob store is corrupted in some way).
-    pub fn values<'a, L: BlobStoreLoad, F, T>(
+    pub fn values(
         &self,
-        loader: &'a L,
-        mut read: F,
-    ) -> impl ExactSizeIterator<Item = BlockStateResult<T>> + use<'a, K, V, L, F, T>
+        loader: &impl BlobStoreLoad,
+    ) -> impl ExactSizeIterator<Item = BlockStateResult<(K, OwnedOrBorrowed<'_, V>)>>
     where
         V: Loadable,
-        F: FnMut(K, OwnedOrBorrowed<'_, V>) -> BlockStateResult<T>,
     {
         match &self.inner {
             LfmbTreeInner::Empty => Either::Left(iter::empty()),
-            LfmbTreeInner::NonEmpty(_, subtree) => Either::Right(subtree.values(
-                loader,
-                self.size(),
-                move |subtree_key, value| read(K::from_u64(subtree_key.0), value),
-            )),
+            LfmbTreeInner::NonEmpty(_, subtree) => {
+                Either::Right(subtree.values(loader, self.size()).map(|item| {
+                    let (subtree_key, value) = item?;
+                    Ok((K::from_u64(subtree_key.0), value))
+                }))
+            }
         }
     }
 
@@ -470,17 +469,15 @@ impl<V> Subtree<V> {
     /// - `read`: Closure that is given each value, either as owned or borrowed,
     ///   and returns the value of type `T` that will be the item in the iterator.
     /// - `node_size`: The number of entries in the subtree.
-    pub fn values<'a, L: BlobStoreLoad, F, T>(
+    pub fn values(
         &self,
-        loader: &'a L,
+        loader: &impl BlobStoreLoad,
         node_size: u64,
-        read: F,
-    ) -> impl ExactSizeIterator<Item = BlockStateResult<T>> + use<'a, V, L, F, T>
+    ) -> impl ExactSizeIterator<Item = BlockStateResult<(SubtreeKey, OwnedOrBorrowed<'_, V>)>>
     where
         V: Loadable,
-        F: FnMut(SubtreeKey, OwnedOrBorrowed<'_, V>) -> BlockStateResult<T>,
     {
-        ValuesIterator::new(self, loader, read, node_size)
+        ValuesIterator::new(self, loader, node_size)
     }
 
     /// Insert `new_value` into the subtree and return a new subtree with the inserted value.
@@ -625,57 +622,35 @@ impl<V> Subtree<V> {
 }
 
 /// Iterator of values in tree.
-struct ValuesIterator<'a, L, F, V> {
+struct ValuesIterator<'a, 'b, L, V> {
     /// Blob store loader reference
     loader: &'a L,
-    /// Already "peeked" value that is the next item if present.
-    peeked_value: Option<HashedCacheableRef<V>>,
     /// Stack of next nodes to visit.
-    node_stack: Vec<HashedCacheableRef<Subtree<V>>>,
-    /// Closure to access iterated values.
-    read: F,
+    node_stack: Vec<OwnedOrBorrowed<'b, Subtree<V>>>,
     /// Size of the full tree (constant).
     tree_size: u64,
     /// Key of next item to be returned by the iterator.
     next_key: SubtreeKey,
 }
 
-impl<'a, L: BlobStoreLoad, F, V> ValuesIterator<'a, L, F, V> {
-    fn new(subtree: &Subtree<V>, loader: &'a L, read: F, tree_size: u64) -> Self {
-        match subtree {
-            Subtree::Leaf(value_ref) => Self {
-                loader,
-                peeked_value: Some(value_ref.clone()),
-                node_stack: vec![],
-                read,
-                tree_size,
-                next_key: SubtreeKey(0),
-            },
-            Subtree::Node(_, left_ref, right_ref) => Self {
-                loader,
-                peeked_value: None,
-                node_stack: vec![right_ref.clone(), left_ref.clone()],
-                read,
-                tree_size,
-                next_key: SubtreeKey(0),
-            },
+impl<'a, 'b, L: BlobStoreLoad, V> ValuesIterator<'a, 'b, L, V> {
+    fn new(subtree: &'b Subtree<V>, loader: &'a L, tree_size: u64) -> Self {
+        Self {
+            loader,
+            node_stack: vec![OwnedOrBorrowed::Borrowed(subtree)],
+            tree_size,
+            next_key: SubtreeKey(0),
         }
     }
 }
 
-impl<'a, L: BlobStoreLoad, F, V: Loadable, T> ExactSizeIterator for ValuesIterator<'a, L, F, V> where
-    F: FnMut(SubtreeKey, OwnedOrBorrowed<'_, V>) -> BlockStateResult<T>
-{
-}
+impl<'a, 'b, L: BlobStoreLoad, V: Loadable> ExactSizeIterator for ValuesIterator<'a, 'b, L, V> {}
 
-impl<'a, L: BlobStoreLoad, F, V: Loadable, T> Iterator for ValuesIterator<'a, L, F, V>
-where
-    F: FnMut(SubtreeKey, OwnedOrBorrowed<'_, V>) -> BlockStateResult<T>,
-{
-    type Item = BlockStateResult<T>;
+impl<'a, 'b, L: BlobStoreLoad, V: Loadable> Iterator for ValuesIterator<'a, 'b, L, V> {
+    type Item = BlockStateResult<(SubtreeKey, OwnedOrBorrowed<'b, V>)>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(next_value) = self.peeked_value.take() {
+        if let Some(next_node_ref) = self.node_stack.pop() {
             if self.next_key.0 == self.tree_size {
                 return Some(Err(BlockStateFailure::Invariant(
                     "LFMB Subtree invariant broken: ValuesIterator next_key equal to tree_size before end of iterator"
@@ -685,26 +660,9 @@ where
             let key = self.next_key;
             self.next_key.0 += 1;
             Some(
-                next_value
-                    .value(self.loader)
-                    .and_then(|val| (self.read)(key, val)),
+                next_value_push_right_branches(self.loader, next_node_ref, &mut self.node_stack)
+                    .map(|v| (key, v)),
             )
-        } else if let Some(next_node_ref) = self.node_stack.pop() {
-            if self.next_key.0 == self.tree_size {
-                return Some(Err(BlockStateFailure::Invariant(
-                    "LFMB Subtree invariant broken: ValuesIterator next_key equal to tree_size before end of iterator"
-                        .to_string(),
-                )));
-            }
-            let key = self.next_key;
-            self.next_key.0 += 1;
-            Some(next_value_push_right_branches(
-                key,
-                self.loader,
-                &next_node_ref,
-                &mut self.node_stack,
-                &mut self.read,
-            ))
         } else {
             if self.next_key.0 != self.tree_size {
                 return Some(Err(BlockStateFailure::Invariant(format!(
@@ -724,23 +682,56 @@ where
 
 /// Follow left branches to reach next value while pushing all right branches to the
 /// node stack.
-fn next_value_push_right_branches<L: BlobStoreLoad, F, V: Loadable, T>(
-    key: SubtreeKey,
+fn next_value_push_right_branches<'b, L: BlobStoreLoad, V: Loadable>(
     loader: &L,
-    node_ref: &HashedCacheableRef<Subtree<V>>,
-    node_stack: &mut Vec<HashedCacheableRef<Subtree<V>>>,
-    read: &mut F,
-) -> BlockStateResult<T>
-where
-    F: FnMut(SubtreeKey, OwnedOrBorrowed<'_, V>) -> BlockStateResult<T>,
-{
-    match &*node_ref.value(loader)? {
-        Subtree::Leaf(value) => read(key, value.value(loader)?),
-        Subtree::Node(_, left_ref, right_ref) => {
-            node_stack.push(right_ref.clone());
-            next_value_push_right_branches(key, loader, left_ref, node_stack, read)
-        }
-    }
+    node: OwnedOrBorrowed<'b, Subtree<V>>,
+    node_stack: &mut Vec<OwnedOrBorrowed<'b, Subtree<V>>>,
+) -> BlockStateResult<OwnedOrBorrowed<'b, V>> {
+    Ok(match node {
+        OwnedOrBorrowed::Borrowed(node) => match node {
+            Subtree::Leaf(value) => value.value(loader)?,
+            Subtree::Node(_, left_ref, right_ref) => {
+                node_stack.push(right_ref.value(loader)?);
+                next_value_push_right_branches(loader, left_ref.value(loader)?, node_stack)?
+            }
+        },
+        OwnedOrBorrowed::Owned(node) => match node {
+            Subtree::Leaf(value) => value
+                .value(loader)?
+                .new_lifetime_if_owned()
+                .expect("Looking up the value in owned node must return owned value"),
+            Subtree::Node(_, left_ref, right_ref) => {
+                node_stack.push(
+                    right_ref
+                        .value(loader)?
+                        .new_lifetime_if_owned()
+                        .expect("Looking up the value in owned node must return owned value"),
+                );
+                next_value_push_right_branches(
+                    loader,
+                    left_ref
+                        .value(loader)?
+                        .new_lifetime_if_owned()
+                        .expect("Looking up the value in owned node must return owned value"),
+                    node_stack,
+                )?
+            }
+        },
+    })
+    // Ok(match node.value(loader)? {
+    //     OwnedOrBorrowed::Borrowed(Subtree::Leaf(value)) => value.value(loader)?,
+    //     OwnedOrBorrowed::Owned(Subtree::Leaf(value)) => {
+    //         value.value(loader)?.new_lifetime_if_owned().expect("")
+    //     }
+    //     OwnedOrBorrowed::Borrowed(Subtree::Node(_, left_ref, right_ref)) => {
+    //         node_stack.push(OwnedOrBorrowed::Borrowed(right_ref));
+    //         next_value_push_right_branches(loader, left_ref, node_stack)?
+    //     }
+    //     OwnedOrBorrowed::Owned(Subtree::Node(_, left_ref, right_ref)) => {
+    //         node_stack.push(OwnedOrBorrowed::Owned(right_ref));
+    //         next_value_push_right_branches(loader, left_ref, node_stack)?
+    //     }
+    // })
 }
 
 impl<K, V> Loadable for LfmbTree<K, V> {
@@ -901,7 +892,7 @@ mod tests {
         }
     }
 
-    fn create_tree(store: &mut impl BlobStoreLoad, size: u64) -> TestTree {
+    fn create_tree_in_memory(store: &mut impl BlobStoreLoad, size: u64) -> TestTree {
         let mut tree = TestTree::empty();
         for i in 0..size {
             let key;
@@ -926,7 +917,7 @@ mod tests {
             let mut store = BlobStoreStub::default();
 
             // Append values to tree
-            let tree = create_tree(&mut store, i);
+            let tree = create_tree_in_memory(&mut store, i);
 
             // Assert size
             assert_eq!(tree.size(), i, "get size for tree of size {}", i);
@@ -940,7 +931,7 @@ mod tests {
             let mut store = BlobStoreStub::default();
 
             // Append values to tree
-            let tree = create_tree(&mut store, i);
+            let tree = create_tree_in_memory(&mut store, i);
 
             // Lookup existing values
             for j in 0..i {
@@ -978,7 +969,7 @@ mod tests {
             let mut store = BlobStoreStub::default();
 
             // Append values to tree and store it
-            let tree = create_tree(&mut store, i);
+            let tree = create_tree_in_memory(&mut store, i);
             let tree = store_value(&mut store, &tree);
 
             // Lookup existing values
@@ -1010,17 +1001,17 @@ mod tests {
         }
     }
 
-    /// Test [`LfmbTree::values`]
+    /// Test [`LfmbTree::values`] for a tree that is in memory.
     #[test]
-    fn prop_test_values() {
+    fn prop_test_values_in_memory() {
         for i in 0..100 {
             let mut store = BlobStoreStub::default();
 
             // Append values to tree
-            let tree = create_tree(&mut store, i);
+            let tree = create_tree_in_memory(&mut store, i);
 
             // Iterate values
-            let mut values = tree.values(&store, |key, val| Ok((key, *val)));
+            let mut values = tree.values(&store);
 
             // Assert values as expected
             assert_eq!(
@@ -1034,7 +1025,7 @@ mod tests {
                 let (key, val) = entry_res.unwrap();
                 assert_eq!(key, TestKey(j), "key {} in tree of size {}", j, i);
                 assert_eq!(
-                    val,
+                    *val,
                     StoreSerialized(j + 10),
                     "value number {} in tree of size {}",
                     j,
@@ -1049,7 +1040,45 @@ mod tests {
         }
     }
 
-    // todo ar fix iterator
+    /// Test [`LfmbTree::values`] for a tree that is stored in blob store.
+    #[test]
+    fn prop_test_values_stored() {
+        for i in 0..100 {
+            let mut store = BlobStoreStub::default();
+
+            // Append values to tree
+            let tree = create_tree_in_memory(&mut store, i);
+            let tree = store_value(&mut store, &tree);
+
+            // Iterate values
+            let mut values = tree.values(&store);
+
+            // Assert values as expected
+            assert_eq!(
+                values.len(),
+                i as usize,
+                "values length for tree of size {}",
+                i
+            );
+            let mut j = 0;
+            while let Some(entry_res) = values.next() {
+                let (key, val) = entry_res.unwrap();
+                assert_eq!(key, TestKey(j), "key {} in tree of size {}", j, i);
+                assert_eq!(
+                    *val,
+                    StoreSerialized(j + 10),
+                    "value number {} in tree of size {}",
+                    j,
+                    i
+                );
+                j += 1;
+                assert_eq!(values.len(), (i - j) as usize);
+            }
+            assert_eq!(values.len(), 0);
+            assert_eq!(values.next().transpose().unwrap(), None);
+            assert_eq!(values.len(), 0);
+        }
+    }
 
     /// Test [`LfmbTree::update_value`]
     #[test]
@@ -1058,7 +1087,7 @@ mod tests {
             let mut store = BlobStoreStub::default();
 
             // Append values to tree
-            let mut tree = create_tree(&mut store, i);
+            let mut tree = create_tree_in_memory(&mut store, i);
 
             // Update each of the values
             for j in 0..i {
@@ -1103,7 +1132,7 @@ mod tests {
             let mut store = BlobStoreStub::default();
 
             // Append values to tree
-            let tree1 = create_tree(&mut store, i);
+            let tree1 = create_tree_in_memory(&mut store, i);
 
             // Store tree
             let blob_ref = blob_store::store_to_store(&mut store, &tree1);
@@ -1121,7 +1150,7 @@ mod tests {
     fn prop_test_cache() {
         for i in 0..100 {
             let mut store = BlobStoreStub::default();
-            let tree1 = create_tree(&mut store, i);
+            let tree1 = create_tree_in_memory(&mut store, i);
             let blob_ref = blob_store::store_to_store(&mut store, &tree1);
             let tree2: TestTree = blob_store::load_from_store(&store, blob_ref).unwrap();
 

--- a/plt/plt-block-state/src/block_state/lfmb_tree.rs
+++ b/plt/plt-block-state/src/block_state/lfmb_tree.rs
@@ -428,15 +428,14 @@ impl<V> Clone for Subtree<V> {
     }
 }
 
+/// [`Subtree`] where blob references have had their values loaded.
+/// Used as return value for [`OwnedOrBorrowed<Subtree>::with_referenced_values`].
 #[derive(Debug)]
-enum SubtreeWithReferencedValues<'b, V> {
-    /// Leaf with value
+enum SubtreeWithValues<'b, V> {
+    /// Leaf with value. See [`Subtree::Leaf`]
     Leaf(OwnedOrBorrowed<'b, V>),
     /// Node with two subtrees/branches.
-    ///
-    /// Invariant relating height `h` and branches:
-    /// * *size of left subtree* `== 2^h`
-    /// * `0 <` *size of right subtree* `<= 2^h`
+    /// See [`Subtree::Node`]
     Node(
         /// Height of tree
         u64,
@@ -465,7 +464,8 @@ impl<'b, V> OwnedOrBorrowed<'b, Subtree<V>> {
     ///
     /// Precondition/invariant: If the given subtree is owned,
     /// it is a precondition/invariant that the referenced values (leaf values and branch subtrees)
-    /// are not be in-memory. The invariant will be fulfilled in the returned subtrees.
+    /// are not be in-memory. The invariant will be fulfilled by the subtrees returned by this
+    /// function.
     /// If the given subtree is borrowed, there is no precondition for using the function.
     ///
     /// Notice that the precondition for owned subtrees is also true for a subtree that has just
@@ -476,31 +476,31 @@ impl<'b, V> OwnedOrBorrowed<'b, Subtree<V>> {
     ///
     /// Panics if the precondition described above is not fulfilled for the subtree.
     fn with_referenced_values(
-        self,
+        &self,
         loader: &impl BlobStoreLoad,
-    ) -> BlockStateResult<SubtreeWithReferencedValues<'b, V>>
+    ) -> BlockStateResult<SubtreeWithValues<'b, V>>
     where
         V: Loadable,
     {
         Ok(match self {
             OwnedOrBorrowed::Borrowed(Subtree::Leaf(value_ref)) => {
-                SubtreeWithReferencedValues::Leaf(value_ref.value(loader)?)
+                SubtreeWithValues::Leaf(value_ref.value(loader)?)
             }
             OwnedOrBorrowed::Borrowed(Subtree::Node(height, left_ref, right_ref)) => {
-                SubtreeWithReferencedValues::Node(
+                SubtreeWithValues::Node(
                     *height,
                     left_ref.value(loader)?,
                     right_ref.value(loader)?,
                 )
             }
-            OwnedOrBorrowed::Owned(Subtree::Leaf(value_ref)) => SubtreeWithReferencedValues::Leaf(
-                value_ref.value(loader)?.new_lifetime_if_owned().expect("Loading value reference in owned subtree should return owned value"),
+            OwnedOrBorrowed::Owned(Subtree::Leaf(value_ref)) => SubtreeWithValues::Leaf(
+                value_ref.value(loader)?.unconstrained_lifetime_if_owned().expect("Loading leaf value reference in owned subtree should return owned value"),
             ),
             OwnedOrBorrowed::Owned(Subtree::Node(height, left_ref, right_ref)) => {
-                SubtreeWithReferencedValues::Node(
-                    height,
-                    left_ref.value(loader)?.new_lifetime_if_owned().expect("Loading left branch reference in owned subtree should return owned subtree"),
-                    right_ref.value(loader)?.new_lifetime_if_owned().expect("Loading right branch reference in owned subtree should return owned subtree"),
+                SubtreeWithValues::Node(
+                    *height,
+                    left_ref.value(loader)?.unconstrained_lifetime_if_owned().expect("Loading left branch reference in owned subtree should return owned subtree"),
+                    right_ref.value(loader)?.unconstrained_lifetime_if_owned().expect("Loading right branch reference in owned subtree should return owned subtree"),
                 )
             }
         })
@@ -524,7 +524,7 @@ impl<'b, V> OwnedOrBorrowed<'b, Subtree<V>> {
         V: Loadable,
     {
         match self.with_referenced_values(loader)? {
-            SubtreeWithReferencedValues::Leaf(val) => {
+            SubtreeWithValues::Leaf(val) => {
                 // When we reach the leaf for the key, the key must be 0.
                 if key != SubtreeKey(0) {
                     return Err(BlockStateFailure::Invariant(format!(
@@ -534,7 +534,7 @@ impl<'b, V> OwnedOrBorrowed<'b, Subtree<V>> {
                 }
                 Ok(val)
             }
-            SubtreeWithReferencedValues::Node(height, left, right) => {
+            SubtreeWithValues::Node(height, left, right) => {
                 // The height'th bit in key decides if we should follow left `0`
                 // or right branch `1`. Additionally, when going right, we set the bit to 0.
                 // This allows us to check the invariant that the key must be identical to 0
@@ -783,8 +783,8 @@ fn next_value_push_right_branches<'b, L: BlobStoreLoad, V: Loadable>(
     node_stack: &mut Vec<OwnedOrBorrowed<'b, Subtree<V>>>,
 ) -> BlockStateResult<OwnedOrBorrowed<'b, V>> {
     Ok(match subtree.with_referenced_values(loader)? {
-        SubtreeWithReferencedValues::Leaf(value) => value,
-        SubtreeWithReferencedValues::Node(_, left, right) => {
+        SubtreeWithValues::Leaf(value) => value,
+        SubtreeWithValues::Node(_, left, right) => {
             node_stack.push(right);
             next_value_push_right_branches(loader, left, node_stack)?
         }

--- a/plt/plt-block-state/src/block_state/lfmb_tree.rs
+++ b/plt/plt-block-state/src/block_state/lfmb_tree.rs
@@ -695,28 +695,28 @@ fn next_value_push_right_branches<'b, L: BlobStoreLoad, V: Loadable>(
                 next_value_push_right_branches(loader, left_ref.value(loader)?, node_stack)?
             }
         },
-        OwnedOrBorrowed::Owned(node) => match node {
-            Subtree::Leaf(value) => value
-                .value(loader)?
-                .new_lifetime_if_owned()
-                .expect("Looking up the value in owned node must return owned value"),
-            Subtree::Node(_, left_ref, right_ref) => {
-                node_stack.push(
-                    right_ref
-                        .value(loader)?
-                        .new_lifetime_if_owned()
-                        .expect("Looking up the value in owned node must return owned value"),
-                );
-                next_value_push_right_branches(
-                    loader,
-                    left_ref
-                        .value(loader)?
-                        .new_lifetime_if_owned()
-                        .expect("Looking up the value in owned node must return owned value"),
-                    node_stack,
-                )?
+        OwnedOrBorrowed::Owned(node) => {
+            match node {
+                Subtree::Leaf(value) => value
+                    .value(loader)?
+                    .new_lifetime_if_owned()
+                    .expect("Looking up the value in owned node must return owned value"),
+                Subtree::Node(_, left_ref, right_ref) => {
+                    node_stack.push(
+                        right_ref.value(loader)?.new_lifetime_if_owned().expect(
+                            "Looking up the right ref in owned node must return owned value",
+                        ),
+                    );
+                    next_value_push_right_branches(
+                        loader,
+                        left_ref.value(loader)?.new_lifetime_if_owned().expect(
+                            "Looking up the left ref in owned node must return owned value",
+                        ),
+                        node_stack,
+                    )?
+                }
             }
-        },
+        }
     })
 }
 

--- a/plt/plt-block-state/src/block_state/lfmb_tree.rs
+++ b/plt/plt-block-state/src/block_state/lfmb_tree.rs
@@ -830,6 +830,8 @@ impl<V> Loadable for Subtree<V> {
         mut buffer: impl Read,
         loader: &impl BlobStoreLoad,
     ) -> BlockStateResult<Self> {
+        // Notice that the load implementation must ensure that the precondition
+        // on with_referenced_values is fulfilled for newly loaded subtrees.
         let disc: u8 = buffer.get().map_parse_err_to_block_state_err()?;
         Ok(match disc {
             0 => {

--- a/plt/plt-block-state/src/block_state/state/protocol_level_tokens.rs
+++ b/plt/plt-block-state/src/block_state/state/protocol_level_tokens.rs
@@ -46,8 +46,8 @@ impl ProtocolLevelTokens {
         &self,
         loader: &impl BlobStoreLoad,
     ) -> impl ExactSizeIterator<Item = BlockStateResult<TokenId>> {
-        self.tokens.values(loader, |_token_index, token| {
-            Ok(match token.configuration.value(loader)? {
+        self.tokens.values(loader).map(|item| {
+            Ok(match item?.1.configuration.value(loader)? {
                 OwnedOrBorrowed::Owned(v) => v.0.token_id,
                 OwnedOrBorrowed::Borrowed(r) => r.0.token_id.clone(),
             })
@@ -207,7 +207,9 @@ impl Loadable for ProtocolLevelTokens {
         // the blob store. This is not ideal. If the state is to be cached after loading, we would
         // rather wait until it is cached in memory before constructing the map.
         let token_id_map = tokens
-            .values(loader, |token_index, plt| {
+            .values(loader)
+            .map(|item| {
+                let (token_index, plt) = item?;
                 let conf = plt.configuration.value(loader)?;
                 Ok((normalize_token_id(&conf.0.token_id), token_index))
             })

--- a/plt/plt-block-state/src/block_state/state/protocol_level_tokens.rs
+++ b/plt/plt-block-state/src/block_state/state/protocol_level_tokens.rs
@@ -65,16 +65,20 @@ impl ProtocolLevelTokens {
         loader: &impl BlobStoreLoad,
         token_index: TokenIndex,
     ) -> BlockStateResult<SimplisticTokenKeyValueState> {
-        self.tokens
-            .lookup_value(loader, token_index, |token| {
-                Ok(match token {
-                    OwnedOrBorrowed::Owned(v) => v.key_value_state.0,
-                    OwnedOrBorrowed::Borrowed(r) => r.key_value_state.0.clone(),
-                })
-            })
-            .ok_or_else(|| {
-                BlockStateFailure::Invariant(format!("token not found by index: {:?}", token_index))
-            })?
+        Ok(
+            match self
+                .tokens
+                .lookup_value(loader, token_index)?
+                .ok_or_else(|| {
+                    BlockStateFailure::Invariant(format!(
+                        "token not found by index: {:?}",
+                        token_index
+                    ))
+                })? {
+                OwnedOrBorrowed::Owned(v) => v.key_value_state.0,
+                OwnedOrBorrowed::Borrowed(r) => r.key_value_state.0.clone(),
+            },
+        )
     }
 
     pub fn token_configuration(
@@ -82,13 +86,16 @@ impl ProtocolLevelTokens {
         loader: &impl BlobStoreLoad,
         token_index: TokenIndex,
     ) -> BlockStateResult<TokenConfiguration> {
-        self.tokens
-            .lookup_value(loader, token_index, |token| {
-                Ok(token.configuration.value(loader)?.into_owned().0)
-            })
+        Ok(self
+            .tokens
+            .lookup_value(loader, token_index)?
             .ok_or_else(|| {
                 BlockStateFailure::Invariant(format!("token not found by index: {:?}", token_index))
             })?
+            .configuration
+            .value(loader)?
+            .into_owned()
+            .0)
     }
 
     pub fn token_circulating_supply(
@@ -96,11 +103,14 @@ impl ProtocolLevelTokens {
         loader: &impl BlobStoreLoad,
         token_index: TokenIndex,
     ) -> BlockStateResult<RawTokenAmount> {
-        self.tokens
-            .lookup_value(loader, token_index, |token| Ok(token.circulating_supply.0))
+        Ok(self
+            .tokens
+            .lookup_value(loader, token_index)?
             .ok_or_else(|| {
                 BlockStateFailure::Invariant(format!("token not found by index: {:?}", token_index))
             })?
+            .circulating_supply
+            .0)
     }
 
     pub fn set_token_circulating_supply(

--- a/plt/plt-block-state/src/block_state/utils.rs
+++ b/plt/plt-block-state/src/block_state/utils.rs
@@ -25,8 +25,8 @@ impl<'a, T> OwnedOrBorrowed<'a, T> {
         }
     }
 
-    /// Return [`Self`] with new lifetime, if it is owned, else `None`.
-    pub fn new_lifetime_if_owned<'b>(self) -> Option<OwnedOrBorrowed<'b, T>> {
+    /// Return [`Self`] with new, unconstrained lifetime, if it is owned, else `None`.
+    pub fn unconstrained_lifetime_if_owned<'b>(self) -> Option<OwnedOrBorrowed<'b, T>> {
         match self {
             OwnedOrBorrowed::Owned(v) => Some(OwnedOrBorrowed::Owned(v)),
             OwnedOrBorrowed::Borrowed(_) => None,

--- a/plt/plt-block-state/src/block_state/utils.rs
+++ b/plt/plt-block-state/src/block_state/utils.rs
@@ -6,18 +6,30 @@ use std::ops::Deref;
 ///
 /// We use our own type instead of `Cow`, since we don't want to require
 /// `T` to implement `Clone` which `Cow` does.
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub enum OwnedOrBorrowed<'a, T> {
     Owned(T),
     Borrowed(&'a T),
 }
 
-impl<'a, T: Clone> OwnedOrBorrowed<'a, T> {
+impl<'a, T> OwnedOrBorrowed<'a, T> {
     /// Convert the possibly owned value into an owned value, by cloning
     /// if the value is represented by a reference.
-    pub fn into_owned(self) -> T {
+    pub fn into_owned(self) -> T
+    where
+        T: Clone,
+    {
         match self {
             OwnedOrBorrowed::Owned(v) => v,
             OwnedOrBorrowed::Borrowed(r) => r.clone(),
+        }
+    }
+
+    /// Return [`Self`] with new lifetime, if it is owned, else `None`.
+    pub fn new_lifetime_if_owned<'b>(self) -> Option<OwnedOrBorrowed<'b, T>> {
+        match self {
+            OwnedOrBorrowed::Owned(v) => Some(OwnedOrBorrowed::Owned(v)),
+            OwnedOrBorrowed::Borrowed(_) => None,
         }
     }
 }


### PR DESCRIPTION
## Purpose

Using the `OnceLock` in `HashedCacheableRef` mean that we can also borrow values when looking them up in the `LfmbTree` and get rid of the read closure.

## Changes

Removed read closure from

* `LfmbTree::lookup_value` 
* `LfmbTree::values`

They both use `LfmbTree::with_referenced_values` in their implementation. Notice that there is an internally enforced invariant described on `with_referenced_values`, that describes, how we can transform `OwnedOrBorrowed<'_, Subtree>` to `OwnedOrBorrowed` leaf value and branch subtrees, without breaking lifetimes.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
