### PR TITLE
Handle "any" lock recipient variant in node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased changes
 
+## 11.2.2 (Devnet)
+
+- Add support for lock configurations with "any" specified for the `recipients` field.
+
 ## 11.2.1 (Devnet)
 
 - Add support for the following "meta update" operations:

--- a/plt/plt-block-state/src/persistent/block_state/p11.rs
+++ b/plt/plt-block-state/src/persistent/block_state/p11.rs
@@ -64,7 +64,7 @@ mod test {
     use crate::persistent::hash::Hashable;
     use crate::persistent::protocol_level_locks::p11::{
         LockConfiguration, LockControllerConfig, LockControllerSimpleV0,
-        LockControllerSimpleV0Grant,
+        LockControllerSimpleV0Grant, LockRecipients,
     };
     use crate::persistent::protocol_level_tokens::p9::{TokenConfiguration, TokenIndex};
     use concordium_base::base::AccountIndex;
@@ -81,10 +81,10 @@ mod test {
         let mut block_state = BlockStateP11::default();
 
         // Create locks
-        let configuration1 = LockConfiguration::new(
-            vec![AccountIndex::from(1), AccountIndex::from(2)],
-            TransactionTime::from(100u64),
-            LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
+        let configuration1 = LockConfiguration {
+            recipients: LockRecipients::from(vec![AccountIndex::from(1), AccountIndex::from(2)]),
+            expiry: TransactionTime::from(100u64),
+            controller: LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
                 grants: vec![LockControllerSimpleV0Grant {
                     account: AccountIndex::from(1),
                     roles: vec![
@@ -96,7 +96,7 @@ mod test {
                 keep_alive: true,
                 memo: Some(CborMemo::Raw(Memo::try_from(vec![0, 1]).unwrap())),
             }),
-        );
+        };
         let lock_id1 = LockId {
             account_index: 1,
             sequence_number: 1,
@@ -117,16 +117,16 @@ mod test {
             sequence_number: 7,
             creation_order: 0,
         };
-        let configuration2 = LockConfiguration::new(
-            vec![],
-            TransactionTime::from(0u64),
-            LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
+        let configuration2 = LockConfiguration {
+            recipients: LockRecipients::from(vec![]),
+            expiry: TransactionTime::from(0u64),
+            controller: LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
                 grants: Vec::new(),
                 tokens: Vec::new(),
                 keep_alive: false,
                 memo: None,
             }),
-        );
+        };
         block_state
             .create_lock(&context, lock_id2.clone(), configuration2.clone())
             .unwrap();
@@ -219,10 +219,10 @@ mod test {
         let _token2 = block_state.create_token(&context, configuration2.clone());
 
         // Create locks
-        let configuration1 = LockConfiguration::new(
-            vec![AccountIndex::from(1), AccountIndex::from(2)],
-            TransactionTime::from(100u64),
-            LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
+        let configuration1 = LockConfiguration {
+            recipients: LockRecipients::from(vec![AccountIndex::from(1), AccountIndex::from(2)]),
+            expiry: TransactionTime::from(100u64),
+            controller: LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
                 grants: vec![LockControllerSimpleV0Grant {
                     account: AccountIndex::from(1),
                     roles: vec![
@@ -234,7 +234,7 @@ mod test {
                 keep_alive: true,
                 memo: Some(CborMemo::Raw(Memo::try_from(vec![0, 1]).unwrap())),
             }),
-        );
+        };
         let lock_id1 = LockId {
             account_index: 1,
             sequence_number: 1,
@@ -255,16 +255,16 @@ mod test {
             sequence_number: 7,
             creation_order: 0,
         };
-        let configuration2 = LockConfiguration::new(
-            vec![],
-            TransactionTime::from(0u64),
-            LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
+        let configuration2 = LockConfiguration {
+            recipients: LockRecipients::from(vec![]),
+            expiry: TransactionTime::from(0u64),
+            controller: LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
                 grants: Vec::new(),
                 tokens: Vec::new(),
                 keep_alive: false,
                 memo: None,
             }),
-        );
+        };
         block_state
             .create_lock(&context, lock_id2.clone(), configuration2)
             .unwrap();

--- a/plt/plt-block-state/src/persistent/protocol_level_locks/p11.rs
+++ b/plt/plt-block-state/src/persistent/protocol_level_locks/p11.rs
@@ -75,24 +75,29 @@ pub enum LockRecipients {
 }
 
 impl LockRecipients {
-    /// Get an iterator over the limited recipient accounts.
-    fn recipients_iter(&self) -> impl Iterator<Item = &AccountIndex> {
-        match self {
-            Self::Any => &[],
-            Self::Limited(recipients) => recipients.as_slice(),
-        }
-        .iter()
+    /// Normalize the recipient representation for storage in block state.
+    pub fn limited(mut recipients: Vec<AccountIndex>) -> Self {
+        recipients.sort();
+        Self::Limited(recipients)
     }
 
     /// Check whether this representation allows any recipient.
-    fn is_any(&self) -> bool {
+    pub fn is_any(&self) -> bool {
         matches!(self, Self::Any)
+    }
+
+    /// Check if the given account is a recipient.
+    pub fn is_recipient(&self, account: &AccountIndex) -> bool {
+        match self {
+            Self::Any => true,
+            Self::Limited(recipients) => recipients.binary_search(account).is_ok(),
+        }
     }
 }
 
 impl From<Vec<AccountIndex>> for LockRecipients {
     fn from(recipients: Vec<AccountIndex>) -> Self {
-        Self::Limited(recipients)
+        Self::limited(recipients)
     }
 }
 
@@ -124,7 +129,7 @@ impl Deserial for LockRecipients {
         Ok(if recipients.as_slice() == [ANY_RECIPIENT_SENTINEL] {
             Self::Any
         } else {
-            Self::Limited(recipients)
+            Self::limited(recipients)
         })
     }
 }
@@ -135,72 +140,11 @@ impl Deserial for LockRecipients {
 #[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub struct LockConfiguration {
     /// Accounts that can receive funds from this lock.
-    recipients: LockRecipients,
+    pub recipients: LockRecipients,
     /// Expiry time of the lock (seconds since epoch).
-    expiry: TransactionTime,
+    pub expiry: TransactionTime,
     /// Controller configuration for the lock.
-    controller: LockControllerConfig,
-}
-
-impl LockConfiguration {
-    /// Construct a lock configuration.
-    pub fn new(
-        recipients: impl Into<LockRecipients>,
-        expiry: TransactionTime,
-        controller: LockControllerConfig,
-    ) -> Self {
-        Self {
-            recipients: recipients.into(),
-            expiry,
-            controller,
-        }
-    }
-
-    /// Construct a lock configuration with limited recipients.
-    pub fn new_limited(
-        recipients: Vec<AccountIndex>,
-        expiry: TransactionTime,
-        controller: LockControllerConfig,
-    ) -> Self {
-        Self::new(recipients, expiry, controller)
-    }
-
-    /// Construct a lock configuration with any-recipient semantics.
-    pub fn new_any(expiry: TransactionTime, controller: LockControllerConfig) -> Self {
-        Self {
-            recipients: LockRecipients::Any,
-            expiry,
-            controller,
-        }
-    }
-
-    /// Get an iterator over the recipient accounts.
-    pub fn recipients_iter(&self) -> impl Iterator<Item = &AccountIndex> {
-        self.recipients.recipients_iter()
-    }
-
-    /// Check whether this configuration represents an any-recipient lock.
-    pub fn has_any_recipient(&self) -> bool {
-        self.recipients.is_any()
-    }
-
-    /// Check if the given account is a recipient.
-    pub fn is_recipient(&self, account: &AccountIndex) -> bool {
-        match &self.recipients {
-            LockRecipients::Any => true,
-            LockRecipients::Limited(recipients) => recipients.binary_search(account).is_ok(),
-        }
-    }
-
-    /// Get the expiry time of the lock.
-    pub fn expiry(&self) -> TransactionTime {
-        self.expiry
-    }
-
-    /// Get the lock controller configuration.
-    pub fn controller(&self) -> &LockControllerConfig {
-        &self.controller
-    }
+    pub controller: LockControllerConfig,
 }
 
 /// Top-level lock controller type.
@@ -267,10 +211,13 @@ mod test {
         use concordium_base::common::types::TransactionTime;
         use concordium_base::protocol_level_locks::LockControllerSimpleV0Capability;
 
-        let lock_config = LockConfiguration::new_limited(
-            vec![AccountIndex::from(1u64), AccountIndex::from(2u64)],
-            TransactionTime::from(1000u64),
-            LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
+        let lock_config = LockConfiguration {
+            recipients: LockRecipients::from(vec![
+                AccountIndex::from(1u64),
+                AccountIndex::from(2u64),
+            ]),
+            expiry: TransactionTime::from(1000u64),
+            controller: LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
                 grants: vec![LockControllerSimpleV0Grant {
                     account: AccountIndex::from(1u64),
                     roles: vec![LockControllerSimpleV0Capability::Fund],
@@ -279,7 +226,7 @@ mod test {
                 keep_alive: true,
                 memo: None,
             }),
-        );
+        };
 
         let bytes = common::to_bytes(&lock_config);
         assert_eq!(
@@ -296,16 +243,16 @@ mod test {
     fn test_lock_configuration_serial_empty_recipients() {
         use concordium_base::common::types::TransactionTime;
 
-        let lock_config = LockConfiguration::new_limited(
-            vec![],
-            TransactionTime::from(500u64),
-            LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
+        let lock_config = LockConfiguration {
+            recipients: LockRecipients::from(vec![]),
+            expiry: TransactionTime::from(500u64),
+            controller: LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
                 grants: vec![],
                 tokens: vec![],
                 keep_alive: false,
                 memo: None,
             }),
-        );
+        };
 
         let bytes = common::to_bytes(&lock_config);
         assert_eq!(hex::encode(&bytes), "000000000000000001f400000000000000");
@@ -316,22 +263,42 @@ mod test {
     }
 
     #[test]
+    fn test_lock_recipients_limited_sorts_accounts() {
+        let recipients =
+            LockRecipients::from(vec![AccountIndex::from(2u64), AccountIndex::from(1u64)]);
+
+        assert_eq!(
+            recipients,
+            LockRecipients::Limited(vec![AccountIndex::from(1u64), AccountIndex::from(2u64)])
+        );
+    }
+
+    #[test]
     fn test_lock_configuration_serial_any_recipient_sentinel() {
         use concordium_base::common::types::TransactionTime;
 
-        let lock_config = LockConfiguration::new_any(
-            TransactionTime::from(500u64),
-            LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
+        let lock_config = LockConfiguration {
+            recipients: LockRecipients::Any,
+            expiry: TransactionTime::from(500u64),
+            controller: LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
                 grants: vec![],
                 tokens: vec![],
                 keep_alive: false,
                 memo: None,
             }),
-        );
+        };
 
-        assert!(lock_config.has_any_recipient());
-        assert!(lock_config.is_recipient(&AccountIndex::from(0u64)));
-        assert!(lock_config.is_recipient(&AccountIndex::from(42u64)));
+        assert!(lock_config.recipients.is_any());
+        assert!(
+            lock_config
+                .recipients
+                .is_recipient(&AccountIndex::from(0u64))
+        );
+        assert!(
+            lock_config
+                .recipients
+                .is_recipient(&AccountIndex::from(42u64))
+        );
 
         let bytes = common::to_bytes(&lock_config);
         assert_eq!(
@@ -342,7 +309,7 @@ mod test {
         let deserialized: LockConfiguration =
             common::from_bytes_complete(bytes.as_slice()).unwrap();
         assert_eq!(deserialized, lock_config);
-        assert!(deserialized.has_any_recipient());
+        assert!(deserialized.recipients.is_any());
     }
 
     #[test]

--- a/plt/plt-block-state/src/persistent/protocol_level_locks/p11.rs
+++ b/plt/plt-block-state/src/persistent/protocol_level_locks/p11.rs
@@ -65,22 +65,49 @@ pub struct PersistentLockP11 {
 /// TODO: COR-2418 - proper "any" recipient representation in block state should remove this.
 const ANY_RECIPIENT_SENTINEL: AccountIndex = AccountIndex { index: u64::MAX };
 
+// Represents a list of lock recipients. This type enforces that the inner list is always sorted
+// to enable binary search.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct LockRecipientsList(Vec<AccountIndex>);
+
+impl LockRecipientsList {
+    /// Create a new list of lock recipients from the given account index list
+    pub fn new(mut recipients: Vec<AccountIndex>) -> Self {
+        recipients.sort();
+        Self(recipients)
+    }
+
+    /// Get an iterator of the account indices in the list
+    pub fn iter(&self) -> impl Iterator<Item = &AccountIndex> {
+        self.0.iter()
+    }
+
+    /// Check whether the given account is a member
+    pub fn is_recipient(&self, account: &AccountIndex) -> bool {
+        self.0.binary_search(account).is_ok()
+    }
+
+    /// Get the length of the list
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Check whether the list is empty
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
 /// Accounts that can receive funds from this lock in block state.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum LockRecipients {
     /// Any eligible account can receive funds from this lock.
     Any,
     /// Only the listed accounts can receive funds from this lock.
-    Limited(Vec<AccountIndex>),
+    Limited(LockRecipientsList),
 }
 
 impl LockRecipients {
-    /// Normalize the recipient representation for storage in block state.
-    pub fn limited(mut recipients: Vec<AccountIndex>) -> Self {
-        recipients.sort();
-        Self::Limited(recipients)
-    }
-
     /// Check whether this representation allows any recipient.
     pub fn is_any(&self) -> bool {
         matches!(self, Self::Any)
@@ -90,14 +117,14 @@ impl LockRecipients {
     pub fn is_recipient(&self, account: &AccountIndex) -> bool {
         match self {
             Self::Any => true,
-            Self::Limited(recipients) => recipients.binary_search(account).is_ok(),
+            Self::Limited(recipients) => recipients.0.binary_search(account).is_ok(),
         }
     }
 }
 
 impl From<Vec<AccountIndex>> for LockRecipients {
     fn from(recipients: Vec<AccountIndex>) -> Self {
-        Self::limited(recipients)
+        Self::Limited(LockRecipientsList::new(recipients))
     }
 }
 
@@ -110,7 +137,7 @@ impl Serial for LockRecipients {
             }
             Self::Limited(recipients) => {
                 (recipients.len() as u16).serial(out);
-                for recipient in recipients {
+                for recipient in recipients.iter() {
                     recipient.serial(out);
                 }
             }
@@ -129,7 +156,7 @@ impl Deserial for LockRecipients {
         Ok(if recipients.as_slice() == [ANY_RECIPIENT_SENTINEL] {
             Self::Any
         } else {
-            Self::limited(recipients)
+            Self::from(recipients)
         })
     }
 }
@@ -269,7 +296,7 @@ mod test {
 
         assert_eq!(
             recipients,
-            LockRecipients::Limited(vec![AccountIndex::from(1u64), AccountIndex::from(2u64)])
+            LockRecipients::from(vec![AccountIndex::from(1u64), AccountIndex::from(2u64)])
         );
     }
 

--- a/plt/plt-block-state/src/persistent/protocol_level_locks/p11.rs
+++ b/plt/plt-block-state/src/persistent/protocol_level_locks/p11.rs
@@ -7,7 +7,7 @@ use crate::persistent::hash::Hashable;
 use crate::persistent::protocol_level_tokens::p9::TokenIndex;
 use concordium_base::base::AccountIndex;
 use concordium_base::common::types::TransactionTime;
-use concordium_base::common::{Buffer, Serialize};
+use concordium_base::common::{Buffer, Deserial, ParseResult, ReadBytesExt, Serial, Serialize};
 use concordium_base::hashes::Hash;
 use concordium_base::protocol_level_locks::{LockControllerSimpleV0Capability, LockId};
 use concordium_base::protocol_level_tokens::{CborMemo, TokenId};
@@ -58,19 +58,84 @@ pub struct PersistentLockP11 {
     pub configuration: LockConfiguration,
 }
 
+/// Sentinel account index used to represent an any-recipient lock in block state.
+///
+/// This temporary representation is local to node block-state code and maps
+/// back to the external `"any"` representation during query/event conversion.
+/// TODO: COR-2418 - proper "any" recipient representation in block state should remove this.
+const ANY_RECIPIENT_SENTINEL: AccountIndex = AccountIndex { index: u64::MAX };
+
+/// Accounts that can receive funds from this lock in block state.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum LockRecipients {
+    /// Any eligible account can receive funds from this lock.
+    Any,
+    /// Only the listed accounts can receive funds from this lock.
+    Limited(Vec<AccountIndex>),
+}
+
+impl LockRecipients {
+    /// Get an iterator over the limited recipient accounts.
+    fn recipients_iter(&self) -> impl Iterator<Item = &AccountIndex> {
+        match self {
+            Self::Any => &[],
+            Self::Limited(recipients) => recipients.as_slice(),
+        }
+        .iter()
+    }
+
+    /// Check whether this representation allows any recipient.
+    fn is_any(&self) -> bool {
+        matches!(self, Self::Any)
+    }
+}
+
+impl From<Vec<AccountIndex>> for LockRecipients {
+    fn from(recipients: Vec<AccountIndex>) -> Self {
+        Self::Limited(recipients)
+    }
+}
+
+impl Serial for LockRecipients {
+    fn serial<B: Buffer>(&self, out: &mut B) {
+        match self {
+            Self::Any => {
+                1u16.serial(out);
+                ANY_RECIPIENT_SENTINEL.serial(out);
+            }
+            Self::Limited(recipients) => {
+                (recipients.len() as u16).serial(out);
+                for recipient in recipients {
+                    recipient.serial(out);
+                }
+            }
+        }
+    }
+}
+
+impl Deserial for LockRecipients {
+    fn deserial<R: ReadBytesExt>(source: &mut R) -> ParseResult<Self> {
+        let len = u16::deserial(source)? as usize;
+        let mut recipients = Vec::with_capacity(len);
+        for _ in 0..len {
+            recipients.push(AccountIndex::deserial(source)?);
+        }
+
+        Ok(if recipients.as_slice() == [ANY_RECIPIENT_SENTINEL] {
+            Self::Any
+        } else {
+            Self::Limited(recipients)
+        })
+    }
+}
+
 /// Lock configuration at the block state level.
 ///
 /// TODO: COR-2295 - proper state implementation
 #[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub struct LockConfiguration {
     /// Accounts that can receive funds from this lock.
-    ///
-    /// The recipients are stored as a sorted vector of account indices, and
-    /// the number of recipients is limited to `u16::MAX` to ensure that the
-    /// serialized form fits within the size limits of the block state.
-    // todo use newtype for the type for this field and make all fields public (for consistency with the other block state types)
-    #[size_length = 2]
-    recipients: Vec<AccountIndex>,
+    recipients: LockRecipients,
     /// Expiry time of the lock (seconds since epoch).
     expiry: TransactionTime,
     /// Controller configuration for the lock.
@@ -78,15 +143,32 @@ pub struct LockConfiguration {
 }
 
 impl LockConfiguration {
+    /// Construct a lock configuration.
     pub fn new(
-        mut recipients: Vec<AccountIndex>,
+        recipients: impl Into<LockRecipients>,
         expiry: TransactionTime,
         controller: LockControllerConfig,
     ) -> Self {
-        assert!(recipients.len() <= u16::MAX as usize, "Too many recipients");
-        recipients.sort();
         Self {
-            recipients,
+            recipients: recipients.into(),
+            expiry,
+            controller,
+        }
+    }
+
+    /// Construct a lock configuration with limited recipients.
+    pub fn new_limited(
+        recipients: Vec<AccountIndex>,
+        expiry: TransactionTime,
+        controller: LockControllerConfig,
+    ) -> Self {
+        Self::new(recipients, expiry, controller)
+    }
+
+    /// Construct a lock configuration with any-recipient semantics.
+    pub fn new_any(expiry: TransactionTime, controller: LockControllerConfig) -> Self {
+        Self {
+            recipients: LockRecipients::Any,
             expiry,
             controller,
         }
@@ -94,12 +176,20 @@ impl LockConfiguration {
 
     /// Get an iterator over the recipient accounts.
     pub fn recipients_iter(&self) -> impl Iterator<Item = &AccountIndex> {
-        self.recipients.iter()
+        self.recipients.recipients_iter()
+    }
+
+    /// Check whether this configuration represents an any-recipient lock.
+    pub fn has_any_recipient(&self) -> bool {
+        self.recipients.is_any()
     }
 
     /// Check if the given account is a recipient.
     pub fn is_recipient(&self, account: &AccountIndex) -> bool {
-        self.recipients.binary_search(account).is_ok()
+        match &self.recipients {
+            LockRecipients::Any => true,
+            LockRecipients::Limited(recipients) => recipients.binary_search(account).is_ok(),
+        }
     }
 
     /// Get the expiry time of the lock.
@@ -177,10 +267,10 @@ mod test {
         use concordium_base::common::types::TransactionTime;
         use concordium_base::protocol_level_locks::LockControllerSimpleV0Capability;
 
-        let lock_config = LockConfiguration {
-            recipients: vec![AccountIndex::from(1u64), AccountIndex::from(2u64)],
-            expiry: TransactionTime::from(1000u64),
-            controller: LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
+        let lock_config = LockConfiguration::new_limited(
+            vec![AccountIndex::from(1u64), AccountIndex::from(2u64)],
+            TransactionTime::from(1000u64),
+            LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
                 grants: vec![LockControllerSimpleV0Grant {
                     account: AccountIndex::from(1u64),
                     roles: vec![LockControllerSimpleV0Capability::Fund],
@@ -189,7 +279,7 @@ mod test {
                 keep_alive: true,
                 memo: None,
             }),
-        };
+        );
 
         let bytes = common::to_bytes(&lock_config);
         assert_eq!(
@@ -206,16 +296,16 @@ mod test {
     fn test_lock_configuration_serial_empty_recipients() {
         use concordium_base::common::types::TransactionTime;
 
-        let lock_config = LockConfiguration {
-            recipients: vec![],
-            expiry: TransactionTime::from(500u64),
-            controller: LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
+        let lock_config = LockConfiguration::new_limited(
+            vec![],
+            TransactionTime::from(500u64),
+            LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
                 grants: vec![],
                 tokens: vec![],
                 keep_alive: false,
                 memo: None,
             }),
-        };
+        );
 
         let bytes = common::to_bytes(&lock_config);
         assert_eq!(hex::encode(&bytes), "000000000000000001f400000000000000");
@@ -223,6 +313,36 @@ mod test {
         let deserialized: LockConfiguration =
             common::from_bytes_complete(bytes.as_slice()).unwrap();
         assert_eq!(deserialized, lock_config);
+    }
+
+    #[test]
+    fn test_lock_configuration_serial_any_recipient_sentinel() {
+        use concordium_base::common::types::TransactionTime;
+
+        let lock_config = LockConfiguration::new_any(
+            TransactionTime::from(500u64),
+            LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
+                grants: vec![],
+                tokens: vec![],
+                keep_alive: false,
+                memo: None,
+            }),
+        );
+
+        assert!(lock_config.has_any_recipient());
+        assert!(lock_config.is_recipient(&AccountIndex::from(0u64)));
+        assert!(lock_config.is_recipient(&AccountIndex::from(42u64)));
+
+        let bytes = common::to_bytes(&lock_config);
+        assert_eq!(
+            hex::encode(&bytes),
+            "0001ffffffffffffffff00000000000001f400000000000000"
+        );
+
+        let deserialized: LockConfiguration =
+            common::from_bytes_complete(bytes.as_slice()).unwrap();
+        assert_eq!(deserialized, lock_config);
+        assert!(deserialized.has_any_recipient());
     }
 
     #[test]

--- a/plt/plt-block-state/tests/block_state_p11.rs
+++ b/plt/plt-block-state/tests/block_state_p11.rs
@@ -10,6 +10,7 @@ use plt_block_state::entity::entity_test_stub;
 use plt_block_state::entity::protocol_level_tokens::p11::Roles;
 use plt_block_state::persistent::protocol_level_locks::p11::{
     LockConfiguration, LockControllerConfig, LockControllerSimpleV0, LockControllerSimpleV0Grant,
+    LockRecipients,
 };
 use plt_block_state::persistent::protocol_level_tokens::p9::{TokenConfiguration, TokenIndex};
 use plt_scheduler_types::types::tokens::RawTokenAmount;
@@ -245,10 +246,10 @@ fn test_create_lock() {
     let mut block_state = BlockStateP11::default();
 
     // Create lock
-    let configuration = LockConfiguration::new(
-        vec![AccountIndex::from(1), AccountIndex::from(2)],
-        TransactionTime::from(100u64),
-        LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
+    let configuration = LockConfiguration {
+        recipients: LockRecipients::from(vec![AccountIndex::from(1), AccountIndex::from(2)]),
+        expiry: TransactionTime::from(100u64),
+        controller: LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
             grants: vec![LockControllerSimpleV0Grant {
                 account: AccountIndex::from(1),
                 roles: vec![
@@ -260,7 +261,7 @@ fn test_create_lock() {
             keep_alive: true,
             memo: Some(CborMemo::Raw(Memo::try_from(vec![0, 1]).unwrap())),
         }),
-    );
+    };
 
     let lock_id = LockId {
         account_index: 1,
@@ -288,16 +289,16 @@ fn test_lock_by_id() {
     let mut block_state = BlockStateP11::default();
 
     // Create lock
-    let configuration = LockConfiguration::new(
-        vec![],
-        TransactionTime::from(0u64),
-        LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
+    let configuration = LockConfiguration {
+        recipients: LockRecipients::from(vec![]),
+        expiry: TransactionTime::from(0u64),
+        controller: LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
             grants: Vec::new(),
             tokens: Vec::new(),
             keep_alive: false,
             memo: None,
         }),
-    );
+    };
 
     let lock_id = LockId {
         account_index: 1,
@@ -336,16 +337,16 @@ fn test_lock_balance_refs() {
     let mut block_state = BlockStateP11::default();
 
     // Create lock
-    let configuration = LockConfiguration::new(
-        vec![],
-        TransactionTime::from(0u64),
-        LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
+    let configuration = LockConfiguration {
+        recipients: LockRecipients::from(vec![]),
+        expiry: TransactionTime::from(0u64),
+        controller: LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
             grants: Vec::new(),
             tokens: Vec::new(),
             keep_alive: false,
             memo: None,
         }),
-    );
+    };
 
     let lock_id = LockId {
         account_index: 1,
@@ -396,16 +397,16 @@ fn test_lock_list() {
     assert_eq!(locks, vec![]);
 
     // Create locks
-    let configuration = LockConfiguration::new(
-        vec![],
-        TransactionTime::from(0u64),
-        LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
+    let configuration = LockConfiguration {
+        recipients: LockRecipients::from(vec![]),
+        expiry: TransactionTime::from(0u64),
+        controller: LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
             grants: Vec::new(),
             tokens: Vec::new(),
             keep_alive: false,
             memo: None,
         }),
-    );
+    };
 
     let lock_id_a = LockId {
         account_index: 1,

--- a/plt/plt-scheduler/src/locks/lock_configuration.rs
+++ b/plt/plt-scheduler/src/locks/lock_configuration.rs
@@ -6,7 +6,9 @@ use crate::{
 };
 use concordium_base::{
     base::AccountIndex,
-    protocol_level_locks::{LockAccountFunds, LockConfig, LockInfo, LockedTokenAmount},
+    protocol_level_locks::{
+        LockAccountFunds, LockConfig, LockInfo, LockRecipients, LockedTokenAmount,
+    },
     protocol_level_tokens::{CborHolderAccount, TokenAmount},
 };
 use plt_block_state::block_state_interface::BlockStateQuery;
@@ -14,19 +16,26 @@ use plt_block_state::entity::protocol_level_locks::p11::LockP11;
 use plt_block_state::external::AccountNotFoundByIndexError;
 use plt_block_state::persistent::protocol_level_locks::p11::LockConfiguration;
 
-/// Get the list of recipient accounts for a lock configuration, resolving
-/// [`AccountIndex`]es to [`CborHolderAccount`]s.
+/// Get the recipients for a lock configuration, resolving [`AccountIndex`]es
+/// to [`CborHolderAccount`]s unless the block-state sentinel represents an
+/// any-recipient lock.
 fn get_recipients<BSQ: BlockStateQuery>(
     bsq: &BSQ,
     configuration: &LockConfiguration,
-) -> Result<Vec<CborHolderAccount>, AccountNotFoundByIndexError> {
-    configuration
+) -> Result<LockRecipients, AccountNotFoundByIndexError> {
+    if configuration.has_any_recipient() {
+        return Ok(LockRecipients::Any);
+    }
+
+    let recipients = configuration
         .recipients_iter()
         .map(|account_index| {
             let with_addr = bsq.account_by_index(*account_index)?;
             Ok(CborHolderAccount::from(with_addr.canonical_account_address))
         })
-        .collect()
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(LockRecipients::Limited(recipients))
 }
 
 /// Get the lock configuration as a CBOR-representable [`LockConfig`] with

--- a/plt/plt-scheduler/src/locks/lock_configuration.rs
+++ b/plt/plt-scheduler/src/locks/lock_configuration.rs
@@ -14,7 +14,9 @@ use concordium_base::{
 use plt_block_state::block_state_interface::BlockStateQuery;
 use plt_block_state::entity::protocol_level_locks::p11::LockP11;
 use plt_block_state::external::AccountNotFoundByIndexError;
-use plt_block_state::persistent::protocol_level_locks::p11::LockConfiguration;
+use plt_block_state::persistent::protocol_level_locks::p11::{
+    LockConfiguration, LockRecipients as BlockStateLockRecipients,
+};
 
 /// Get the recipients for a lock configuration, resolving [`AccountIndex`]es
 /// to [`CborHolderAccount`]s unless the block-state sentinel represents an
@@ -23,19 +25,20 @@ fn get_recipients<BSQ: BlockStateQuery>(
     bsq: &BSQ,
     configuration: &LockConfiguration,
 ) -> Result<LockRecipients, AccountNotFoundByIndexError> {
-    if configuration.has_any_recipient() {
-        return Ok(LockRecipients::Any);
+    match &configuration.recipients {
+        BlockStateLockRecipients::Any => Ok(LockRecipients::Any),
+        BlockStateLockRecipients::Limited(recipients) => {
+            let recipients = recipients
+                .iter()
+                .map(|account_index| {
+                    let with_addr = bsq.account_by_index(*account_index)?;
+                    Ok(CborHolderAccount::from(with_addr.canonical_account_address))
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
+            Ok(LockRecipients::Limited(recipients))
+        }
     }
-
-    let recipients = configuration
-        .recipients_iter()
-        .map(|account_index| {
-            let with_addr = bsq.account_by_index(*account_index)?;
-            Ok(CborHolderAccount::from(with_addr.canonical_account_address))
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-
-    Ok(LockRecipients::Limited(recipients))
 }
 
 /// Get the lock configuration as a CBOR-representable [`LockConfig`] with
@@ -45,11 +48,11 @@ pub fn get_lock_config<BSQ: BlockStateQuery>(
     configuration: &LockConfiguration,
 ) -> Result<LockConfig, AccountNotFoundByIndexError> {
     let recipients = get_recipients(bsq, configuration)?;
-    let controller = configuration.controller().to_cbor_controller(bsq)?;
+    let controller = configuration.controller.to_cbor_controller(bsq)?;
 
     Ok(LockConfig {
         recipients,
-        expiry: configuration.expiry(),
+        expiry: configuration.expiry,
         controller,
     })
 }
@@ -69,7 +72,7 @@ pub fn get_lock_info<BSQ: BlockStateQuery>(
     // by the `lock-info` payload. Variant-specific resolution (e.g. expanding grant
     // `AccountIndex`es to `CborHolderAccount`) lives on the per-variant
     // `crate::locks::lock_controller::LockController` impl.
-    let controller = configuration.controller().to_cbor_controller(bsq)?;
+    let controller = configuration.controller.to_cbor_controller(bsq)?;
 
     // Group the tracked `(account, token)` balances by account so we emit a single
     // `LockAccountFunds` entry per account.
@@ -116,7 +119,7 @@ pub fn get_lock_info<BSQ: BlockStateQuery>(
     Ok(LockInfo {
         lock: lock.lock_id().clone(),
         recipients,
-        expiry: configuration.expiry(),
+        expiry: configuration.expiry,
         controller,
         funds,
     })

--- a/plt/plt-scheduler/src/scheduler/plt_scheduler.rs
+++ b/plt/plt-scheduler/src/scheduler/plt_scheduler.rs
@@ -106,13 +106,13 @@ where
 
     let lock_configuration = lock.lock_configuration(context);
     if lock_configuration
-        .expiry()
+        .expiry
         .is_expired(transaction_execution.timestamp())
     {
         return Err(TransactionRejectReason::LockExpired(lock.lock_id().clone()).into());
     }
 
-    lock_configuration.controller().validate_operation(
+    lock_configuration.controller.validate_operation(
         &bsq,
         transaction_execution.sender_account_address(),
         transaction_execution.sender_account(),
@@ -182,7 +182,7 @@ where
 
     let lock_configuration = lock.lock_configuration(context);
     if lock_configuration
-        .expiry()
+        .expiry
         .is_expired(transaction_execution.timestamp())
     {
         return Err(TransactionRejectReason::LockExpired(lock.lock_id().clone()).into());
@@ -219,7 +219,10 @@ where
         return Err(token_update_error_reject_reason(&token_configuration, err));
     }
 
-    if !lock_configuration.is_recipient(&recipient.account_index()) {
+    if !lock_configuration
+        .recipients
+        .is_recipient(&recipient.account_index())
+    {
         return Err(TransactionRejectReason::LockRecipientNotPermitted(
             lock.lock_id().clone(),
             recipient_address,
@@ -227,7 +230,7 @@ where
         .into());
     }
 
-    lock_configuration.controller().validate_operation(
+    lock_configuration.controller.validate_operation(
         &bsq,
         transaction_execution.sender_account_address(),
         transaction_execution.sender_account(),
@@ -294,7 +297,7 @@ where
 
     let lock_configuration = lock.lock_configuration(context);
     if lock_configuration
-        .expiry()
+        .expiry
         .is_expired(transaction_execution.timestamp())
     {
         return Err(TransactionRejectReason::LockExpired(lock.lock_id().clone()).into());
@@ -305,7 +308,7 @@ where
         .account_by_address(&source_address)
         .map_err(|_| TransactionRejectReason::InvalidAccountReference(source_address))?;
 
-    lock_configuration.controller().validate_operation(
+    lock_configuration.controller.validate_operation(
         &bsq,
         transaction_execution.sender_account_address(),
         transaction_execution.sender_account(),
@@ -394,7 +397,11 @@ where
                 .collect::<Result<Vec<_>, TransactionRejectReason>>()?,
         ),
     };
-    let configuration = LockConfiguration::new(recipients, expiry, controller);
+    let configuration = LockConfiguration {
+        recipients,
+        expiry,
+        controller,
+    };
 
     let config = get_lock_config(&bsq, &configuration).map_err(|err| {
         BlockStateFailure::Invariant(format!("Failed to get lock config for created lock: {err}"))
@@ -433,10 +440,10 @@ where
     let memo: Option<transactions::Memo> = details.memo.clone().map(transactions::Memo::from);
 
     if !lock_configuration
-        .expiry()
+        .expiry
         .is_expired(transaction_execution.timestamp())
     {
-        lock_configuration.controller().validate_operation(
+        lock_configuration.controller.validate_operation(
             &bsq,
             transaction_execution.sender_account_address(),
             transaction_execution.sender_account(),
@@ -491,7 +498,7 @@ fn remove_lock_balance_ref<C: EntityContextTypes>(
 }
 
 fn lock_configuration_keeps_alive(configuration: &LockConfiguration) -> bool {
-    match configuration.controller() {
+    match &configuration.controller {
         LockControllerConfig::SimpleV0(controller) => controller.keep_alive,
     }
 }

--- a/plt/plt-scheduler/src/scheduler/plt_scheduler.rs
+++ b/plt/plt-scheduler/src/scheduler/plt_scheduler.rs
@@ -383,8 +383,8 @@ where
 
     let recipients = match recipients {
         CborLockRecipients::Any => LockRecipients::Any,
-        CborLockRecipients::Limited(recipients) => LockRecipients::Limited(
-            recipients
+        CborLockRecipients::Limited(recipients) => {
+            let recipients = recipients
                 .into_iter()
                 .map(
                     |recipient| match context.account_by_address(&recipient.address) {
@@ -394,8 +394,9 @@ where
                         )),
                     },
                 )
-                .collect::<Result<Vec<_>, TransactionRejectReason>>()?,
-        ),
+                .collect::<Result<Vec<_>, TransactionRejectReason>>()?;
+            LockRecipients::from(recipients)
+        }
     };
     let configuration = LockConfiguration {
         recipients,

--- a/plt/plt-scheduler/src/scheduler/plt_scheduler.rs
+++ b/plt/plt-scheduler/src/scheduler/plt_scheduler.rs
@@ -12,7 +12,7 @@ use crate::scheduler::TransactionFailure;
 use crate::transaction_execution::TransactionExecution;
 use concordium_base::base::AccountIndex;
 use concordium_base::common::cbor::{self};
-use concordium_base::protocol_level_locks::LockId;
+use concordium_base::protocol_level_locks::{LockId, LockRecipients as CborLockRecipients};
 use concordium_base::protocol_level_tokens::meta_operations::{
     LockOperation, MetaLockCancelDetails, MetaLockCreateDetails, MetaLockFundDetails,
     MetaLockReturnDetails, MetaLockSendDetails,
@@ -29,7 +29,7 @@ use plt_block_state::entity::block_state::p11::BlockStateP11;
 use plt_block_state::entity::{EntityContext, EntityContextTypes};
 use plt_block_state::failure::BlockStateFailure;
 use plt_block_state::persistent::protocol_level_locks::p11::{
-    LockConfiguration, LockControllerConfig,
+    LockConfiguration, LockControllerConfig, LockRecipients,
 };
 use plt_block_state::persistent::protocol_level_tokens::p9::TokenConfiguration;
 use plt_scheduler_types::types::events::{self, BlockItemEvent};
@@ -367,26 +367,34 @@ where
         context: context.clone(),
     };
 
-    let config = details.config;
     let account_index = transaction_execution.sender_account().account_index();
     let sequence_number = transaction_execution.transaction_sequence_number();
     let creation_order = transaction_execution.next_lock_creation_order();
     let lock_id = LockId::new(account_index, sequence_number, creation_order);
-    let controller = LockController::new(&bsq, config.controller)?;
+    let concordium_base::protocol_level_locks::LockConfig {
+        recipients,
+        expiry,
+        controller: controller_config,
+    } = details.config;
+    let controller = LockController::new(&bsq, controller_config)?;
 
-    let recipients = config
-        .recipients
-        .iter()
-        .map(
-            |recipient| match context.account_by_address(&recipient.address) {
-                Ok(account) => Ok(account.account_index()),
-                Err(_) => Err(TransactionRejectReason::InvalidAccountReference(
-                    recipient.address,
-                )),
-            },
-        )
-        .collect::<Result<Vec<_>, TransactionRejectReason>>()?;
-    let configuration = LockConfiguration::new(recipients, config.expiry, controller);
+    let recipients = match recipients {
+        CborLockRecipients::Any => LockRecipients::Any,
+        CborLockRecipients::Limited(recipients) => LockRecipients::Limited(
+            recipients
+                .into_iter()
+                .map(
+                    |recipient| match context.account_by_address(&recipient.address) {
+                        Ok(account) => Ok(account.account_index()),
+                        Err(_) => Err(TransactionRejectReason::InvalidAccountReference(
+                            recipient.address,
+                        )),
+                    },
+                )
+                .collect::<Result<Vec<_>, TransactionRejectReason>>()?,
+        ),
+    };
+    let configuration = LockConfiguration::new(recipients, expiry, controller);
 
     let config = get_lock_config(&bsq, &configuration).map_err(|err| {
         BlockStateFailure::Invariant(format!("Failed to get lock config for created lock: {err}"))

--- a/plt/plt-scheduler/tests/lock_create.rs
+++ b/plt/plt-scheduler/tests/lock_create.rs
@@ -8,7 +8,7 @@ use concordium_base::{
     common::{cbor, types::TransactionTime},
     protocol_level_locks::{
         LockConfig, LockController, LockControllerSimpleV0, LockControllerSimpleV0Capability,
-        LockControllerSimpleV0Grant, LockId,
+        LockControllerSimpleV0Grant, LockId, LockRecipients,
     },
     protocol_level_tokens::{
         MetadataUrl, RawCbor, TokenAmount, TokenId, TokenModuleInitializationParameters,
@@ -54,7 +54,7 @@ fn test_create_simple_lock() {
         .expect("create pltX");
 
     let config = LockConfig {
-        recipients: vec![account_1.into()],
+        recipients: LockRecipients::Limited(vec![account_1.into()]),
         expiry: TransactionTime::from_seconds(1000),
         controller: LockController::SimpleV0(LockControllerSimpleV0 {
             grants: vec![LockControllerSimpleV0Grant {
@@ -96,4 +96,84 @@ fn test_create_simple_lock() {
             lock_config: RawCbor::from(cbor::cbor_encode(&config))
         })
     );
+}
+
+#[test]
+fn test_create_any_recipient_lock() {
+    let mut context = entity_test_stub::new_stubbed_context();
+    let mut block_state = BlockStateLatest::default();
+
+    let account_index_1 = context.external.create_account().account_index();
+    let account_1 = context.external.account_canonical_address(account_index_1);
+
+    let plt_x: TokenId = "pltX".parse().unwrap();
+    let parameters = TokenModuleInitializationParameters {
+        name: Some("Test PLT 1".to_owned()),
+        metadata: Some(MetadataUrl::from("https://pltX.token".to_string())),
+        governance_account: Some(account_1.into()),
+        allow_list: None,
+        deny_list: None,
+        initial_supply: Some(TokenAmount::from_raw(10000, 2)),
+        mintable: Some(true),
+        burnable: Some(true),
+    };
+    let initialization_parameters = cbor::cbor_encode(&parameters).into();
+    let payload = UpdatePayload::CreatePlt(CreatePlt {
+        token_id: plt_x.clone(),
+        token_module: TOKEN_MODULE_REF,
+        decimals: 2,
+        initialization_parameters,
+    });
+    block_state
+        .execute_chain_update(&mut context, payload)
+        .expect("create pltX");
+
+    let config = LockConfig {
+        recipients: LockRecipients::Any,
+        expiry: TransactionTime::from_seconds(1000),
+        controller: LockController::SimpleV0(LockControllerSimpleV0 {
+            grants: vec![LockControllerSimpleV0Grant {
+                account: account_1.into(),
+                roles: vec![LockControllerSimpleV0Capability::Fund],
+            }],
+            tokens: vec![plt_x],
+            keep_alive: false,
+            memo: None,
+        }),
+    };
+    let operations = vec![lock_create(config.clone())];
+    let payload = MetaUpdatePayload {
+        operations: RawCbor::from(cbor::cbor_encode(&operations)),
+    };
+
+    let result = block_state
+        .execute_transaction(
+            &mut context,
+            plt_scheduler::TransactionContext {
+                energy_limit: Energy::from(u64::MAX),
+                sender_account_address: account_1,
+                transaction_sequence_number: 1.into(),
+                block_timestamp: 0.into(),
+            },
+            account_index_1,
+            Payload::MetaUpdate { payload },
+        )
+        .expect("transaction internal error");
+    let events = assert_matches!(result.outcome, plt_scheduler_types::types::execution::TransactionOutcome::Success(events) => events);
+    assert_eq!(events.len(), 1);
+    assert_eq!(
+        events[0],
+        BlockItemEvent::LockCreated(LockCreateEvent {
+            lock_id: LockId::new(account_index_1, 1, 0),
+            lock_config: RawCbor::from(cbor::cbor_encode(&config))
+        })
+    );
+
+    let lock = block_state
+        .lock_by_id(&context, &LockId::new(account_index_1, 1, 0))
+        .expect("lock lookup must succeed")
+        .expect("lock must exist");
+    let configuration = lock.lock_configuration(&context);
+    assert!(configuration.has_any_recipient());
+    assert_eq!(configuration.recipients_iter().count(), 0);
 }

--- a/plt/plt-scheduler/tests/lock_create.rs
+++ b/plt/plt-scheduler/tests/lock_create.rs
@@ -174,6 +174,5 @@ fn test_create_any_recipient_lock() {
         .expect("lock lookup must succeed")
         .expect("lock must exist");
     let configuration = lock.lock_configuration(&context);
-    assert!(configuration.has_any_recipient());
-    assert_eq!(configuration.recipients_iter().count(), 0);
+    assert!(configuration.recipients.is_any());
 }

--- a/plt/plt-scheduler/tests/lock_send.rs
+++ b/plt/plt-scheduler/tests/lock_send.rs
@@ -6,13 +6,14 @@ use assert_matches::assert_matches;
 use concordium_base::base::Energy;
 use concordium_base::common::cbor;
 use concordium_base::protocol_level_locks::LockInfo;
-use concordium_base::protocol_level_locks::{LockControllerSimpleV0Capability, LockId};
-use concordium_base::protocol_level_tokens::meta_operations::{
-    MetaUpdateOperations, MetaUpdatePayload, lock_fund, lock_send,
+use concordium_base::protocol_level_locks::{
+    LockConfig, LockController, LockControllerSimpleV0, LockControllerSimpleV0Capability,
+    LockControllerSimpleV0Grant as CborLockControllerSimpleV0Grant, LockId, LockRecipients,
 };
 use concordium_base::protocol_level_tokens::{
     CborHolderAccount, OperationNotPermittedRejectReason, RawCbor, TokenAmount, TokenId,
     TokenListUpdateDetails, TokenModuleAccountState, TokenModuleRejectReason, TokenOperation,
+    meta_operations::{MetaUpdateOperations, MetaUpdatePayload, lock_create, lock_fund, lock_send},
 };
 use concordium_base::transactions::Payload;
 use plt_block_state::{
@@ -196,6 +197,89 @@ fn test_lock_send_moves_locked_funds_to_recipient() {
     assert_eq!(lock_info.funds.len(), 1);
     assert_eq!(lock_info.funds[0].amounts[0].amount.value(), 150);
 }
+#[test]
+fn test_lock_send_allows_any_recipient() {
+    let mut context = entity_test_stub::new_stubbed_context();
+    let mut block_state = BlockStateLatest::default();
+
+    let owner = context.external.create_account();
+    let arbitrary_recipient = context.external.create_account();
+    let token_id: TokenId = "pltX".parse().unwrap();
+    utils::create_and_init_token_p11(
+        &mut context,
+        &mut block_state,
+        token_id.clone(),
+        TokenInitTestParams::default().mintable(),
+        4,
+        None,
+    );
+    utils::increment_account_balance_p11(
+        &mut context,
+        &mut block_state,
+        owner.account_index(),
+        &token_id,
+        RawTokenAmount(1000),
+    );
+
+    let owner_addr = context
+        .external
+        .account_canonical_address(owner.account_index());
+    let recipient_addr = context
+        .external
+        .account_canonical_address(arbitrary_recipient.account_index());
+
+    let lock_id = LockId::new(owner.account_index(), 1u64, 0); // 1 matches the seq number given by `execute_meta_update`
+    let operations = vec![
+        lock_create(LockConfig {
+            recipients: LockRecipients::Any,
+            expiry: 1_804_806_000.into(),
+            controller: LockController::SimpleV0(LockControllerSimpleV0 {
+                grants: vec![CborLockControllerSimpleV0Grant {
+                    account: CborHolderAccount::from(owner_addr),
+                    roles: vec![
+                        LockControllerSimpleV0Capability::Fund,
+                        LockControllerSimpleV0Capability::Send,
+                    ],
+                }],
+                tokens: vec![token_id.clone()],
+                keep_alive: false,
+                memo: None,
+            }),
+        }),
+        lock_fund(
+            token_id.clone(),
+            lock_id.clone(),
+            TokenAmount::from_raw(250, 4),
+            None,
+        ),
+        lock_send(
+            token_id.clone(),
+            lock_id.clone(),
+            owner_addr,
+            recipient_addr,
+            TokenAmount::from_raw(100, 4),
+            None,
+        ),
+    ];
+
+    let outcome = execute_meta_update!(
+        &mut context,
+        &mut block_state,
+        owner.account_index(),
+        0,
+        operations,
+    );
+    assert_matches!(outcome, TransactionOutcome::Success(_));
+
+    let lock_info: LockInfo = cbor::cbor_decode(
+        block_state
+            .query_lock_info(&context, &lock_id)
+            .expect("lock info query must succeed"),
+    )
+    .expect("lock info must decode");
+    assert_eq!(lock_info.recipients, LockRecipients::Any);
+}
+
 #[test]
 fn test_lock_send_rejects_non_recipient() {
     let mut context = entity_test_stub::new_stubbed_context();

--- a/plt/plt-scheduler/tests/plt_lock_queries.rs
+++ b/plt/plt-scheduler/tests/plt_lock_queries.rs
@@ -7,9 +7,13 @@ use concordium_base::common::cbor;
 use concordium_base::common::types::TransactionTime;
 use concordium_base::protocol_level_locks::LockInfo;
 use concordium_base::protocol_level_locks::{
-    LockController, LockControllerSimpleV0Capability, LockId,
+    LockController, LockControllerSimpleV0Capability, LockId, LockRecipients,
 };
-use concordium_base::protocol_level_tokens::{CborHolderAccount, TokenId};
+use concordium_base::protocol_level_tokens::meta_operations::{
+    MetaUpdateOperations, MetaUpdatePayload, lock_create,
+};
+use concordium_base::protocol_level_tokens::{CborHolderAccount, RawCbor, TokenId};
+use concordium_base::transactions::Payload;
 use plt_block_state::entity::entity_test_stub;
 use plt_block_state::persistent::protocol_level_locks::p11::LockControllerSimpleV0Grant;
 use plt_scheduler::queries::QueryLockError;
@@ -86,7 +90,7 @@ fn test_query_lock_info_cbor_round_trip_with_funded_balances() {
     assert_eq!(decoded.lock, lock_id);
     assert_eq!(
         decoded.recipients,
-        vec![CborHolderAccount::from(recipient_addr)]
+        LockRecipients::Limited(vec![CborHolderAccount::from(recipient_addr)])
     );
     assert_eq!(decoded.expiry, TransactionTime::from(1_804_806_000));
     assert_matches!(decoded.controller, LockController::SimpleV0(simple) => {
@@ -110,6 +114,78 @@ fn test_query_lock_info_cbor_round_trip_with_funded_balances() {
 
 /// `query_lock_info` returns [`QueryLockError::LockDoesNotExist`] when the
 /// lock id is not present in the block state.
+#[test]
+fn test_query_lock_info_any_recipient() {
+    let mut context = entity_test_stub::new_stubbed_context();
+    let mut block_state = BlockStateLatest::default();
+
+    let owner = context.external.create_account();
+    let token_id: TokenId = "TokenLockAny".parse().unwrap();
+    utils::create_and_init_token_p11(
+        &mut context,
+        &mut block_state,
+        token_id.clone(),
+        TokenInitTestParams::default().mintable(),
+        2,
+        Some(RawTokenAmount(0)),
+    );
+
+    let lock_id = LockId {
+        account_index: owner.account_index().into(),
+        sequence_number: 1,
+        creation_order: 0,
+    };
+    let sender_addr = context
+        .external
+        .account_canonical_address(owner.account_index());
+    let operations = MetaUpdateOperations {
+        operations: vec![lock_create(
+            concordium_base::protocol_level_locks::LockConfig {
+                recipients: LockRecipients::Any,
+                expiry: TransactionTime::from(1_804_806_000u64),
+                controller: LockController::SimpleV0(
+                    concordium_base::protocol_level_locks::LockControllerSimpleV0 {
+                        grants: vec![
+                            concordium_base::protocol_level_locks::LockControllerSimpleV0Grant {
+                                account: CborHolderAccount::from(sender_addr),
+                                roles: vec![LockControllerSimpleV0Capability::Fund],
+                            },
+                        ],
+                        tokens: vec![token_id.clone()],
+                        keep_alive: false,
+                        memo: None,
+                    },
+                ),
+            },
+        )],
+    };
+    block_state
+        .execute_transaction(
+            &mut context,
+            plt_scheduler::TransactionContext {
+                energy_limit: concordium_base::base::Energy::from(u64::MAX),
+                sender_account_address: sender_addr,
+                transaction_sequence_number: 1.into(),
+                block_timestamp: 0.into(),
+            },
+            owner.account_index(),
+            Payload::MetaUpdate {
+                payload: MetaUpdatePayload {
+                    operations: RawCbor::from(cbor::cbor_encode(&operations)),
+                },
+            },
+        )
+        .expect("create any-recipient lock must succeed");
+
+    let bytes = block_state
+        .query_lock_info(&context, &lock_id)
+        .expect("query_lock_info must succeed for an existing lock");
+    let decoded: LockInfo =
+        cbor::cbor_decode(&bytes).expect("CBOR encoding produced by query_lock_info must decode");
+
+    assert_eq!(decoded.recipients, LockRecipients::Any);
+}
+
 #[test]
 fn test_query_lock_info_unknown_lock() {
     let context = entity_test_stub::new_stubbed_context();

--- a/plt/plt-scheduler/tests/utils/lock.rs
+++ b/plt/plt-scheduler/tests/utils/lock.rs
@@ -46,7 +46,8 @@ pub fn create_lock(
                 .canonical_account_address,
         )
     };
-    let recipients = config.recipients.iter().map(resolve_account).collect();
+    let recipients =
+        LockRecipients::Limited(config.recipients.iter().map(resolve_account).collect());
     let grants = config
         .grants
         .iter()


### PR DESCRIPTION
Closes COR-2427

## Purpose

Adds handling for the "any" recipients variant in a lock configuration. This implements a temporary non-breaking solution in the block state to allow upgrading the current devnet with support.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.