### PR TITLE
Add lock queries to grpc servivce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Extend gRPC API with `GetLockList` (streaming `LockId`) and `GetLockInfo` (single CBOR-encoded `LockInfo`) v2 endpoints for inspecting protocol-level locks.
+
 # 11.1.0 (Devnet)
 
 - Support token operations in P11:

--- a/concordium-consensus/lib.def
+++ b/concordium-consensus/lib.def
@@ -25,6 +25,8 @@ EXPORTS
  getAccountInfoV2
  getTokenInfoV2
  getTokenAuthorizationsV2
+ getLockListV2
+ getLockInfoV2
  getAccountListV2
  getTokenListV2
  getModuleListV2

--- a/concordium-consensus/src-lib/Concordium/External/GRPC2.hs
+++ b/concordium-consensus/src-lib/Concordium/External/GRPC2.hs
@@ -240,7 +240,7 @@ getLockInfoV2 ::
     -- | Block hash.
     Ptr Word8 ->
     -- | Lock ID (24 bytes: three big-endian Word64 fields).
-    Ptr Word8 ->
+    Ptr SerializedLockId ->
     -- | Out pointer for writing the block hash that was used.
     Ptr Word8 ->
     Ptr ReceiverVec ->
@@ -251,7 +251,7 @@ getLockInfoV2 cptr blockType blockHashPtr lockIdPtr outHash outVec copierCbk = d
     Ext.ConsensusRunner mvr <- deRefStablePtr cptr
     let copier = callCopyToVecCallback copierCbk
     bhi <- decodeBlockHashInput blockType blockHashPtr
-    lockId <- peek (castPtr lockIdPtr) :: IO SerializedLockId
+    lockId <- peek (castPtr lockIdPtr)
     res <- runMVR (Q.getLockInfo bhi lockId) mvr
     case res of
         Q.BQRBlock _ (Left QLEUnknownLock) -> do
@@ -1419,7 +1419,7 @@ foreign export ccall
         -- | Block hash.
         Ptr Word8 ->
         -- | Lock ID (24 bytes: three big-endian Word64 fields).
-        Ptr Word8 ->
+        Ptr SerializedLockId ->
         -- | Out pointer for writing the block hash that was used.
         Ptr Word8 ->
         Ptr ReceiverVec ->

--- a/concordium-consensus/src-lib/Concordium/External/GRPC2.hs
+++ b/concordium-consensus/src-lib/Concordium/External/GRPC2.hs
@@ -20,7 +20,6 @@ import Data.Functor
 import Data.Int
 import qualified Data.ProtoLens as Proto
 import qualified Data.ProtoLens.Combinators as Proto
-import qualified Data.Serialize as S
 import qualified Data.Vector as Vec
 import Data.Word
 import Foreign
@@ -43,9 +42,12 @@ import Concordium.Crypto.SHA256 (Hash (Hash))
 import Concordium.External.Helpers
 import Concordium.GlobalState.Parameters (CryptographicParameters)
 import Concordium.ID.Parameters (withGlobalContext)
-import Concordium.Scheduler.ProtocolLevelTokens.Queries (QueryLockError (..), QueryTokenModuleError (..))
+import Concordium.Scheduler.ProtocolLevelTokens.Queries (
+    QueryLockError (..),
+    QueryTokenModuleError (..),
+    SerializedLockId,
+ )
 import qualified Concordium.Types.InvokeContract as InvokeContract
-import qualified Concordium.Types.Locks as Locks
 import qualified Concordium.Wasm as Wasm
 
 -- | An opaque representation of a Rust vector. This is used by callbacks to copy
@@ -230,15 +232,6 @@ getLockListV2 ::
     IO Int64
 getLockListV2 = blockStreamHelper Q.getLockList
 
--- | Decode a 'Locks.LockId' from a foreign pointer. Assumes 24 bytes are available
--- (three big-endian Word64 fields, matching the @Serialize LockId@ instance).
-decodeLockId :: Ptr Word8 -> IO Locks.LockId
-decodeLockId lockIdPtr = do
-    bs <- BS.unsafePackCStringLen (castPtr lockIdPtr, 24)
-    case S.decode bs of
-        Left err -> error $ "Precondition violation in FFI call (decodeLockId): " ++ err
-        Right lockId -> return lockId
-
 -- | Foreign-exported FFI entry point for the unary `GetLockInfo` gRPC v2 endpoint.
 getLockInfoV2 ::
     StablePtr Ext.ConsensusRunner ->
@@ -258,7 +251,7 @@ getLockInfoV2 cptr blockType blockHashPtr lockIdPtr outHash outVec copierCbk = d
     Ext.ConsensusRunner mvr <- deRefStablePtr cptr
     let copier = callCopyToVecCallback copierCbk
     bhi <- decodeBlockHashInput blockType blockHashPtr
-    lockId <- decodeLockId lockIdPtr
+    lockId <- peek (castPtr lockIdPtr) :: IO SerializedLockId
     res <- runMVR (Q.getLockInfo bhi lockId) mvr
     case res of
         Q.BQRBlock _ (Left QLEUnknownLock) -> do

--- a/concordium-consensus/src-lib/Concordium/External/GRPC2.hs
+++ b/concordium-consensus/src-lib/Concordium/External/GRPC2.hs
@@ -43,7 +43,7 @@ import Concordium.Crypto.SHA256 (Hash (Hash))
 import Concordium.External.Helpers
 import Concordium.GlobalState.Parameters (CryptographicParameters)
 import Concordium.ID.Parameters (withGlobalContext)
-import Concordium.Scheduler.ProtocolLevelTokens.Queries (QueryLockModuleError (..), QueryTokenModuleError (..))
+import Concordium.Scheduler.ProtocolLevelTokens.Queries (QueryLockError (..), QueryTokenModuleError (..))
 import qualified Concordium.Types.InvokeContract as InvokeContract
 import qualified Concordium.Types.Locks as Locks
 import qualified Concordium.Wasm as Wasm
@@ -261,16 +261,9 @@ getLockInfoV2 cptr blockType blockHashPtr lockIdPtr outHash outVec copierCbk = d
     lockId <- decodeLockId lockIdPtr
     res <- runMVR (Q.getLockInfo bhi lockId) mvr
     case res of
-        Q.BQRBlock _ (Left QLMEUnknownLock) -> do
+        Q.BQRBlock _ (Left QLEUnknownLock) -> do
             copyHashTo outHash res
             return $ queryResultCode QRNotFound
-        Q.BQRBlock _ (Left e@QLMEInternal{}) -> do
-            mvLog mvr Logger.External Logger.LLError $
-                "Internal error processing GetLockInfo: " ++ show e
-            return $ queryResultCode QRInternalError
-        Q.BQRBlock _ (Left QLMEUnavailable) -> do
-            copyHashTo outHash res
-            return $ queryResultCode QRUnavailable
         Q.BQRBlock _ (Right r) ->
             returnMessageWithBlock (copier outVec) outHash (res $> r)
         Q.BQRNoBlock ->

--- a/concordium-consensus/src-lib/Concordium/External/GRPC2.hs
+++ b/concordium-consensus/src-lib/Concordium/External/GRPC2.hs
@@ -20,6 +20,7 @@ import Data.Functor
 import Data.Int
 import qualified Data.ProtoLens as Proto
 import qualified Data.ProtoLens.Combinators as Proto
+import qualified Data.Serialize as S
 import qualified Data.Vector as Vec
 import Data.Word
 import Foreign
@@ -42,8 +43,9 @@ import Concordium.Crypto.SHA256 (Hash (Hash))
 import Concordium.External.Helpers
 import Concordium.GlobalState.Parameters (CryptographicParameters)
 import Concordium.ID.Parameters (withGlobalContext)
-import Concordium.Scheduler.ProtocolLevelTokens.Queries (QueryTokenModuleError (..))
+import Concordium.Scheduler.ProtocolLevelTokens.Queries (QueryLockModuleError (..), QueryTokenModuleError (..))
 import qualified Concordium.Types.InvokeContract as InvokeContract
+import qualified Concordium.Types.Locks as Locks
 import qualified Concordium.Wasm as Wasm
 
 -- | An opaque representation of a Rust vector. This is used by callbacks to copy
@@ -212,6 +214,67 @@ getTokenAuthorizationsV2 cptr blockType blockHashPtr tokenIdPtr tokenIdLen outHa
                     returnMessageWithBlock (copier outVec) outHash (res $> r)
                 Q.BQRNoBlock ->
                     return $ queryResultCode QRNotFound
+
+-- | Foreign-exported FFI entry point for the streaming `GetLockList` gRPC v2 endpoint.
+-- Streams the list of all PLT lock ids that exist at the end of the resolved block.
+getLockListV2 ::
+    StablePtr Ext.ConsensusRunner ->
+    Ptr SenderChannel ->
+    -- | Block type.
+    Word8 ->
+    -- | Block hash.
+    Ptr Word8 ->
+    -- | Out pointer for writing the block hash that was used.
+    Ptr Word8 ->
+    FunPtr (Ptr SenderChannel -> Ptr Word8 -> Int64 -> IO Int32) ->
+    IO Int64
+getLockListV2 = blockStreamHelper Q.getLockList
+
+-- | Decode a 'Locks.LockId' from a foreign pointer. Assumes 24 bytes are available
+-- (three big-endian Word64 fields, matching the @Serialize LockId@ instance).
+decodeLockId :: Ptr Word8 -> IO Locks.LockId
+decodeLockId lockIdPtr = do
+    bs <- BS.unsafePackCStringLen (castPtr lockIdPtr, 24)
+    case S.decode bs of
+        Left err -> error $ "Precondition violation in FFI call (decodeLockId): " ++ err
+        Right lockId -> return lockId
+
+-- | Foreign-exported FFI entry point for the unary `GetLockInfo` gRPC v2 endpoint.
+getLockInfoV2 ::
+    StablePtr Ext.ConsensusRunner ->
+    -- | Block type.
+    Word8 ->
+    -- | Block hash.
+    Ptr Word8 ->
+    -- | Lock ID (24 bytes: three big-endian Word64 fields).
+    Ptr Word8 ->
+    -- | Out pointer for writing the block hash that was used.
+    Ptr Word8 ->
+    Ptr ReceiverVec ->
+    -- | Callback to output data.
+    FunPtr CopyToVecCallback ->
+    IO Int64
+getLockInfoV2 cptr blockType blockHashPtr lockIdPtr outHash outVec copierCbk = do
+    Ext.ConsensusRunner mvr <- deRefStablePtr cptr
+    let copier = callCopyToVecCallback copierCbk
+    bhi <- decodeBlockHashInput blockType blockHashPtr
+    lockId <- decodeLockId lockIdPtr
+    res <- runMVR (Q.getLockInfo bhi lockId) mvr
+    case res of
+        Q.BQRBlock _ (Left QLMEUnknownLock) -> do
+            copyHashTo outHash res
+            return $ queryResultCode QRNotFound
+        Q.BQRBlock _ (Left e@QLMEInternal{}) -> do
+            mvLog mvr Logger.External Logger.LLError $
+                "Internal error processing GetLockInfo: " ++ show e
+            return $ queryResultCode QRInternalError
+        Q.BQRBlock _ (Left QLMEUnavailable) -> do
+            copyHashTo outHash res
+            return $ queryResultCode QRUnavailable
+        Q.BQRBlock _ (Right r) ->
+            returnMessageWithBlock (copier outVec) outHash (res $> r)
+        Q.BQRNoBlock ->
+            return $ queryResultCode QRNotFound
 
 -- | Optionally copy a block hash (32 bytes) to a pointer.
 -- Used to provide back the block hash used in a given query, via the FFI.
@@ -1360,6 +1423,35 @@ foreign export ccall
         Ptr ReceiverVec ->
         -- | Callback to output data.
         FunPtr CopyToVecCallback ->
