### PR TITLE
Fix migration reads from incorrect blob store.

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Accounts.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Accounts.hs
@@ -515,7 +515,7 @@ migrateAccounts ::
 migrateAccounts migration Accounts{..} = do
     logEvent GlobalState LLTrace "Migrating accounts"
     let migrateAccount acct = do
-            canonicalAddress <- accountCanonicalAddress =<< lift (refLoad acct)
+            canonicalAddress <- lift (accountCanonicalAddress =<< refLoad acct)
             logEvent GlobalState LLTrace $ "Migrating account: " <> show canonicalAddress
             newAcct <- migrateHashedCachedRef' (migratePersistentAccount migration) acct
             -- Increment the account index counter.

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -620,7 +620,7 @@ migrateBlockRewardDetails StateMigrationParametersP2P3 _ _ _ _ = \case
     (BlockRewardDetailsV0 heb) -> BlockRewardDetailsV0 <$> migrateHashedEpochBlocks heb
 migrateBlockRewardDetails (StateMigrationParametersP3ToP4 _) curBakers nextBakers (SomeParam TimeParametersV1{..}) _ = \case
     (BlockRewardDetailsV0 heb) -> do
-        blockCounts <- bakersFromEpochBlocks (hebBlocks heb)
+        blockCounts <- lift $ bakersFromEpochBlocks (hebBlocks heb)
         (!newRef, _) <- refFlush =<< refMake =<< migratePoolRewardsP1 curBakers nextBakers blockCounts (rewardPeriodEpochs _tpRewardPeriodLength) _tpMintPerPayday
         return (BlockRewardDetailsV1 newRef)
 migrateBlockRewardDetails StateMigrationParametersP4ToP5{} _ _ (SomeParam TimeParametersV1{..}) _ = \case


### PR DESCRIPTION
## Purpose

This fixes two (relatively minor) issues in the block state migration code where a function with a `MonadBlobStore` constraint is being executed against the incorrect `BlobStore`. While these are potentially catastrophic issues, in practice these are not actually seen.

## Changes

- `accountCanonicalAddress` moved inside `lift`. Although this in principle could be an issue, the implementation of `accountCanonicalAddress` does not actually read from the `BlobStore`. (Of course, this could potentially change in the future.)
- `bakersFromEpochBlocks` moved inside `lift`. This only applies to the P3->P4 migration and is likely never triggered due to the caching behaviour ensuring that the epoch blocks are loaded into memory, and therefore will not be read from the (incorrect) `BlobStore`.