### PR TITLE
Fix concordium-base warnings blocking release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -310,11 +310,13 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ env.RUST_VERSION }}-x86_64-pc-windows-msvc
+          rustflags: ""
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ env.RUST_VERSION }}-x86_64-pc-windows-gnu
+          rustflags: ""
 
       - name: Setup node folder
         run: |
@@ -436,6 +438,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
+          rustflags: ""
 
       - uses: haskell-actions/setup@v2
         with:


### PR DESCRIPTION
## Purpose

Fixes an issue where concordium-base compiled with rust version 1.94 (used in the new node build) fails due to `-D warnings` being set by default by `actions-rust-lang/setup-rust-toolchain@v1`. This is useful when used in CI checks, but not for a release.