+        IO Int64
+
+foreign export ccall
+    getLockInfoV2 ::
+        StablePtr Ext.ConsensusRunner ->
+        -- | Block type.
+        Word8 ->
+        -- | Block hash.
+        Ptr Word8 ->
+        -- | Lock ID (24 bytes: three big-endian Word64 fields).
+        Ptr Word8 ->
+        -- | Out pointer for writing the block hash that was used.
+        Ptr Word8 ->
+        Ptr ReceiverVec ->
+        -- | Callback to output data.
+        FunPtr CopyToVecCallback ->
+        IO Int64
+
+foreign export ccall
+    getLockListV2 ::
+        StablePtr Ext.ConsensusRunner ->
+        Ptr SenderChannel ->
+        -- | Block type.
+        Word8 ->
+        -- | Block hash.
+        Ptr Word8 ->
+        -- | Out pointer for writing the block hash that was used.
+        Ptr Word8 ->
+        FunPtr (Ptr SenderChannel -> Ptr Word8 -> Int64 -> IO Int32) ->
         IO Int64
 
 foreign export ccall

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -1214,8 +1214,7 @@ getTokenAuthorizations blockHashInput tokenId = liftSkovQueryStateBHI (queryToke
 getLockList :: BlockHashInput -> MVR finconf (BHIQueryResponse [Locks.LockId])
 getLockList = liftSkovQueryStateBHI queryLockList
 
--- | Get the CBOR-encoded `lock-info` payload for a given lock id, wrapped in the opaque
--- 'LockQueries.LockInfo' newtype.
+-- | Get the CBOR-encoded `lock-info` payload for a given lock id.
 getLockInfo :: BlockHashInput -> Locks.LockId -> MVR finconf (BHIQueryResponse (Either QueryLockError Locks.LockInfo))
 getLockInfo blockHashInput lockId = liftSkovQueryStateBHI (queryLockInfo lockId) blockHashInput
 

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -94,6 +94,7 @@ import Concordium.MultiVersion
 import Concordium.Scheduler.ProtocolLevelTokens.Queries (
     QueryLockError,
     QueryTokenModuleError,
+    SerializedLockId,
     queryAccountTokens,
     queryLockInfo,
     queryLockList,
@@ -1215,7 +1216,7 @@ getLockList :: BlockHashInput -> MVR finconf (BHIQueryResponse [Locks.LockId])
 getLockList = liftSkovQueryStateBHI queryLockList
 
 -- | Get the CBOR-encoded `lock-info` payload for a given lock id.
-getLockInfo :: BlockHashInput -> Locks.LockId -> MVR finconf (BHIQueryResponse (Either QueryLockError Locks.LockInfo))
+getLockInfo :: BlockHashInput -> SerializedLockId -> MVR finconf (BHIQueryResponse (Either QueryLockError Locks.LockInfo))
 getLockInfo blockHashInput lockId = liftSkovQueryStateBHI (queryLockInfo lockId) blockHashInput
 
 -- | Get the details of an account in the block state.

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -92,7 +92,7 @@ import Concordium.Kontrol
 import Concordium.Kontrol.BestBlock
 import Concordium.MultiVersion
 import Concordium.Scheduler.ProtocolLevelTokens.Queries (
-    QueryLockModuleError,
+    QueryLockError,
     QueryTokenModuleError,
     queryAccountTokens,
     queryLockInfo,
@@ -1216,7 +1216,7 @@ getLockList = liftSkovQueryStateBHI queryLockList
 
 -- | Get the CBOR-encoded `lock-info` payload for a given lock id, wrapped in the opaque
 -- 'LockQueries.LockInfo' newtype.
-getLockInfo :: BlockHashInput -> Locks.LockId -> MVR finconf (BHIQueryResponse (Either QueryLockModuleError Locks.LockInfo))
+getLockInfo :: BlockHashInput -> Locks.LockId -> MVR finconf (BHIQueryResponse (Either QueryLockError Locks.LockInfo))
 getLockInfo blockHashInput lockId = liftSkovQueryStateBHI (queryLockInfo lockId) blockHashInput
 
 -- | Get the details of an account in the block state.

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -46,10 +46,12 @@ import Concordium.Types.Execution (
  )
 import Concordium.Types.HashableTo
 import Concordium.Types.IdentityProviders
+import qualified Concordium.Types.Locks as Locks
 import Concordium.Types.Option
 import Concordium.Types.Parameters
 import Concordium.Types.Queries hiding (PassiveCommitteeInfo (..), bakerId)
 import qualified Concordium.Types.Queries.KonsensusV1 as QueriesKonsensusV1
+import qualified Concordium.Types.Queries.Locks as Locks
 import qualified Concordium.Types.Queries.Tokens as Tokens
 import Concordium.Types.SeedState
 import Concordium.Types.Transactions
@@ -89,7 +91,16 @@ import qualified Concordium.KonsensusV1.Types as SkovV1
 import Concordium.Kontrol
 import Concordium.Kontrol.BestBlock
 import Concordium.MultiVersion
-import Concordium.Scheduler.ProtocolLevelTokens.Queries (QueryTokenModuleError, queryAccountTokens, queryPLTList, queryTokenAuthorizations, queryTokenInfo)
+import Concordium.Scheduler.ProtocolLevelTokens.Queries (
+    QueryLockModuleError,
+    QueryTokenModuleError,
+    queryAccountTokens,
+    queryLockInfo,
+    queryLockList,
+    queryPLTList,
+    queryTokenAuthorizations,
+    queryTokenInfo,
+ )
 import Concordium.Skov as Skov (
     SkovQueryMonad (getBlocksAtHeight),
     evalSkovT,
@@ -1198,6 +1209,15 @@ getTokenInfo blockHashInput tokenId = liftSkovQueryStateBHI (queryTokenInfo toke
 -- | Get the details of token authorizations in the block state.
 getTokenAuthorizations :: BlockHashInput -> TokenId -> MVR finconf (BHIQueryResponse (Either QueryTokenModuleError Tokens.TokenAuthorizations))
 getTokenAuthorizations blockHashInput tokenId = liftSkovQueryStateBHI (queryTokenAuthorizations tokenId) blockHashInput
+
+-- | Get a list of all PLT lock ids that exist in the block state.
+getLockList :: BlockHashInput -> MVR finconf (BHIQueryResponse [Locks.LockId])
+getLockList = liftSkovQueryStateBHI queryLockList
+
+-- | Get the CBOR-encoded `lock-info` payload for a given lock id, wrapped in the opaque
+-- 'LockQueries.LockInfo' newtype.
+getLockInfo :: BlockHashInput -> Locks.LockId -> MVR finconf (BHIQueryResponse (Either QueryLockModuleError Locks.LockInfo))
+getLockInfo blockHashInput lockId = liftSkovQueryStateBHI (queryLockInfo lockId) blockHashInput
 
 -- | Get the details of an account in the block state.
 --  The account can be given via an address, an account index or a credential registration id.

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Queries.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Queries.hs
@@ -6,7 +6,7 @@
 
 module Concordium.Scheduler.ProtocolLevelTokens.Queries (
     QueryTokenModuleError (..),
-    QueryLockModuleError (..),
+    QueryLockError (..),
     queryTokenInfo,
     queryAccountTokens,
     queryPLTList,
@@ -210,26 +210,17 @@ queryPLTList bs =
         SPLTStateV0 -> BS.getPLTList bs
         SPLTStateV1 -> RustQ.queryPLTList bs
 
--- | An error that may occur as a result of 'queryLockInfo'.
-data QueryLockModuleError
+-- | An error that may occur as a result of a lock query.
+data QueryLockError
     = -- | The requested lock does not exist in the block.
-      QLMEUnknownLock
-    | -- | An internal error occurred during the lock query (currently unused; kept for parity
-      --   with 'QueryTokenModuleError' so future failure modes can be reported without
-      --   changing the public API).
-      QLMEInternal
-    | -- | The protocol version does not support the query.
-      QLMEUnavailable
+      QLEUnknownLock
     deriving (Eq)
 
-instance Show QueryLockModuleError where
-    show QLMEUnknownLock = "unknown lock"
-    show QLMEInternal = "internal error processing lock query"
-    show QLMEUnavailable = "The information is not available for this block"
+instance Show QueryLockError where
+    show QLEUnknownLock = "unknown lock"
 
 -- | Get the list of all PLT lock ids that exist in the given block. Pre-V1 PLT state versions
--- (including no PLT support) return the empty list, mirroring 'queryPLTList'. The returned ids
--- are forwarded verbatim from the Rust scheduler.
+-- (including no PLT support) return the empty list.
 queryLockList ::
     forall m.
     (BS.BlockStateQuery m) =>
@@ -241,21 +232,17 @@ queryLockList bs =
         SPLTStateV0 -> return []
         SPLTStateV1 -> RustQ.queryLockList bs
 
--- | Get the CBOR-encoded `lock-info` payload for a given lock id, wrapped in the opaque
--- 'LockQueries.LockInfo' newtype. The Haskell layer treats the payload as opaque bytes —
--- it never parses, validates, or re-encodes the CBOR. Pre-V1 PLT state versions return
--- 'QLMEUnknownLock' (this matches the precedent set by 'queryTokenAuthorizations' for
--- the V0 / no-PLT cases).
+-- | Get the 'LockQueries.LockInfo' for a goven lock ID.
 queryLockInfo ::
     forall m.
     (BS.BlockStateQuery m) =>
     Locks.LockId ->
     BlockState m ->
-    m (Either QueryLockModuleError LockQueries.LockInfo)
+    m (Either QueryLockError LockQueries.LockInfo)
 queryLockInfo lockId bs = case sPltStateVersionFor (protocolVersion @(MPV m)) of
-    SPLTStateNone -> return (Left QLMEUnknownLock)
-    SPLTStateV0 -> return (Left QLMEUnknownLock)
+    SPLTStateNone -> return (Left QLEUnknownLock)
+    SPLTStateV0 -> return (Left QLEUnknownLock)
     SPLTStateV1 ->
         RustQ.queryLockInfo bs lockId <&> \case
             Just lockInfo -> Right lockInfo
-            Nothing -> Left QLMEUnknownLock
+            Nothing -> Left QLEUnknownLock

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Queries.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Queries.hs
@@ -6,10 +6,13 @@
 
 module Concordium.Scheduler.ProtocolLevelTokens.Queries (
     QueryTokenModuleError (..),
+    QueryLockModuleError (..),
     queryTokenInfo,
     queryAccountTokens,
     queryPLTList,
     queryTokenAuthorizations,
+    queryLockList,
+    queryLockInfo,
 ) where
 
 import Control.Monad
@@ -20,6 +23,8 @@ import qualified Data.Map.Strict as Map
 import Data.Void
 
 import Concordium.Types
+import qualified Concordium.Types.Locks as Locks
+import qualified Concordium.Types.Queries.Locks as LockQueries
 import Concordium.Types.Queries.Tokens
 
 import qualified Concordium.GlobalState.BlockState as BS
@@ -204,3 +209,53 @@ queryPLTList bs =
         SPLTStateNone -> return []
         SPLTStateV0 -> BS.getPLTList bs
         SPLTStateV1 -> RustQ.queryPLTList bs
+
+-- | An error that may occur as a result of 'queryLockInfo'.
+data QueryLockModuleError
+    = -- | The requested lock does not exist in the block.
+      QLMEUnknownLock
+    | -- | An internal error occurred during the lock query (currently unused; kept for parity
+      --   with 'QueryTokenModuleError' so future failure modes can be reported without
+      --   changing the public API).
+      QLMEInternal
+    | -- | The protocol version does not support the query.
+      QLMEUnavailable
+    deriving (Eq)
+
+instance Show QueryLockModuleError where
+    show QLMEUnknownLock = "unknown lock"
+    show QLMEInternal = "internal error processing lock query"
+    show QLMEUnavailable = "The information is not available for this block"
+
+-- | Get the list of all PLT lock ids that exist in the given block. Pre-V1 PLT state versions
+-- (including no PLT support) return the empty list, mirroring 'queryPLTList'. The returned ids
+-- are forwarded verbatim from the Rust scheduler.
+queryLockList ::
+    forall m.
+    (BS.BlockStateQuery m) =>
+    BlockState m ->
+    m [Locks.LockId]
+queryLockList bs =
+    case sPltStateVersionFor (protocolVersion @(MPV m)) of
+        SPLTStateNone -> return []
+        SPLTStateV0 -> return []
+        SPLTStateV1 -> RustQ.queryLockList bs
+
+-- | Get the CBOR-encoded `lock-info` payload for a given lock id, wrapped in the opaque
+-- 'LockQueries.LockInfo' newtype. The Haskell layer treats the payload as opaque bytes —
+-- it never parses, validates, or re-encodes the CBOR. Pre-V1 PLT state versions return
+-- 'QLMEUnknownLock' (this matches the precedent set by 'queryTokenAuthorizations' for
+-- the V0 / no-PLT cases).
+queryLockInfo ::
+    forall m.
+    (BS.BlockStateQuery m) =>
+    Locks.LockId ->
+    BlockState m ->
+    m (Either QueryLockModuleError LockQueries.LockInfo)
+queryLockInfo lockId bs = case sPltStateVersionFor (protocolVersion @(MPV m)) of
+    SPLTStateNone -> return (Left QLMEUnknownLock)
+    SPLTStateV0 -> return (Left QLMEUnknownLock)
+    SPLTStateV1 ->
+        RustQ.queryLockInfo bs lockId <&> \case
+            Just lockInfo -> Right lockInfo
+            Nothing -> Left QLMEUnknownLock

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Queries.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Queries.hs
@@ -232,7 +232,7 @@ queryLockList bs =
         SPLTStateV0 -> return []
         SPLTStateV1 -> RustQ.queryLockList bs
 
--- | Get the 'LockQueries.LockInfo' for a goven lock ID.
+-- | Get the 'LockQueries.LockInfo' for a given lock ID.
 queryLockInfo ::
     forall m.
     (BS.BlockStateQuery m) =>

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Queries.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/Queries.hs
@@ -7,6 +7,7 @@
 module Concordium.Scheduler.ProtocolLevelTokens.Queries (
     QueryTokenModuleError (..),
     QueryLockError (..),
+    SerializedLockId,
     queryTokenInfo,
     queryAccountTokens,
     queryPLTList,
@@ -232,11 +233,13 @@ queryLockList bs =
         SPLTStateV0 -> return []
         SPLTStateV1 -> RustQ.queryLockList bs
 
+type SerializedLockId = RustQ.SerializedLockId
+
 -- | Get the 'LockQueries.LockInfo' for a given lock ID.
 queryLockInfo ::
     forall m.
     (BS.BlockStateQuery m) =>
-    Locks.LockId ->
+    SerializedLockId ->
     BlockState m ->
     m (Either QueryLockError LockQueries.LockInfo)
 queryLockInfo lockId bs = case sPltStateVersionFor (protocolVersion @(MPV m)) of

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/RustPLTScheduler/Queries.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/RustPLTScheduler/Queries.hs
@@ -614,19 +614,17 @@ foreign import ccall "ffi_query_lock_list"
         FFI.Ptr FFI.CSize ->
         IO Word.Word8
 
-lockIdSize :: Int
-lockIdSize = 24
-
+-- | Placeholder type representing the size of a serialized 'LockId' (24 bytes).
 data LockIdSize
 
 instance FBS.FixedLength LockIdSize where
-    fixedLength _ = lockIdSize
+    fixedLength _ = 24
 
--- | A serialized lock id as passed across the FFI boundary.
+-- | A serialized Lock ID as passed across the FFI boundary.
 newtype SerializedLockId = SerializedLockId (FBS.FixedByteString LockIdSize)
     deriving (FFI.Storable)
 
--- | Get the CBOR-encoded `lock-info` payload for a given lock id, for a protocol version where the
+-- | Get the CBOR-encoded `lock-info` payload for a given Lock ID, for a protocol version where the
 -- PLT state is managed in Rust. The returned 'LockInfo' wraps the raw CBOR bytes verbatim; this
 -- module never parses or re-encodes them. Pattern follows 'queryTokenInfo'.
 queryLockInfo ::
@@ -678,10 +676,6 @@ queryLockInfo bs lockId = do
                         FFI.freeHaskellFunPtr getTokenAccountStatesCallbackPtr
                         returnDataLen <- FFI.peek returnDataLenOutPtr
                         returnDataPtr <- FFI.peek returnDataPtrOutPtr
-                        -- Copy the FFI output buffer into a strict 'ByteString' that owns its
-                        -- storage, so the buffer can be released by the finalizer immediately
-                        -- after this call returns. The CBOR bytes are stored opaquely in
-                        -- 'LockQueries.LockInfo'.
                         returnData <-
                             BS.unsafePackCStringFinalizer
                                 returnDataPtr
@@ -689,7 +683,7 @@ queryLockInfo bs lockId = do
                                 (Memory.rs_free_array_len_2 returnDataPtr (fromIntegral returnDataLen))
                         case Status.parseStatusCode statusCode of
                             Just Status.FSCSuccess ->
-                                return $ Just $ LockQueries.LockInfo (BS.copy returnData)
+                                return $ Just $ LockQueries.LockInfo returnData
                             Just Status.FSCFailed ->
                                 return Nothing
                             Just Status.FSCPanic -> do

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/RustPLTScheduler/Queries.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/RustPLTScheduler/Queries.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -7,6 +8,7 @@
 --
 -- Each foreign imported function must match the signature of functions found on the Rust side.
 module Concordium.Scheduler.ProtocolLevelTokens.RustPLTScheduler.Queries (
+    SerializedLockId,
     queryPLTList,
     queryTokenInfo,
     queryTokenAccountInfos,
@@ -40,6 +42,7 @@ import qualified Concordium.GlobalState.Types as BS
 import Concordium.Scheduler.ProtocolLevelTokens.RustPLTScheduler.BlockStateCallbacks
 import qualified Concordium.Scheduler.ProtocolLevelTokens.RustPLTScheduler.Memory as Memory
 import qualified Concordium.Scheduler.ProtocolLevelTokens.RustPLTScheduler.Status as Status
+import qualified Data.FixedByteString as FBS
 import qualified Data.Text.Encoding as Text
 
 -- | Get the list of all tokens, for protocol version where the PLT state is managed in Rust.
@@ -611,6 +614,18 @@ foreign import ccall "ffi_query_lock_list"
         FFI.Ptr FFI.CSize ->
         IO Word.Word8
 
+lockIdSize :: Int
+lockIdSize = 24
+
+data LockIdSize
+
+instance FBS.FixedLength LockIdSize where
+    fixedLength _ = lockIdSize
+
+-- | A serialized lock id as passed across the FFI boundary.
+newtype SerializedLockId = SerializedLockId (FBS.FixedByteString LockIdSize)
+    deriving (FFI.Storable)
+
 -- | Get the CBOR-encoded `lock-info` payload for a given lock id, for a protocol version where the
 -- PLT state is managed in Rust. The returned 'LockInfo' wraps the raw CBOR bytes verbatim; this
 -- module never parses or re-encodes them. Pattern follows 'queryTokenInfo'.
@@ -619,8 +634,8 @@ queryLockInfo ::
     (Types.PVSupportsRustManagedPLT (Types.MPV m), BS.BlockStateQuery m) =>
     -- | Block state to query.
     BS.BlockState m ->
-    -- | The lock to query.
-    Locks.LockId ->
+    -- | The serialized lock id to query.
+    SerializedLockId ->
     -- | The lock info, or 'Nothing' if the lock does not exist.
     m (Maybe LockQueries.LockInfo)
 queryLockInfo bs lockId = do
@@ -644,21 +659,19 @@ queryLockInfo bs lockId = do
                         getAccountIndexByAddressCallbackPtr <- wrapGetAccountIndexByAddress $ getAccountIndexByAddress queryCallbacks
                         getAccountAddressByIndexCallbackPtr <- wrapGetAccountAddressByIndex $ getAccountAddressByIndex queryCallbacks
                         getTokenAccountStatesCallbackPtr <- wrapGetTokenAccountStates $ getTokenAccountStates queryCallbacks
-                        -- Serialize the LockId as 24 big-endian bytes (three Word64s), which is the
-                        -- exact representation expected by `ffi_query_lock_info`.
-                        let lockIdBytes = S.encode lockId
                         statusCode <- PLTBlockState.withPLTBlockState pltBlockState $ \pltBlockStatePtr ->
-                            BS.unsafeUseAsCString lockIdBytes $ \lockIdPtr ->
-                                ffiQueryLockInfo
-                                    loadCallbackPtr
-                                    readTokenAccountBalanceCallbackPtr
-                                    getAccountIndexByAddressCallbackPtr
-                                    getAccountAddressByIndexCallbackPtr
-                                    getTokenAccountStatesCallbackPtr
-                                    pltBlockStatePtr
-                                    (FFI.castPtr lockIdPtr)
-                                    returnDataPtrOutPtr
-                                    returnDataLenOutPtr
+                            let SerializedLockId lockIdBytes = lockId
+                            in  FBS.withPtrReadOnly lockIdBytes $ \lockIdPtr ->
+                                    ffiQueryLockInfo
+                                        loadCallbackPtr
+                                        readTokenAccountBalanceCallbackPtr
+                                        getAccountIndexByAddressCallbackPtr
+                                        getAccountAddressByIndexCallbackPtr
+                                        getTokenAccountStatesCallbackPtr
+                                        pltBlockStatePtr
+                                        lockIdPtr
+                                        returnDataPtrOutPtr
+                                        returnDataLenOutPtr
                         FFI.freeHaskellFunPtr readTokenAccountBalanceCallbackPtr
                         FFI.freeHaskellFunPtr getAccountIndexByAddressCallbackPtr
                         FFI.freeHaskellFunPtr getAccountAddressByIndexCallbackPtr

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/RustPLTScheduler/Queries.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/RustPLTScheduler/Queries.hs
@@ -11,6 +11,8 @@ module Concordium.Scheduler.ProtocolLevelTokens.RustPLTScheduler.Queries (
     queryTokenInfo,
     queryTokenAccountInfos,
     queryTokenAuthorizations,
+    queryLockList,
+    queryLockInfo,
 ) where
 
 import Control.Monad
@@ -25,6 +27,8 @@ import qualified Foreign as FFI
 import qualified Foreign.C.Types as FFI
 
 import qualified Concordium.Types as Types
+import qualified Concordium.Types.Locks as Locks
+import qualified Concordium.Types.Queries.Locks as LockQueries
 import qualified Concordium.Types.Queries.Tokens as QueriesTypes
 import qualified Concordium.Utils.Serialization as CS
 
@@ -548,3 +552,196 @@ unliftBlockStateQueryCallbacks bs = BS.withUnliftBSQ $ \unlift ->
                 fmap Map.toList $ unlift $ BS.getAccountTokens account
 
         return BlockStateQueryCallbacks{..}
+
+-- | Get the list of all PLT lock ids, for a protocol version where the PLT state is
+-- managed in Rust. Pattern follows 'queryPLTList'.
+queryLockList ::
+    forall m.
+    (Types.PVSupportsRustManagedPLT (Types.MPV m), BS.BlockStateQuery m) =>
+    -- | Block state to query.
+    BS.BlockState m ->
+    -- | The list of lock ids
+    m [Locks.LockId]
+queryLockList bs = do
+    queryCallbacks <- unliftBlockStateQueryCallbacks bs
+    pltState <- BS.getRustPLTBlockState bs
+    let protocolVersion = Types.demoteProtocolVersion $ Types.protocolVersion @(Types.MPV m)
+    BS.liftBlobStore $ queryLockListInBlobStoreMonad pltState queryCallbacks protocolVersion
+  where
+    queryLockListInBlobStoreMonad ::
+        (BlobStore.MonadBlobStore m') =>
+        PLTBlockState.ForeignPLTBlockStatePtr ->
+        BlockStateQueryCallbacks ->
+        Types.ProtocolVersion ->
+        m' [Locks.LockId]
+    queryLockListInBlobStoreMonad
+        pltBlockState
+        queryCallbacks
+        protocolVersion =
+            do
+                loadCallbackPtr <- fst <$> BlobStore.getCallbacks
+                liftIO $ FFI.alloca $ \returnDataPtrOutPtr -> FFI.alloca $ \returnDataLenOutPtr ->
+                    do
+                        readTokenAccountBalanceCallbackPtr <- wrapReadTokenAccountBalance $ readTokenAccountBalance queryCallbacks
+                        getAccountIndexByAddressCallbackPtr <- wrapGetAccountIndexByAddress $ getAccountIndexByAddress queryCallbacks
+                        getAccountAddressByIndexCallbackPtr <- wrapGetAccountAddressByIndex $ getAccountAddressByIndex queryCallbacks
+                        getTokenAccountStatesCallbackPtr <- wrapGetTokenAccountStates $ getTokenAccountStates queryCallbacks
+                        statusCode <- PLTBlockState.withPLTBlockState pltBlockState $ \pltBlockStatePtr ->
+                            ffiQueryLockList
+                                loadCallbackPtr
+                                readTokenAccountBalanceCallbackPtr
+                                getAccountIndexByAddressCallbackPtr
+                                getAccountAddressByIndexCallbackPtr
+                                getTokenAccountStatesCallbackPtr
+                                pltBlockStatePtr
+                                (Types.protocolVersionToWord64 protocolVersion)
+                                returnDataPtrOutPtr
+                                returnDataLenOutPtr
+                        FFI.freeHaskellFunPtr readTokenAccountBalanceCallbackPtr
+                        FFI.freeHaskellFunPtr getAccountIndexByAddressCallbackPtr
+                        FFI.freeHaskellFunPtr getAccountAddressByIndexCallbackPtr
+                        FFI.freeHaskellFunPtr getTokenAccountStatesCallbackPtr
+                        returnDataLen <- FFI.peek returnDataLenOutPtr
+                        returnDataPtr <- FFI.peek returnDataPtrOutPtr
+                        returnData <-
+                            BS.unsafePackCStringFinalizer
+                                returnDataPtr
+                                (fromIntegral returnDataLen)
+                                (Memory.rs_free_array_len_2 returnDataPtr (fromIntegral returnDataLen))
+                        case Status.parseStatusCode statusCode of
+                            Just Status.FSCSuccess -> do
+                                let getLockIdList = S.isolate (BS.length returnData) $ CS.getListOf S.get
+                                let lockIdList =
+                                        either
+                                            (\message -> error $ "Lock id list from Rust PLT Scheduler could not be deserialized: " ++ message)
+                                            id
+                                            $ S.runGet getLockIdList returnData
+                                return lockIdList
+                            Just Status.FSCPanic -> do
+                                let message = case Text.decodeUtf8' returnData of
+                                        Right decoded -> decoded
+                                        Left _ -> "<panic message was invalid UTF-8>"
+                                error ("Call to 'ffiQueryLockList' resulted in panic with message: " ++ show message)
+                            _ -> error ("Unexpected status code from calling 'ffiQueryLockList': " ++ show statusCode)
+
+-- | C-binding for calling the Rust function `plt_scheduler::queries::query_lock_list`.
+--
+-- Returns a byte representing the result:
+--
+-- - `0`: The query was successful
+--
+-- See the exported function in the Rust code for documentation of safety.
+foreign import ccall "ffi_query_lock_list"
+    ffiQueryLockList ::
+        FFI.LoadCallback ->
+        ReadTokenAccountBalanceCallbackPtr ->
+        GetAccountIndexByAddressCallbackPtr ->
+        GetAccountAddressByIndexCallbackPtr ->
+        GetTokenAccountStatesCallbackPtr ->
+        FFI.Ptr PLTBlockState.RustPLTBlockState ->
+        Word.Word64 ->
+        FFI.Ptr (FFI.Ptr Word.Word8) ->
+        FFI.Ptr FFI.CSize ->
+        IO Word.Word8
+
+-- | Get the CBOR-encoded `lock-info` payload for a given lock id, for a protocol version where the
+-- PLT state is managed in Rust. The returned 'LockInfo' wraps the raw CBOR bytes verbatim; this
+-- module never parses or re-encodes them. Pattern follows 'queryTokenInfo'.
+queryLockInfo ::
+    forall m.
+    (Types.PVSupportsRustManagedPLT (Types.MPV m), BS.BlockStateQuery m) =>
+    -- | Block state to query.
+    BS.BlockState m ->
+    -- | The lock to query.
+    Locks.LockId ->
+    -- | The lock info, or 'Nothing' if the lock does not exist.
+    m (Maybe LockQueries.LockInfo)
+queryLockInfo bs lockId = do
+    queryCallbacks <- unliftBlockStateQueryCallbacks bs
+    pltState <- BS.getRustPLTBlockState bs
+    let protocolVersion = Types.demoteProtocolVersion $ Types.protocolVersion @(Types.MPV m)
+    BS.liftBlobStore $ queryLockInfoInBlobStoreMonad pltState queryCallbacks protocolVersion
+  where
+    queryLockInfoInBlobStoreMonad ::
+        (BlobStore.MonadBlobStore m') =>
+        PLTBlockState.ForeignPLTBlockStatePtr ->
+        BlockStateQueryCallbacks ->
+        Types.ProtocolVersion ->
+        m' (Maybe LockQueries.LockInfo)
+    queryLockInfoInBlobStoreMonad
+        pltBlockState
+        queryCallbacks
+        protocolVersion =
+            do
+                loadCallbackPtr <- fst <$> BlobStore.getCallbacks
+                liftIO $ FFI.alloca $ \returnDataPtrOutPtr -> FFI.alloca $ \returnDataLenOutPtr ->
+                    do
+                        readTokenAccountBalanceCallbackPtr <- wrapReadTokenAccountBalance $ readTokenAccountBalance queryCallbacks
+                        getAccountIndexByAddressCallbackPtr <- wrapGetAccountIndexByAddress $ getAccountIndexByAddress queryCallbacks
+                        getAccountAddressByIndexCallbackPtr <- wrapGetAccountAddressByIndex $ getAccountAddressByIndex queryCallbacks
+                        getTokenAccountStatesCallbackPtr <- wrapGetTokenAccountStates $ getTokenAccountStates queryCallbacks
+                        -- Serialize the LockId as 24 big-endian bytes (three Word64s), which is the
+                        -- exact representation expected by `ffi_query_lock_info`.
+                        let lockIdBytes = S.encode lockId
+                        statusCode <- PLTBlockState.withPLTBlockState pltBlockState $ \pltBlockStatePtr ->
+                            BS.unsafeUseAsCString lockIdBytes $ \lockIdPtr ->
+                                ffiQueryLockInfo
+                                    loadCallbackPtr
+                                    readTokenAccountBalanceCallbackPtr
+                                    getAccountIndexByAddressCallbackPtr
+                                    getAccountAddressByIndexCallbackPtr
+                                    getTokenAccountStatesCallbackPtr
+                                    pltBlockStatePtr
+                                    (Types.protocolVersionToWord64 protocolVersion)
+                                    (FFI.castPtr lockIdPtr)
+                                    returnDataPtrOutPtr
+                                    returnDataLenOutPtr
+                        FFI.freeHaskellFunPtr readTokenAccountBalanceCallbackPtr
+                        FFI.freeHaskellFunPtr getAccountIndexByAddressCallbackPtr
+                        FFI.freeHaskellFunPtr getAccountAddressByIndexCallbackPtr
+                        FFI.freeHaskellFunPtr getTokenAccountStatesCallbackPtr
+                        returnDataLen <- FFI.peek returnDataLenOutPtr
+                        returnDataPtr <- FFI.peek returnDataPtrOutPtr
+                        -- Copy the FFI output buffer into a strict 'ByteString' that owns its
+                        -- storage, so the buffer can be released by the finalizer immediately
+                        -- after this call returns. The CBOR bytes are stored opaquely in
+                        -- 'LockQueries.LockInfo'.
+                        returnData <-
+                            BS.unsafePackCStringFinalizer
+                                returnDataPtr
+                                (fromIntegral returnDataLen)
+                                (Memory.rs_free_array_len_2 returnDataPtr (fromIntegral returnDataLen))
+                        case Status.parseStatusCode statusCode of
+                            Just Status.FSCSuccess ->
+                                return $ Just $ LockQueries.LockInfo (BS.copy returnData)
+                            Just Status.FSCFailed ->
+                                return Nothing
+                            Just Status.FSCPanic -> do
+                                let message = case Text.decodeUtf8' returnData of
+                                        Right decoded -> decoded
+                                        Left _ -> "<panic message was invalid UTF-8>"
+                                error ("Call to 'ffiQueryLockInfo' resulted in panic with message: " ++ show message)
+                            Nothing -> error ("Unexpected status code from calling 'ffiQueryLockInfo': " ++ show statusCode)
+
+-- | C-binding for calling the Rust function `plt_scheduler::queries::query_lock_info`.
+--
+-- Returns a byte representing the result:
+--
+-- - `0`: The query was successful
+-- - `1`: The lock does not exist
+--
+-- See the exported function in the Rust code for documentation of safety.
+foreign import ccall "ffi_query_lock_info"
+    ffiQueryLockInfo ::
+        FFI.LoadCallback ->
+        ReadTokenAccountBalanceCallbackPtr ->
+        GetAccountIndexByAddressCallbackPtr ->
+        GetAccountAddressByIndexCallbackPtr ->
+        GetTokenAccountStatesCallbackPtr ->
+        FFI.Ptr PLTBlockState.RustPLTBlockState ->
+        Word.Word64 ->
+        -- | Pointer to 24 bytes containing the serialized 'LockId'.
+        FFI.Ptr Word.Word8 ->
+        FFI.Ptr (FFI.Ptr Word.Word8) ->
+        FFI.Ptr FFI.CSize ->
+        IO Word.Word8

--- a/concordium-node/build.rs
+++ b/concordium-node/build.rs
@@ -229,6 +229,15 @@ fn build_grpc2(proto_root_input: &str) -> std::io::Result<()> {
         )
         .method(
             tonic_build::manual::Method::builder()
+                .name("get_lock_info")
+                .route_name("GetLockInfo")
+                .input_type("crate::grpc2::types::LockInfoRequest")
+                .output_type("Vec<u8>")
+                .codec_path("crate::grpc2::RawCodec")
+                .build(),
+        )
+        .method(
+            tonic_build::manual::Method::builder()
                 .name("get_account_list")
                 .route_name("GetAccountList")
                 .input_type("crate::grpc2::types::BlockHashInput")
@@ -241,6 +250,16 @@ fn build_grpc2(proto_root_input: &str) -> std::io::Result<()> {
             tonic_build::manual::Method::builder()
                 .name("get_token_list")
                 .route_name("GetTokenList")
+                .input_type("crate::grpc2::types::BlockHashInput")
+                .output_type("Vec<u8>")
+                .codec_path("crate::grpc2::RawCodec")
+                .server_streaming()
+                .build(),
+        )
+        .method(
+            tonic_build::manual::Method::builder()
+                .name("get_lock_list")
+                .route_name("GetLockList")
                 .input_type("crate::grpc2::types::BlockHashInput")
                 .output_type("Vec<u8>")
                 .codec_path("crate::grpc2::RawCodec")

--- a/concordium-node/src/consensus_ffi/ffi.rs
+++ b/concordium-node/src/consensus_ffi/ffi.rs
@@ -623,7 +623,7 @@ extern "C" {
         consensus: *mut consensus_runner,
         block_id_type: u8,
         block_id: *const u8,
-        lock_id: *const u8,
+        lock_id: *const [u8; 24],
         out_hash: *mut u8,
         out: *mut Vec<u8>,
         copier: CopyToVecCallback,
@@ -2749,13 +2749,7 @@ impl ConsensusContainer {
         let bhi = crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
         let (block_id_type, block_hash) = bhi.to_ptr();
 
-        // Serialize the LockId as three big-endian u64 fields, exactly 24 bytes.
-        // This matches the Haskell `Serialize LockId` instance and the FFI input contract
-        // documented on `getLockInfoV2`.
-        let mut lock_id_bytes = [0u8; 24];
-        lock_id_bytes[0..8].copy_from_slice(&lock_id.account_index.to_be_bytes());
-        lock_id_bytes[8..16].copy_from_slice(&lock_id.sequence_number.to_be_bytes());
-        lock_id_bytes[16..24].copy_from_slice(&lock_id.creation_order.to_be_bytes());
+        let lock_id = crate::grpc2::types::lock_id_to_ffi(lock_id);
 
         let consensus = self.consensus.load(Ordering::SeqCst);
         let mut out_data: Vec<u8> = Vec::new();
@@ -2766,7 +2760,7 @@ impl ConsensusContainer {
                 consensus,
                 block_id_type,
                 block_hash.as_ptr(),
-                lock_id_bytes.as_ptr(),
+                &lock_id,
                 out_hash.as_mut_ptr(),
                 &mut out_data,
                 copy_to_vec_callback,

--- a/concordium-node/src/consensus_ffi/ffi.rs
+++ b/concordium-node/src/consensus_ffi/ffi.rs
@@ -584,6 +584,51 @@ extern "C" {
         copier: CopyToVecCallback,
     ) -> i64;
 
+    /// Stream the list of all PLT lock ids that exist in the given block.
+    ///
+    /// Individual lock ids are enqueued using the provided callback.
+    ///
+    /// * `consensus` - Pointer to the current consensus.
+    /// * `stream` - Pointer to the response stream.
+    /// * `block_id_type` - Type of block identifier.
+    /// * `block_id` - Location with the block identifier. Length must match the
+    ///   corresponding type of block identifier.
+    /// * `out_hash` - Location to write the block hash used in the query.
+    /// * `callback` - Callback for writing to the response stream.
+    pub fn getLockListV2(
+        consensus: *mut consensus_runner,
+        stream: *mut futures::channel::mpsc::Sender<Result<Vec<u8>, tonic::Status>>,
+        block_id_type: u8,
+        block_id: *const u8,
+        out_hash: *mut u8,
+        callback: extern "C" fn(
+            *mut futures::channel::mpsc::Sender<Result<Vec<u8>, tonic::Status>>,
+            *const u8,
+            i64,
+        ) -> i32,
+    ) -> i64;
+
+    /// Get the proto-encoded `LockInfo` message for a single lock in a given block.
+    ///
+    /// * `consensus` - Pointer to the current consensus.
+    /// * `block_id_type` - Type of block identifier.
+    /// * `block_id` - Location with the block identifier. Length must match the
+    ///   corresponding type of block identifier.
+    /// * `lock_id` - Pointer to 24 bytes containing the serialized `LockId` (three
+    ///   big-endian `u64` fields: `account_index`, `sequence_number`, `creation_order`).
+    /// * `out_hash` - Location to write the block hash used in the query.
+    /// * `out` - Location to write the proto-encoded `plt.LockInfo` bytes.
+    /// * `copier` - Callback for writing the output.
+    pub fn getLockInfoV2(
+        consensus: *mut consensus_runner,
+        block_id_type: u8,
+        block_id: *const u8,
+        lock_id: *const u8,
+        out_hash: *mut u8,
+        out: *mut Vec<u8>,
+        copier: CopyToVecCallback,
+    ) -> i64;
+
     /// Get next account sequence number.
     ///
     /// * `consensus` - Pointer to the current consensus.
@@ -2646,6 +2691,91 @@ impl ConsensusContainer {
         } else {
             Ok(buf)
         }
+    }
+
+    /// Look up locks in the given block, and return a stream of their
+    /// `LockId`s.
+    ///
+    /// Mirrors [`Self::get_token_list_v2`]. The return value is a block hash
+    /// used for the query.
+    ///
+    /// If the requested block does not exist a [tonic::Status::not_found] is returned.
+    pub fn get_lock_list_v2(
+        &self,
+        block_hash: &crate::grpc2::types::BlockHashInput,
+        sender: futures::channel::mpsc::Sender<Result<Vec<u8>, tonic::Status>>,
+    ) -> Result<[u8; 32], tonic::Status> {
+        use crate::grpc2::Require;
+
+        let sender = Box::new(sender);
+        let consensus = self.consensus.load(Ordering::SeqCst);
+        let mut buf = [0u8; 32];
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
+        let (block_id_type, block_hash) = bhi.to_ptr();
+        let sender_ptr = Box::into_raw(sender);
+
+        let response: ConsensusQueryResponse = unsafe {
+            getLockListV2(
+                consensus,
+                sender_ptr,
+                block_id_type,
+                block_hash.as_ptr(),
+                buf.as_mut_ptr(),
+                enqueue_bytearray_callback,
+            )
+        }
+        .try_into()?;
+
+        if let Err(e) = response.ensure_ok("block") {
+            let _ = unsafe { Box::from_raw(sender_ptr) }; // deallocate sender since it is unused by Haskell.
+            Err(e)
+        } else {
+            Ok(buf)
+        }
+    }
+
+    /// Get the `plt.LockInfo` proto-encoded payload for a single lock in a given
+    /// block. The Haskell side performs the proto encoding; this method returns the
+    /// wire bytes for the gRPC handler to forward through `RawCodec`.
+    ///
+    /// If the lock cannot be found a [tonic::Status::not_found] is returned.
+    pub fn get_lock_info_v2(
+        &self,
+        block_hash: &crate::grpc2::types::BlockHashInput,
+        lock_id: &crate::grpc2::types::plt::LockId,
+    ) -> Result<([u8; 32], Vec<u8>), tonic::Status> {
+        use crate::grpc2::Require;
+
+        let bhi = crate::grpc2::types::block_hash_input_to_ffi(block_hash).require()?;
+        let (block_id_type, block_hash) = bhi.to_ptr();
+
+        // Serialize the LockId as three big-endian u64 fields, exactly 24 bytes.
+        // This matches the Haskell `Serialize LockId` instance and the FFI input contract
+        // documented on `getLockInfoV2`.
+        let mut lock_id_bytes = [0u8; 24];
+        lock_id_bytes[0..8].copy_from_slice(&lock_id.account_index.to_be_bytes());
+        lock_id_bytes[8..16].copy_from_slice(&lock_id.sequence_number.to_be_bytes());
+        lock_id_bytes[16..24].copy_from_slice(&lock_id.creation_order.to_be_bytes());
+
+        let consensus = self.consensus.load(Ordering::SeqCst);
+        let mut out_data: Vec<u8> = Vec::new();
+        let mut out_hash = [0u8; 32];
+
+        let response: ConsensusQueryResponse = unsafe {
+            getLockInfoV2(
+                consensus,
+                block_id_type,
+                block_hash.as_ptr(),
+                lock_id_bytes.as_ptr(),
+                out_hash.as_mut_ptr(),
+                &mut out_data,
+                copy_to_vec_callback,
+            )
+            .try_into()?
+        };
+
+        response.ensure_ok("lockId or block")?;
+        Ok((out_hash, out_data))
     }
 
     /// Get a list of all smart contract modules. The stream will end

--- a/concordium-node/src/consensus_ffi/ffi.rs
+++ b/concordium-node/src/consensus_ffi/ffi.rs
@@ -584,9 +584,9 @@ extern "C" {
         copier: CopyToVecCallback,
     ) -> i64;
 
-    /// Stream the list of all PLT lock ids that exist in the given block.
+    /// Stream the list of all PLT Lock IDs that exist in the given block.
     ///
-    /// Individual lock ids are enqueued using the provided callback.
+    /// Individual Lock IDs are enqueued using the provided callback.
     ///
     /// * `consensus` - Pointer to the current consensus.
     /// * `stream` - Pointer to the response stream.

--- a/concordium-node/src/grpc2.rs
+++ b/concordium-node/src/grpc2.rs
@@ -229,6 +229,17 @@ pub mod types {
         }
     }
 
+    // Serialize the LockId as three big-endian u64 fields, exactly 24 bytes.
+    // This matches the Haskell `SerializedLockId` type and the FFI input contract
+    // documented on `getLockInfoV2`.
+    pub(crate) fn lock_id_to_ffi(lock_id: &plt::LockId) -> [u8; 24] {
+        let mut lock_id_bytes = [0u8; 24];
+        lock_id_bytes[0..8].copy_from_slice(&lock_id.account_index.to_be_bytes());
+        lock_id_bytes[8..16].copy_from_slice(&lock_id.sequence_number.to_be_bytes());
+        lock_id_bytes[16..24].copy_from_slice(&lock_id.creation_order.to_be_bytes());
+        lock_id_bytes
+    }
+
     impl From<Amount> for concordium_base::common::types::Amount {
         fn from(n: Amount) -> Self {
             Self::from_micro_ccd(n.value)

--- a/concordium-node/src/grpc2.rs
+++ b/concordium-node/src/grpc2.rs
@@ -919,11 +919,15 @@ struct ServiceConfig {
     #[serde(default)]
     get_token_list: bool,
     #[serde(default)]
+    get_lock_list: bool,
+    #[serde(default)]
     get_account_info: bool,
     #[serde(default)]
     get_token_info: bool,
     #[serde(default)]
     get_token_authorizations: bool,
+    #[serde(default)]
+    get_lock_info: bool,
     #[serde(default)]
     get_module_list: bool,
     #[serde(default)]
@@ -1050,9 +1054,11 @@ impl ServiceConfig {
             get_blocks: true,
             get_account_list: true,
             get_token_list: true,
+            get_lock_list: true,
             get_account_info: true,
             get_token_info: true,
             get_token_authorizations: true,
+            get_lock_info: true,
             get_module_list: true,
             get_module_source: true,
             get_instance_list: true,
@@ -1218,7 +1224,7 @@ pub mod server {
             },
             messaging::{ConsensusMessage, MessageType},
         },
-        health,
+        grpc2, health,
         p2p::P2PNode,
     };
     use anyhow::Context;
@@ -1732,13 +1738,15 @@ pub mod server {
             futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
         /// Return type for the 'GetTokenList' method.
         type GetTokenListStream = futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
+        /// Return type for the 'GetLockList' method.
+        type GetLockListStream = futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
         /// Return type for the 'GetWinningBakersEpoch' method.
         type GetWinningBakersEpochStream =
             futures::channel::mpsc::Receiver<Result<Vec<u8>, tonic::Status>>;
 
         async fn get_blocks(
             &self,
-            _request: tonic::Request<crate::grpc2::types::Empty>,
+            _request: tonic::Request<grpc2::types::Empty>,
         ) -> Result<tonic::Response<Self::GetBlocksStream>, tonic::Status> {
             if !self.service_config.get_blocks {
                 return Err(tonic::Status::unimplemented("`GetBlocks` is not enabled."));
@@ -1760,7 +1768,7 @@ pub mod server {
 
         async fn get_finalized_blocks(
             &self,
-            _request: tonic::Request<crate::grpc2::types::Empty>,
+            _request: tonic::Request<grpc2::types::Empty>,
         ) -> Result<tonic::Response<Self::GetFinalizedBlocksStream>, tonic::Status> {
             if !self.service_config.get_finalized_blocks {
                 return Err(tonic::Status::unimplemented(
@@ -1784,7 +1792,7 @@ pub mod server {
 
         async fn get_account_info(
             &self,
-            request: tonic::Request<crate::grpc2::types::AccountInfoRequest>,
+            request: tonic::Request<grpc2::types::AccountInfoRequest>,
         ) -> Result<tonic::Response<Vec<u8>>, tonic::Status> {
             if !self.service_config.get_account_info {
                 return Err(tonic::Status::unimplemented(
@@ -1807,7 +1815,7 @@ pub mod server {
 
         async fn get_token_info(
             &self,
-            request: tonic::Request<crate::grpc2::types::TokenInfoRequest>,
+            request: tonic::Request<grpc2::types::TokenInfoRequest>,
         ) -> Result<tonic::Response<Vec<u8>>, tonic::Status> {
             if !self.service_config.get_token_info {
                 return Err(tonic::Status::unimplemented(
@@ -1830,7 +1838,7 @@ pub mod server {
 
         async fn get_token_authorizations(
             &self,
-            request: tonic::Request<crate::grpc2::types::TokenAuthorizationsRequest>,
+            request: tonic::Request<grpc2::types::TokenAuthorizationsRequest>,
         ) -> Result<tonic::Response<Vec<u8>>, tonic::Status> {
             if !self.service_config.get_token_authorizations {
                 return Err(tonic::Status::unimplemented(
@@ -1853,7 +1861,7 @@ pub mod server {
 
         async fn get_account_list(
             &self,
-            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+            request: tonic::Request<grpc2::types::BlockHashInput>,
         ) -> Result<tonic::Response<Self::GetAccountListStream>, tonic::Status> {
             if !self.service_config.get_account_list {
                 return Err(tonic::Status::unimplemented(
@@ -1873,7 +1881,7 @@ pub mod server {
 
         async fn get_token_list(
             &self,
-            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+            request: tonic::Request<grpc2::types::BlockHashInput>,
         ) -> Result<tonic::Response<Self::GetTokenListStream>, tonic::Status> {
             if !self.service_config.get_token_list {
                 return Err(tonic::Status::unimplemented(
@@ -1891,9 +1899,52 @@ pub mod server {
             Ok(response)
         }
 
+        async fn get_lock_list(
+            &self,
+            request: tonic::Request<grpc2::types::BlockHashInput>,
+        ) -> Result<tonic::Response<Self::GetLockListStream>, tonic::Status> {
+            if !self.service_config.get_lock_list {
+                return Err(tonic::Status::unimplemented(
+                    "`GetLockList` is not enabled.",
+                ));
+            }
+            let (sender, receiver) = futures::channel::mpsc::channel(100);
+            let hash = self
+                .run_blocking(move |consensus| {
+                    consensus.get_lock_list_v2(request.get_ref(), sender)
+                })
+                .await?;
+            let mut response = tonic::Response::new(receiver);
+            add_hash(&mut response, hash)?;
+            Ok(response)
+        }
+
+        async fn get_lock_info(
+            &self,
+            request: tonic::Request<grpc2::types::LockInfoRequest>,
+        ) -> Result<tonic::Response<Vec<u8>>, tonic::Status> {
+            if !self.service_config.get_lock_info {
+                return Err(tonic::Status::unimplemented(
+                    "`GetLockInfo` is not enabled.",
+                ));
+            }
+            let (hash, response) = self
+                .run_blocking(move |consensus| {
+                    let request = request.get_ref();
+                    let block_hash = request.block_hash.as_ref().require()?;
+                    let lock_id = request.lock_id.as_ref().require()?;
+                    consensus.get_lock_info_v2(block_hash, lock_id)
+                })
+                .await?;
+
+            let mut response = tonic::Response::new(response);
+            add_hash(&mut response, hash)?;
+            Ok(response)
+        }
+
         async fn get_module_list(
             &self,
-            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+            request: tonic::Request<grpc2::types::BlockHashInput>,
         ) -> Result<tonic::Response<Self::GetModuleListStream>, tonic::Status> {
             if !self.service_config.get_module_list {
                 return Err(tonic::Status::unimplemented(
@@ -1913,7 +1964,7 @@ pub mod server {
 
         async fn get_module_source(
             &self,
-            request: tonic::Request<crate::grpc2::types::ModuleSourceRequest>,
+            request: tonic::Request<grpc2::types::ModuleSourceRequest>,
         ) -> Result<tonic::Response<Vec<u8>>, tonic::Status> {
             if !self.service_config.get_module_source {
                 return Err(tonic::Status::unimplemented(
@@ -1935,7 +1986,7 @@ pub mod server {
 
         async fn get_instance_list(
             &self,
-            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+            request: tonic::Request<grpc2::types::BlockHashInput>,
         ) -> Result<tonic::Response<Self::GetInstanceListStream>, tonic::Status> {
             if !self.service_config.get_instance_list {
                 return Err(tonic::Status::unimplemented(
@@ -1955,7 +2006,7 @@ pub mod server {
 
         async fn get_instance_info(
             &self,
-            request: tonic::Request<crate::grpc2::types::InstanceInfoRequest>,
+            request: tonic::Request<grpc2::types::InstanceInfoRequest>,
         ) -> Result<tonic::Response<Vec<u8>>, tonic::Status> {
             if !self.service_config.get_instance_info {
                 return Err(tonic::Status::unimplemented(
@@ -1977,7 +2028,7 @@ pub mod server {
 
         async fn get_instance_state(
             &self,
-            request: tonic::Request<crate::grpc2::types::InstanceInfoRequest>,
+            request: tonic::Request<grpc2::types::InstanceInfoRequest>,
         ) -> Result<tonic::Response<Self::GetInstanceStateStream>, tonic::Status> {
             if !self.service_config.get_instance_state {
                 return Err(tonic::Status::unimplemented(
@@ -2079,7 +2130,7 @@ pub mod server {
 
         async fn get_next_account_sequence_number(
             &self,
-            request: tonic::Request<crate::grpc2::types::AccountAddress>,
+            request: tonic::Request<grpc2::types::AccountAddress>,
         ) -> Result<tonic::Response<Vec<u8>>, tonic::Status> {
             if !self.service_config.get_next_account_sequence_number {
                 return Err(tonic::Status::unimplemented(
@@ -2096,7 +2147,7 @@ pub mod server {
 
         async fn get_consensus_info(
             &self,
-            _request: tonic::Request<crate::grpc2::types::Empty>,
+            _request: tonic::Request<grpc2::types::Empty>,
         ) -> Result<tonic::Response<Vec<u8>>, tonic::Status> {
             if !self.service_config.get_consensus_info {
                 return Err(tonic::Status::unimplemented(
@@ -2111,7 +2162,7 @@ pub mod server {
 
         async fn get_consensus_detailed_status(
             &self,
-            request: tonic::Request<crate::grpc2::types::ConsensusDetailedStatusQuery>,
+            request: tonic::Request<grpc2::types::ConsensusDetailedStatusQuery>,
         ) -> Result<tonic::Response<Vec<u8>>, tonic::Status> {
             if !self.service_config.get_consensus_detailed_status {
                 return Err(tonic::Status::unimplemented(
@@ -2129,7 +2180,7 @@ pub mod server {
 
         async fn get_ancestors(
             &self,
-            request: tonic::Request<crate::grpc2::types::AncestorsRequest>,
+            request: tonic::Request<grpc2::types::AncestorsRequest>,
         ) -> Result<tonic::Response<Self::GetAncestorsStream>, tonic::Status> {
             if !self.service_config.get_ancestors {
                 return Err(tonic::Status::unimplemented(
@@ -2152,7 +2203,7 @@ pub mod server {
 
         async fn get_block_item_status(
             &self,
-            request: tonic::Request<crate::grpc2::types::TransactionHash>,
+            request: tonic::Request<grpc2::types::TransactionHash>,
         ) -> Result<tonic::Response<Vec<u8>>, tonic::Status> {
             if !self.service_config.get_block_item_status {
                 return Err(tonic::Status::unimplemented(
@@ -2169,7 +2220,7 @@ pub mod server {
 
         async fn invoke_instance(
             &self,
-            mut request: tonic::Request<crate::grpc2::types::InvokeInstanceRequest>,
+            mut request: tonic::Request<grpc2::types::InvokeInstanceRequest>,
         ) -> Result<tonic::Response<Vec<u8>>, tonic::Status> {
             if !self.service_config.invoke_instance {
                 return Err(tonic::Status::unimplemented(
@@ -2180,7 +2231,7 @@ pub mod server {
             if let Some(nrg) = request.get_ref().energy.as_ref() {
                 max_energy = std::cmp::min(max_energy, nrg.value);
             }
-            request.get_mut().energy = Some(crate::grpc2::types::Energy { value: max_energy });
+            request.get_mut().energy = Some(grpc2::types::Energy { value: max_energy });
             let (hash, response) = self
                 .run_blocking(move |consensus| consensus.invoke_instance_v2(request.get_ref()))
                 .await?;
@@ -2191,9 +2242,8 @@ pub mod server {
 
         async fn get_cryptographic_parameters(
             &self,
-            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
-        ) -> Result<tonic::Response<crate::grpc2::types::CryptographicParameters>, tonic::Status>
-        {
+            request: tonic::Request<grpc2::types::BlockHashInput>,
+        ) -> Result<tonic::Response<grpc2::types::CryptographicParameters>, tonic::Status> {
             if !self.service_config.get_cryptographic_parameters {
                 return Err(tonic::Status::unimplemented(
                     "`GetCryptographicParameters` is not enabled.",
@@ -2211,7 +2261,7 @@ pub mod server {
 
         async fn get_block_info(
             &self,
-            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+            request: tonic::Request<grpc2::types::BlockHashInput>,
         ) -> Result<tonic::Response<Vec<u8>>, tonic::Status> {
             if !self.service_config.get_block_info {
                 return Err(tonic::Status::unimplemented(
@@ -2228,7 +2278,7 @@ pub mod server {
 
         async fn get_baker_list(
             &self,
-            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+            request: tonic::Request<grpc2::types::BlockHashInput>,
         ) -> Result<tonic::Response<Self::GetBakerListStream>, tonic::Status> {
             if !self.service_config.get_baker_list {
                 return Err(tonic::Status::unimplemented(
@@ -2248,7 +2298,7 @@ pub mod server {
 
         async fn get_pool_info(
             &self,
-            request: tonic::Request<crate::grpc2::types::PoolInfoRequest>,
+            request: tonic::Request<grpc2::types::PoolInfoRequest>,
         ) -> Result<tonic::Response<Vec<u8>>, tonic::Status> {
             if !self.service_config.get_pool_info {
                 return Err(tonic::Status::unimplemented(
@@ -2265,7 +2315,7 @@ pub mod server {
 
         async fn get_passive_delegation_info(
             &self,
-            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+            request: tonic::Request<grpc2::types::BlockHashInput>,
         ) -> Result<tonic::Response<Vec<u8>>, tonic::Status> {
             if !self.service_config.get_passive_delegation_info {
                 return Err(tonic::Status::unimplemented(
@@ -2284,7 +2334,7 @@ pub mod server {
 
         async fn get_blocks_at_height(
             &self,
-            request: tonic::Request<crate::grpc2::types::BlocksAtHeightRequest>,
+            request: tonic::Request<grpc2::types::BlocksAtHeightRequest>,
         ) -> Result<tonic::Response<Vec<u8>>, tonic::Status> {
             if !self.service_config.get_blocks_at_height {
                 return Err(tonic::Status::unimplemented(
@@ -2300,7 +2350,7 @@ pub mod server {
 
         async fn get_tokenomics_info(
             &self,
-            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+            request: tonic::Request<grpc2::types::BlockHashInput>,
         ) -> Result<tonic::Response<Vec<u8>>, tonic::Status> {
             if !self.service_config.get_tokenomics_info {
                 return Err(tonic::Status::unimplemented(
@@ -2317,7 +2367,7 @@ pub mod server {
 
         async fn get_pool_delegators(
             &self,
-            request: tonic::Request<crate::grpc2::types::GetPoolDelegatorsRequest>,
+            request: tonic::Request<grpc2::types::GetPoolDelegatorsRequest>,
         ) -> Result<tonic::Response<Self::GetPoolDelegatorsStream>, tonic::Status> {
             if !self.service_config.get_pool_delegators {
                 return Err(tonic::Status::unimplemented(
@@ -2337,7 +2387,7 @@ pub mod server {
 
         async fn get_pool_delegators_reward_period(
             &self,
-            request: tonic::Request<crate::grpc2::types::GetPoolDelegatorsRequest>,
+            request: tonic::Request<grpc2::types::GetPoolDelegatorsRequest>,
         ) -> Result<tonic::Response<Self::GetPoolDelegatorsRewardPeriodStream>, tonic::Status>
         {
             if !self.service_config.get_pool_delegators_reward_period {
@@ -2358,7 +2408,7 @@ pub mod server {
 
         async fn get_passive_delegators(
             &self,
-            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+            request: tonic::Request<grpc2::types::BlockHashInput>,
         ) -> Result<tonic::Response<Self::GetPassiveDelegatorsStream>, tonic::Status> {
             if !self.service_config.get_passive_delegators {
                 return Err(tonic::Status::unimplemented(
@@ -2378,7 +2428,7 @@ pub mod server {
 
         async fn get_passive_delegators_reward_period(
             &self,
-            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+            request: tonic::Request<grpc2::types::BlockHashInput>,
         ) -> Result<tonic::Response<Self::GetPassiveDelegatorsRewardPeriodStream>, tonic::Status>
         {
             if !self.service_config.get_passive_delegators_reward_period {
@@ -2399,7 +2449,7 @@ pub mod server {
 
         async fn get_branches(
             &self,
-            _request: tonic::Request<crate::grpc2::types::Empty>,
+            _request: tonic::Request<grpc2::types::Empty>,
         ) -> Result<tonic::Response<Vec<u8>>, tonic::Status> {
             if !self.service_config.get_branches {
                 return Err(tonic::Status::unimplemented(
@@ -2414,7 +2464,7 @@ pub mod server {
 
         async fn get_election_info(
             &self,
-            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+            request: tonic::Request<grpc2::types::BlockHashInput>,
         ) -> Result<tonic::Response<Vec<u8>>, tonic::Status> {
             if !self.service_config.get_election_info {
                 return Err(tonic::Status::unimplemented(
@@ -2431,7 +2481,7 @@ pub mod server {
 
         async fn get_identity_providers(
             &self,
-            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+            request: tonic::Request<grpc2::types::BlockHashInput>,
         ) -> Result<tonic::Response<Self::GetIdentityProvidersStream>, tonic::Status> {
             if !self.service_config.get_identity_providers {
                 return Err(tonic::Status::unimplemented(
@@ -2451,7 +2501,7 @@ pub mod server {
 
         async fn get_anonymity_revokers(
             &self,
-            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+            request: tonic::Request<grpc2::types::BlockHashInput>,
         ) -> Result<tonic::Response<Self::GetAnonymityRevokersStream>, tonic::Status> {
             if !self.service_config.get_anonymity_revokers {
                 return Err(tonic::Status::unimplemented(
@@ -2471,7 +2521,7 @@ pub mod server {
 
         async fn get_account_non_finalized_transactions(
             &self,
-            request: tonic::Request<crate::grpc2::types::AccountAddress>,
+            request: tonic::Request<grpc2::types::AccountAddress>,
         ) -> Result<tonic::Response<Self::GetAccountNonFinalizedTransactionsStream>, tonic::Status>
         {
             if !self.service_config.get_account_non_finalized_transactions {
@@ -2490,7 +2540,7 @@ pub mod server {
 
         async fn get_block_transaction_events(
             &self,
-            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+            request: tonic::Request<grpc2::types::BlockHashInput>,
         ) -> Result<tonic::Response<Self::GetBlockTransactionEventsStream>, tonic::Status> {
             if !self.service_config.get_block_transaction_events {
                 return Err(tonic::Status::unimplemented(
@@ -2510,7 +2560,7 @@ pub mod server {
 
         async fn get_block_special_events(
             &self,
-            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+            request: tonic::Request<grpc2::types::BlockHashInput>,
         ) -> Result<tonic::Response<Self::GetBlockSpecialEventsStream>, tonic::Status> {
             if !self.service_config.get_block_special_events {
                 return Err(tonic::Status::unimplemented(
@@ -2530,7 +2580,7 @@ pub mod server {
 
         async fn get_block_pending_updates(
             &self,
-            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+            request: tonic::Request<grpc2::types::BlockHashInput>,
         ) -> Result<tonic::Response<Self::GetBlockPendingUpdatesStream>, tonic::Status> {
             if !self.service_config.get_block_pending_updates {
                 return Err(tonic::Status::unimplemented(
@@ -2550,7 +2600,7 @@ pub mod server {
 
         async fn get_next_update_sequence_numbers(
             &self,
-            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+            request: tonic::Request<grpc2::types::BlockHashInput>,
         ) -> Result<tonic::Response<Vec<u8>>, tonic::Status> {
             if !self.service_config.get_next_update_sequence_numbers {
                 return Err(tonic::Status::unimplemented(
@@ -2569,7 +2619,7 @@ pub mod server {
 
         async fn get_scheduled_release_accounts(
             &self,
-            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+            request: tonic::Request<grpc2::types::BlockHashInput>,
         ) -> Result<tonic::Response<Self::GetScheduledReleaseAccountsStream>, tonic::Status>
         {
             if !self.service_config.get_scheduled_release_accounts {
@@ -2590,7 +2640,7 @@ pub mod server {
 
         async fn get_cooldown_accounts(
             &self,
-            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+            request: tonic::Request<grpc2::types::BlockHashInput>,
         ) -> Result<tonic::Response<Self::GetCooldownAccountsStream>, tonic::Status> {
             if !self.service_config.get_cooldown_accounts {
                 return Err(tonic::Status::unimplemented(
@@ -2610,7 +2660,7 @@ pub mod server {
 
         async fn get_pre_cooldown_accounts(
             &self,
-            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+            request: tonic::Request<grpc2::types::BlockHashInput>,
         ) -> Result<tonic::Response<Self::GetPreCooldownAccountsStream>, tonic::Status> {
             if !self.service_config.get_pre_cooldown_accounts {
                 return Err(tonic::Status::unimplemented(
@@ -2630,7 +2680,7 @@ pub mod server {
 
         async fn get_pre_pre_cooldown_accounts(
             &self,
-            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+            request: tonic::Request<grpc2::types::BlockHashInput>,
         ) -> Result<tonic::Response<Self::GetPrePreCooldownAccountsStream>, tonic::Status> {
             if !self.service_config.get_pre_pre_cooldown_accounts {
                 return Err(tonic::Status::unimplemented(
@@ -2650,7 +2700,7 @@ pub mod server {
 
         async fn get_block_chain_parameters(
             &self,
-            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+            request: tonic::Request<grpc2::types::BlockHashInput>,
         ) -> Result<tonic::Response<Vec<u8>>, tonic::Status> {
             if !self.service_config.get_block_chain_parameters {
                 return Err(tonic::Status::unimplemented(
@@ -2669,7 +2719,7 @@ pub mod server {
 
         async fn get_block_finalization_summary(
             &self,
-            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+            request: tonic::Request<grpc2::types::BlockHashInput>,
         ) -> Result<tonic::Response<Vec<u8>>, tonic::Status> {
             if !self.service_config.get_block_finalization_summary {
                 return Err(tonic::Status::unimplemented(
@@ -2688,7 +2738,7 @@ pub mod server {
 
         async fn get_bakers_reward_period(
             &self,
-            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+            request: tonic::Request<grpc2::types::BlockHashInput>,
         ) -> Result<tonic::Response<Self::GetBakersRewardPeriodStream>, tonic::Status> {
             if !self.service_config.get_bakers_reward_period {
                 return Err(tonic::Status::unimplemented(
@@ -2708,7 +2758,7 @@ pub mod server {
 
         async fn get_baker_earliest_win_time(
             &self,
-            request: tonic::Request<crate::grpc2::types::BakerId>,
+            request: tonic::Request<grpc2::types::BakerId>,
         ) -> Result<tonic::Response<Vec<u8>>, tonic::Status> {
             if !self.service_config.get_baker_earliest_win_time {
                 return Err(tonic::Status::unimplemented(
@@ -2726,13 +2776,13 @@ pub mod server {
 
         async fn shutdown(
             &self,
-            _request: tonic::Request<crate::grpc2::types::Empty>,
-        ) -> Result<tonic::Response<crate::grpc2::types::Empty>, tonic::Status> {
+            _request: tonic::Request<grpc2::types::Empty>,
+        ) -> Result<tonic::Response<grpc2::types::Empty>, tonic::Status> {
             if !self.service_config.shutdown {
                 return Err(tonic::Status::unimplemented("`Shutdown` is not enabled."));
             }
             match self.node.close() {
-                Ok(_) => Ok(tonic::Response::new(crate::grpc2::types::Empty {})),
+                Ok(_) => Ok(tonic::Response::new(grpc2::types::Empty {})),
                 Err(e) => Err(tonic::Status::internal(format!(
                     "Unable to shutdown server {}.",
                     e
@@ -2742,8 +2792,8 @@ pub mod server {
 
         async fn peer_connect(
             &self,
-            request: tonic::Request<crate::grpc2::types::IpSocketAddress>,
-        ) -> Result<tonic::Response<crate::grpc2::types::Empty>, tonic::Status> {
+            request: tonic::Request<grpc2::types::IpSocketAddress>,
+        ) -> Result<tonic::Response<grpc2::types::Empty>, tonic::Status> {
             if !self.service_config.peer_connect {
                 return Err(tonic::Status::unimplemented(
                     "`PeerConnect` is not enabled.",
@@ -2763,7 +2813,7 @@ pub mod server {
                             peer_type: crate::common::PeerType::Node,
                             given: true,
                         });
-                    Ok(tonic::Response::new(crate::grpc2::types::Empty {}))
+                    Ok(tonic::Response::new(grpc2::types::Empty {}))
                 } else {
                     Err(tonic::Status::invalid_argument("Invalid IP address."))
                 }
@@ -2772,8 +2822,8 @@ pub mod server {
 
         async fn peer_disconnect(
             &self,
-            request: tonic::Request<crate::grpc2::types::IpSocketAddress>,
-        ) -> Result<tonic::Response<crate::grpc2::types::Empty>, tonic::Status> {
+            request: tonic::Request<grpc2::types::IpSocketAddress>,
+        ) -> Result<tonic::Response<grpc2::types::Empty>, tonic::Status> {
             if !self.service_config.peer_disconnect {
                 return Err(tonic::Status::unimplemented(
                     "`PeerDisconnect` is not enabled.",
@@ -2788,7 +2838,7 @@ pub mod server {
                 if let Ok(ip) = peer_connect.ip.require()?.value.parse::<std::net::IpAddr>() {
                     let addr = SocketAddr::new(ip, peer_connect.port.require()?.value as u16);
                     if self.node.drop_addr(addr) {
-                        Ok(tonic::Response::new(crate::grpc2::types::Empty {}))
+                        Ok(tonic::Response::new(grpc2::types::Empty {}))
                     } else {
                         Err(tonic::Status::not_found("The peer was not found."))
                     }
@@ -2800,8 +2850,8 @@ pub mod server {
 
         async fn get_banned_peers(
             &self,
-            _request: tonic::Request<crate::grpc2::types::Empty>,
-        ) -> Result<tonic::Response<crate::grpc2::types::BannedPeers>, tonic::Status> {
+            _request: tonic::Request<grpc2::types::Empty>,
+        ) -> Result<tonic::Response<grpc2::types::BannedPeers>, tonic::Status> {
             if !self.service_config.get_banned_peers {
                 return Err(tonic::Status::unimplemented(
                     "`GetBannedPeers` is not enabled.",
@@ -2814,14 +2864,12 @@ pub mod server {
                         let ip_address = match banned_peer {
                             crate::p2p::bans::PersistedBanId::Ip(addr) => addr.to_string(),
                         };
-                        crate::grpc2::types::BannedPeer {
-                            ip_address: Some(crate::grpc2::types::IpAddress { value: ip_address }),
+                        grpc2::types::BannedPeer {
+                            ip_address: Some(grpc2::types::IpAddress { value: ip_address }),
                         }
                     })
                     .collect();
-                Ok(tonic::Response::new(crate::grpc2::types::BannedPeers {
-                    peers,
-                }))
+                Ok(tonic::Response::new(grpc2::types::BannedPeers { peers }))
             } else {
                 Err(tonic::Status::internal("Could not load banned peers."))
             }
@@ -2829,15 +2877,15 @@ pub mod server {
 
         async fn ban_peer(
             &self,
-            request: tonic::Request<crate::grpc2::types::PeerToBan>,
-        ) -> Result<tonic::Response<crate::grpc2::types::Empty>, tonic::Status> {
+            request: tonic::Request<grpc2::types::PeerToBan>,
+        ) -> Result<tonic::Response<grpc2::types::Empty>, tonic::Status> {
             if !self.service_config.ban_peer {
                 return Err(tonic::Status::unimplemented("`BanPeer` is not enabled."));
             }
             let ip = request.into_inner().ip_address.require()?;
             match ip.value.parse::<std::net::IpAddr>() {
                 Ok(ip_addr) => match self.node.drop_by_ip_and_ban(ip_addr) {
-                    Ok(_) => Ok(tonic::Response::new(crate::grpc2::types::Empty {})),
+                    Ok(_) => Ok(tonic::Response::new(grpc2::types::Empty {})),
                     Err(e) => Err(tonic::Status::internal(format!(
                         "Could not ban peer {}.",
                         e
@@ -2852,8 +2900,8 @@ pub mod server {
 
         async fn unban_peer(
             &self,
-            request: tonic::Request<crate::grpc2::types::BannedPeer>,
-        ) -> Result<tonic::Response<crate::grpc2::types::Empty>, tonic::Status> {
+            request: tonic::Request<grpc2::types::BannedPeer>,
+        ) -> Result<tonic::Response<grpc2::types::Empty>, tonic::Status> {
             if !self.service_config.unban_peer {
                 return Err(tonic::Status::unimplemented("`UnbanPeer` is not enabled."));
             }
@@ -2867,7 +2915,7 @@ pub mod server {
                 Ok(ip_addr) => {
                     let banned_id = crate::p2p::bans::PersistedBanId::Ip(ip_addr);
                     match self.node.unban_node(banned_id) {
-                        Ok(_) => Ok(tonic::Response::new(crate::grpc2::types::Empty {})),
+                        Ok(_) => Ok(tonic::Response::new(grpc2::types::Empty {})),
                         Err(e) => Err(tonic::Status::internal(format!(
                             "Could not unban peer {}.",
                             e
@@ -2884,8 +2932,8 @@ pub mod server {
         #[cfg(feature = "network_dump")]
         async fn dump_start(
             &self,
-            request: tonic::Request<crate::grpc2::types::DumpRequest>,
-        ) -> Result<tonic::Response<crate::grpc2::types::Empty>, tonic::Status> {
+            request: tonic::Request<grpc2::types::DumpRequest>,
+        ) -> Result<tonic::Response<grpc2::types::Empty>, tonic::Status> {
             if !self.service_config.dump_start {
                 return Err(tonic::Status::unimplemented("`DumpStart` is not enabled."));
             }
@@ -2896,7 +2944,7 @@ pub mod server {
                 ))
             } else {
                 match self.node.activate_dump(&file_path, request.get_ref().raw) {
-                    Ok(_) => Ok(tonic::Response::new(crate::grpc2::types::Empty {})),
+                    Ok(_) => Ok(tonic::Response::new(grpc2::types::Empty {})),
                     Err(e) => Err(tonic::Status::internal(format!(
                         "Could not start network dump {}",
                         e
@@ -2908,8 +2956,8 @@ pub mod server {
         #[cfg(not(feature = "network_dump"))]
         async fn dump_start(
             &self,
-            _request: tonic::Request<crate::grpc2::types::DumpRequest>,
-        ) -> Result<tonic::Response<crate::grpc2::types::Empty>, tonic::Status> {
+            _request: tonic::Request<grpc2::types::DumpRequest>,
+        ) -> Result<tonic::Response<grpc2::types::Empty>, tonic::Status> {
             if !self.service_config.dump_start {
                 return Err(tonic::Status::unimplemented("`DumpStart` is not enabled."));
             }
@@ -2921,13 +2969,13 @@ pub mod server {
         #[cfg(feature = "network_dump")]
         async fn dump_stop(
             &self,
-            _request: tonic::Request<crate::grpc2::types::Empty>,
-        ) -> Result<tonic::Response<crate::grpc2::types::Empty>, tonic::Status> {
+            _request: tonic::Request<grpc2::types::Empty>,
+        ) -> Result<tonic::Response<grpc2::types::Empty>, tonic::Status> {
             if !self.service_config.dump_stop {
                 return Err(tonic::Status::unimplemented("`DumpStop` is not enabled."));
             }
             match self.node.stop_dump() {
-                Ok(_) => Ok(tonic::Response::new(crate::grpc2::types::Empty {})),
+                Ok(_) => Ok(tonic::Response::new(grpc2::types::Empty {})),
                 Err(e) => Err(tonic::Status::internal(format!(
                     "Could not stop network dump {}",
                     e
@@ -2938,8 +2986,8 @@ pub mod server {
         #[cfg(not(feature = "network_dump"))]
         async fn dump_stop(
             &self,
-            _request: tonic::Request<crate::grpc2::types::Empty>,
-        ) -> Result<tonic::Response<crate::grpc2::types::Empty>, tonic::Status> {
+            _request: tonic::Request<grpc2::types::Empty>,
+        ) -> Result<tonic::Response<grpc2::types::Empty>, tonic::Status> {
             if !self.service_config.dump_stop {
                 return Err(tonic::Status::unimplemented("`DumpStop` is not enabled."));
             }
@@ -2950,8 +2998,8 @@ pub mod server {
 
         async fn get_peers_info(
             &self,
-            _request: tonic::Request<crate::grpc2::types::Empty>,
-        ) -> Result<tonic::Response<crate::grpc2::types::PeersInfo>, tonic::Status> {
+            _request: tonic::Request<grpc2::types::Empty>,
+        ) -> Result<tonic::Response<grpc2::types::PeersInfo>, tonic::Status> {
             if !self.service_config.get_peers_info {
                 return Err(tonic::Status::unimplemented(
                     "`GetPeersInfo` is not enabled.",
@@ -2965,7 +3013,7 @@ pub mod server {
                 .into_iter()
                 .map(|peer_stats| {
                     // Collect the network statistics
-                    let network_stats = Some(crate::grpc2::types::peers_info::peer::NetworkStats {
+                    let network_stats = Some(grpc2::types::peers_info::peer::NetworkStats {
                         packets_sent: peer_stats.msgs_sent,
                         packets_received: peer_stats.msgs_received,
                         latency: peer_stats.latency,
@@ -2976,39 +3024,39 @@ pub mod server {
                         crate::common::PeerType::Node => {
                             let catchup_status = match peer_statuses.get(&peer_stats.local_id) {
                                 Some(crate::consensus_ffi::catch_up::PeerStatus::CatchingUp) => {
-                                    crate::grpc2::types::peers_info::peer::CatchupStatus::Catchingup
+                                    grpc2::types::peers_info::peer::CatchupStatus::Catchingup
                                 }
                                 Some(crate::consensus_ffi::catch_up::PeerStatus::UpToDate) => {
-                                    crate::grpc2::types::peers_info::peer::CatchupStatus::Uptodate
+                                    grpc2::types::peers_info::peer::CatchupStatus::Uptodate
                                 }
-                                _ => crate::grpc2::types::peers_info::peer::CatchupStatus::Pending,
+                                _ => grpc2::types::peers_info::peer::CatchupStatus::Pending,
                             };
-                            crate::grpc2::types::peers_info::peer::ConsensusInfo::NodeCatchupStatus(
+                            grpc2::types::peers_info::peer::ConsensusInfo::NodeCatchupStatus(
                                 catchup_status.into(),
                             )
                         }
                         // Bootstrappers do not have a catchup status as they are not participating
                         // in the consensus protocol.
                         crate::common::PeerType::Bootstrapper => {
-                            crate::grpc2::types::peers_info::peer::ConsensusInfo::Bootstrapper(
-                                crate::grpc2::types::Empty::default(),
+                            grpc2::types::peers_info::peer::ConsensusInfo::Bootstrapper(
+                                grpc2::types::Empty::default(),
                             )
                         }
                     };
                     // Get the catchup status of the peer.
-                    let socket_address = crate::grpc2::types::IpSocketAddress {
-                        ip: Some(crate::grpc2::types::IpAddress {
+                    let socket_address = grpc2::types::IpSocketAddress {
+                        ip: Some(grpc2::types::IpAddress {
                             value: peer_stats.external_address().ip().to_string(),
                         }),
-                        port: Some(crate::grpc2::types::Port {
+                        port: Some(grpc2::types::Port {
                             value: peer_stats.external_port as u32,
                         }),
                     };
                     // Wrap the peer id.
-                    let peer_id = crate::grpc2::types::PeerId {
+                    let peer_id = grpc2::types::PeerId {
                         value: format!("{}", peer_stats.self_id),
                     };
-                    crate::grpc2::types::peers_info::Peer {
+                    grpc2::types::peers_info::Peer {
                         peer_id: Some(peer_id),
                         socket_address: Some(socket_address),
                         consensus_info: Some(consensus_info),
@@ -3016,14 +3064,12 @@ pub mod server {
                     }
                 })
                 .collect();
-            Ok(tonic::Response::new(crate::grpc2::types::PeersInfo {
-                peers,
-            }))
+            Ok(tonic::Response::new(grpc2::types::PeersInfo { peers }))
         }
 
         async fn get_node_info(
             &self,
-            _request: tonic::Request<crate::grpc2::types::Empty>,
+            _request: tonic::Request<grpc2::types::Empty>,
         ) -> Result<tonic::Response<types::NodeInfo>, tonic::Status> {
             if !self.service_config.get_node_info {
                 return Err(tonic::Status::unimplemented(
@@ -3149,8 +3195,8 @@ pub mod server {
 
         async fn send_block_item(
             &self,
-            request: tonic::Request<crate::grpc2::types::SendBlockItemRequest>,
-        ) -> Result<tonic::Response<crate::grpc2::types::TransactionHash>, tonic::Status> {
+            request: tonic::Request<grpc2::types::SendBlockItemRequest>,
+        ) -> Result<tonic::Response<grpc2::types::TransactionHash>, tonic::Status> {
             use ConsensusFfiResponse::*;
             if !self.service_config.send_block_item {
                 return Err(tonic::Status::unimplemented(
@@ -3212,7 +3258,7 @@ pub mod server {
                             ));
                         }
                     };
-                    Ok(tonic::Response::new(crate::grpc2::types::TransactionHash {
+                    Ok(tonic::Response::new(grpc2::types::TransactionHash {
                         value: transaction_hash.to_vec(),
                     }))
                 }
@@ -3249,8 +3295,8 @@ pub mod server {
 
         async fn get_account_transaction_sign_hash(
             &self,
-            request: tonic::Request<crate::grpc2::types::PreAccountTransaction>,
-        ) -> Result<tonic::Response<crate::grpc2::types::AccountTransactionSignHash>, tonic::Status>
+            request: tonic::Request<grpc2::types::PreAccountTransaction>,
+        ) -> Result<tonic::Response<grpc2::types::AccountTransactionSignHash>, tonic::Status>
         {
             if !self.service_config.get_account_transaction_sign_hash {
                 return Err(tonic::Status::unimplemented(
@@ -3268,7 +3314,7 @@ pub mod server {
 
         async fn get_block_items(
             &self,
-            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+            request: tonic::Request<grpc2::types::BlockHashInput>,
         ) -> Result<tonic::Response<Self::GetBlockItemsStream>, tonic::Status> {
             if !self.service_config.get_block_items {
                 return Err(tonic::Status::unimplemented(
@@ -3288,7 +3334,7 @@ pub mod server {
 
         async fn get_block_certificates(
             &self,
-            request: tonic::Request<crate::grpc2::types::BlockHashInput>,
+            request: tonic::Request<grpc2::types::BlockHashInput>,
         ) -> Result<tonic::Response<Vec<u8>>, tonic::Status> {
             if !self.service_config.get_block_certificates {
                 return Err(tonic::Status::unimplemented(
@@ -3307,8 +3353,8 @@ pub mod server {
 
         async fn get_first_block_epoch(
             &self,
-            request: tonic::Request<crate::grpc2::types::EpochRequest>,
-        ) -> Result<tonic::Response<crate::grpc2::types::BlockHash>, tonic::Status> {
+            request: tonic::Request<grpc2::types::EpochRequest>,
+        ) -> Result<tonic::Response<grpc2::types::BlockHash>, tonic::Status> {
             if !self.service_config.get_first_block_epoch {
                 return Err(tonic::Status::unimplemented(
                     "`GetFirstBlockEpoch` is not enabled.",
@@ -3326,7 +3372,7 @@ pub mod server {
 
         async fn get_winning_bakers_epoch(
             &self,
-            request: tonic::Request<crate::grpc2::types::EpochRequest>,
+            request: tonic::Request<grpc2::types::EpochRequest>,
         ) -> Result<tonic::Response<Self::GetWinningBakersEpochStream>, tonic::Status> {
             if !self.service_config.get_winning_bakers_epoch {
                 return Err(tonic::Status::unimplemented(
@@ -3343,7 +3389,7 @@ pub mod server {
 
         async fn dry_run(
             &self,
-            request: tonic::Request<tonic::Streaming<crate::grpc2::types::DryRunRequest>>,
+            request: tonic::Request<tonic::Streaming<grpc2::types::DryRunRequest>>,
         ) -> Result<tonic::Response<Self::DryRunStream>, tonic::Status> {
             if !self.service_config.dry_run {
                 return Err(tonic::Status::unimplemented("`DryRun` is not enabled."));

--- a/plt/plt-block-state/src/block_state.rs
+++ b/plt/plt-block-state/src/block_state.rs
@@ -4,7 +4,7 @@ use crate::block_state::blob_store::{BlobStoreLoad, BlobStoreStore, Loadable, St
 use crate::block_state::cacheable::Cacheable;
 use crate::block_state::external::{ExternalBlockStateOperations, ExternalBlockStateQuery};
 use crate::block_state::hash::Hashable;
-use crate::block_state::state::protocol_level_locks::ProtocolLevelLocks;
+use crate::block_state::state::protocol_level_locks::{Lock, ProtocolLevelLocks};
 use crate::block_state::state::protocol_level_tokens::ProtocolLevelTokens;
 use crate::block_state::types::AccountWithCanonicalAddress;
 use crate::block_state::types::protocol_level_locks::LockConfiguration;
@@ -337,6 +337,21 @@ impl<IntState: HasBlockState, Load: BlobStoreLoad, ExtState: ExternalBlockStateQ
         self.protocol_version
     }
 
+    fn lock_list(&self) -> impl ExactSizeIterator<Item = LockId> {
+        // The lock map is stored in memory, so we materialize the keys eagerly. The
+        // returned iterator preserves the BTreeMap ordering and reports the exact
+        // number of locks via `ExactSizeIterator`.
+        self.internal_block_state
+            .block_state()
+            .locks
+            .locks
+            .0
+            .keys()
+            .cloned()
+            .collect::<Vec<LockId>>()
+            .into_iter()
+    }
+
     fn lock_by_id(&self, lock_id: &LockId) -> Result<LockId, LockNotFoundByIdError> {
         if self
             .internal_block_state
@@ -441,18 +456,45 @@ impl<Load: BlobStoreLoad, ExtState: ExternalBlockStateOperations> BlockStateOper
             .unwrap();
     }
 
-    // TODO: lock creation implemented as part of COR-2302
-    fn create_lock(&mut self, _lock_id: &LockId, _configuration: &LockConfiguration) -> LockId {
-        todo!()
+    fn create_lock(&mut self, lock_id: &LockId, configuration: &LockConfiguration) -> LockId {
+        self.internal_block_state
+            .update_block_state_(|mut state| {
+                let prev = state.locks.locks.0.insert(
+                    lock_id.clone(),
+                    Lock {
+                        locked_balances: Default::default(),
+                        configuration: configuration.clone(),
+                    },
+                );
+                debug_assert!(prev.is_none(), "create_lock called for an existing lock id");
+                Ok(state)
+            })
+            .unwrap();
+        lock_id.clone()
     }
 
-    // TODO: Implement as part of COR-2305.
     fn add_lock_balance_ref(
         &mut self,
-        _lock: &LockId,
-        _account: &Self::Account,
-        _token: &Self::Token,
+        lock: &LockId,
+        account: &Self::Account,
+        token: &Self::Token,
     ) {
-        todo!()
+        let account_index = *account;
+        let token_index = *token;
+        let lock_id = lock.clone();
+        self.internal_block_state
+            .update_block_state_(|mut state| {
+                let lock_entry = state
+                    .locks
+                    .locks
+                    .0
+                    .get_mut(&lock_id)
+                    .expect("add_lock_balance_ref called for an unknown lock id");
+                lock_entry
+                    .locked_balances
+                    .insert((account_index, token_index));
+                Ok(state)
+            })
+            .unwrap();
     }
 }

--- a/plt/plt-block-state/src/block_state.rs
+++ b/plt/plt-block-state/src/block_state.rs
@@ -426,9 +426,6 @@ impl<IntState: HasBlockState, Load: BlobStoreLoad, ExtState: ExternalBlockStateQ
     }
 
     fn lock_list(&self) -> impl ExactSizeIterator<Item = LockId> {
-        // The lock map is stored in memory, so we materialize the keys eagerly. The
-        // returned iterator preserves the BTreeMap ordering and reports the exact
-        // number of locks via `ExactSizeIterator`.
         self.internal_block_state
             .block_state()
             .locks
@@ -436,8 +433,6 @@ impl<IntState: HasBlockState, Load: BlobStoreLoad, ExtState: ExternalBlockStateQ
             .0
             .keys()
             .cloned()
-            .collect::<Vec<LockId>>()
-            .into_iter()
     }
 
     fn lock_by_id(&self, lock_id: &LockId) -> Result<LockId, LockNotFoundByIdError> {
@@ -545,6 +540,7 @@ impl<Load: BlobStoreLoad, ExtState: ExternalBlockStateOperations> BlockStateOper
     }
 
     fn create_lock(&mut self, lock_id: &LockId, configuration: &LockConfiguration) -> LockId {
+        // todo propagate block state error as part of https://linear.app/concordium/issue/COR-2346/push-blockstateerror-to-scheduler-code
         self.internal_block_state
             .update_block_state_(|mut state| {
                 let prev = state.locks.locks.0.insert(
@@ -570,6 +566,7 @@ impl<Load: BlobStoreLoad, ExtState: ExternalBlockStateOperations> BlockStateOper
         let account_index = *account;
         let token_index = *token;
         let lock_id = lock.clone();
+        // todo propagate block state error as part of https://linear.app/concordium/issue/COR-2346/push-blockstateerror-to-scheduler-code
         self.internal_block_state
             .update_block_state_(|mut state| {
                 let lock_entry = state

--- a/plt/plt-block-state/src/block_state_interface.rs
+++ b/plt/plt-block-state/src/block_state_interface.rs
@@ -185,6 +185,13 @@ pub trait BlockStateQuery {
     /// Query the protocol version of the block state.
     fn protocol_version(&self) -> ProtocolVersion;
 
+    /// Get the [`LockId`]s of all protocol-level locks registered on the chain at the
+    /// end of the block.
+    ///
+    /// If the protocol version does not support protocol-level locks, this will return the empty
+    /// list.
+    fn lock_list(&self) -> impl ExactSizeIterator<Item = LockId>;
+
     /// Get the lock associated with a [`LockId`] (if it exists).
     ///
     /// # Arguments
@@ -321,6 +328,12 @@ pub trait BlockStateOperations: BlockStateQuery {
     /// - `lock` The lock to update.
     /// - `account` The account whose locked balance is tracked.
     /// - `token` The token whose locked balance is tracked.
+    ///
+    /// The caller must ensure the following conditions are true, and failing to do so results in
+    /// undefined behavior.
+    ///
+    /// - The `lock` MUST already exist in the block state, i.e.
+    ///   `s.lock_by_id(lock_id).expect("lock exists")`.
     fn add_lock_balance_ref(&mut self, lock: &LockId, account: &Self::Account, token: &Self::Token);
 }
 

--- a/plt/plt-block-state/tests/block_state.rs
+++ b/plt/plt-block-state/tests/block_state.rs
@@ -1,15 +1,19 @@
 //! Tests of the block state [`PltBlockState`](plt_scheduler::block_state::PltBlockState).
 
 use concordium_base::base::ProtocolVersion;
+use concordium_base::common::types::TransactionTime;
+use concordium_base::protocol_level_locks::LockId;
 use concordium_base::protocol_level_tokens::{TokenId, TokenModuleRef};
 use plt_block_state::block_state::blob_store::BlobStoreLocation;
 use plt_block_state::block_state::blob_store::test_stub::BlobStoreStub;
 use plt_block_state::block_state::hash::Hashable;
+use plt_block_state::block_state::types::protocol_level_locks::LockConfiguration;
 use plt_block_state::block_state::types::protocol_level_tokens::{
     TokenConfiguration, TokenStateKey, TokenStateValue,
 };
 use plt_block_state::block_state::{BlockState, blob_store};
 use plt_block_state::block_state_interface::{BlockStateOperations, BlockStateQuery};
+use plt_scheduler_types::types::locks::{LockControllerConfig, LockControllerSimpleV0};
 use plt_scheduler_types::types::tokens::RawTokenAmount;
 
 mod block_state_no_external;
@@ -58,6 +62,42 @@ fn test_plt_list() {
     // Read PLT list
     let tokens: Vec<_> = block_state.plt_list().collect();
     assert_eq!(tokens, vec![token_id1, token_id2]);
+}
+
+/// Test getting list of locks. Mirrors `test_plt_list` for the lock side of the block state.
+#[test]
+fn test_lock_list() {
+    let mut block_state = block_state_no_external::new_mutable_block_state(ProtocolVersion::P11);
+
+    // Empty configuration is sufficient for `lock_list` — we only care about which lock ids
+    // were created, not their content.
+    let configuration = LockConfiguration {
+        recipients: Vec::new(),
+        expiry: TransactionTime::from(0u64),
+        controller: LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
+            grants: Vec::new(),
+            tokens: Vec::new(),
+            keep_alive: false,
+            memo: None,
+        }),
+    };
+
+    let lock_a = LockId {
+        account_index: 1,
+        sequence_number: 1,
+        creation_order: 0,
+    };
+    let lock_b = LockId {
+        account_index: 2,
+        sequence_number: 7,
+        creation_order: 0,
+    };
+    block_state.create_lock(&lock_a, &configuration);
+    block_state.create_lock(&lock_b, &configuration);
+
+    // Read lock list
+    let locks: Vec<_> = block_state.lock_list().collect();
+    assert_eq!(locks, vec![lock_a, lock_b]);
 }
 
 /// Test getting token by id.

--- a/plt/plt-scheduler/src/ffi/queries.rs
+++ b/plt/plt-scheduler/src/ffi/queries.rs
@@ -479,7 +479,7 @@ extern "C" fn ffi_query_lock_info(
     get_account_address_by_index_callback: GetCanonicalAddressByAccountIndexCallback,
     get_token_account_states_callback: GetTokenAccountStatesCallback,
     block_state: *const BlockState,
-    lock_id: *const u8,
+    lock_id: *const [u8; 24],
     return_data_out: *mut *mut u8,
     return_data_len_out: *mut size_t,
 ) -> status::FfiStatusCode {
@@ -507,7 +507,7 @@ extern "C" fn ffi_query_lock_info(
             external_block_state: external_callbacks,
         };
         // The Haskell side serializes a `LockId` as three big-endian `u64`s, exactly 24 bytes.
-        let lock_id_bytes = unsafe { std::slice::from_raw_parts(lock_id, 24) };
+        let lock_id_bytes = unsafe { lock_id.as_ref_unchecked() };
         let lock_id: LockId = common::from_bytes_complete(lock_id_bytes)
             .expect("Bytes for the LockId could not be deserialized");
         match queries::query_lock_info(&block_state, &lock_id) {

--- a/plt/plt-scheduler/src/ffi/queries.rs
+++ b/plt/plt-scheduler/src/ffi/queries.rs
@@ -4,9 +4,10 @@
 
 use crate::ffi::status;
 use crate::queries;
-use crate::queries::QueryTokenInfoError;
+use crate::queries::{QueryLockError, QueryTokenInfoError};
 use concordium_base::base::{AccountIndex, ProtocolVersion};
 use concordium_base::common;
+use concordium_base::protocol_level_locks::LockId;
 use libc::size_t;
 use plt_block_state::block_state::{BlockState, ExecutionTimeBlockState};
 use plt_block_state::ffi::blob_store_callbacks::LoadCallback;
@@ -363,6 +364,177 @@ extern "C" fn ffi_query_token_account_infos(
             queries::query_token_account_infos(&block_state, AccountIndex::from(account_index));
         let return_data = common::to_bytes(&token_account_infos);
         (status::FfiStatusCode::Success, return_data)
+    });
+    let array = memory::alloc_array_from_vec(return_data);
+    unsafe {
+        *return_data_len_out = array.length;
+        *return_data_out = array.array;
+    }
+    return_status
+}
+
+/// C-binding for calling [`queries::query_lock_list`].
+///
+/// Returns a byte representing the result:
+///
+/// - `0`: Query succeeded
+///
+/// # Arguments
+///
+/// - `load_callback` External function to call for loading bytes a reference from the blob store.
+/// - `read_token_account_balance_callback` External function to call reading the token balance of an account.
+/// - `get_account_address_by_index_callback` External function for getting account canonical address by account index.
+/// - `get_account_index_by_address_callback` External function for getting account index by account address.
+/// - `get_token_account_states_callback` External function for getting token account states.
+/// - `block_state` Shared pointer to a block state to use for queries.
+/// - `return_data_out` Location for writing pointer to array containing return data, which is the
+///   serialized list of lock ids. The pointer written is to a uniquely owned array. The caller must
+///   free the written array using `free_array_len_2` when it is no longer used.
+/// - `return_data_len_out` Location for writing the length of the array whose pointer was written
+///   to `return_data_out`.
+///
+/// # Safety
+///
+/// - All callback arguments must be valid function pointers to functions with a signature matching
+///   the signature of the Rust type of the function pointer.
+/// - Argument `block_state` must be a non-null pointer to a well-formed [`BlockState`]. The pointer
+///   is to a shared instance, hence only valid for reading (writing only allowed through interior
+///   mutability).
+/// - Argument `return_data_out` must be a non-null and valid pointer for writing.
+/// - Argument `return_data_len_out` must be a non-null and valid pointer for writing.
+#[unsafe(no_mangle)]
+extern "C" fn ffi_query_lock_list(
+    load_callback: LoadCallback,
+    read_token_account_balance_callback: ReadTokenAccountBalanceCallback,
+    get_account_index_by_address_callback: GetAccountIndexByAddressCallback,
+    get_account_address_by_index_callback: GetCanonicalAddressByAccountIndexCallback,
+    get_token_account_states_callback: GetTokenAccountStatesCallback,
+    block_state: *const BlockState,
+    protocol_version: u64,
+    return_data_out: *mut *mut u8,
+    return_data_len_out: *mut size_t,
+) -> status::FfiStatusCode {
+    let (return_status, return_data) = status::catch_unwind(|| {
+        assert!(!block_state.is_null(), "block_state is a null pointer.");
+        assert!(
+            !return_data_len_out.is_null(),
+            "return_data_len_out is a null pointer."
+        );
+        assert!(
+            !return_data_out.is_null(),
+            "return_data_out is a null pointer."
+        );
+        let external_callbacks = ExternalBlockStateQueryCallbacks {
+            read_token_account_balance_ptr: read_token_account_balance_callback,
+            get_account_address_by_index_ptr: get_account_address_by_index_callback,
+            get_account_index_by_address_ptr: get_account_index_by_address_callback,
+            get_token_account_states_ptr: get_token_account_states_callback,
+        };
+        let protocol_version =
+            ProtocolVersion::try_from(protocol_version).expect("Unknown protocol version");
+        let internal_block_state = unsafe { &*block_state };
+        let block_state = ExecutionTimeBlockState {
+            protocol_version,
+            internal_block_state,
+            blob_store_load: load_callback,
+            external_block_state: external_callbacks,
+        };
+        let lock_ids = queries::query_lock_list(&block_state);
+        let return_data = common::to_bytes(&lock_ids);
+        (status::FfiStatusCode::Success, return_data)
+    });
+    let array = memory::alloc_array_from_vec(return_data);
+    unsafe {
+        *return_data_len_out = array.length;
+        *return_data_out = array.array;
+    }
+    return_status
+}
+
+/// C-binding for calling [`queries::query_lock_info`].
+///
+/// Returns a byte representing the result:
+///
+/// - `0`: Query succeeded
+/// - `1`: Lock does not exist
+///
+/// # Arguments
+///
+/// - `load_callback` External function to call for loading bytes a reference from the blob store.
+/// - `read_token_account_balance_callback` External function to call reading the token balance of an account.
+/// - `get_account_address_by_index_callback` External function for getting account canonical address by account index.
+/// - `get_account_index_by_address_callback` External function for getting account index by account address.
+/// - `get_token_account_states_callback` External function for getting token account states.
+/// - `block_state` Shared pointer to a block state to use for queries.
+/// - `lock_id` Pointer to 24 bytes containing the [`LockId`] (three big-endian `u64` fields:
+///   `account_index`, `sequence_number`, `creation_order`).
+/// - `return_data_out` Location for writing pointer to array containing return data, which is the
+///   raw CBOR-encoded `lock-info` payload. The pointer written is to a uniquely owned array; the
+///   caller must free the written array using `free_array_len_2` when it is no longer used.
+///   If the return value is `1`, the data is empty (zero bytes).
+/// - `return_data_len_out` Location for writing the length of the array whose pointer was written
+///   to `return_data_out`.
+///
+/// # Safety
+///
+/// - All callback arguments must be valid function pointers to functions with a signature matching
+///   the signature of the Rust type of the function pointer.
+/// - Argument `block_state` must be a non-null pointer to a well-formed [`BlockState`]. The pointer
+///   is to a shared instance, hence only valid for reading (writing only allowed through interior
+///   mutability).
+/// - Argument `lock_id` must be non-null and valid for reads of exactly 24 bytes.
+/// - Argument `return_data_out` must be a non-null and valid pointer for writing.
+/// - Argument `return_data_len_out` must be a non-null and valid pointer for writing.
+#[unsafe(no_mangle)]
+extern "C" fn ffi_query_lock_info(
+    load_callback: LoadCallback,
+    read_token_account_balance_callback: ReadTokenAccountBalanceCallback,
+    get_account_index_by_address_callback: GetAccountIndexByAddressCallback,
+    get_account_address_by_index_callback: GetCanonicalAddressByAccountIndexCallback,
+    get_token_account_states_callback: GetTokenAccountStatesCallback,
+    block_state: *const BlockState,
+    protocol_version: u64,
+    lock_id: *const u8,
+    return_data_out: *mut *mut u8,
+    return_data_len_out: *mut size_t,
+) -> status::FfiStatusCode {
+    let (return_status, return_data) = status::catch_unwind(|| {
+        assert!(!block_state.is_null(), "block_state is a null pointer.");
+        assert!(!lock_id.is_null(), "lock_id is a null pointer.");
+        assert!(
+            !return_data_len_out.is_null(),
+            "return_data_len_out is a null pointer."
+        );
+        assert!(
+            !return_data_out.is_null(),
+            "return_data_out is a null pointer."
+        );
+        let external_callbacks = ExternalBlockStateQueryCallbacks {
+            read_token_account_balance_ptr: read_token_account_balance_callback,
+            get_account_address_by_index_ptr: get_account_address_by_index_callback,
+            get_account_index_by_address_ptr: get_account_index_by_address_callback,
+            get_token_account_states_ptr: get_token_account_states_callback,
+        };
+        let protocol_version =
+            ProtocolVersion::try_from(protocol_version).expect("Unknown protocol version");
+        let internal_block_state = unsafe { &*block_state };
+        let block_state = ExecutionTimeBlockState {
+            protocol_version,
+            internal_block_state,
+            blob_store_load: load_callback,
+            external_block_state: external_callbacks,
+        };
+        // The Haskell side serializes a `LockId` as three big-endian `u64`s, exactly 24 bytes.
+        let lock_id_bytes = unsafe { std::slice::from_raw_parts(lock_id, 24) };
+        let lock_id: LockId = common::from_bytes_complete(lock_id_bytes)
+            .expect("Bytes for the LockId could not be deserialized");
+        match queries::query_lock_info(&block_state, &lock_id) {
+            Ok(cbor_bytes) => (status::FfiStatusCode::Success, cbor_bytes),
+            Err(QueryLockError::LockDoesNotExist) => (status::FfiStatusCode::Failed, Vec::new()),
+            Err(QueryLockError::StateInvariantViolation(message)) => {
+                (status::FfiStatusCode::Panic, message.into_bytes())
+            }
+        }
     });
     let array = memory::alloc_array_from_vec(return_data);
     unsafe {

--- a/plt/plt-scheduler/src/locks.rs
+++ b/plt/plt-scheduler/src/locks.rs
@@ -1,2 +1,5 @@
+mod lock_configuration;
 pub mod lock_controller;
 mod lock_controller_simple;
+
+pub use lock_configuration::*;

--- a/plt/plt-scheduler/src/locks.rs
+++ b/plt/plt-scheduler/src/locks.rs
@@ -1,2 +1,2 @@
-mod lock_controller;
+pub mod lock_controller;
 mod lock_controller_simple;

--- a/plt/plt-scheduler/src/locks/lock_configuration.rs
+++ b/plt/plt-scheduler/src/locks/lock_configuration.rs
@@ -1,0 +1,97 @@
+use std::collections::BTreeMap;
+
+use concordium_base::{
+    base::AccountIndex,
+    protocol_level_locks::{LockAccountFunds, LockId, LockInfo, LockedTokenAmount},
+    protocol_level_tokens::{CborHolderAccount, TokenAmount},
+};
+use plt_block_state::{
+    block_state::types::protocol_level_locks::LockConfiguration,
+    block_state_interface::BlockStateQuery,
+};
+
+use crate::{
+    locks::lock_controller::LockController, queries::QueryLockError,
+    token_context::TokenQueryContext, token_module,
+};
+
+/// Build the [`LockInfo`] for a lock from its [`LockConfiguration`] and the live
+/// per-`(account, token)` balances held by the lock.
+pub fn get_lock_info<BSQ: BlockStateQuery>(
+    bsq: &BSQ,
+    lock_id: &LockId,
+    configuration: &LockConfiguration,
+) -> Result<LockInfo, QueryLockError> {
+    // Resolve recipients (block-state `AccountIndex`es) into `CborHolderAccount` values
+    // by looking up each account's canonical address.
+    let recipients: Vec<CborHolderAccount> = configuration
+        .recipients
+        .iter()
+        .map(|account_index| {
+            let with_addr = bsq.account_by_index(*account_index).map_err(|_| {
+                QueryLockError::StateInvariantViolation(format!(
+                    "recipient account index {} recorded in lock configuration does not exist",
+                    account_index
+                ))
+            })?;
+            Ok(CborHolderAccount::from(with_addr.canonical_account_address))
+        })
+        .collect::<Result<_, QueryLockError>>()?;
+
+    // Convert the lock controller configuration into the CBOR `LockController` shape used
+    // by the `lock-info` payload. Variant-specific resolution (e.g. expanding grant
+    // `AccountIndex`es to `CborHolderAccount`) lives on the per-variant
+    // `crate::locks::lock_controller::LockController` impl.
+    let controller = configuration.controller.to_cbor_controller(bsq)?;
+
+    // Group the tracked `(account, token)` balances by account so we emit a single
+    // `LockAccountFunds` entry per account.
+    let mut funds_by_account: BTreeMap<AccountIndex, Vec<LockedTokenAmount>> = BTreeMap::new();
+    for (account, token) in bsq.lock_balances(lock_id) {
+        let account_index = bsq.account_index(&account);
+        let token_configuration = bsq.token_configuration(&token);
+        let token_module_state = bsq.mutable_token_key_value_state(&token);
+        let context = TokenQueryContext {
+            block_state: bsq,
+            token_module_state: &token_module_state,
+        };
+
+        // for each locked balance record for the lock, get the locked token amount recorded in the
+        // account state of the token.
+        let raw_balance =
+            token_module::query_locked_balance(&context, account_index, lock_id.clone())?;
+        let amount = TokenAmount::from_raw(raw_balance.0, token_configuration.decimals);
+        funds_by_account
+            .entry(account_index)
+            .or_default()
+            .push(LockedTokenAmount {
+                token: token_configuration.token_id,
+                amount,
+            });
+    }
+
+    // Resolve the account addresses for the accounts holding locked funds
+    let funds: Vec<LockAccountFunds> = funds_by_account
+        .into_iter()
+        .map(|(account_index, amounts)| {
+            let with_addr = bsq.account_by_index(account_index).map_err(|_| {
+                QueryLockError::StateInvariantViolation(format!(
+                    "account index {} returned by `lock_balances` does not exist",
+                    account_index
+                ))
+            })?;
+            Ok(LockAccountFunds {
+                account: CborHolderAccount::from(with_addr.canonical_account_address),
+                amounts,
+            })
+        })
+        .collect::<Result<_, QueryLockError>>()?;
+
+    Ok(LockInfo {
+        lock: lock_id.clone(),
+        recipients,
+        expiry: configuration.expiry,
+        controller,
+        funds,
+    })
+}

--- a/plt/plt-scheduler/src/locks/lock_controller.rs
+++ b/plt/plt-scheduler/src/locks/lock_controller.rs
@@ -1,11 +1,13 @@
 //! Runtime interface for protocol-level lock controllers.
 
 use concordium_base::{
-    protocol_level_locks::LockId,
+    protocol_level_locks::{LockController as CborLockController, LockId},
     protocol_level_tokens::{CborHolderAccount, CborMemo, TokenAmount, TokenId},
 };
 use plt_block_state::block_state_interface::BlockStateQuery;
 use plt_scheduler_types::types::locks::LockControllerConfig;
+
+use crate::queries::QueryLockError;
 
 /// Runtime lock operation model. This corresponds to the "fund", "send", "return", and "cancel"
 /// CBOR operations for interacting with locks from concordium-base.
@@ -43,13 +45,7 @@ pub enum LockOperation {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct LockControllerRejectReason;
 
-/// Placeholded type for the lock info returned when querying a lock for data.
-/// FIXME: replace with the corresponding type in concordium-base as part of COR-2309
-#[derive(Debug, Clone)]
-pub struct LockInfo;
-
 /// Runtime interface implemented by protocol-level locks.
-#[allow(dead_code)] // FIXME: remove when this is used.
 pub trait LockController {
     /// Approve or reject a lock operation.
     ///
@@ -57,6 +53,7 @@ pub trait LockController {
     /// * `sender`: the transaction sender reference
     /// * `lock`: the lock reference. This is used instead of the lock ID from the operation.
     /// * `operation`: the lock operation to approve/reject.
+    #[allow(dead_code)] // FIXME: remove when this is used.
     fn validate_operation<BSQ: BlockStateQuery>(
         &self,
         bsq: &BSQ,
@@ -64,8 +61,19 @@ pub trait LockController {
         operation: &LockOperation,
     ) -> Result<(), LockControllerRejectReason>;
 
-    /// Query controller configuration and state as CBOR.
-    fn query_info<BSQ: BlockStateQuery>(&self, bsq: &BSQ, lock: &LockId) -> LockInfo;
+    /// Convert this controller configuration to its canonical CBOR
+    /// [`concordium_base::protocol_level_locks::LockController`] representation, used by the
+    /// `lock-info` payload returned from `query_lock_info`.
+    ///
+    /// Resolves any block-state `AccountIndex` references (e.g. grant accounts) to their
+    /// canonical [`CborHolderAccount`] form via `bsq`. Surfaces a
+    /// [`QueryLockError::StateInvariantViolation`] if a recorded `AccountIndex` cannot be
+    /// looked up — that signals corrupted block state, since lock configurations are only
+    /// allowed to reference accounts that exist at creation time.
+    fn to_cbor_controller<BSQ: BlockStateQuery>(
+        &self,
+        bsq: &BSQ,
+    ) -> Result<CborLockController, QueryLockError>;
 }
 
 impl LockController for LockControllerConfig {
@@ -82,10 +90,13 @@ impl LockController for LockControllerConfig {
         }
     }
 
-    fn query_info<BSQ: BlockStateQuery>(&self, bsq: &BSQ, lock: &LockId) -> LockInfo {
+    fn to_cbor_controller<BSQ: BlockStateQuery>(
+        &self,
+        bsq: &BSQ,
+    ) -> Result<CborLockController, QueryLockError> {
         match self {
             LockControllerConfig::SimpleV0(lock_controller_simple_v0) => {
-                lock_controller_simple_v0.query_info(bsq, lock)
+                lock_controller_simple_v0.to_cbor_controller(bsq)
             }
         }
     }

--- a/plt/plt-scheduler/src/locks/lock_controller.rs
+++ b/plt/plt-scheduler/src/locks/lock_controller.rs
@@ -1,7 +1,7 @@
 //! Runtime interface for protocol-level lock controllers.
 
 use concordium_base::{
-    protocol_level_locks::{LockController as CborLockController, LockId},
+    protocol_level_locks::LockId,
     protocol_level_tokens::{CborHolderAccount, CborMemo, TokenAmount, TokenId},
 };
 use plt_block_state::block_state_interface::BlockStateQuery;
@@ -73,7 +73,7 @@ pub trait LockController {
     fn to_cbor_controller<BSQ: BlockStateQuery>(
         &self,
         bsq: &BSQ,
-    ) -> Result<CborLockController, QueryLockError>;
+    ) -> Result<concordium_base::protocol_level_locks::LockController, QueryLockError>;
 }
 
 impl LockController for LockControllerConfig {
@@ -93,7 +93,7 @@ impl LockController for LockControllerConfig {
     fn to_cbor_controller<BSQ: BlockStateQuery>(
         &self,
         bsq: &BSQ,
-    ) -> Result<CborLockController, QueryLockError> {
+    ) -> Result<concordium_base::protocol_level_locks::LockController, QueryLockError> {
         match self {
             LockControllerConfig::SimpleV0(lock_controller_simple_v0) => {
                 lock_controller_simple_v0.to_cbor_controller(bsq)

--- a/plt/plt-scheduler/src/locks/lock_controller_simple.rs
+++ b/plt/plt-scheduler/src/locks/lock_controller_simple.rs
@@ -1,10 +1,13 @@
-use concordium_base::protocol_level_locks::LockId;
+use concordium_base::protocol_level_locks::{
+    LockController as CborLockController, LockControllerSimpleV0 as CborLockControllerSimpleV0,
+    LockControllerSimpleV0Grant as CborLockControllerSimpleV0Grant,
+};
+use concordium_base::protocol_level_tokens::CborHolderAccount;
 use plt_block_state::block_state_interface::BlockStateQuery;
 use plt_scheduler_types::types::locks::LockControllerSimpleV0;
 
-use crate::locks::lock_controller::{
-    LockController, LockControllerRejectReason, LockInfo, LockOperation,
-};
+use crate::locks::lock_controller::{LockController, LockControllerRejectReason, LockOperation};
+use crate::queries::QueryLockError;
 
 impl LockController for LockControllerSimpleV0 {
     // TODO: implemented as part of COR-2305
@@ -17,8 +20,32 @@ impl LockController for LockControllerSimpleV0 {
         todo!()
     }
 
-    // TODO: implemented as part of COR-2309
-    fn query_info<BSQ: BlockStateQuery>(&self, _bsq: &BSQ, _lock: &LockId) -> LockInfo {
-        todo!()
+    fn to_cbor_controller<BSQ: BlockStateQuery>(
+        &self,
+        bsq: &BSQ,
+    ) -> Result<CborLockController, QueryLockError> {
+        let grants = self
+            .grants
+            .iter()
+            .map(|grant| {
+                let with_addr = bsq.account_by_index(grant.account).map_err(|_| {
+                    QueryLockError::StateInvariantViolation(format!(
+                        "controller grant account index {} recorded in lock configuration \
+                         does not exist",
+                        grant.account
+                    ))
+                })?;
+                Ok(CborLockControllerSimpleV0Grant {
+                    account: CborHolderAccount::from(with_addr.canonical_account_address),
+                    roles: grant.roles.clone(),
+                })
+            })
+            .collect::<Result<_, QueryLockError>>()?;
+        Ok(CborLockController::SimpleV0(CborLockControllerSimpleV0 {
+            grants,
+            tokens: self.tokens.clone(),
+            keep_alive: self.keep_alive,
+            memo: self.memo.clone(),
+        }))
     }
 }

--- a/plt/plt-scheduler/src/locks/lock_controller_simple.rs
+++ b/plt/plt-scheduler/src/locks/lock_controller_simple.rs
@@ -1,7 +1,3 @@
-use concordium_base::protocol_level_locks::{
-    LockController as CborLockController, LockControllerSimpleV0 as CborLockControllerSimpleV0,
-    LockControllerSimpleV0Grant as CborLockControllerSimpleV0Grant,
-};
 use concordium_base::protocol_level_tokens::CborHolderAccount;
 use plt_block_state::block_state_interface::BlockStateQuery;
 use plt_scheduler_types::types::locks::LockControllerSimpleV0;
@@ -23,7 +19,7 @@ impl LockController for LockControllerSimpleV0 {
     fn to_cbor_controller<BSQ: BlockStateQuery>(
         &self,
         bsq: &BSQ,
-    ) -> Result<CborLockController, QueryLockError> {
+    ) -> Result<concordium_base::protocol_level_locks::LockController, QueryLockError> {
         let grants = self
             .grants
             .iter()
@@ -35,17 +31,23 @@ impl LockController for LockControllerSimpleV0 {
                         grant.account
                     ))
                 })?;
-                Ok(CborLockControllerSimpleV0Grant {
-                    account: CborHolderAccount::from(with_addr.canonical_account_address),
-                    roles: grant.roles.clone(),
-                })
+                Ok(
+                    concordium_base::protocol_level_locks::LockControllerSimpleV0Grant {
+                        account: CborHolderAccount::from(with_addr.canonical_account_address),
+                        roles: grant.roles.clone(),
+                    },
+                )
             })
             .collect::<Result<_, QueryLockError>>()?;
-        Ok(CborLockController::SimpleV0(CborLockControllerSimpleV0 {
-            grants,
-            tokens: self.tokens.clone(),
-            keep_alive: self.keep_alive,
-            memo: self.memo.clone(),
-        }))
+        Ok(
+            concordium_base::protocol_level_locks::LockController::SimpleV0(
+                concordium_base::protocol_level_locks::LockControllerSimpleV0 {
+                    grants,
+                    tokens: self.tokens.clone(),
+                    keep_alive: self.keep_alive,
+                    memo: self.memo.clone(),
+                },
+            ),
+        )
     }
 }

--- a/plt/plt-scheduler/src/queries.rs
+++ b/plt/plt-scheduler/src/queries.rs
@@ -2,13 +2,22 @@
 
 use crate::token_context::TokenQueryContext;
 use crate::token_module;
-use concordium_base::protocol_level_tokens::TokenId;
-use plt_block_state::block_state_interface::{BlockStateQuery, TokenNotFoundByIdError};
+use concordium_base::base::AccountIndex;
+use concordium_base::common::cbor::cbor_encode;
+use concordium_base::protocol_level_locks::{
+    LockAccountFunds, LockController, LockControllerSimpleV0, LockControllerSimpleV0Grant, LockId,
+    LockInfo, LockedTokenAmount,
+};
+use concordium_base::protocol_level_tokens::{CborHolderAccount, TokenId};
+use plt_block_state::block_state_interface::{
+    BlockStateQuery, LockNotFoundByIdError, TokenNotFoundByIdError,
+};
+use plt_scheduler_types::types::locks::LockControllerConfig;
 use plt_scheduler_types::types::queries::{
     TokenAccountInfo, TokenAccountState, TokenAuthorizations, TokenInfo, TokenState,
 };
 use plt_scheduler_types::types::tokens::TokenAmount;
-
+use std::collections::BTreeMap;
 /// Get the [`TokenId`]s of all protocol-level tokens registered on the chain.
 pub fn query_plt_list(block_state: &impl BlockStateQuery) -> Vec<TokenId> {
     block_state.plt_list().collect()
@@ -122,4 +131,161 @@ pub fn query_token_authorizations(
         token_id: token_configuration.token_id,
         details,
     })
+}
+
+/// Get the [`LockId`]s of all protocol-level locks registered on the chain at the
+/// end of the block.
+pub fn query_lock_list(block_state: &impl BlockStateQuery) -> Vec<LockId> {
+    block_state.lock_list().collect()
+}
+
+/// Reasons why a lock query (e.g. [`query_lock_info`]) may fail.
+#[derive(Debug, thiserror::Error)]
+pub enum QueryLockError {
+    /// The requested lock does not exist in the block state.
+    #[error("Lock does not exist")]
+    LockDoesNotExist,
+    /// On-chain block / token-module state violates an invariant assumed by the
+    /// `lock-info` assembly path — e.g. an `AccountIndex` recorded in the lock
+    /// configuration or returned by `lock_balances` does not resolve, or a tracked
+    /// `(account, token)` pair has an undecodable `quanta` entry in the token-module
+    /// key-value state. These are unrecoverable for clients and surface as `Panic`
+    /// over FFI.
+    #[error("State invariant violation while assembling lock info: {0}")]
+    StateInvariantViolation(String),
+}
+
+impl From<token_module::QueryTokenModuleError> for QueryLockError {
+    fn from(err: token_module::QueryTokenModuleError) -> Self {
+        QueryLockError::StateInvariantViolation(err.to_string())
+    }
+}
+
+impl From<LockNotFoundByIdError> for QueryLockError {
+    fn from(_: LockNotFoundByIdError) -> Self {
+        QueryLockError::LockDoesNotExist
+    }
+}
+
+/// Assemble the canonical [`LockInfo`] CBOR payload for a lock.
+///
+/// The function resolves the lock via [`BlockStateQuery::lock_by_id`], collects its
+/// [`BlockStateQuery::lock_configuration`] and per-`(account, token)`
+/// [`BlockStateQuery::account_token_balance`] entries, builds a
+/// [`concordium_base::protocol_level_locks::queries::LockInfo`] value, and CBOR-encodes
+/// it via the existing `CborSerialize` derive. The returned `Vec<u8>` is the canonical
+/// CBOR `lock-info` payload — callers MUST treat it as opaque.
+pub fn query_lock_info<BSQ: BlockStateQuery>(
+    block_state: &BSQ,
+    lock_id: &LockId,
+) -> Result<Vec<u8>, QueryLockError> {
+    let lock = block_state.lock_by_id(lock_id)?;
+    let configuration = block_state.lock_configuration(&lock);
+
+    // Resolve recipients (block-state `AccountIndex`es) into `CborHolderAccount` values
+    // by looking up each account's canonical address.
+    let recipients: Vec<CborHolderAccount> = configuration
+        .recipients
+        .iter()
+        .map(|account_index| {
+            let with_addr = block_state.account_by_index(*account_index).map_err(|_| {
+                QueryLockError::StateInvariantViolation(format!(
+                    "recipient account index {} recorded in lock configuration does not exist",
+                    account_index
+                ))
+            })?;
+            Ok(CborHolderAccount::from(with_addr.canonical_account_address))
+        })
+        .collect::<Result<_, QueryLockError>>()?;
+
+    // Convert the lock controller configuration into the CBOR `LockController` shape used
+    // by the `lock-info` payload.
+    let controller = match configuration.controller {
+        LockControllerConfig::SimpleV0(simple) => {
+            let grants = simple
+                .grants
+                .into_iter()
+                .map(|grant| {
+                    let with_addr = block_state.account_by_index(grant.account).map_err(|_| {
+                        QueryLockError::StateInvariantViolation(format!(
+                            "controller grant account index {} recorded in lock configuration \
+                             does not exist",
+                            grant.account
+                        ))
+                    })?;
+                    Ok(LockControllerSimpleV0Grant {
+                        account: CborHolderAccount::from(with_addr.canonical_account_address),
+                        roles: grant.roles,
+                    })
+                })
+                .collect::<Result<_, QueryLockError>>()?;
+            LockController::SimpleV0(LockControllerSimpleV0 {
+                grants,
+                tokens: simple.tokens,
+                keep_alive: simple.keep_alive,
+                memo: simple.memo,
+            })
+        }
+    };
+
+    // Group the tracked `(account, token)` balances by account so we emit a single
+    // `LockAccountFunds` entry per account, matching the CBOR `lock-info` shape. We key
+    // the intermediate map by `AccountIndex` (which is `Ord`) since the opaque
+    // `BSQ::Account` associated type is not required by the trait to support ordering.
+    //
+    // The locked amount for each `(account, token)` pair is read from the token-module
+    // key-value state via `token_module::query_locked_balance` (see
+    // `plt-scheduler/src/token_module/key_value_state.rs::get_locked_balance_for`),
+    // which is the source of truth for per-`(account, token, lock)` locked amounts.
+    // Reading the account's full token balance here would over-report by including the
+    // unlocked portion.
+    let mut funds_by_account: BTreeMap<AccountIndex, Vec<LockedTokenAmount>> = BTreeMap::new();
+    for (account, token) in block_state.lock_balances(lock_id) {
+        let account_index = block_state.account_index(&account);
+        let token_configuration = block_state.token_configuration(&token);
+        let token_module_state = block_state.mutable_token_key_value_state(&token);
+        let context = TokenQueryContext {
+            block_state,
+            token_module_state: &token_module_state,
+        };
+        let raw_balance =
+            token_module::query_locked_balance(&context, account_index, lock_id.clone())?;
+        let amount = concordium_base::protocol_level_tokens::TokenAmount::from_raw(
+            raw_balance.0,
+            token_configuration.decimals,
+        );
+        funds_by_account
+            .entry(account_index)
+            .or_default()
+            .push(LockedTokenAmount {
+                token: token_configuration.token_id,
+                amount,
+            });
+    }
+
+    let funds: Vec<LockAccountFunds> = funds_by_account
+        .into_iter()
+        .map(|(account_index, amounts)| {
+            let with_addr = block_state.account_by_index(account_index).map_err(|_| {
+                QueryLockError::StateInvariantViolation(format!(
+                    "account index {} returned by `lock_balances` does not exist",
+                    account_index
+                ))
+            })?;
+            Ok(LockAccountFunds {
+                account: CborHolderAccount::from(with_addr.canonical_account_address),
+                amounts,
+            })
+        })
+        .collect::<Result<_, QueryLockError>>()?;
+
+    let lock_info = LockInfo {
+        lock,
+        recipients,
+        expiry: configuration.expiry,
+        controller,
+        funds,
+    };
+
+    Ok(cbor_encode(&lock_info))
 }

--- a/plt/plt-scheduler/src/queries.rs
+++ b/plt/plt-scheduler/src/queries.rs
@@ -1,14 +1,11 @@
 //! Implementation of queries related to protocol-level tokens.
 
-use crate::locks::lock_controller::LockController;
+use crate::locks;
 use crate::token_context::TokenQueryContext;
 use crate::token_module;
-use concordium_base::base::AccountIndex;
 use concordium_base::common::cbor::cbor_encode;
-use concordium_base::protocol_level_locks::{
-    LockAccountFunds, LockId, LockInfo, LockedTokenAmount,
-};
-use concordium_base::protocol_level_tokens::{CborHolderAccount, TokenId};
+use concordium_base::protocol_level_locks::LockId;
+use concordium_base::protocol_level_tokens::TokenId;
 use plt_block_state::block_state_interface::{
     BlockStateQuery, LockNotFoundByIdError, TokenNotFoundByIdError,
 };
@@ -16,7 +13,6 @@ use plt_scheduler_types::types::queries::{
     TokenAccountInfo, TokenAccountState, TokenAuthorizations, TokenInfo, TokenState,
 };
 use plt_scheduler_types::types::tokens::TokenAmount;
-use std::collections::BTreeMap;
 /// Get the [`TokenId`]s of all protocol-level tokens registered on the chain.
 pub fn query_plt_list(block_state: &impl BlockStateQuery) -> Vec<TokenId> {
     block_state.plt_list().collect()
@@ -164,82 +160,19 @@ impl From<LockNotFoundByIdError> for QueryLockError {
 }
 
 /// Assemble the [`LockInfo`] CBOR payload for a lock.
+///
+/// Thin orchestrator: resolves `lock_id` to a [`LockConfiguration`] via the block state
+/// and delegates payload assembly to
+/// [`crate::locks::lock_configuration::LockInfoQuery::query_info`].
+///
+/// [`LockInfo`]: concordium_base::protocol_level_locks::LockInfo
+/// [`LockConfiguration`]: plt_block_state::block_state::types::protocol_level_locks::LockConfiguration
 pub fn query_lock_info<BSQ: BlockStateQuery>(
     block_state: &BSQ,
     lock_id: &LockId,
 ) -> Result<Vec<u8>, QueryLockError> {
     let lock = block_state.lock_by_id(lock_id)?;
     let configuration = block_state.lock_configuration(&lock);
-
-    // Resolve recipients (block-state `AccountIndex`es) into `CborHolderAccount` values
-    // by looking up each account's canonical address.
-    let recipients: Vec<CborHolderAccount> = configuration
-        .recipients
-        .iter()
-        .map(|account_index| {
-            let with_addr = block_state.account_by_index(*account_index).map_err(|_| {
-                QueryLockError::StateInvariantViolation(format!(
-                    "recipient account index {} recorded in lock configuration does not exist",
-                    account_index
-                ))
-            })?;
-            Ok(CborHolderAccount::from(with_addr.canonical_account_address))
-        })
-        .collect::<Result<_, QueryLockError>>()?;
-
-    // Convert the lock controller configuration into the CBOR `LockController` shape used
-    // by the `lock-info` payload.
-    let controller = configuration.controller.to_cbor_controller(block_state)?;
-
-    // Group the tracked `(account, token)` balances by account so we emit a single
-    // `LockAccountFunds` entry per account.
-    let mut funds_by_account: BTreeMap<AccountIndex, Vec<LockedTokenAmount>> = BTreeMap::new();
-    for (account, token) in block_state.lock_balances(lock_id) {
-        let account_index = block_state.account_index(&account);
-        let token_configuration = block_state.token_configuration(&token);
-        let token_module_state = block_state.mutable_token_key_value_state(&token);
-        let context = TokenQueryContext {
-            block_state,
-            token_module_state: &token_module_state,
-        };
-        let raw_balance =
-            token_module::query_locked_balance(&context, account_index, lock_id.clone())?;
-        let amount = concordium_base::protocol_level_tokens::TokenAmount::from_raw(
-            raw_balance.0,
-            token_configuration.decimals,
-        );
-        funds_by_account
-            .entry(account_index)
-            .or_default()
-            .push(LockedTokenAmount {
-                token: token_configuration.token_id,
-                amount,
-            });
-    }
-
-    let funds: Vec<LockAccountFunds> = funds_by_account
-        .into_iter()
-        .map(|(account_index, amounts)| {
-            let with_addr = block_state.account_by_index(account_index).map_err(|_| {
-                QueryLockError::StateInvariantViolation(format!(
-                    "account index {} returned by `lock_balances` does not exist",
-                    account_index
-                ))
-            })?;
-            Ok(LockAccountFunds {
-                account: CborHolderAccount::from(with_addr.canonical_account_address),
-                amounts,
-            })
-        })
-        .collect::<Result<_, QueryLockError>>()?;
-
-    let lock_info = LockInfo {
-        lock,
-        recipients,
-        expiry: configuration.expiry,
-        controller,
-        funds,
-    };
-
+    let lock_info = locks::get_lock_info(block_state, lock_id, &configuration)?;
     Ok(cbor_encode(&lock_info))
 }

--- a/plt/plt-scheduler/src/queries.rs
+++ b/plt/plt-scheduler/src/queries.rs
@@ -144,11 +144,8 @@ pub enum QueryLockError {
     /// The requested lock does not exist in the block state.
     #[error("Lock does not exist")]
     LockDoesNotExist,
-    /// On-chain block / token-module state violates an invariant assumed by the
-    /// `lock-info` assembly path — e.g. an `AccountIndex` recorded in the lock
-    /// configuration or returned by `lock_balances` does not resolve, or a tracked
-    /// `(account, token)` pair has an undecodable `quanta` entry in the token-module
-    /// key-value state. These are unrecoverable for clients and surface as `Panic`
+    /// On-chain block state violates an invariant assumed by the
+    /// query assembly path. These are unrecoverable for clients and surface as `Panic`
     /// over FFI.
     #[error("State invariant violation while assembling lock info: {0}")]
     StateInvariantViolation(String),
@@ -166,14 +163,7 @@ impl From<LockNotFoundByIdError> for QueryLockError {
     }
 }
 
-/// Assemble the canonical [`LockInfo`] CBOR payload for a lock.
-///
-/// The function resolves the lock via [`BlockStateQuery::lock_by_id`], collects its
-/// [`BlockStateQuery::lock_configuration`] and per-`(account, token)`
-/// [`BlockStateQuery::account_token_balance`] entries, builds a
-/// [`concordium_base::protocol_level_locks::queries::LockInfo`] value, and CBOR-encodes
-/// it via the existing `CborSerialize` derive. The returned `Vec<u8>` is the canonical
-/// CBOR `lock-info` payload — callers MUST treat it as opaque.
+/// Assemble the [`LockInfo`] CBOR payload for a lock.
 pub fn query_lock_info<BSQ: BlockStateQuery>(
     block_state: &BSQ,
     lock_id: &LockId,

--- a/plt/plt-scheduler/src/queries.rs
+++ b/plt/plt-scheduler/src/queries.rs
@@ -130,6 +130,9 @@ pub fn query_token_authorizations(
 
 /// Get the [`LockId`]s of all protocol-level locks registered on the chain at the
 /// end of the block.
+///
+/// NOTE: this is a naive implementation. We might need to optimize with a streaming solution
+/// instead, to not load all locks in existance into memory all at once.
 pub fn query_lock_list(block_state: &impl BlockStateQuery) -> Vec<LockId> {
     block_state.lock_list().collect()
 }

--- a/plt/plt-scheduler/src/queries.rs
+++ b/plt/plt-scheduler/src/queries.rs
@@ -1,18 +1,17 @@
 //! Implementation of queries related to protocol-level tokens.
 
+use crate::locks::lock_controller::LockController;
 use crate::token_context::TokenQueryContext;
 use crate::token_module;
 use concordium_base::base::AccountIndex;
 use concordium_base::common::cbor::cbor_encode;
 use concordium_base::protocol_level_locks::{
-    LockAccountFunds, LockController, LockControllerSimpleV0, LockControllerSimpleV0Grant, LockId,
-    LockInfo, LockedTokenAmount,
+    LockAccountFunds, LockId, LockInfo, LockedTokenAmount,
 };
 use concordium_base::protocol_level_tokens::{CborHolderAccount, TokenId};
 use plt_block_state::block_state_interface::{
     BlockStateQuery, LockNotFoundByIdError, TokenNotFoundByIdError,
 };
-use plt_scheduler_types::types::locks::LockControllerConfig;
 use plt_scheduler_types::types::queries::{
     TokenAccountInfo, TokenAccountState, TokenAuthorizations, TokenInfo, TokenState,
 };
@@ -200,45 +199,10 @@ pub fn query_lock_info<BSQ: BlockStateQuery>(
 
     // Convert the lock controller configuration into the CBOR `LockController` shape used
     // by the `lock-info` payload.
-    let controller = match configuration.controller {
-        LockControllerConfig::SimpleV0(simple) => {
-            let grants = simple
-                .grants
-                .into_iter()
-                .map(|grant| {
-                    let with_addr = block_state.account_by_index(grant.account).map_err(|_| {
-                        QueryLockError::StateInvariantViolation(format!(
-                            "controller grant account index {} recorded in lock configuration \
-                             does not exist",
-                            grant.account
-                        ))
-                    })?;
-                    Ok(LockControllerSimpleV0Grant {
-                        account: CborHolderAccount::from(with_addr.canonical_account_address),
-                        roles: grant.roles,
-                    })
-                })
-                .collect::<Result<_, QueryLockError>>()?;
-            LockController::SimpleV0(LockControllerSimpleV0 {
-                grants,
-                tokens: simple.tokens,
-                keep_alive: simple.keep_alive,
-                memo: simple.memo,
-            })
-        }
-    };
+    let controller = configuration.controller.to_cbor_controller(block_state)?;
 
     // Group the tracked `(account, token)` balances by account so we emit a single
-    // `LockAccountFunds` entry per account, matching the CBOR `lock-info` shape. We key
-    // the intermediate map by `AccountIndex` (which is `Ord`) since the opaque
-    // `BSQ::Account` associated type is not required by the trait to support ordering.
-    //
-    // The locked amount for each `(account, token)` pair is read from the token-module
-    // key-value state via `token_module::query_locked_balance` (see
-    // `plt-scheduler/src/token_module/key_value_state.rs::get_locked_balance_for`),
-    // which is the source of truth for per-`(account, token, lock)` locked amounts.
-    // Reading the account's full token balance here would over-report by including the
-    // unlocked portion.
+    // `LockAccountFunds` entry per account.
     let mut funds_by_account: BTreeMap<AccountIndex, Vec<LockedTokenAmount>> = BTreeMap::new();
     for (account, token) in block_state.lock_balances(lock_id) {
         let account_index = block_state.account_index(&account);

--- a/plt/plt-scheduler/src/token_module/key_value_state.rs
+++ b/plt/plt-scheduler/src/token_module/key_value_state.rs
@@ -147,8 +147,6 @@ fn account_roles_state_key(account_index: AccountIndex) -> TokenStateKey {
     TokenStateKey(account_key)
 }
 
-// FIXME: Remove `dead_code` allowance once locked-balance state is wired into module flows.
-#[allow(dead_code)] // Used by locked-balance helpers that are not wired in yet.
 fn account_quanta_state_key(lock_id: LockId) -> Vec<u8> {
     let mut locked_balance_key =
         Vec::with_capacity(ACCOUNT_STATE_KEY_QUANTA.len() + size_of::<LockId>());
@@ -454,8 +452,6 @@ pub fn set_deny_list_for<BSO: BlockStateOperations>(
 }
 
 /// Get the locked balance for the given account and lock.
-// FIXME: Remove `dead_code` allowance once locked-balance state is wired into module flows.
-#[allow(dead_code)] // Public helper kept for upcoming locked-balance usage.
 pub fn get_locked_balance_for(
     context: &impl ReadTokenKeyValueState,
     account: AccountIndex,

--- a/plt/plt-scheduler/src/token_module/module/queries.rs
+++ b/plt/plt-scheduler/src/token_module/module/queries.rs
@@ -3,10 +3,12 @@ use crate::token_module::errors::TokenStateInvariantError;
 use crate::token_module::key_value_state;
 use concordium_base::base::AccountIndex;
 use concordium_base::common::cbor;
+use concordium_base::protocol_level_locks::LockId;
 use concordium_base::protocol_level_tokens::{
     CborHolderAccount, RawCbor, TokenModuleAccountState, TokenModuleState,
 };
 use plt_block_state::block_state_interface::BlockStateQuery;
+use plt_scheduler_types::types::tokens::RawTokenAmount;
 
 /// Represents the reasons why a query to the token module can fail.
 #[derive(Debug, thiserror::Error)]
@@ -101,4 +103,23 @@ pub fn query_token_authorizations<BSQ: BlockStateQuery>(
     Ok(RawCbor::from(cbor::cbor_encode(
         &key_value_state::get_token_authorizations(context)?,
     )))
+}
+
+/// Get the locked balance of `account` under `lock` for the token in context.
+///
+/// Reads the canonical `account_state(account) || "quanta" || lock` entry from the
+/// token-module key-value state. Returns `RawTokenAmount(0)` when no entry exists.
+///
+/// This is the source of truth for per-`(account, token, lock)` locked amounts
+/// surfaced by `lock-info` queries; callers iterating over `BlockStateQuery::lock_balances`
+/// should resolve each pair through this function rather than reading the account's
+/// total token balance.
+pub fn query_locked_balance<BSQ: BlockStateQuery>(
+    context: &TokenQueryContext<'_, BSQ>,
+    account: AccountIndex,
+    lock: LockId,
+) -> Result<RawTokenAmount, QueryTokenModuleError> {
+    Ok(key_value_state::get_locked_balance_for(
+        context, account, lock,
+    )?)
 }

--- a/plt/plt-scheduler/src/token_module/module/queries.rs
+++ b/plt/plt-scheduler/src/token_module/module/queries.rs
@@ -106,14 +106,6 @@ pub fn query_token_authorizations<BSQ: BlockStateQuery>(
 }
 
 /// Get the locked balance of `account` under `lock` for the token in context.
-///
-/// Reads the canonical `account_state(account) || "quanta" || lock` entry from the
-/// token-module key-value state. Returns `RawTokenAmount(0)` when no entry exists.
-///
-/// This is the source of truth for per-`(account, token, lock)` locked amounts
-/// surfaced by `lock-info` queries; callers iterating over `BlockStateQuery::lock_balances`
-/// should resolve each pair through this function rather than reading the account's
-/// total token balance.
 pub fn query_locked_balance<BSQ: BlockStateQuery>(
     context: &TokenQueryContext<'_, BSQ>,
     account: AccountIndex,

--- a/plt/plt-scheduler/tests/plt_lock_queries.rs
+++ b/plt/plt-scheduler/tests/plt_lock_queries.rs
@@ -1,0 +1,128 @@
+//! Tests for the new `query_lock_list` and `query_lock_info` scheduler query functions.
+
+use assert_matches::assert_matches;
+use concordium_base::common::cbor;
+use concordium_base::common::types::TransactionTime;
+use concordium_base::protocol_level_locks::LockInfo;
+use concordium_base::protocol_level_locks::{
+    LockController, LockControllerSimpleV0Capability, LockId,
+};
+use concordium_base::protocol_level_tokens::{CborHolderAccount, TokenId};
+use plt_scheduler::queries::{self, QueryLockError};
+use plt_scheduler_types::types::locks::LockControllerSimpleV0Grant;
+use plt_scheduler_types::types::tokens::RawTokenAmount;
+use utils::block_state_external_stubbed::{
+    BlockStateWithExternalStateStubbed, TokenInitTestParams,
+};
+
+mod utils;
+
+/// `query_lock_list` returns lock ids in the same order as the underlying
+/// block-state map enumeration (`BTreeMap` order on `LockId`).
+#[test]
+fn test_query_lock_list_ordering() {
+    let mut stub = BlockStateWithExternalStateStubbed::new(utils::LATEST_PROTOCOL_VERSION);
+    let recipient = stub.create_account();
+
+    let lock_a = LockId {
+        account_index: 1,
+        sequence_number: 5,
+        creation_order: 0,
+    };
+    let lock_b = LockId {
+        account_index: 2,
+        sequence_number: 1,
+        creation_order: 0,
+    };
+
+    // Insert in `b, a` order to verify the result is dictated by the block-state map
+    // ordering (BTreeMap on LockId), not insertion order.
+    stub.create_lock(&lock_b, vec![recipient], vec![], vec![], 1000);
+    stub.create_lock(&lock_a, vec![recipient], vec![], vec![], 1000);
+
+    let listed = queries::query_lock_list(stub.state());
+    assert_eq!(listed, vec![lock_a, lock_b]);
+}
+
+/// `query_lock_info` produces the canonical CBOR encoding of the assembled
+/// `LockInfo` value, and the round-trip via `cbor_decode` recovers an equal value.
+#[test]
+fn test_query_lock_info_cbor_round_trip_with_funded_balances() {
+    let mut stub = BlockStateWithExternalStateStubbed::new(utils::LATEST_PROTOCOL_VERSION);
+
+    let recipient = stub.create_account();
+    let funding_account = stub.create_account();
+    let recipient_addr = stub.account_canonical_address(&recipient);
+    let funding_addr = stub.account_canonical_address(&funding_account);
+
+    let token_id: TokenId = "TokenLockA".parse().unwrap();
+    let (token, _gov_account) = stub.create_and_init_token(
+        token_id.clone(),
+        TokenInitTestParams::default().mintable(),
+        2,
+        Some(RawTokenAmount(0)),
+    );
+    stub.increment_account_balance(funding_account, token, RawTokenAmount(123_400));
+
+    let lock_id = LockId {
+        account_index: 7,
+        sequence_number: 2,
+        creation_order: 0,
+    };
+    stub.create_lock(
+        &lock_id,
+        vec![recipient],
+        vec![LockControllerSimpleV0Grant {
+            account: funding_account,
+            roles: vec![LockControllerSimpleV0Capability::Fund],
+        }],
+        vec![token_id.clone()],
+        1_804_806_000,
+    );
+    // Track the (account, token) pair under the lock and record the locked amount in
+    // the token-module key-value state so it shows up in `lock_balances` / `funds`.
+    stub.lock_balance(&lock_id, &funding_account, &token, RawTokenAmount(100));
+
+    let bytes = queries::query_lock_info(stub.state(), &lock_id)
+        .expect("query_lock_info must succeed for an existing lock");
+    let decoded: LockInfo =
+        cbor::cbor_decode(&bytes).expect("CBOR encoding produced by query_lock_info must decode");
+
+    assert_eq!(decoded.lock, lock_id);
+    assert_eq!(
+        decoded.recipients,
+        vec![CborHolderAccount::from(recipient_addr)]
+    );
+    assert_eq!(decoded.expiry, TransactionTime::from(1_804_806_000));
+    assert_matches!(decoded.controller, LockController::SimpleV0(simple) => {
+        assert_eq!(simple.grants.len(), 1);
+        assert_eq!(simple.grants[0].account, CborHolderAccount::from(funding_addr));
+        assert_eq!(simple.grants[0].roles, vec![LockControllerSimpleV0Capability::Fund]);
+        assert_eq!(simple.tokens, vec![token_id.clone()]);
+        assert!(!simple.keep_alive);
+        assert!(simple.memo.is_none());
+    });
+    assert_eq!(decoded.funds.len(), 1);
+    assert_eq!(
+        decoded.funds[0].account,
+        CborHolderAccount::from(funding_addr)
+    );
+    assert_eq!(decoded.funds[0].amounts.len(), 1);
+    assert_eq!(decoded.funds[0].amounts[0].token, token_id);
+    assert_eq!(decoded.funds[0].amounts[0].amount.value(), 100);
+    assert_eq!(decoded.funds[0].amounts[0].amount.decimals(), 2);
+}
+
+/// `query_lock_info` returns [`QueryLockError::LockDoesNotExist`] when the
+/// lock id is not present in the block state.
+#[test]
+fn test_query_lock_info_unknown_lock() {
+    let stub = BlockStateWithExternalStateStubbed::new(utils::LATEST_PROTOCOL_VERSION);
+    let unknown = LockId {
+        account_index: 999,
+        sequence_number: 999,
+        creation_order: 0,
+    };
+    let result = queries::query_lock_info(stub.state(), &unknown);
+    assert_matches!(result, Err(QueryLockError::LockDoesNotExist));
+}

--- a/plt/plt-scheduler/tests/plt_lock_queries.rs
+++ b/plt/plt-scheduler/tests/plt_lock_queries.rs
@@ -17,33 +17,6 @@ use utils::block_state_external_stubbed::{
 
 mod utils;
 
-/// `query_lock_list` returns lock ids in the same order as the underlying
-/// block-state map enumeration (`BTreeMap` order on `LockId`).
-#[test]
-fn test_query_lock_list_ordering() {
-    let mut stub = BlockStateWithExternalStateStubbed::new(utils::LATEST_PROTOCOL_VERSION);
-    let recipient = stub.create_account();
-
-    let lock_a = LockId {
-        account_index: 1,
-        sequence_number: 5,
-        creation_order: 0,
-    };
-    let lock_b = LockId {
-        account_index: 2,
-        sequence_number: 1,
-        creation_order: 0,
-    };
-
-    // Insert in `b, a` order to verify the result is dictated by the block-state map
-    // ordering (BTreeMap on LockId), not insertion order.
-    stub.create_lock(&lock_b, vec![recipient], vec![], vec![], 1000);
-    stub.create_lock(&lock_a, vec![recipient], vec![], vec![], 1000);
-
-    let listed = queries::query_lock_list(stub.state());
-    assert_eq!(listed, vec![lock_a, lock_b]);
-}
-
 /// `query_lock_info` produces the canonical CBOR encoding of the assembled
 /// `LockInfo` value, and the round-trip via `cbor_decode` recovers an equal value.
 #[test]

--- a/plt/plt-scheduler/tests/utils/block_state_external_stubbed.rs
+++ b/plt/plt-scheduler/tests/utils/block_state_external_stubbed.rs
@@ -8,8 +8,11 @@
 
 use assert_matches::assert_matches;
 use concordium_base::base::{AccountIndex, Energy, ProtocolVersion};
+use concordium_base::common;
 use concordium_base::common::cbor;
+use concordium_base::common::types::TransactionTime;
 use concordium_base::contracts_common::AccountAddress;
+use concordium_base::protocol_level_locks::LockId;
 use concordium_base::protocol_level_tokens::{
     CborHolderAccount, MetadataUrl, RawCbor, TokenAmount, TokenId,
     TokenModuleInitializationParameters, TokenModuleState, TokenOperation, TokenOperationsPayload,
@@ -22,7 +25,10 @@ use plt_block_state::block_state::blob_store::{BlobStoreLoad, BlobStoreLocation}
 use plt_block_state::block_state::external::{
     ExternalBlockStateOperations, ExternalBlockStateQuery,
 };
-use plt_block_state::block_state::types::protocol_level_tokens::{TokenAccountState, TokenIndex};
+use plt_block_state::block_state::types::protocol_level_locks::LockConfiguration;
+use plt_block_state::block_state::types::protocol_level_tokens::{
+    TokenAccountState, TokenIndex, TokenStateKey, TokenStateValue,
+};
 use plt_block_state::block_state::{BlockState, ExecutionTimeBlockState, MutableBlockState};
 use plt_block_state::block_state_interface::{
     AccountNotFoundByAddressError, AccountNotFoundByIndexError, BlockStateOperations,
@@ -31,8 +37,23 @@ use plt_block_state::block_state_interface::{
 use plt_scheduler::{TOKEN_MODULE_REF, queries, scheduler};
 use plt_scheduler_types::types::events::BlockItemEvent;
 use plt_scheduler_types::types::execution::TransactionOutcome;
+use plt_scheduler_types::types::locks::{
+    LockControllerConfig, LockControllerSimpleV0, LockControllerSimpleV0Grant,
+};
 use plt_scheduler_types::types::tokens::RawTokenAmount;
 use std::collections::BTreeMap;
+
+// --- Token module key-value state encoding for locked balances ----------------------
+//
+// The constants below MUST stay in sync with `plt-scheduler/src/token_module/
+// key_value_state.rs`, which owns the canonical encoding. We duplicate them here
+// rather than expose them publicly because (a) the encoding is internal to the
+// scheduler crate today and (b) this whole helper is a stand-in until COR-2305
+// wires lock-balance updates through a real transaction payload, at which point the
+// duplicated constants disappear.
+
+const TOKEN_KV_ACCOUNT_STATE_PREFIX: [u8; 2] = 40307u16.to_le_bytes();
+const TOKEN_KV_ACCOUNT_STATE_KEY_QUANTA: &[u8] = b"quanta";
 
 type ExecutionTimeBlockStateWithExternalStubbed =
     ExecutionTimeBlockState<MutableBlockState, UnreachableBlobStore, ExternalBlockStateStub>;
@@ -280,6 +301,87 @@ impl BlockStateWithExternalStateStubbed {
             .external_block_state
             .plt_update_instruction_sequence_number
     }
+
+    /// Create a lock in the block state. The lock controller is hard-coded to the
+    /// `SimpleV0` variant (the only one currently exposed) with `keep_alive = false`
+    /// and no memo — individual tests may extend this helper if other variants are
+    /// needed.
+    ///
+    /// TODO: (COR-2302) Once lock-creation transaction payloads land, this helper
+    /// should construct and execute that payload via `scheduler::execute_transaction`
+    /// (mirroring `create_and_init_token`) instead of poking `BlockStateOperations`
+    /// directly, so the test path exercises the same scheduler entry point as
+    /// production traffic.
+    pub fn create_lock(
+        &mut self,
+        lock_id: &LockId,
+        recipients: Vec<AccountIndex>,
+        grants: Vec<LockControllerSimpleV0Grant>,
+        tokens: Vec<TokenId>,
+        expiry: u64,
+    ) {
+        let configuration = LockConfiguration {
+            recipients,
+            expiry: TransactionTime::from(expiry),
+            controller: LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
+                grants,
+                tokens,
+                keep_alive: false,
+                memo: None,
+            }),
+        };
+        self.block_state.create_lock(lock_id, &configuration);
+    }
+
+    /// Track a `(account, token)` balance reference under the given lock and record the
+    /// locked `amount` for the account in the token-module key-value state.
+    ///
+    /// TODO: (COR-2305) Once lock-operation transaction payloads land (the ones that
+    /// move balances into / out of locks), this helper should drive those payloads
+    /// through `scheduler::execute_transaction` (mirroring `increment_account_balance`)
+    /// instead of poking the block state and key-value store directly. At that point
+    /// the constants duplicated above can also be removed.
+    pub fn lock_balance(
+        &mut self,
+        lock_id: &LockId,
+        account: &AccountIndex,
+        token: &Token,
+        amount: RawTokenAmount,
+    ) {
+        // 1. Register the (account, token) pair with the lock.
+        self.block_state
+            .add_lock_balance_ref(lock_id, account, token);
+
+        // 2. Write the locked amount into the token-module key-value state.
+        let mut kv_state = self.block_state.mutable_token_key_value_state(token);
+        let key = locked_balance_kv_key(*account, lock_id);
+        let value = if amount == RawTokenAmount(0) {
+            None
+        } else {
+            Some(TokenStateValue(common::to_bytes(&amount)))
+        };
+        self.block_state
+            .update_token_state_value(&mut kv_state, &key, value);
+        self.block_state.set_token_key_value_state(token, kv_state);
+    }
+}
+
+/// Build the token-module key-value key under which the locked balance for `(account,
+/// lock)` is stored. Mirrors `account_state_key(account, account_quanta_state_key(lock))`
+/// in `plt-scheduler/src/token_module/key_value_state.rs`.
+fn locked_balance_kv_key(account: AccountIndex, lock: &LockId) -> TokenStateKey {
+    use concordium_base::common::Serial;
+    let mut key = Vec::with_capacity(
+        TOKEN_KV_ACCOUNT_STATE_PREFIX.len()
+            + size_of::<AccountIndex>()
+            + TOKEN_KV_ACCOUNT_STATE_KEY_QUANTA.len()
+            + size_of::<LockId>(),
+    );
+    key.extend_from_slice(&TOKEN_KV_ACCOUNT_STATE_PREFIX);
+    account.serial(&mut key);
+    key.extend_from_slice(TOKEN_KV_ACCOUNT_STATE_KEY_QUANTA);
+    lock.serial(&mut key);
+    TokenStateKey(key)
 }
 
 #[derive(Debug, Clone, Default, Eq, PartialEq)]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,4 @@
 # used in the static_libraries image found in the workflow of `.github/workflow/release.yaml`,
 # otherwise it causes issues during linking the static builds.
 [toolchain]
-channel = "1.94.0"
+channel = "1.95.0"


### PR DESCRIPTION
Closes COR-2309

Dependent on https://github.com/Concordium/concordium-base/pull/927

## Purpose

Adds grpc service queries for lock list and lock info for a given lock id.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.