### PR TITLE
Improve performance of quorum message tests by avoiding huge finalizer sets

### DIFF
--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Quorum.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Quorum.hs
@@ -38,11 +38,11 @@ genFinalizerWeight = VoterPower <$> arbitrary
 genBakerId :: Gen BakerId
 genBakerId = BakerId . AccountIndex <$> arbitrary
 
--- | Generate a 'QuorumMessage' for a particular block.
+-- | Generate a 'QuorumMessage' for a particular block with a reasonably-sized finalizer index.
 genQuorumMessageFor :: BlockHash -> Gen QuorumMessage
 genQuorumMessageFor bh = do
     qmSignature <- genQuorumSignature
-    qmFinalizerIndex <- genFinalizerIndex
+    qmFinalizerIndex <- genSmallFinalizerIndex
     qmRound <- genRound
     qmEpoch <- genEpoch
     return QuorumMessage{qmBlock = bh, ..}
@@ -52,7 +52,7 @@ genQuorumMessageFor bh = do
 --  then the weight is being accumulated and signatures are aggregated.
 propAddQuorumMessage :: SProtocolVersion pv -> Property
 propAddQuorumMessage sProtocolVersion =
-    forAll genQuorumMessage $ \qm0 ->
+    forAll (genQuorumMessageFor =<< genBlockHash) $ \qm0 ->
         forAll (genQuorumMessageFor (qmBlock qm0)) $ \qm1 ->
             (qm0 /= qm1) ==>
                 forAll genFinalizerWeight $ \weight -> forAll genBakerId $ \bakerId0 -> forAll genBakerId $ \bakerId1 -> do

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Types.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Types.hs
@@ -464,7 +464,7 @@ encodedFinalizerSet01310 = runPut $ do
     putWord8 0x0b
 
 genSmallFinalizerIndex :: Gen FinalizerIndex
-genSmallFinalizerIndex = FinalizerIndex . fromIntegral <$> chooseInt (0, 255)
+genSmallFinalizerIndex = FinalizerIndex . fromIntegral <$> chooseInt (0, 4096)
 
 -- | 'memberFinalizerSet' returns 'True' for all finalizer indices in the list of finalizer
 -- indices used to construct the `FinalizerSet`


### PR DESCRIPTION
## Purpose

Fix an issue where quorum message prop tests run for a very long time, sometimes causing CI to crash

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
