### PR TITLE
Add token chain parameters + authorizations

### DIFF
--- a/concordium-consensus/benchmarks/transactions/SchedulerBench/Helpers.hs
+++ b/concordium-consensus/benchmarks/transactions/SchedulerBench/Helpers.hs
@@ -139,7 +139,7 @@ createTestBlockStateWithAccounts accounts = do
             DummyData.dummyIdentityProviders
             DummyData.dummyArs
             keys
-            DummyData.dummyChainParameters
+            (DummyData.dummyChainParameters @pv)
     -- save block state and accounts.
     void $ BS.saveBlockState bs
     void $ BS.saveGlobalMaps bs

--- a/concordium-consensus/src/Concordium/GlobalState/DummyData.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/DummyData.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -374,8 +375,21 @@ dummyValidatorScoreParameters =
           _vspMaxMissedRounds = 1
         }
 
-dummyChainParameters :: forall cpv. (IsChainParametersVersion cpv) => ChainParameters' cpv
-dummyChainParameters = case chainParametersVersion @cpv of
+-- | Dummy chain parameters for the given protocol version.
+--
+-- For P11 this includes an initial max lock duration, which is required by the
+-- node-owned external chain-parameters component.
+dummyChainParameters :: forall pv. (IsProtocolVersion pv) => ChainParameters pv
+dummyChainParameters = case protocolVersion @pv of
+    SP11 -> (dummyChainParameters' @(ChainParametersVersionFor pv)){_cpMaxLockDuration = SomeParam (Just (Duration 42))}
+    _ -> dummyChainParameters' @(ChainParametersVersionFor pv)
+
+-- | Dummy chain parameters for the given chain-parameters version.
+--
+-- This helper is intentionally indexed by chain-parameters version only. For
+-- protocol-aware genesis/test data, prefer 'dummyChainParameters'.
+dummyChainParameters' :: forall cpv. (IsChainParametersVersion cpv) => ChainParameters' cpv
+dummyChainParameters' = case chainParametersVersion @cpv of
     SChainParametersV0 ->
         ChainParameters
             { _cpConsensusParameters = ConsensusParametersV0 $ makeElectionDifficulty 50000,

--- a/concordium-consensus/src/Concordium/GlobalState/DummyData.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/DummyData.hs
@@ -95,7 +95,8 @@ dummyAuthorizations =
           asAddIdentityProvider = theOnly,
           asCooldownParameters = conditionally (sSupportsCooldownParametersAccessStructure (sing @auv)) theOnly,
           asTimeParameters = conditionally (sSupportsTimeParameters (sing @auv)) theOnly,
-          asCreatePLT = conditionally (sSupportsCreatePLT (sing @auv)) theOnly
+          asCreatePLT = conditionally (sSupportsCreatePLT (sing @auv)) theOnly,
+          asTokenParameters = conditionally (sSupportsTokenParameters (sing @auv)) theOnly
         }
   where
     theOnly = AccessStructure (Set.singleton 0) 1
@@ -392,7 +393,8 @@ dummyChainParameters = case chainParametersVersion @cpv of
                     { _ppBakerStakeThreshold = 300000000000
                     },
               _cpFinalizationCommitteeParameters = NoParam,
-              _cpValidatorScoreParameters = NoParam
+              _cpValidatorScoreParameters = NoParam,
+              _cpMaxLockDuration = NoParam
             }
     SChainParametersV1 ->
         ChainParameters
@@ -431,7 +433,8 @@ dummyChainParameters = case chainParametersVersion @cpv of
                             }
                     },
               _cpFinalizationCommitteeParameters = NoParam,
-              _cpValidatorScoreParameters = NoParam
+              _cpValidatorScoreParameters = NoParam,
+              _cpMaxLockDuration = NoParam
             }
     SChainParametersV2 ->
         ChainParameters
@@ -470,7 +473,8 @@ dummyChainParameters = case chainParametersVersion @cpv of
                             }
                     },
               _cpFinalizationCommitteeParameters = SomeParam dummyFinalizationCommitteeParameters,
-              _cpValidatorScoreParameters = NoParam
+              _cpValidatorScoreParameters = NoParam,
+              _cpMaxLockDuration = NoParam
             }
     SChainParametersV3 ->
         ChainParameters
@@ -509,7 +513,8 @@ dummyChainParameters = case chainParametersVersion @cpv of
                             }
                     },
               _cpFinalizationCommitteeParameters = SomeParam dummyFinalizationCommitteeParameters,
-              _cpValidatorScoreParameters = SomeParam dummyValidatorScoreParameters
+              _cpValidatorScoreParameters = SomeParam dummyValidatorScoreParameters,
+              _cpMaxLockDuration = SomeParam Nothing
             }
   where
     fullRange = InclusiveRange (makeAmountFraction 0) (makeAmountFraction 100000)

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState.hs
@@ -65,6 +65,7 @@ import qualified Concordium.GlobalState.Persistent.Accounts as LMDBAccountMap
 import Concordium.GlobalState.Persistent.Bakers
 import Concordium.GlobalState.Persistent.BlobStore
 import qualified Concordium.GlobalState.Persistent.BlockState.Modules as Modules
+import qualified Concordium.GlobalState.Persistent.BlockState.Parameters as PCP
 import qualified Concordium.GlobalState.Persistent.BlockState.ProtocolLevelTokens as PLT
 import Concordium.GlobalState.Persistent.BlockState.Updates
 import qualified Concordium.GlobalState.Persistent.Cache as Cache
@@ -2681,7 +2682,7 @@ doUpdateBakerStake pbs ai newStake = do
                     let curEpoch = bspBirkParameters bsp ^. birkSeedState . epoch
                     upds <- refLoad (bspUpdates bsp)
                     cooldownEpochs <-
-                        (2 +) . _cpBakerExtraCooldownEpochs . _cpCooldownParameters . unStoreSerialized
+                        (2 +) . _cpBakerExtraCooldownEpochs . _cpCooldownParameters . PCP.persistentChainParametersToChainParameters
                             <$> refLoad (currentParameters upds)
 
                     bakerStakeThreshold <- (^. cpPoolParameters . ppBakerStakeThreshold) <$> doGetChainParameters pbs
@@ -2740,7 +2741,7 @@ doRemoveBaker pbs ai = do
                     let curEpoch = bspBirkParameters bsp ^. birkSeedState . epoch
                     upds <- refLoad (bspUpdates bsp)
                     cooldownEpochs <-
-                        (2 +) . _cpBakerExtraCooldownEpochs . _cpCooldownParameters . unStoreSerialized
+                        (2 +) . _cpBakerExtraCooldownEpochs . _cpCooldownParameters . PCP.persistentChainParametersToChainParameters
                             <$> refLoad (currentParameters upds)
                     let updAcc =
                             setAccountStakePendingChange $
@@ -3525,7 +3526,7 @@ doGetCurrentElectionDifficulty ::
 doGetCurrentElectionDifficulty pbs = do
     bsp <- loadPBS pbs
     upds <- refLoad (bspUpdates bsp)
-    _cpElectionDifficulty . _cpConsensusParameters . unStoreSerialized <$> refLoad (currentParameters upds)
+    _cpElectionDifficulty . _cpConsensusParameters . PCP.persistentChainParametersToChainParameters <$> refLoad (currentParameters upds)
 
 doGetUpdates :: (SupportsPersistentState pv m) => PersistentBlockState pv -> m (UQ.Updates pv)
 doGetUpdates = makeBasicUpdates <=< refLoad . bspUpdates <=< loadPBS
@@ -4993,8 +4994,8 @@ migrateBlockPointers migration BlockStatePointers{..} = do
     nextBakers <- extractBakerStakes =<< refLoad (_birkNextEpochBakers newBirkParameters)
     -- clear transaction outcomes.
     let newTransactionOutcomes = emptyTransactionOutcomes (Proxy @pv)
-    chainParams <- refLoad . currentParameters =<< refLoad newUpdates
-    let timeParams = _cpTimeParameters . unStoreSerialized $ chainParams
+    chainParams <- PCP.persistentChainParametersToChainParameters <$> (refLoad . currentParameters =<< refLoad newUpdates)
+    let timeParams = _cpTimeParameters chainParams
     logEvent GlobalState LLTrace "Migrating reward details"
     newRewardDetails <-
         migrateBlockRewardDetails migration curBakers nextBakers timeParams oldEpoch bspRewardDetails

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/ExternalChainParameters.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/ExternalChainParameters.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -13,7 +14,6 @@ module Concordium.GlobalState.Persistent.BlockState.ExternalChainParameters (
     RustExternalChainParameters,
     ForeignExternalChainParametersPtr,
     wrapFFIPtr,
-    empty,
     p11NewExternalChainParameters,
     withExternalChainParameters,
     ExternalChainParametersHash (..),
@@ -41,10 +41,10 @@ data RustExternalChainParameters
 -- | Opaque pointer to immutable external chain parameters managed by Rust.
 --
 -- Memory is deallocated using a finalizer.
-newtype ForeignExternalChainParametersPtr = ForeignExternalChainParametersPtr (FFI.ForeignPtr RustExternalChainParameters)
+newtype ForeignExternalChainParametersPtr (pv :: Types.ProtocolVersion) = ForeignExternalChainParametersPtr (FFI.ForeignPtr RustExternalChainParameters)
 
 -- | Convert a raw pointer returned by Rust into a managed pointer.
-wrapFFIPtr :: FFI.Ptr RustExternalChainParameters -> IO ForeignExternalChainParametersPtr
+wrapFFIPtr :: FFI.Ptr RustExternalChainParameters -> IO (ForeignExternalChainParametersPtr pv)
 wrapFFIPtr paramsPtr = ForeignExternalChainParametersPtr <$> FFI.newForeignPtr ffiFreeExternalChainParameters paramsPtr
 
 -- | Deallocate a pointer to external chain parameters.
@@ -54,29 +54,11 @@ foreign import ccall unsafe "&ffi_free_external_chain_parameters"
 -- | Get temporary access to the external chain-parameters pointer.
 --
 -- The pointer must not be leaked from the computation.
-withExternalChainParameters :: ForeignExternalChainParametersPtr -> (FFI.Ptr RustExternalChainParameters -> IO a) -> IO a
+withExternalChainParameters :: ForeignExternalChainParametersPtr pv -> (FFI.Ptr RustExternalChainParameters -> IO a) -> IO a
 withExternalChainParameters (ForeignExternalChainParametersPtr foreignPtr) = FFI.withForeignPtr foreignPtr
 
-p11ProtocolVersion :: FFI.Word64
-p11ProtocolVersion = Types.protocolVersionToWord64 Types.P11
-
--- | Allocate new empty external chain parameters.
-empty :: (BlobStore.MonadBlobStore m) => m ForeignExternalChainParametersPtr
-empty = liftIO $ do
-    FFI.alloca $ \paramsDestPtr -> do
-        status <- ffiEmptyExternalChainParameters p11ProtocolVersion paramsDestPtr
-        Monad.unless (status == 0) $ error "Unexpected panic when creating external chain parameters"
-        params <- FFI.peek paramsDestPtr
-        wrapFFIPtr params
-
-foreign import ccall "ffi_empty_external_chain_parameters"
-    ffiEmptyExternalChainParameters ::
-        FFI.Word64 ->
-        FFI.Ptr (FFI.Ptr RustExternalChainParameters) ->
-        IO FFI.Word8
-
 -- | Allocate new P11 external chain parameters with an initial maximum lock duration.
-p11NewExternalChainParameters :: (BlobStore.MonadBlobStore m) => Duration -> m ForeignExternalChainParametersPtr
+p11NewExternalChainParameters :: (BlobStore.MonadBlobStore m) => Duration -> m (ForeignExternalChainParametersPtr 'Types.P11)
 p11NewExternalChainParameters (Duration maxLockDuration) = liftIO $ do
     FFI.alloca $ \paramsDestPtr -> do
         status <- ffiP11NewExternalChainParameters maxLockDuration paramsDestPtr
@@ -90,14 +72,19 @@ foreign import ccall "ffi_p11_new_external_chain_parameters"
         FFI.Ptr (FFI.Ptr RustExternalChainParameters) ->
         IO FFI.Word8
 
-instance (BlobStore.MonadBlobStore m) => BlobStore.BlobStorable m ForeignExternalChainParametersPtr where
+instance (BlobStore.MonadBlobStore m, Types.IsProtocolVersion pv) => BlobStore.BlobStorable m (ForeignExternalChainParametersPtr pv) where
     load = do
         blobRef <- S.get
         pure $! do
             loadCallback <- fst <$> BlobStore.getCallbacks
             liftIO $! do
                 FFI.alloca $ \paramsDestPtr -> do
-                    status <- ffiLoadExternalChainParameters loadCallback blobRef p11ProtocolVersion paramsDestPtr
+                    status <-
+                        ffiLoadExternalChainParameters
+                            loadCallback
+                            blobRef
+                            (Types.protocolVersionToWord64 $ Types.demoteProtocolVersion $ Types.protocolVersion @pv)
+                            paramsDestPtr
                     Monad.unless (status == 0) $ error "Unexpected panic when loading external chain parameters"
                     params <- FFI.peek paramsDestPtr
                     wrapFFIPtr params
@@ -124,7 +111,7 @@ foreign import ccall "ffi_store_external_chain_parameters"
         FFI.Ptr RustExternalChainParameters ->
         IO FFI.Word8
 
-instance (BlobStore.MonadBlobStore m) => BlobStore.Cacheable m ForeignExternalChainParametersPtr where
+instance (BlobStore.MonadBlobStore m) => BlobStore.Cacheable m (ForeignExternalChainParametersPtr pv) where
     cache params = do
         loadCallback <- fst <$> BlobStore.getCallbacks
         status <- liftIO $! withExternalChainParameters params (ffiCacheExternalChainParameters loadCallback)
@@ -141,7 +128,7 @@ foreign import ccall "ffi_cache_external_chain_parameters"
 newtype ExternalChainParametersHash = ExternalChainParametersHash {theExternalChainParametersHash :: SHA256.Hash}
     deriving newtype (Eq, Ord, Show, S.Serialize)
 
-instance (BlobStore.MonadBlobStore m) => Hashable.MHashableTo m ExternalChainParametersHash ForeignExternalChainParametersPtr where
+instance (BlobStore.MonadBlobStore m) => Hashable.MHashableTo m ExternalChainParametersHash (ForeignExternalChainParametersPtr pv) where
     getHashM params = do
         loadCallback <- fst <$> BlobStore.getCallbacks
         ((), hash) <-
@@ -160,7 +147,7 @@ foreign import ccall "ffi_hash_external_chain_parameters"
         IO FFI.Word8
 
 -- | Read the current maximum lock duration from external chain parameters.
-getMaxLockDuration :: ForeignExternalChainParametersPtr -> IO Duration
+getMaxLockDuration :: ForeignExternalChainParametersPtr pv -> IO Duration
 getMaxLockDuration params =
     withExternalChainParameters params $ \paramsPtr ->
         FFI.alloca $ \durationPtr -> do

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/ExternalChainParameters.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/ExternalChainParameters.hs
@@ -1,0 +1,159 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | Bindings to the Rust external chain-parameters implementation.
+--
+-- The component stores node-internal chain-parameter state whose public query
+-- representation is assembled by the node. It is deliberately separate from
+-- the public/wire chain-parameter types in @concordium-base@.
+module Concordium.GlobalState.Persistent.BlockState.ExternalChainParameters (
+    RustExternalChainParameters,
+    ForeignExternalChainParametersPtr,
+    wrapFFIPtr,
+    empty,
+    withExternalChainParameters,
+    ExternalChainParametersHash (..),
+    getMaxLockDuration,
+) where
+
+import Control.Monad.Trans (liftIO)
+import qualified Data.Serialize as S
+import qualified Foreign as FFI
+
+import Concordium.Common.Time (Duration (..))
+import qualified Concordium.Crypto.SHA256 as SHA256
+import qualified Concordium.Types as Types
+import qualified Concordium.Types.HashableTo as Hashable
+import qualified Control.Monad as Monad
+import qualified Data.FixedByteString as FixedByteString
+
+import qualified Concordium.GlobalState.ContractStateFFIHelpers as FFI
+import qualified Concordium.GlobalState.Persistent.BlobStore as BlobStore
+
+-- | Opaque type representing Rust-maintained external chain parameters.
+-- The value is allocated and deallocated in Rust.
+data RustExternalChainParameters
+
+-- | Opaque pointer to immutable external chain parameters managed by Rust.
+--
+-- Memory is deallocated using a finalizer.
+newtype ForeignExternalChainParametersPtr = ForeignExternalChainParametersPtr (FFI.ForeignPtr RustExternalChainParameters)
+
+-- | Convert a raw pointer returned by Rust into a managed pointer.
+wrapFFIPtr :: FFI.Ptr RustExternalChainParameters -> IO ForeignExternalChainParametersPtr
+wrapFFIPtr paramsPtr = ForeignExternalChainParametersPtr <$> FFI.newForeignPtr ffiFreeExternalChainParameters paramsPtr
+
+-- | Deallocate a pointer to external chain parameters.
+foreign import ccall unsafe "&ffi_free_external_chain_parameters"
+    ffiFreeExternalChainParameters :: FFI.FinalizerPtr RustExternalChainParameters
+
+-- | Get temporary access to the external chain-parameters pointer.
+--
+-- The pointer must not be leaked from the computation.
+withExternalChainParameters :: ForeignExternalChainParametersPtr -> (FFI.Ptr RustExternalChainParameters -> IO a) -> IO a
+withExternalChainParameters (ForeignExternalChainParametersPtr foreignPtr) = FFI.withForeignPtr foreignPtr
+
+p11ProtocolVersion :: FFI.Word64
+p11ProtocolVersion = Types.protocolVersionToWord64 Types.P11
+
+-- | Allocate new empty external chain parameters.
+empty :: (BlobStore.MonadBlobStore m) => m ForeignExternalChainParametersPtr
+empty = liftIO $ do
+    FFI.alloca $ \paramsDestPtr -> do
+        status <- ffiEmptyExternalChainParameters p11ProtocolVersion paramsDestPtr
+        Monad.unless (status == 0) $ error "Unexpected panic when creating external chain parameters"
+        params <- FFI.peek paramsDestPtr
+        wrapFFIPtr params
+
+foreign import ccall "ffi_empty_external_chain_parameters"
+    ffiEmptyExternalChainParameters ::
+        FFI.Word64 ->
+        FFI.Ptr (FFI.Ptr RustExternalChainParameters) ->
+        IO FFI.Word8
+
+instance (BlobStore.MonadBlobStore m) => BlobStore.BlobStorable m ForeignExternalChainParametersPtr where
+    load = do
+        blobRef <- S.get
+        pure $! do
+            loadCallback <- fst <$> BlobStore.getCallbacks
+            liftIO $! do
+                FFI.alloca $ \paramsDestPtr -> do
+                    status <- ffiLoadExternalChainParameters loadCallback blobRef p11ProtocolVersion paramsDestPtr
+                    Monad.unless (status == 0) $ error "Unexpected panic when loading external chain parameters"
+                    params <- FFI.peek paramsDestPtr
+                    wrapFFIPtr params
+    storeUpdate params = do
+        storeCallback <- snd <$> BlobStore.getCallbacks
+        blobRef <- liftIO $ FFI.alloca $ \blobRefDestPtr -> do
+            status <- withExternalChainParameters params $ ffiStoreExternalChainParameters storeCallback blobRefDestPtr
+            Monad.unless (status == 0) $ error "Unexpected panic when storing external chain parameters"
+            BlobStore.BlobRef @RustExternalChainParameters <$> FFI.peek blobRefDestPtr
+        return (S.put blobRef, params)
+
+foreign import ccall "ffi_load_external_chain_parameters"
+    ffiLoadExternalChainParameters ::
+        FFI.LoadCallback ->
+        BlobStore.BlobRef RustExternalChainParameters ->
+        FFI.Word64 ->
+        FFI.Ptr (FFI.Ptr RustExternalChainParameters) ->
+        IO FFI.Word8
+
+foreign import ccall "ffi_store_external_chain_parameters"
+    ffiStoreExternalChainParameters ::
+        FFI.StoreCallback ->
+        FFI.Ptr FFI.Word64 ->
+        FFI.Ptr RustExternalChainParameters ->
+        IO FFI.Word8
+
+instance (BlobStore.MonadBlobStore m) => BlobStore.Cacheable m ForeignExternalChainParametersPtr where
+    cache params = do
+        loadCallback <- fst <$> BlobStore.getCallbacks
+        status <- liftIO $! withExternalChainParameters params (ffiCacheExternalChainParameters loadCallback)
+        Monad.unless (status == 0) $ error "Unexpected panic when caching external chain parameters"
+        return params
+
+foreign import ccall "ffi_cache_external_chain_parameters"
+    ffiCacheExternalChainParameters ::
+        FFI.LoadCallback ->
+        FFI.Ptr RustExternalChainParameters ->
+        IO FFI.Word8
+
+-- | The hash of external chain parameters.
+newtype ExternalChainParametersHash = ExternalChainParametersHash {theExternalChainParametersHash :: SHA256.Hash}
+    deriving newtype (Eq, Ord, Show, S.Serialize)
+
+instance (BlobStore.MonadBlobStore m) => Hashable.MHashableTo m ExternalChainParametersHash ForeignExternalChainParametersPtr where
+    getHashM params = do
+        loadCallback <- fst <$> BlobStore.getCallbacks
+        ((), hash) <-
+            liftIO $
+                withExternalChainParameters params $ \paramsPtr ->
+                    FixedByteString.createWith $ \hashDestPtr -> do
+                        status <- ffiHashExternalChainParameters loadCallback paramsPtr hashDestPtr
+                        Monad.unless (status == 0) $ error "Unexpected panic when hashing external chain parameters"
+        return $ ExternalChainParametersHash (SHA256.Hash hash)
+
+foreign import ccall "ffi_hash_external_chain_parameters"
+    ffiHashExternalChainParameters ::
+        FFI.LoadCallback ->
+        FFI.Ptr RustExternalChainParameters ->
+        FFI.Ptr FFI.Word8 ->
+        IO FFI.Word8
+
+-- | Read the current maximum lock duration from external chain parameters.
+getMaxLockDuration :: ForeignExternalChainParametersPtr -> IO Duration
+getMaxLockDuration params =
+    withExternalChainParameters params $ \paramsPtr ->
+        FFI.alloca $ \durationPtr -> do
+            status <- ffiGetExternalChainParametersMaxLockDuration paramsPtr durationPtr
+            Monad.unless (status == 0) $ error "Unexpected panic when reading max lock duration"
+            Duration <$> FFI.peek durationPtr
+
+foreign import ccall "ffi_get_external_chain_parameters_max_lock_duration"
+    ffiGetExternalChainParametersMaxLockDuration ::
+        FFI.Ptr RustExternalChainParameters ->
+        FFI.Ptr FFI.Word64 ->
+        IO FFI.Word8

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/ExternalChainParameters.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/ExternalChainParameters.hs
@@ -14,6 +14,7 @@ module Concordium.GlobalState.Persistent.BlockState.ExternalChainParameters (
     ForeignExternalChainParametersPtr,
     wrapFFIPtr,
     empty,
+    p11NewExternalChainParameters,
     withExternalChainParameters,
     ExternalChainParametersHash (..),
     getMaxLockDuration,
@@ -70,6 +71,21 @@ empty = liftIO $ do
 
 foreign import ccall "ffi_empty_external_chain_parameters"
     ffiEmptyExternalChainParameters ::
+        FFI.Word64 ->
+        FFI.Ptr (FFI.Ptr RustExternalChainParameters) ->
+        IO FFI.Word8
+
+-- | Allocate new P11 external chain parameters with an initial maximum lock duration.
+p11NewExternalChainParameters :: (BlobStore.MonadBlobStore m) => Duration -> m ForeignExternalChainParametersPtr
+p11NewExternalChainParameters (Duration maxLockDuration) = liftIO $ do
+    FFI.alloca $ \paramsDestPtr -> do
+        status <- ffiP11NewExternalChainParameters maxLockDuration paramsDestPtr
+        Monad.unless (status == 0) $ error "Unexpected panic when creating P11 external chain parameters"
+        params <- FFI.peek paramsDestPtr
+        wrapFFIPtr params
+
+foreign import ccall "ffi_p11_new_external_chain_parameters"
+    ffiP11NewExternalChainParameters ::
         FFI.Word64 ->
         FFI.Ptr (FFI.Ptr RustExternalChainParameters) ->
         IO FFI.Word8

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/Parameters.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/Parameters.hs
@@ -11,7 +11,7 @@
 -- This type is the persistent node representation used by the update state. It
 -- is distinct from the @concordium-base@ public/wire @ChainParameters'@ view.
 -- The aggregate public/wire type is only used at conversion boundaries; the
--- persistent storage model has its own record fields and a P11-and-onwards
+-- persistent storage model has its own record fields and a
 -- Rust-managed external chain-parameters pointer.
 module Concordium.GlobalState.Persistent.BlockState.Parameters (
     PersistentChainParameters,
@@ -23,7 +23,6 @@ module Concordium.GlobalState.Persistent.BlockState.Parameters (
 ) where
 
 import Control.Monad.IO.Class
-import Data.Bool.Singletons
 import qualified Data.ByteString as BS
 import qualified Data.Serialize as S
 import Data.Singletons
@@ -37,7 +36,7 @@ import Concordium.Types.HashableTo
 import Concordium.Types.Parameters
 
 -- | Persistent node-owned chain parameters.
-data PersistentChainParameters' cpv auv = PersistentChainParameters
+data PersistentChainParameters' (pv :: ProtocolVersion) cpv auv = PersistentChainParameters
     { -- | Consensus parameters.
       pcpConsensusParameters :: !(ConsensusParameters cpv),
       -- | Exchange rates.
@@ -58,19 +57,19 @@ data PersistentChainParameters' cpv auv = PersistentChainParameters
       pcpFinalizationCommitteeParameters :: !(OParam 'PTFinalizationCommitteeParameters cpv FinalizationCommitteeParameters),
       -- | Validator score parameters.
       pcpValidatorScoreParameters :: !(OParam 'PTValidatorScoreParameters cpv ValidatorScoreParameters),
-      -- | Rust-managed external chain parameters, present for P11-and-onwards authorization versions.
-      pcpExternalChainParameters :: !(Conditionally (SupportsTokenParameters auv) ECP.ForeignExternalChainParametersPtr)
+      -- | Rust-managed external chain parameters, present when token parameters are supported.
+      pcpExternalChainParameters :: !(Conditionally (SupportsTokenParameters auv) (ECP.ForeignExternalChainParametersPtr pv))
     }
 
 -- | Protocol-indexed persistent node-owned chain parameters.
-type PersistentChainParameters pv = PersistentChainParameters' (ChainParametersVersionFor pv) (AuthorizationsVersionFor pv)
+type PersistentChainParameters pv = PersistentChainParameters' pv (ChainParametersVersionFor pv) (AuthorizationsVersionFor pv)
 
 -- | Convert a public/wire chain-parameter view and external pointer into the
 -- persistent node representation.
 fromChainParameters ::
     ChainParameters' cpv ->
-    Conditionally (SupportsTokenParameters auv) ECP.ForeignExternalChainParametersPtr ->
-    PersistentChainParameters' cpv auv
+    Conditionally (SupportsTokenParameters auv) (ECP.ForeignExternalChainParametersPtr pv) ->
+    PersistentChainParameters' pv cpv auv
 fromChainParameters ChainParameters{..} pcpExternalChainParameters =
     PersistentChainParameters
         { pcpConsensusParameters = _cpConsensusParameters,
@@ -88,28 +87,35 @@ fromChainParameters ChainParameters{..} pcpExternalChainParameters =
 
 -- | Construct persistent chain parameters from the public/wire view.
 makePersistentChainParameters ::
-    forall m cpv auv.
-    (MonadBlobStore m, IsAuthorizationsVersion auv) =>
-    ChainParameters' cpv ->
-    m (PersistentChainParameters' cpv auv)
+    forall m pv.
+    (MonadBlobStore m, IsProtocolVersion pv) =>
+    ChainParameters pv ->
+    m (PersistentChainParameters pv)
 makePersistentChainParameters chainParameters = do
-    externalChainParameters <- makeInitialExternalChainParameters @m @cpv @auv chainParameters
+    externalChainParameters <- makeInitialExternalChainParameters @m @pv chainParameters
     return $ fromChainParameters chainParameters externalChainParameters
 
 -- | Construct initial external chain parameters from the public chain-parameter view.
 makeInitialExternalChainParameters ::
-    forall m cpv auv.
-    (MonadBlobStore m, IsAuthorizationsVersion auv) =>
-    ChainParameters' cpv ->
-    m (Conditionally (SupportsTokenParameters auv) ECP.ForeignExternalChainParametersPtr)
-makeInitialExternalChainParameters ChainParameters{..} =
-    case sSupportsTokenParameters (authorizationsVersion @auv) of
-        SFalse -> return CFalse
-        STrue ->
-            CTrue <$> case _cpMaxLockDuration of
-                SomeParam (Just duration) -> ECP.p11NewExternalChainParameters duration
-                SomeParam Nothing -> error "P11 external chain parameters require max lock duration"
-                NoParam -> error "P11 external chain parameters require max lock duration"
+    forall m pv.
+    (MonadBlobStore m, IsProtocolVersion pv) =>
+    ChainParameters pv ->
+    m (Conditionally (SupportsTokenParameters (AuthorizationsVersionFor pv)) (ECP.ForeignExternalChainParametersPtr pv))
+makeInitialExternalChainParameters chainParameters = case protocolVersion @pv of
+    SP1 -> return CFalse
+    SP2 -> return CFalse
+    SP3 -> return CFalse
+    SP4 -> return CFalse
+    SP5 -> return CFalse
+    SP6 -> return CFalse
+    SP7 -> return CFalse
+    SP8 -> return CFalse
+    SP9 -> return CFalse
+    SP10 -> return CFalse
+    SP11 ->
+        CTrue <$> case _cpMaxLockDuration chainParameters of
+            SomeParam (Just duration) -> ECP.p11NewExternalChainParameters duration
+            SomeParam Nothing -> error "P11 external chain parameters require max lock duration"
 
 -- | Placeholder public-view value for the max-lock-duration field.
 --
@@ -124,9 +130,9 @@ maxLockDurationPlaceholder = \case
 -- | Convert persistent chain parameters to the public/wire view, using the
 -- placeholder external fields.
 persistentChainParametersToChainParameters ::
-    forall cpv auv.
+    forall pv cpv auv.
     (IsChainParametersVersion cpv) =>
-    PersistentChainParameters' cpv auv ->
+    PersistentChainParameters' pv cpv auv ->
     ChainParameters' cpv
 persistentChainParametersToChainParameters params =
     makeChainParametersView params (maxLockDurationPlaceholder (chainParametersVersion @cpv))
@@ -134,9 +140,9 @@ persistentChainParametersToChainParameters params =
 -- | Convert persistent chain parameters to the public/wire view, sourcing
 -- externally-managed fields from the external chain-parameters component when present.
 persistentChainParametersToChainParametersM ::
-    forall m cpv auv.
+    forall m pv cpv auv.
     (MonadIO m, IsChainParametersVersion cpv) =>
-    PersistentChainParameters' cpv auv ->
+    PersistentChainParameters' pv cpv auv ->
     m (ChainParameters' cpv)
 persistentChainParametersToChainParametersM params@PersistentChainParameters{..} = do
     maxLockDuration <- case pcpExternalChainParameters of
@@ -151,7 +157,7 @@ persistentChainParametersToChainParametersM params@PersistentChainParameters{..}
 -- | Construct the public/wire view from persistent fields and a supplied
 -- max-lock-duration value.
 makeChainParametersView ::
-    PersistentChainParameters' cpv auv ->
+    PersistentChainParameters' pv cpv auv ->
     OParam 'PTMaxLockDuration cpv (Maybe Duration) ->
     ChainParameters' cpv
 makeChainParametersView PersistentChainParameters{..} maxLockDuration =
@@ -173,13 +179,13 @@ makeChainParametersView PersistentChainParameters{..} maxLockDuration =
 -- Rust-managed external chain-parameters pointer.
 updateChainParameters ::
     ChainParameters' cpv ->
-    PersistentChainParameters' cpv auv ->
-    PersistentChainParameters' cpv auv
+    PersistentChainParameters' pv cpv auv ->
+    PersistentChainParameters' pv cpv auv
 updateChainParameters newChainParameters PersistentChainParameters{..} =
     fromChainParameters newChainParameters pcpExternalChainParameters
 
 -- | Serialize persistent chain parameters.
-putPersistentChainParameters :: forall cpv auv. (IsChainParametersVersion cpv) => S.Putter (PersistentChainParameters' cpv auv)
+putPersistentChainParameters :: forall pv cpv auv. (IsChainParametersVersion cpv) => S.Putter (PersistentChainParameters' pv cpv auv)
 putPersistentChainParameters PersistentChainParameters{..} = do
     withIsConsensusParametersVersionFor (chainParametersVersion @cpv) $ S.put pcpConsensusParameters
     S.put pcpExchangeRates
@@ -211,8 +217,8 @@ getPersistentChainParametersFields = do
     return ChainParameters{..}
 
 instance
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
-    BlobStorable m (PersistentChainParameters' cpv auv)
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    BlobStorable m (PersistentChainParameters' pv cpv auv)
     where
     storeUpdate params@PersistentChainParameters{..} = do
         (pExternal :: S.Put, external') <- case pcpExternalChainParameters of
@@ -236,7 +242,7 @@ instance
 
 instance
     (MonadBlobStore m) =>
-    Cacheable m (PersistentChainParameters' cpv auv)
+    Cacheable m (PersistentChainParameters' pv cpv auv)
     where
     cache params@PersistentChainParameters{..} = do
         external' <- traverse cache pcpExternalChainParameters
@@ -244,7 +250,7 @@ instance
 
 instance
     (MonadBlobStore m, IsChainParametersVersion cpv) =>
-    MHashableTo m H.Hash (PersistentChainParameters' cpv auv)
+    MHashableTo m H.Hash (PersistentChainParameters' pv cpv auv)
     where
     getHashM params@PersistentChainParameters{..} = do
         hExternal <- traverse (getHashM @_ @ECP.ExternalChainParametersHash) pcpExternalChainParameters

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/Parameters.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/Parameters.hs
@@ -1,0 +1,263 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | Node-owned persistent chain parameters.
+--
+-- This type is the persistent node representation used by the update state. It
+-- is distinct from the @concordium-base@ public/wire @ChainParameters'@ view.
+-- The aggregate public/wire type is only used at conversion boundaries; the
+-- persistent storage model has its own record fields and a P11-and-onwards
+-- Rust-managed external chain-parameters pointer.
+module Concordium.GlobalState.Persistent.BlockState.Parameters (
+    PersistentChainParameters (..),
+    makePersistentChainParameters,
+    persistentChainParametersToChainParameters,
+    persistentChainParametersToChainParametersM,
+    updateChainParameters,
+    migratePersistentChainParameters,
+) where
+
+import Control.Monad.IO.Class
+import Data.Bool.Singletons
+import qualified Data.ByteString as BS
+import qualified Data.Serialize as S
+import Data.Singletons
+
+import qualified Concordium.Crypto.SHA256 as H
+import Concordium.Genesis.Data (StateMigrationParameters)
+import Concordium.GlobalState.Persistent.BlobStore
+import qualified Concordium.GlobalState.Persistent.BlockState.ExternalChainParameters as ECP
+import Concordium.GlobalState.Persistent.Migration
+import Concordium.Types
+import Concordium.Types.Conditionally
+import Concordium.Types.HashableTo
+import Concordium.Types.Parameters
+
+-- | Persistent node-owned chain parameters.
+data PersistentChainParameters cpv auv = PersistentChainParameters
+    { -- | Consensus parameters.
+      pcpConsensusParameters :: !(ConsensusParameters cpv),
+      -- | Exchange rates.
+      pcpExchangeRates :: !ExchangeRates,
+      -- | Cooldown parameters.
+      pcpCooldownParameters :: !(CooldownParameters cpv),
+      -- | Time parameters.
+      pcpTimeParameters :: !(OParam 'PTTimeParameters cpv TimeParameters),
+      -- | LimitAccountCreation: the maximum number of accounts that may be created in one block.
+      pcpAccountCreationLimit :: !CredentialsPerBlockLimit,
+      -- | Reward parameters.
+      pcpRewardParameters :: !(RewardParameters cpv),
+      -- | Foundation account index.
+      pcpFoundationAccount :: !AccountIndex,
+      -- | Parameters for baker pools.
+      pcpPoolParameters :: !(PoolParameters cpv),
+      -- | Finalization committee parameters.
+      pcpFinalizationCommitteeParameters :: !(OParam 'PTFinalizationCommitteeParameters cpv FinalizationCommitteeParameters),
+      -- | Validator score parameters.
+      pcpValidatorScoreParameters :: !(OParam 'PTValidatorScoreParameters cpv ValidatorScoreParameters),
+      -- | Rust-managed external chain parameters, present for P11-and-onwards authorization versions.
+      pcpExternalChainParameters :: !(Conditionally (SupportsTokenParameters auv) ECP.ForeignExternalChainParametersPtr)
+    }
+
+-- | Convert a public/wire chain-parameter view and external pointer into the
+-- persistent node representation.
+fromChainParameters ::
+    ChainParameters' cpv ->
+    Conditionally (SupportsTokenParameters auv) ECP.ForeignExternalChainParametersPtr ->
+    PersistentChainParameters cpv auv
+fromChainParameters ChainParameters{..} pcpExternalChainParameters =
+    PersistentChainParameters
+        { pcpConsensusParameters = _cpConsensusParameters,
+          pcpExchangeRates = _cpExchangeRates,
+          pcpCooldownParameters = _cpCooldownParameters,
+          pcpTimeParameters = _cpTimeParameters,
+          pcpAccountCreationLimit = _cpAccountCreationLimit,
+          pcpRewardParameters = _cpRewardParameters,
+          pcpFoundationAccount = _cpFoundationAccount,
+          pcpPoolParameters = _cpPoolParameters,
+          pcpFinalizationCommitteeParameters = _cpFinalizationCommitteeParameters,
+          pcpValidatorScoreParameters = _cpValidatorScoreParameters,
+          pcpExternalChainParameters = pcpExternalChainParameters
+        }
+
+-- | Construct persistent chain parameters from the public/wire view.
+makePersistentChainParameters ::
+    forall m cpv auv.
+    (MonadBlobStore m, IsAuthorizationsVersion auv) =>
+    ChainParameters' cpv ->
+    m (PersistentChainParameters cpv auv)
+makePersistentChainParameters chainParameters = do
+    externalChainParameters <- conditionallyA (sSupportsTokenParameters (authorizationsVersion @auv)) ECP.empty
+    return $ fromChainParameters chainParameters externalChainParameters
+
+-- | Placeholder public-view value for the max-lock-duration field.
+--
+-- The authoritative P11 value is in the external chain-parameters component.
+maxLockDurationPlaceholder :: SChainParametersVersion cpv -> OParam 'PTMaxLockDuration cpv (Maybe Duration)
+maxLockDurationPlaceholder = \case
+    SChainParametersV0 -> NoParam
+    SChainParametersV1 -> NoParam
+    SChainParametersV2 -> NoParam
+    SChainParametersV3 -> SomeParam Nothing
+
+-- | Convert persistent chain parameters to the public/wire view, using the
+-- placeholder external fields.
+persistentChainParametersToChainParameters ::
+    forall cpv auv.
+    (IsChainParametersVersion cpv) =>
+    PersistentChainParameters cpv auv ->
+    ChainParameters' cpv
+persistentChainParametersToChainParameters params =
+    makeChainParametersView params (maxLockDurationPlaceholder (chainParametersVersion @cpv))
+
+-- | Convert persistent chain parameters to the public/wire view, sourcing
+-- externally-managed fields from the external chain-parameters component when present.
+persistentChainParametersToChainParametersM ::
+    forall m cpv auv.
+    (MonadIO m, IsChainParametersVersion cpv) =>
+    PersistentChainParameters cpv auv ->
+    m (ChainParameters' cpv)
+persistentChainParametersToChainParametersM params@PersistentChainParameters{..} = do
+    maxLockDuration <- case pcpExternalChainParameters of
+        CFalse -> return $ maxLockDurationPlaceholder (chainParametersVersion @cpv)
+        CTrue external -> case chainParametersVersion @cpv of
+            SChainParametersV3 -> do
+                duration <- liftIO $ ECP.getMaxLockDuration external
+                return $ SomeParam (Just duration)
+            _ -> return $ maxLockDurationPlaceholder (chainParametersVersion @cpv)
+    return $ makeChainParametersView params maxLockDuration
+
+-- | Construct the public/wire view from persistent fields and a supplied
+-- max-lock-duration value.
+makeChainParametersView ::
+    PersistentChainParameters cpv auv ->
+    OParam 'PTMaxLockDuration cpv (Maybe Duration) ->
+    ChainParameters' cpv
+makeChainParametersView PersistentChainParameters{..} maxLockDuration =
+    ChainParameters
+        { _cpConsensusParameters = pcpConsensusParameters,
+          _cpExchangeRates = pcpExchangeRates,
+          _cpCooldownParameters = pcpCooldownParameters,
+          _cpTimeParameters = pcpTimeParameters,
+          _cpAccountCreationLimit = pcpAccountCreationLimit,
+          _cpRewardParameters = pcpRewardParameters,
+          _cpFoundationAccount = pcpFoundationAccount,
+          _cpPoolParameters = pcpPoolParameters,
+          _cpFinalizationCommitteeParameters = pcpFinalizationCommitteeParameters,
+          _cpValidatorScoreParameters = pcpValidatorScoreParameters,
+          _cpMaxLockDuration = maxLockDuration
+        }
+
+-- | Update the Haskell-managed chain parameters while preserving any
+-- Rust-managed external chain-parameters pointer.
+updateChainParameters ::
+    ChainParameters' cpv ->
+    PersistentChainParameters cpv auv ->
+    PersistentChainParameters cpv auv
+updateChainParameters newChainParameters PersistentChainParameters{..} =
+    fromChainParameters newChainParameters pcpExternalChainParameters
+
+-- | Migrate persistent chain parameters through a protocol update.
+migratePersistentChainParameters ::
+    forall oldpv pv t m.
+    ( IsProtocolVersion oldpv,
+      IsProtocolVersion pv,
+      SupportMigration m t
+    ) =>
+    StateMigrationParameters oldpv pv ->
+    PersistentChainParameters (ChainParametersVersionFor oldpv) (AuthorizationsVersionFor oldpv) ->
+    t m (PersistentChainParameters (ChainParametersVersionFor pv) (AuthorizationsVersionFor pv))
+migratePersistentChainParameters migration oldParameters = do
+    let newChainParameters = migrateChainParameters migration (persistentChainParametersToChainParameters oldParameters)
+    newExternalChainParameters <- case sSupportsTokenParameters (sAuthorizationsVersionFor (protocolVersion @oldpv)) of
+        STrue -> case sSupportsTokenParameters (sAuthorizationsVersionFor (protocolVersion @pv)) of
+            STrue -> return (pcpExternalChainParameters oldParameters)
+            SFalse -> case migration of {}
+        SFalse -> case sSupportsTokenParameters (sAuthorizationsVersionFor (protocolVersion @pv)) of
+            STrue -> CTrue <$> ECP.empty
+            SFalse -> return (pcpExternalChainParameters oldParameters)
+    return $ fromChainParameters newChainParameters newExternalChainParameters
+
+-- | Serialize persistent chain parameters.
+putPersistentChainParameters :: forall cpv auv. (IsChainParametersVersion cpv) => S.Putter (PersistentChainParameters cpv auv)
+putPersistentChainParameters PersistentChainParameters{..} = do
+    withIsConsensusParametersVersionFor (chainParametersVersion @cpv) $ S.put pcpConsensusParameters
+    S.put pcpExchangeRates
+    putCooldownParameters pcpCooldownParameters
+    S.put pcpTimeParameters
+    S.put pcpAccountCreationLimit
+    S.put pcpRewardParameters
+    S.put pcpFoundationAccount
+    putPoolParameters pcpPoolParameters
+    S.put pcpFinalizationCommitteeParameters
+    S.put pcpValidatorScoreParameters
+
+-- | Deserialize persistent chain parameters, excluding the external component. 
+--
+-- This is an internal helper function
+getPersistentChainParametersFields :: forall cpv. (IsChainParametersVersion cpv) => S.Get (ChainParameters' cpv)
+getPersistentChainParametersFields = do
+    _cpConsensusParameters <- withIsConsensusParametersVersionFor (chainParametersVersion @cpv) S.get
+    _cpExchangeRates <- S.get
+    _cpCooldownParameters <- withIsCooldownParametersVersionFor (chainParametersVersion @cpv) S.get
+    _cpTimeParameters <- S.get
+    _cpAccountCreationLimit <- S.get
+    _cpRewardParameters <- S.get
+    _cpFoundationAccount <- S.get
+    _cpPoolParameters <- withIsPoolParametersVersionFor (chainParametersVersion @cpv) S.get
+    _cpFinalizationCommitteeParameters <- S.get
+    _cpValidatorScoreParameters <- S.get
+    let _cpMaxLockDuration = maxLockDurationPlaceholder (chainParametersVersion @cpv)
+    return ChainParameters{..}
+
+instance
+    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    BlobStorable m (PersistentChainParameters cpv auv)
+    where
+    storeUpdate params@PersistentChainParameters{..} = do
+        (pExternal :: S.Put, external') <- case pcpExternalChainParameters of
+            CFalse -> return (return (), CFalse)
+            CTrue external -> do
+                (putExternal, external') <- storeUpdate external
+                return (putExternal, CTrue external')
+        let newParams = params{pcpExternalChainParameters = external'}
+        return
+            ( do
+                putPersistentChainParameters params
+                pExternal,
+              newParams
+            )
+    load = do
+        chainParameters <- getPersistentChainParametersFields
+        mExternal <- conditionallyA (sSupportsTokenParameters (sing @auv)) load
+        return $ do
+            externalChainParameters <- sequenceA mExternal
+            return $ fromChainParameters chainParameters externalChainParameters
+
+instance
+    (MonadBlobStore m) =>
+    Cacheable m (PersistentChainParameters cpv auv)
+    where
+    cache params@PersistentChainParameters{..} = do
+        external' <- traverse cache pcpExternalChainParameters
+        return params{pcpExternalChainParameters = external'}
+
+instance
+    (MonadBlobStore m, IsChainParametersVersion cpv) =>
+    MHashableTo m H.Hash (PersistentChainParameters cpv auv)
+    where
+    getHashM params@PersistentChainParameters{..} = do
+        hExternal <- traverse (getHashM @_ @ECP.ExternalChainParametersHash) pcpExternalChainParameters
+        return $
+            H.hash $
+                S.runPut (putPersistentChainParameters params)
+                    <> externalHashBytes hExternal
+      where
+        externalHashBytes :: Conditionally b ECP.ExternalChainParametersHash -> BS.ByteString
+        externalHashBytes = \case
+            CFalse -> mempty
+            CTrue (ECP.ExternalChainParametersHash h) -> H.hashToByteString h

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/Parameters.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/Parameters.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE GADTs #-}
@@ -13,12 +14,12 @@
 -- persistent storage model has its own record fields and a P11-and-onwards
 -- Rust-managed external chain-parameters pointer.
 module Concordium.GlobalState.Persistent.BlockState.Parameters (
-    PersistentChainParameters (..),
+    PersistentChainParameters,
+    PersistentChainParameters' (..),
     makePersistentChainParameters,
     persistentChainParametersToChainParameters,
     persistentChainParametersToChainParametersM,
     updateChainParameters,
-    migratePersistentChainParameters,
 ) where
 
 import Control.Monad.IO.Class
@@ -28,17 +29,15 @@ import qualified Data.Serialize as S
 import Data.Singletons
 
 import qualified Concordium.Crypto.SHA256 as H
-import Concordium.Genesis.Data (StateMigrationParameters)
 import Concordium.GlobalState.Persistent.BlobStore
 import qualified Concordium.GlobalState.Persistent.BlockState.ExternalChainParameters as ECP
-import Concordium.GlobalState.Persistent.Migration
 import Concordium.Types
 import Concordium.Types.Conditionally
 import Concordium.Types.HashableTo
 import Concordium.Types.Parameters
 
 -- | Persistent node-owned chain parameters.
-data PersistentChainParameters cpv auv = PersistentChainParameters
+data PersistentChainParameters' cpv auv = PersistentChainParameters
     { -- | Consensus parameters.
       pcpConsensusParameters :: !(ConsensusParameters cpv),
       -- | Exchange rates.
@@ -63,12 +62,15 @@ data PersistentChainParameters cpv auv = PersistentChainParameters
       pcpExternalChainParameters :: !(Conditionally (SupportsTokenParameters auv) ECP.ForeignExternalChainParametersPtr)
     }
 
+-- | Protocol-indexed persistent node-owned chain parameters.
+type PersistentChainParameters pv = PersistentChainParameters' (ChainParametersVersionFor pv) (AuthorizationsVersionFor pv)
+
 -- | Convert a public/wire chain-parameter view and external pointer into the
 -- persistent node representation.
 fromChainParameters ::
     ChainParameters' cpv ->
     Conditionally (SupportsTokenParameters auv) ECP.ForeignExternalChainParametersPtr ->
-    PersistentChainParameters cpv auv
+    PersistentChainParameters' cpv auv
 fromChainParameters ChainParameters{..} pcpExternalChainParameters =
     PersistentChainParameters
         { pcpConsensusParameters = _cpConsensusParameters,
@@ -89,10 +91,25 @@ makePersistentChainParameters ::
     forall m cpv auv.
     (MonadBlobStore m, IsAuthorizationsVersion auv) =>
     ChainParameters' cpv ->
-    m (PersistentChainParameters cpv auv)
+    m (PersistentChainParameters' cpv auv)
 makePersistentChainParameters chainParameters = do
-    externalChainParameters <- conditionallyA (sSupportsTokenParameters (authorizationsVersion @auv)) ECP.empty
+    externalChainParameters <- makeInitialExternalChainParameters @m @cpv @auv chainParameters
     return $ fromChainParameters chainParameters externalChainParameters
+
+-- | Construct initial external chain parameters from the public chain-parameter view.
+makeInitialExternalChainParameters ::
+    forall m cpv auv.
+    (MonadBlobStore m, IsAuthorizationsVersion auv) =>
+    ChainParameters' cpv ->
+    m (Conditionally (SupportsTokenParameters auv) ECP.ForeignExternalChainParametersPtr)
+makeInitialExternalChainParameters ChainParameters{..} =
+    case sSupportsTokenParameters (authorizationsVersion @auv) of
+        SFalse -> return CFalse
+        STrue ->
+            CTrue <$> case _cpMaxLockDuration of
+                SomeParam (Just duration) -> ECP.p11NewExternalChainParameters duration
+                SomeParam Nothing -> error "P11 external chain parameters require max lock duration"
+                NoParam -> error "P11 external chain parameters require max lock duration"
 
 -- | Placeholder public-view value for the max-lock-duration field.
 --
@@ -109,7 +126,7 @@ maxLockDurationPlaceholder = \case
 persistentChainParametersToChainParameters ::
     forall cpv auv.
     (IsChainParametersVersion cpv) =>
-    PersistentChainParameters cpv auv ->
+    PersistentChainParameters' cpv auv ->
     ChainParameters' cpv
 persistentChainParametersToChainParameters params =
     makeChainParametersView params (maxLockDurationPlaceholder (chainParametersVersion @cpv))
@@ -119,7 +136,7 @@ persistentChainParametersToChainParameters params =
 persistentChainParametersToChainParametersM ::
     forall m cpv auv.
     (MonadIO m, IsChainParametersVersion cpv) =>
-    PersistentChainParameters cpv auv ->
+    PersistentChainParameters' cpv auv ->
     m (ChainParameters' cpv)
 persistentChainParametersToChainParametersM params@PersistentChainParameters{..} = do
     maxLockDuration <- case pcpExternalChainParameters of
@@ -134,7 +151,7 @@ persistentChainParametersToChainParametersM params@PersistentChainParameters{..}
 -- | Construct the public/wire view from persistent fields and a supplied
 -- max-lock-duration value.
 makeChainParametersView ::
-    PersistentChainParameters cpv auv ->
+    PersistentChainParameters' cpv auv ->
     OParam 'PTMaxLockDuration cpv (Maybe Duration) ->
     ChainParameters' cpv
 makeChainParametersView PersistentChainParameters{..} maxLockDuration =
@@ -156,34 +173,13 @@ makeChainParametersView PersistentChainParameters{..} maxLockDuration =
 -- Rust-managed external chain-parameters pointer.
 updateChainParameters ::
     ChainParameters' cpv ->
-    PersistentChainParameters cpv auv ->
-    PersistentChainParameters cpv auv
+    PersistentChainParameters' cpv auv ->
+    PersistentChainParameters' cpv auv
 updateChainParameters newChainParameters PersistentChainParameters{..} =
     fromChainParameters newChainParameters pcpExternalChainParameters
 
--- | Migrate persistent chain parameters through a protocol update.
-migratePersistentChainParameters ::
-    forall oldpv pv t m.
-    ( IsProtocolVersion oldpv,
-      IsProtocolVersion pv,
-      SupportMigration m t
-    ) =>
-    StateMigrationParameters oldpv pv ->
-    PersistentChainParameters (ChainParametersVersionFor oldpv) (AuthorizationsVersionFor oldpv) ->
-    t m (PersistentChainParameters (ChainParametersVersionFor pv) (AuthorizationsVersionFor pv))
-migratePersistentChainParameters migration oldParameters = do
-    let newChainParameters = migrateChainParameters migration (persistentChainParametersToChainParameters oldParameters)
-    newExternalChainParameters <- case sSupportsTokenParameters (sAuthorizationsVersionFor (protocolVersion @oldpv)) of
-        STrue -> case sSupportsTokenParameters (sAuthorizationsVersionFor (protocolVersion @pv)) of
-            STrue -> return (pcpExternalChainParameters oldParameters)
-            SFalse -> case migration of {}
-        SFalse -> case sSupportsTokenParameters (sAuthorizationsVersionFor (protocolVersion @pv)) of
-            STrue -> CTrue <$> ECP.empty
-            SFalse -> return (pcpExternalChainParameters oldParameters)
-    return $ fromChainParameters newChainParameters newExternalChainParameters
-
 -- | Serialize persistent chain parameters.
-putPersistentChainParameters :: forall cpv auv. (IsChainParametersVersion cpv) => S.Putter (PersistentChainParameters cpv auv)
+putPersistentChainParameters :: forall cpv auv. (IsChainParametersVersion cpv) => S.Putter (PersistentChainParameters' cpv auv)
 putPersistentChainParameters PersistentChainParameters{..} = do
     withIsConsensusParametersVersionFor (chainParametersVersion @cpv) $ S.put pcpConsensusParameters
     S.put pcpExchangeRates
@@ -196,7 +192,7 @@ putPersistentChainParameters PersistentChainParameters{..} = do
     S.put pcpFinalizationCommitteeParameters
     S.put pcpValidatorScoreParameters
 
--- | Deserialize persistent chain parameters, excluding the external component. 
+-- | Deserialize persistent chain parameters, excluding the external component.
 --
 -- This is an internal helper function
 getPersistentChainParametersFields :: forall cpv. (IsChainParametersVersion cpv) => S.Get (ChainParameters' cpv)
@@ -216,7 +212,7 @@ getPersistentChainParametersFields = do
 
 instance
     (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
-    BlobStorable m (PersistentChainParameters cpv auv)
+    BlobStorable m (PersistentChainParameters' cpv auv)
     where
     storeUpdate params@PersistentChainParameters{..} = do
         (pExternal :: S.Put, external') <- case pcpExternalChainParameters of
@@ -240,7 +236,7 @@ instance
 
 instance
     (MonadBlobStore m) =>
-    Cacheable m (PersistentChainParameters cpv auv)
+    Cacheable m (PersistentChainParameters' cpv auv)
     where
     cache params@PersistentChainParameters{..} = do
         external' <- traverse cache pcpExternalChainParameters
@@ -248,7 +244,7 @@ instance
 
 instance
     (MonadBlobStore m, IsChainParametersVersion cpv) =>
-    MHashableTo m H.Hash (PersistentChainParameters cpv auv)
+    MHashableTo m H.Hash (PersistentChainParameters' cpv auv)
     where
     getHashM params@PersistentChainParameters{..} = do
         hExternal <- traverse (getHashM @_ @ECP.ExternalChainParametersHash) pcpExternalChainParameters

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/Updates.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/Updates.hs
@@ -34,6 +34,7 @@ import Concordium.Utils.Serialization.Put
 
 import Concordium.GlobalState.Parameters
 import Concordium.GlobalState.Persistent.BlobStore
+import qualified Concordium.GlobalState.Persistent.BlockState.Parameters as PCP
 import Concordium.GlobalState.Persistent.Migration
 import qualified Concordium.Types.AnonymityRevokers as ARS
 import qualified Concordium.Types.IdentityProviders as IPS
@@ -666,8 +667,8 @@ data Updates' (cpv :: ChainParametersVersion) (auv :: AuthorizationsVersion) = U
       currentKeyCollection :: !(HashedBufferedRef (StoreSerialized (UpdateKeysCollection auv))),
       -- | Current protocol update.
       currentProtocolUpdate :: !(Nullable (HashedBufferedRef (StoreSerialized ProtocolUpdate))),
-      -- | Current chain parameters.
-      currentParameters :: !(HashedBufferedRef (StoreSerialized (ChainParameters' cpv))),
+      -- | Current node-owned persistent chain parameters.
+      currentParameters :: !(HashedBufferedRef (PCP.PersistentChainParameters' cpv auv)),
       -- | Pending updates.
       pendingUpdates :: !(PendingUpdates cpv auv),
       -- | Sequence number for updates to the protocol level tokens (PLT).
@@ -697,7 +698,7 @@ migrateUpdates migration Updates{..} = do
                 migrateHashedBufferedRef
                     (return . StoreSerialized . migrateKeysCollection . unStoreSerialized)
                     currentKeyCollection
-    newParameters <- migrateHashedBufferedRef (return . StoreSerialized . migrateChainParameters migration . unStoreSerialized) currentParameters
+    newParameters <- migrateHashedBufferedRef (migrateChainParameters migration) currentParameters
 
     let newPltUpdateSequenceNumber = case sSupportsCreatePLT (sAuthorizationsVersionFor (protocolVersion @oldpv)) of
             STrue -> case sSupportsCreatePLT (sAuthorizationsVersionFor (protocolVersion @pv)) of
@@ -802,7 +803,7 @@ initialUpdates ::
 initialUpdates initialKeyCollection chainParams = do
     currentKeyCollection <- makeHashedBufferedRef (StoreSerialized initialKeyCollection)
     let currentProtocolUpdate = Null
-    currentParameters <- makeHashedBufferedRef (StoreSerialized chainParams)
+    currentParameters <- makeHashedBufferedRef =<< PCP.makePersistentChainParameters chainParams
     pendingUpdates <- emptyPendingUpdates
     let pltUpdateSequenceNumber = conditionally (sSupportsCreatePLT (authorizationsVersion @auv)) minUpdateSequenceNumber
     return Updates{..}
@@ -818,7 +819,7 @@ makePersistentUpdates UQ.Updates{..} = do
     currentProtocolUpdate <- case _currentProtocolUpdate of
         Nothing -> return Null
         Just pu -> Some <$> refMake (StoreSerialized pu)
-    currentParameters <- refMake (StoreSerialized _currentParameters)
+    currentParameters <- refMake =<< PCP.makePersistentChainParameters _currentParameters
     pendingUpdates <- makePersistentPendingUpdates _pendingUpdates
     let pltUpdateSequenceNumber = _pltUpdateSequenceNumber
     return Updates{..}
@@ -827,7 +828,7 @@ makePersistentUpdates UQ.Updates{..} = do
 makeBasicUpdates ::
     forall m cpv auv.
     (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
-    (Updates' cpv auv) ->
+    Updates' cpv auv ->
     m (UQ.Updates' cpv auv)
 makeBasicUpdates Updates{..} = do
     hKC <- getHashM currentKeyCollection
@@ -836,10 +837,28 @@ makeBasicUpdates Updates{..} = do
     _currentProtocolUpdate <- case currentProtocolUpdate of
         Null -> return Nothing
         Some pu -> Just . unStoreSerialized <$> refLoad pu
-    _currentParameters <- unStoreSerialized <$> refLoad currentParameters
+    _currentParameters <- PCP.persistentChainParametersToChainParametersM =<< refLoad currentParameters
     _pendingUpdates <- makeBasicPendingUpdates pendingUpdates
     let _pltUpdateSequenceNumber = pltUpdateSequenceNumber
     return UQ.Updates{..}
+
+-- | Load the public/wire view of current chain parameters from the persistent node representation.
+loadChainParametersRef ::
+    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    HashedBufferedRef (PCP.PersistentChainParameters' cpv auv) ->
+    m (ChainParameters' cpv)
+loadChainParametersRef currentParameters =
+    PCP.persistentChainParametersToChainParameters <$> refLoad currentParameters
+
+-- | Store a new chain-parameter value while preserving node-internal external state.
+makeUpdatedChainParametersRef ::
+    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    HashedBufferedRef (PCP.PersistentChainParameters' cpv auv) ->
+    ChainParameters' cpv ->
+    m (HashedBufferedRef (PCP.PersistentChainParameters' cpv auv))
+makeUpdatedChainParametersRef currentParameters newChainParameters = do
+    persistentParameters <- refLoad currentParameters
+    refMake $ PCP.updateChainParameters newChainParameters persistentParameters
 
 -- | Process the update queue to determine the new value of a parameter (or the authorizations).
 --  This splits the queue at the given timestamp. The last value up to and including the timestamp
@@ -946,11 +965,11 @@ processElectionDifficultyUpdates t bu = do
             processValueUpdates t oldQ (return (Map.empty, bu)) $ \newEDp newQ m ->
                 (UVElectionDifficulty <$> m,) <$> do
                     newpQ <- refMake newQ
-                    StoreSerialized oldCP <- refLoad currentParameters
+                    oldCP <- loadChainParametersRef currentParameters
                     StoreSerialized newED <- refLoad newEDp
                     let newConsensusParameters = case oldCP ^. cpConsensusParameters of
                             ConsensusParametersV0{} -> ConsensusParametersV0 newED
-                    newParameters <- refMake $ StoreSerialized $ oldCP & (cpConsensusParameters .~ newConsensusParameters)
+                    newParameters <- makeUpdatedChainParametersRef currentParameters $ oldCP & (cpConsensusParameters .~ newConsensusParameters)
                     refMake
                         u
                             { currentParameters = newParameters,
@@ -969,9 +988,9 @@ processEuroPerEnergyUpdates t bu = do
     processValueUpdates t oldQ (return (Map.empty, bu)) $ \newEPEp newQ m ->
         (UVEuroPerEnergy <$> m,) <$> do
             newpQ <- refMake newQ
-            StoreSerialized oldCP <- refLoad currentParameters
+            oldCP <- loadChainParametersRef currentParameters
             StoreSerialized newEPE <- refLoad newEPEp
-            newParameters <- refMake $ StoreSerialized $ oldCP & euroPerEnergy .~ newEPE
+            newParameters <- makeUpdatedChainParametersRef currentParameters $ oldCP & euroPerEnergy .~ newEPE
             refMake
                 u
                     { currentParameters = newParameters,
@@ -990,9 +1009,9 @@ processMicroGTUPerEuroUpdates t bu = do
     processValueUpdates t oldQ (return (Map.empty, bu)) $ \newMGTUPEp newQ m ->
         (UVMicroGTUPerEuro <$> m,) <$> do
             newpQ <- refMake newQ
-            StoreSerialized oldCP <- refLoad currentParameters
+            oldCP <- loadChainParametersRef currentParameters
             StoreSerialized newMGTUPE <- refLoad newMGTUPEp
-            newParameters <- refMake $ StoreSerialized $ oldCP & microGTUPerEuro .~ newMGTUPE
+            newParameters <- makeUpdatedChainParametersRef currentParameters $ oldCP & microGTUPerEuro .~ newMGTUPE
             refMake
                 u
                     { currentParameters = newParameters,
@@ -1010,9 +1029,9 @@ processFoundationAccountUpdates t bu = do
     processValueUpdates t oldQ (return (Map.empty, bu)) $ \newParamPtr newQ m ->
         (UVFoundationAccount <$> m,) <$> do
             newpQ <- refMake newQ
-            StoreSerialized oldCP <- refLoad currentParameters
+            oldCP <- loadChainParametersRef currentParameters
             StoreSerialized newParam <- refLoad newParamPtr
-            newParameters <- refMake $ StoreSerialized $ oldCP & cpFoundationAccount .~ newParam
+            newParameters <- makeUpdatedChainParametersRef currentParameters $ oldCP & cpFoundationAccount .~ newParam
             refMake
                 u
                     { currentParameters = newParameters,
@@ -1031,9 +1050,9 @@ processMintDistributionUpdates t bu = withIsMintDistributionVersionFor (chainPar
     processValueUpdates t oldQ (return (Map.empty, bu)) $ \newParamPtr newQ m ->
         (UVMintDistribution <$> m,) <$> do
             newpQ <- refMake newQ
-            StoreSerialized oldCP <- refLoad currentParameters
+            oldCP <- loadChainParametersRef currentParameters
             StoreSerialized newParam <- refLoad newParamPtr
-            newParameters <- refMake $ StoreSerialized $ oldCP & rpMintDistribution .~ newParam
+            newParameters <- makeUpdatedChainParametersRef currentParameters $ oldCP & rpMintDistribution .~ newParam
             refMake
                 u
                     { currentParameters = newParameters,
@@ -1051,9 +1070,9 @@ processTransactionFeeDistributionUpdates t bu = do
     processValueUpdates t oldQ (return (Map.empty, bu)) $ \newParamPtr newQ m ->
         (UVTransactionFeeDistribution <$> m,) <$> do
             newpQ <- refMake newQ
-            StoreSerialized oldCP <- refLoad currentParameters
+            oldCP <- loadChainParametersRef currentParameters
             StoreSerialized newParam <- refLoad newParamPtr
-            newParameters <- refMake $ StoreSerialized $ oldCP & rpTransactionFeeDistribution .~ newParam
+            newParameters <- makeUpdatedChainParametersRef currentParameters $ oldCP & rpTransactionFeeDistribution .~ newParam
             refMake
                 u
                     { currentParameters = newParameters,
@@ -1072,9 +1091,9 @@ processGASRewardsUpdates t bu = withIsGASRewardsVersionFor (chainParametersVersi
     processValueUpdates t oldQ (return (Map.empty, bu)) $ \newParamPtr newQ m ->
         (UVGASRewards <$> m,) <$> do
             newpQ <- refMake newQ
-            StoreSerialized oldCP <- refLoad currentParameters
+            oldCP <- loadChainParametersRef currentParameters
             StoreSerialized newParam <- refLoad newParamPtr
-            newParameters <- refMake $ StoreSerialized $ oldCP & rpGASRewards .~ newParam
+            newParameters <- makeUpdatedChainParametersRef currentParameters $ oldCP & rpGASRewards .~ newParam
             refMake
                 u
                     { currentParameters = newParameters,
@@ -1093,9 +1112,9 @@ processPoolParamatersUpdates t bu = withIsPoolParametersVersionFor (chainParamet
     processValueUpdates t oldQ (return (Map.empty, bu)) $ \newParamPtr newQ m ->
         (UVPoolParameters <$> m,) <$> do
             newpQ <- refMake newQ
-            StoreSerialized oldCP <- refLoad currentParameters
+            oldCP <- loadChainParametersRef currentParameters
             StoreSerialized newParam <- refLoad newParamPtr
-            newParameters <- refMake $ StoreSerialized $ oldCP & cpPoolParameters .~ newParam
+            newParameters <- makeUpdatedChainParametersRef currentParameters $ oldCP & cpPoolParameters .~ newParam
             refMake
                 u
                     { currentParameters = newParameters,
@@ -1118,9 +1137,9 @@ processCooldownParametersUpdates t bu = do
             processValueUpdates t oldQ (return (Map.empty, bu)) $ \newParamPtr newQ m ->
                 (UVCooldownParameters <$> m,) <$> do
                     newpQ <- refMake newQ
-                    StoreSerialized oldCP <- refLoad currentParameters
+                    oldCP <- loadChainParametersRef currentParameters
                     StoreSerialized newParam <- refLoad newParamPtr
-                    newParameters <- refMake $ StoreSerialized $ oldCP & cpCooldownParameters .~ newParam
+                    newParameters <- makeUpdatedChainParametersRef currentParameters $ oldCP & cpCooldownParameters .~ newParam
                     refMake
                         u
                             { currentParameters = newParameters,
@@ -1142,9 +1161,9 @@ processTimeParametersUpdates t bu = do
             processValueUpdates t oldQ (return (Map.empty, bu)) $ \newParamPtr newQ m ->
                 (UVTimeParameters <$> m,) <$> do
                     newpQ <- refMake newQ
-                    StoreSerialized oldCP <- refLoad currentParameters
+                    oldCP <- loadChainParametersRef currentParameters
                     StoreSerialized newParam <- refLoad newParamPtr
-                    newParameters <- refMake $ StoreSerialized $ oldCP & cpTimeParameters .~ SomeParam newParam
+                    newParameters <- makeUpdatedChainParametersRef currentParameters $ oldCP & cpTimeParameters .~ SomeParam newParam
                     refMake
                         u
                             { currentParameters = newParameters,
@@ -1170,11 +1189,11 @@ processTimeoutParametersUpdates t bu = do
             processValueUpdates t oldQ (return (Map.empty, bu)) $ \newTOp newQ m ->
                 (UVTimeoutParameters <$> m,) <$> do
                     newpQ <- refMake newQ
-                    StoreSerialized oldCP <- refLoad currentParameters
+                    oldCP <- loadChainParametersRef currentParameters
                     StoreSerialized newTimeoutParameters <- refLoad newTOp
                     let newConsensusParameters = case oldCP ^. cpConsensusParameters of
                             cp@ConsensusParametersV1{} -> cp & cpTimeoutParameters .~ newTimeoutParameters
-                    newParameters <- refMake $ StoreSerialized $ oldCP & (cpConsensusParameters .~ newConsensusParameters)
+                    newParameters <- makeUpdatedChainParametersRef currentParameters $ oldCP & (cpConsensusParameters .~ newConsensusParameters)
                     refMake
                         u
                             { currentParameters = newParameters,
@@ -1200,11 +1219,11 @@ processMinBlockTimeUpdates t bu = do
             processValueUpdates t oldQ (return (Map.empty, bu)) $ \newMBTp newQ m ->
                 (UVMinBlockTime <$> m,) <$> do
                     newpQ <- refMake newQ
-                    StoreSerialized oldCP <- refLoad currentParameters
+                    oldCP <- loadChainParametersRef currentParameters
                     StoreSerialized newMinBlockTime <- refLoad newMBTp
                     let newConsensusParameters = case oldCP ^. cpConsensusParameters of
                             cp@ConsensusParametersV1{} -> cp & cpMinBlockTime .~ newMinBlockTime
-                    newParameters <- refMake $ StoreSerialized $ oldCP & (cpConsensusParameters .~ newConsensusParameters)
+                    newParameters <- makeUpdatedChainParametersRef currentParameters $ oldCP & (cpConsensusParameters .~ newConsensusParameters)
                     refMake
                         u
                             { currentParameters = newParameters,
@@ -1230,11 +1249,11 @@ processBlockEnergyLimitUpdates t bu = do
             processValueUpdates t oldQ (return (Map.empty, bu)) $ \newBELp newQ m ->
                 (UVBlockEnergyLimit <$> m,) <$> do
                     newpQ <- refMake newQ
-                    StoreSerialized oldCP <- refLoad currentParameters
+                    oldCP <- loadChainParametersRef currentParameters
                     StoreSerialized newBlockEnergyLimit <- refLoad newBELp
                     let newConsensusParameters = case oldCP ^. cpConsensusParameters of
                             cp@ConsensusParametersV1{} -> cp & cpBlockEnergyLimit .~ newBlockEnergyLimit
-                    newParameters <- refMake $ StoreSerialized $ oldCP & (cpConsensusParameters .~ newConsensusParameters)
+                    newParameters <- makeUpdatedChainParametersRef currentParameters $ oldCP & (cpConsensusParameters .~ newConsensusParameters)
                     refMake
                         u
                             { currentParameters = newParameters,
@@ -1260,13 +1279,12 @@ processFinalizationCommitteeParametersUpdates t bu = do
             processValueUpdates t oldQ (return (Map.empty, bu)) $ \newBELp newQ m ->
                 (UVFinalizationCommitteeParameters <$> m,) <$> do
                     newpQ <- refMake newQ
-                    StoreSerialized oldCP <- refLoad currentParameters
+                    oldCP <- loadChainParametersRef currentParameters
                     StoreSerialized newFinalizationCommitteeParameters <- refLoad newBELp
                     newParameters <-
-                        refMake $
-                            StoreSerialized $
-                                oldCP
-                                    & (cpFinalizationCommitteeParameters . supportedOParam .~ newFinalizationCommitteeParameters)
+                        makeUpdatedChainParametersRef currentParameters $
+                            oldCP
+                                & (cpFinalizationCommitteeParameters . supportedOParam .~ newFinalizationCommitteeParameters)
                     refMake
                         u
                             { currentParameters = newParameters,
@@ -1292,13 +1310,12 @@ processValidationScoreParametersUpdates t bu = do
             processValueUpdates t oldQ (return (Map.empty, bu)) $ \newBELp newQ m ->
                 (UVValidatorScoreParameters <$> m,) <$> do
                     newpQ <- refMake newQ
-                    StoreSerialized oldCP <- refLoad currentParameters
+                    oldCP <- loadChainParametersRef currentParameters
                     StoreSerialized newValidatorScoreParameters <- refLoad newBELp
                     newParameters <-
-                        refMake $
-                            StoreSerialized $
-                                oldCP
-                                    & (cpValidatorScoreParameters . supportedOParam .~ newValidatorScoreParameters)
+                        makeUpdatedChainParametersRef currentParameters $
+                            oldCP
+                                & (cpValidatorScoreParameters . supportedOParam .~ newValidatorScoreParameters)
                     refMake
                         u
                             { currentParameters = newParameters,
@@ -1512,7 +1529,7 @@ futureElectionDifficulty uref ts = do
     Updates{..} <- refLoad uref
     oldQ <- refLoad $ unOParam $ pElectionDifficultyQueue pendingUpdates
     let getCurED = do
-            StoreSerialized cp <- refLoad currentParameters
+            cp <- loadChainParametersRef currentParameters
             return $ cp ^. cpConsensusParameters . cpElectionDifficulty
     processValueUpdates ts oldQ getCurED (\newEDp _ _ -> unStoreSerialized <$> refLoad newEDp)
 
@@ -1694,8 +1711,8 @@ overwriteElectionDifficulty ::
     m (BufferedRef (Updates' cpv auv))
 overwriteElectionDifficulty newDifficulty uref = do
     u@Updates{pendingUpdates = p@PendingUpdates{..}, ..} <- refLoad uref
-    StoreSerialized cp <- refLoad currentParameters
-    newCurrentParameters <- refMake $ StoreSerialized (cp & cpConsensusParameters . cpElectionDifficulty .~ newDifficulty)
+    cp <- loadChainParametersRef currentParameters
+    newCurrentParameters <- makeUpdatedChainParametersRef currentParameters (cp & cpConsensusParameters . cpElectionDifficulty .~ newDifficulty)
     newPendingUpdates <- clearQueue (unOParam pElectionDifficultyQueue) <&> \newQ -> p{pElectionDifficultyQueue = SomeParam newQ}
     refMake u{currentParameters = newCurrentParameters, pendingUpdates = newPendingUpdates}
 
@@ -1717,7 +1734,7 @@ lookupExchangeRates ::
     m ExchangeRates
 lookupExchangeRates uref = do
     Updates{..} <- refLoad uref
-    StoreSerialized ChainParameters{..} <- refLoad currentParameters
+    ChainParameters{..} <- loadChainParametersRef currentParameters
     return _cpExchangeRates
 
 -- | Look up the current chain parameters.
@@ -1727,7 +1744,7 @@ lookupCurrentParameters ::
     m (ChainParameters' cpv)
 lookupCurrentParameters uref = do
     Updates{..} <- refLoad uref
-    unStoreSerialized <$> refLoad currentParameters
+    PCP.persistentChainParametersToChainParametersM =<< refLoad currentParameters
 
 -- | Look up the pending changes to the time parameters.
 lookupPendingTimeParameters ::

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/Updates.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/Updates.hs
@@ -1627,6 +1627,9 @@ lookupNextUpdateSequenceNumber uref uty = withCPVConstraints (chainParametersVer
                     minUpdateSequenceNumber
                     id
                     pltUpdateSequenceNumber
+        -- TODO: Add a max-lock-duration update queue and sequence number in the
+        -- update-queue implementation in subsequent PR.
+        UpdateMaxLockDuration -> error "UpdateMaxLockDuration sequence number queue is not implemented"
 
 -- | Enqueue an update in the appropriate queue, incrementing the sequence number of this queue.
 -- Note that incrementing the sequence number of updates to protocol level tokens is handled separately.

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/Updates.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/Updates.hs
@@ -662,13 +662,13 @@ makeBasicPendingUpdates PendingUpdates{..} = withCPVConstraints (chainParameters
     return UQ.PendingUpdates{..}
 
 -- | Current state of updatable parameters and update queues.
-data Updates' (cpv :: ChainParametersVersion) (auv :: AuthorizationsVersion) = Updates
+data Updates' (pv :: ProtocolVersion) (cpv :: ChainParametersVersion) (auv :: AuthorizationsVersion) = Updates
     { -- | Current update authorizations.
       currentKeyCollection :: !(HashedBufferedRef (StoreSerialized (UpdateKeysCollection auv))),
       -- | Current protocol update.
       currentProtocolUpdate :: !(Nullable (HashedBufferedRef (StoreSerialized ProtocolUpdate))),
       -- | Current node-owned persistent chain parameters.
-      currentParameters :: !(HashedBufferedRef (PCP.PersistentChainParameters' cpv auv)),
+      currentParameters :: !(HashedBufferedRef (PCP.PersistentChainParameters' pv cpv auv)),
       -- | Pending updates.
       pendingUpdates :: !(PendingUpdates cpv auv),
       -- | Sequence number for updates to the protocol level tokens (PLT).
@@ -728,9 +728,9 @@ migrateUpdates migration Updates{..} = do
               pltUpdateSequenceNumber = newPltUpdateSequenceNumber
             }
 
-type Updates (pv :: ProtocolVersion) = Updates' (ChainParametersVersionFor pv) (AuthorizationsVersionFor pv)
+type Updates (pv :: ProtocolVersion) = Updates' pv (ChainParametersVersionFor pv) (AuthorizationsVersionFor pv)
 
-instance (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) => MHashableTo m H.Hash (Updates' cpv auv) where
+instance (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) => MHashableTo m H.Hash (Updates' pv cpv auv) where
     getHashM Updates{..} = do
         hCA <- getHashM currentKeyCollection
         mHCPU <- mapM getHashM currentProtocolUpdate
@@ -752,8 +752,8 @@ instance (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersio
                 put usn
 
 instance
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
-    BlobStorable m (Updates' cpv auv)
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    BlobStorable m (Updates' pv cpv auv)
     where
     storeUpdate Updates{..} = do
         (pKC, kC) <- storeUpdate currentKeyCollection
@@ -783,7 +783,7 @@ instance
             pendingUpdates <- mPU
             return Updates{..}
 
-instance (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) => Cacheable m (Updates' cpv auv) where
+instance (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) => Cacheable m (Updates' pv cpv auv) where
     cache Updates{..} =
         Updates
             <$> cache currentKeyCollection
@@ -795,25 +795,25 @@ instance (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersio
 -- | An initial 'Updates' with the given initial 'Authorizations'
 --  and 'ChainParameters'.
 initialUpdates ::
-    forall m cpv auv.
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
-    UpdateKeysCollection auv ->
-    ChainParameters' cpv ->
-    m (Updates' cpv auv)
+    forall m pv.
+    (MonadBlobStore m, IsProtocolVersion pv) =>
+    UpdateKeysCollection (AuthorizationsVersionFor pv) ->
+    ChainParameters pv ->
+    m (Updates pv)
 initialUpdates initialKeyCollection chainParams = do
     currentKeyCollection <- makeHashedBufferedRef (StoreSerialized initialKeyCollection)
     let currentProtocolUpdate = Null
     currentParameters <- makeHashedBufferedRef =<< PCP.makePersistentChainParameters chainParams
     pendingUpdates <- emptyPendingUpdates
-    let pltUpdateSequenceNumber = conditionally (sSupportsCreatePLT (authorizationsVersion @auv)) minUpdateSequenceNumber
+    let pltUpdateSequenceNumber = conditionally (sSupportsCreatePLT (sAuthorizationsVersionFor (protocolVersion @pv))) minUpdateSequenceNumber
     return Updates{..}
 
 -- | Make a persistent 'Updates' from an in-memory one.
 makePersistentUpdates ::
-    forall m cpv auv.
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
-    UQ.Updates' cpv auv ->
-    m (Updates' cpv auv)
+    forall m pv.
+    (MonadBlobStore m, IsProtocolVersion pv) =>
+    UQ.Updates' (ChainParametersVersionFor pv) (AuthorizationsVersionFor pv) ->
+    m (Updates pv)
 makePersistentUpdates UQ.Updates{..} = do
     currentKeyCollection <- refMake (StoreSerialized (_unhashed _currentKeyCollection))
     currentProtocolUpdate <- case _currentProtocolUpdate of
@@ -826,9 +826,9 @@ makePersistentUpdates UQ.Updates{..} = do
 
 -- | Convert a persistent 'Updates' to an in-memory 'UQ.Updates'.
 makeBasicUpdates ::
-    forall m cpv auv.
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
-    Updates' cpv auv ->
+    forall m pv cpv auv.
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    Updates' pv cpv auv ->
     m (UQ.Updates' cpv auv)
 makeBasicUpdates Updates{..} = do
     hKC <- getHashM currentKeyCollection
@@ -844,18 +844,18 @@ makeBasicUpdates Updates{..} = do
 
 -- | Load the public/wire view of current chain parameters from the persistent node representation.
 loadChainParametersRef ::
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
-    HashedBufferedRef (PCP.PersistentChainParameters' cpv auv) ->
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    HashedBufferedRef (PCP.PersistentChainParameters' pv cpv auv) ->
     m (ChainParameters' cpv)
 loadChainParametersRef currentParameters =
     PCP.persistentChainParametersToChainParameters <$> refLoad currentParameters
 
 -- | Store a new chain-parameter value while preserving node-internal external state.
 makeUpdatedChainParametersRef ::
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
-    HashedBufferedRef (PCP.PersistentChainParameters' cpv auv) ->
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    HashedBufferedRef (PCP.PersistentChainParameters' pv cpv auv) ->
     ChainParameters' cpv ->
-    m (HashedBufferedRef (PCP.PersistentChainParameters' cpv auv))
+    m (HashedBufferedRef (PCP.PersistentChainParameters' pv cpv auv))
 makeUpdatedChainParametersRef currentParameters newChainParameters = do
     persistentParameters <- refLoad currentParameters
     refMake $ PCP.updateChainParameters newChainParameters persistentParameters
@@ -886,11 +886,11 @@ processValueUpdates t uq noUpdate doUpdate = case ql of
 
 -- | Process root keys updates.
 processRootKeysUpdates ::
-    forall m cpv auv.
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    forall m pv cpv auv.
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
     Timestamp ->
-    BufferedRef (Updates' cpv auv) ->
-    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' cpv auv))
+    BufferedRef (Updates' pv cpv auv) ->
+    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' pv cpv auv))
 processRootKeysUpdates t bu = do
     u@Updates{..} <- refLoad bu
     rootKeysQueue <- refLoad (pRootKeysUpdateQueue pendingUpdates)
@@ -908,11 +908,11 @@ processRootKeysUpdates t bu = do
 
 -- | Process level 1 keys updates.
 processLevel1KeysUpdates ::
-    forall m cpv auv.
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    forall m pv cpv auv.
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
     Timestamp ->
-    BufferedRef (Updates' cpv auv) ->
-    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' cpv auv))
+    BufferedRef (Updates' pv cpv auv) ->
+    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' pv cpv auv))
 processLevel1KeysUpdates t bu = do
     u@Updates{..} <- refLoad bu
     level1KeysQueue <- refLoad (pLevel1KeysUpdateQueue pendingUpdates)
@@ -930,11 +930,11 @@ processLevel1KeysUpdates t bu = do
 
 -- | Process level 2 keys updates.
 processLevel2KeysUpdates ::
-    forall m cpv auv.
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    forall m pv cpv auv.
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
     Timestamp ->
-    BufferedRef (Updates' cpv auv) ->
-    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' cpv auv))
+    BufferedRef (Updates' pv cpv auv) ->
+    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' pv cpv auv))
 processLevel2KeysUpdates t bu = do
     u@Updates{..} <- refLoad bu
     level2KeysQueue <- refLoad (pLevel2KeysUpdateQueue pendingUpdates)
@@ -952,10 +952,10 @@ processLevel2KeysUpdates t bu = do
 
 -- | Process election difficulty updates.
 processElectionDifficultyUpdates ::
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
     Timestamp ->
-    BufferedRef (Updates' cpv auv) ->
-    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' cpv auv))
+    BufferedRef (Updates' pv cpv auv) ->
+    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' pv cpv auv))
 processElectionDifficultyUpdates t bu = do
     u@Updates{..} <- refLoad bu
     case pElectionDifficultyQueue pendingUpdates of
@@ -978,10 +978,10 @@ processElectionDifficultyUpdates t bu = do
 
 -- | Process Euro:energy rate updates.
 processEuroPerEnergyUpdates ::
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
     Timestamp ->
-    BufferedRef (Updates' cpv auv) ->
-    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' cpv auv))
+    BufferedRef (Updates' pv cpv auv) ->
+    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' pv cpv auv))
 processEuroPerEnergyUpdates t bu = do
     u@Updates{..} <- refLoad bu
     oldQ <- refLoad (pEuroPerEnergyQueue pendingUpdates)
@@ -999,10 +999,10 @@ processEuroPerEnergyUpdates t bu = do
 
 -- | Process microGTU:Euro rate updates.
 processMicroGTUPerEuroUpdates ::
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
     Timestamp ->
-    BufferedRef (Updates' cpv auv) ->
-    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' cpv auv))
+    BufferedRef (Updates' pv cpv auv) ->
+    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' pv cpv auv))
 processMicroGTUPerEuroUpdates t bu = do
     u@Updates{..} <- refLoad bu
     oldQ <- refLoad (pMicroGTUPerEuroQueue pendingUpdates)
@@ -1019,10 +1019,10 @@ processMicroGTUPerEuroUpdates t bu = do
                     }
 
 processFoundationAccountUpdates ::
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
     Timestamp ->
-    BufferedRef (Updates' cpv auv) ->
-    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' cpv auv))
+    BufferedRef (Updates' pv cpv auv) ->
+    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' pv cpv auv))
 processFoundationAccountUpdates t bu = do
     u@Updates{..} <- refLoad bu
     oldQ <- refLoad (pFoundationAccountQueue pendingUpdates)
@@ -1039,11 +1039,11 @@ processFoundationAccountUpdates t bu = do
                     }
 
 processMintDistributionUpdates ::
-    forall m cpv auv.
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    forall m pv cpv auv.
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
     Timestamp ->
-    BufferedRef (Updates' cpv auv) ->
-    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' cpv auv))
+    BufferedRef (Updates' pv cpv auv) ->
+    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' pv cpv auv))
 processMintDistributionUpdates t bu = withIsMintDistributionVersionFor (chainParametersVersion @cpv) $ do
     u@Updates{..} <- refLoad bu
     oldQ <- refLoad (pMintDistributionQueue pendingUpdates)
@@ -1060,10 +1060,10 @@ processMintDistributionUpdates t bu = withIsMintDistributionVersionFor (chainPar
                     }
 
 processTransactionFeeDistributionUpdates ::
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
     Timestamp ->
-    BufferedRef (Updates' cpv auv) ->
-    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' cpv auv))
+    BufferedRef (Updates' pv cpv auv) ->
+    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' pv cpv auv))
 processTransactionFeeDistributionUpdates t bu = do
     u@Updates{..} <- refLoad bu
     oldQ <- refLoad (pTransactionFeeDistributionQueue pendingUpdates)
@@ -1080,11 +1080,11 @@ processTransactionFeeDistributionUpdates t bu = do
                     }
 
 processGASRewardsUpdates ::
-    forall m cpv auv.
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    forall m pv cpv auv.
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
     Timestamp ->
-    BufferedRef (Updates' cpv auv) ->
-    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' cpv auv))
+    BufferedRef (Updates' pv cpv auv) ->
+    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' pv cpv auv))
 processGASRewardsUpdates t bu = withIsGASRewardsVersionFor (chainParametersVersion @cpv) $ do
     u@Updates{..} <- refLoad bu
     oldQ <- refLoad (pGASRewardsQueue pendingUpdates)
@@ -1101,11 +1101,11 @@ processGASRewardsUpdates t bu = withIsGASRewardsVersionFor (chainParametersVersi
                     }
 
 processPoolParamatersUpdates ::
-    forall m cpv auv.
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    forall m pv cpv auv.
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
     Timestamp ->
-    BufferedRef (Updates' cpv auv) ->
-    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' cpv auv))
+    BufferedRef (Updates' pv cpv auv) ->
+    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' pv cpv auv))
 processPoolParamatersUpdates t bu = withIsPoolParametersVersionFor (chainParametersVersion @cpv) $ do
     u@Updates{..} <- refLoad bu
     oldQ <- refLoad (pPoolParametersQueue pendingUpdates)
@@ -1123,11 +1123,11 @@ processPoolParamatersUpdates t bu = withIsPoolParametersVersionFor (chainParamet
 
 -- | Process cooldown parameters updates.
 processCooldownParametersUpdates ::
-    forall m cpv auv.
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    forall m pv cpv auv.
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
     Timestamp ->
-    BufferedRef (Updates' cpv auv) ->
-    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' cpv auv))
+    BufferedRef (Updates' pv cpv auv) ->
+    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' pv cpv auv))
 processCooldownParametersUpdates t bu = do
     u@Updates{..} <- refLoad bu
     case pCooldownParametersQueue pendingUpdates of
@@ -1148,10 +1148,10 @@ processCooldownParametersUpdates t bu = do
 
 -- | Process time parameters updates.
 processTimeParametersUpdates ::
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
     Timestamp ->
-    BufferedRef (Updates' cpv auv) ->
-    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' cpv auv))
+    BufferedRef (Updates' pv cpv auv) ->
+    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' pv cpv auv))
 processTimeParametersUpdates t bu = do
     u@Updates{..} <- refLoad bu
     case pTimeParametersQueue pendingUpdates of
@@ -1175,11 +1175,11 @@ processTimeParametersUpdates t bu = do
 --  update them (if an update was enqueued and its time is now)
 --  and update the 'pendingUpdates' accordingly.
 processTimeoutParametersUpdates ::
-    forall m cpv auv.
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    forall m pv cpv auv.
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
     Timestamp ->
-    BufferedRef (Updates' cpv auv) ->
-    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' cpv auv))
+    BufferedRef (Updates' pv cpv auv) ->
+    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' pv cpv auv))
 processTimeoutParametersUpdates t bu = do
     u@Updates{..} <- refLoad bu
     case pTimeoutParametersQueue pendingUpdates of
@@ -1205,11 +1205,11 @@ processTimeoutParametersUpdates t bu = do
 --  update it (if an update was enqueued and its time is now)
 --  and update the 'pendingUpdates' accordingly.
 processMinBlockTimeUpdates ::
-    forall m cpv auv.
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    forall m pv cpv auv.
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
     Timestamp ->
-    BufferedRef (Updates' cpv auv) ->
-    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' cpv auv))
+    BufferedRef (Updates' pv cpv auv) ->
+    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' pv cpv auv))
 processMinBlockTimeUpdates t bu = do
     u@Updates{..} <- refLoad bu
     case pMinBlockTimeQueue pendingUpdates of
@@ -1235,11 +1235,11 @@ processMinBlockTimeUpdates t bu = do
 --  update it (if an update was enqueued and its time is now)
 --  and update the 'pendingUpdates' accordingly.
 processBlockEnergyLimitUpdates ::
-    forall m cpv auv.
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    forall m pv cpv auv.
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
     Timestamp ->
-    BufferedRef (Updates' cpv auv) ->
-    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' cpv auv))
+    BufferedRef (Updates' pv cpv auv) ->
+    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' pv cpv auv))
 processBlockEnergyLimitUpdates t bu = do
     u@Updates{..} <- refLoad bu
     case pBlockEnergyLimitQueue pendingUpdates of
@@ -1265,11 +1265,11 @@ processBlockEnergyLimitUpdates t bu = do
 --  update them (if an update was enqueued and its time is now)
 --  and update the 'pendingUpdates' accordingly.
 processFinalizationCommitteeParametersUpdates ::
-    forall m cpv auv.
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    forall m pv cpv auv.
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
     Timestamp ->
-    BufferedRef (Updates' cpv auv) ->
-    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' cpv auv))
+    BufferedRef (Updates' pv cpv auv) ->
+    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' pv cpv auv))
 processFinalizationCommitteeParametersUpdates t bu = do
     u@Updates{..} <- refLoad bu
     case pFinalizationCommitteeParametersQueue pendingUpdates of
@@ -1296,11 +1296,11 @@ processFinalizationCommitteeParametersUpdates t bu = do
 --  update them (if an update was enqueued and its time is now)
 --  and update the 'pendingUpdates' accordingly.
 processValidationScoreParametersUpdates ::
-    forall m cpv auv.
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    forall m pv cpv auv.
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
     Timestamp ->
-    BufferedRef (Updates' cpv auv) ->
-    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' cpv auv))
+    BufferedRef (Updates' pv cpv auv) ->
+    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' pv cpv auv))
 processValidationScoreParametersUpdates t bu = do
     u@Updates{..} <- refLoad bu
     case pValidatorScoreParametersQueue pendingUpdates of
@@ -1325,11 +1325,11 @@ processValidationScoreParametersUpdates t bu = do
 -- | Process the add anonymity revoker update queue.
 --   Ignores updates with duplicate ARs.
 processAddAnonymityRevokerUpdates ::
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
     Timestamp ->
-    BufferedRef (Updates' cpv auv) ->
+    BufferedRef (Updates' pv cpv auv) ->
     HashedBufferedRef ARS.AnonymityRevokers ->
-    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' cpv auv), HashedBufferedRef ARS.AnonymityRevokers)
+    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' pv cpv auv), HashedBufferedRef ARS.AnonymityRevokers)
 processAddAnonymityRevokerUpdates t bu hbar = do
     u@Updates{..} <- refLoad bu
     oldQ <- refLoad (pAddAnonymityRevokerQueue pendingUpdates)
@@ -1353,11 +1353,11 @@ processAddAnonymityRevokerUpdates t bu hbar = do
 -- | Process the add identity provider update queue.
 --   Ignores updates with duplicate IPs.
 processAddIdentityProviderUpdates ::
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
     Timestamp ->
-    BufferedRef (Updates' cpv auv) ->
+    BufferedRef (Updates' pv cpv auv) ->
     HashedBufferedRef IPS.IdentityProviders ->
-    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' cpv auv), HashedBufferedRef IPS.IdentityProviders)
+    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' pv cpv auv), HashedBufferedRef IPS.IdentityProviders)
 processAddIdentityProviderUpdates t bu hbip = do
     u@Updates{..} <- refLoad bu
     oldQ <- refLoad (pAddIdentityProviderQueue pendingUpdates)
@@ -1410,10 +1410,10 @@ addAndAccumNonduplicateUpdates oldMap getKey toUV = foldM go (Map.empty, oldMap)
 --  FIXME: We may just want to keep unused protocol updates in the queue, even if their timestamps have
 --  elapsed.
 processProtocolUpdates ::
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
     Timestamp ->
-    BufferedRef (Updates' cpv auv) ->
-    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' cpv auv))
+    BufferedRef (Updates' pv cpv auv) ->
+    m (Map.Map TransactionTime (UpdateValue cpv auv), BufferedRef (Updates' pv cpv auv))
 processProtocolUpdates t bu = do
     u@Updates{..} <- refLoad bu
     protQueue <- refLoad (pProtocolQueue pendingUpdates)
@@ -1441,17 +1441,17 @@ processProtocolUpdates t bu = do
         v <- UVProtocol . unStoreSerialized <$> refLoad r
         return $! Map.insert tt v m
 
-type UpdatesWithARsAndIPs (cpv :: ChainParametersVersion) (auv :: AuthorizationsVersion) =
-    (BufferedRef (Updates' cpv auv), HashedBufferedRef ARS.AnonymityRevokers, HashedBufferedRef IPS.IdentityProviders)
+type UpdatesWithARsAndIPs (pv :: ProtocolVersion) (cpv :: ChainParametersVersion) (auv :: AuthorizationsVersion) =
+    (BufferedRef (Updates' pv cpv auv), HashedBufferedRef ARS.AnonymityRevokers, HashedBufferedRef IPS.IdentityProviders)
 
 -- | Process all update queues. This returns a list of the updates that occurred, with their times,
 --  ordered by the time.
 processUpdateQueues ::
-    forall m cpv auv.
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    forall m pv cpv auv.
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
     Timestamp ->
-    UpdatesWithARsAndIPs cpv auv ->
-    m ([(TransactionTime, UpdateValue cpv auv)], UpdatesWithARsAndIPs cpv auv)
+    UpdatesWithARsAndIPs pv cpv auv ->
+    m ([(TransactionTime, UpdateValue cpv auv)], UpdatesWithARsAndIPs pv cpv auv)
 processUpdateQueues t (u0, ars, ips) = do
     (ms, u1) <-
         combine
@@ -1493,8 +1493,8 @@ processUpdateQueues t (u0, ars, ips) = do
     -- The return value is the final state of updates, and the list of
     -- updates. The list is in **reverse** order of the input list.
     combine ::
-        [BufferedRef (Updates' cpv auv) -> m (r, BufferedRef (Updates' cpv auv))] ->
-        m ([r], BufferedRef (Updates' cpv auv))
+        [BufferedRef (Updates' pv cpv auv) -> m (r, BufferedRef (Updates' pv cpv auv))] ->
+        m ([r], BufferedRef (Updates' pv cpv auv))
     combine =
         foldM
             ( \(ms, updates) action -> do
@@ -1518,11 +1518,12 @@ processUpdateQueues t (u0, ars, ips) = do
 --  on a current 'Updates'.
 futureElectionDifficulty ::
     ( MonadBlobStore m,
+      IsProtocolVersion pv,
       IsChainParametersVersion cpv,
       IsAuthorizationsVersion auv,
       ConsensusParametersVersionFor cpv ~ 'ConsensusParametersVersion0
     ) =>
-    BufferedRef (Updates' cpv auv) ->
+    BufferedRef (Updates' pv cpv auv) ->
     Timestamp ->
     m ElectionDifficulty
 futureElectionDifficulty uref ts = do
@@ -1536,8 +1537,8 @@ futureElectionDifficulty uref ts = do
 -- | Get the protocol update status: either an effective protocol update or
 --  a list of pending future protocol updates.
 protocolUpdateStatus ::
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
-    BufferedRef (Updates' cpv auv) ->
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    BufferedRef (Updates' pv cpv auv) ->
     m UQ.ProtocolUpdateStatus
 protocolUpdateStatus uref = do
     Updates{..} <- refLoad uref
@@ -1549,8 +1550,8 @@ protocolUpdateStatus uref = do
 
 -- | Get whether a protocol update is effective
 isProtocolUpdateEffective ::
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
-    BufferedRef (Updates' cpv auv) ->
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    BufferedRef (Updates' pv cpv auv) ->
     m Bool
 isProtocolUpdateEffective uref = do
     Updates{..} <- refLoad uref
@@ -1560,9 +1561,9 @@ isProtocolUpdateEffective uref = do
 
 -- | Determine the next sequence number for a given update type.
 lookupNextUpdateSequenceNumber ::
-    forall m cpv auv.
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
-    BufferedRef (Updates' cpv auv) ->
+    forall m pv cpv auv.
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    BufferedRef (Updates' pv cpv auv) ->
     UpdateType ->
     m UpdateSequenceNumber
 lookupNextUpdateSequenceNumber uref uty = withCPVConstraints (chainParametersVersion @cpv) $ do
@@ -1634,12 +1635,12 @@ lookupNextUpdateSequenceNumber uref uty = withCPVConstraints (chainParametersVer
 -- | Enqueue an update in the appropriate queue, incrementing the sequence number of this queue.
 -- Note that incrementing the sequence number of updates to protocol level tokens is handled separately.
 enqueueUpdate ::
-    forall m cpv auv.
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    forall m pv cpv auv.
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
     TransactionTime ->
     UpdateValue cpv auv ->
-    BufferedRef (Updates' cpv auv) ->
-    m (BufferedRef (Updates' cpv auv))
+    BufferedRef (Updates' pv cpv auv) ->
+    m (BufferedRef (Updates' pv cpv auv))
 enqueueUpdate effectiveTime payload uref = withCPVConstraints (chainParametersVersion @cpv) $ do
     u@Updates{pendingUpdates = p@PendingUpdates{..}} <- refLoad uref
     newPendingUpdates <- case payload of
@@ -1692,10 +1693,10 @@ enqueueUpdate effectiveTime payload uref = withCPVConstraints (chainParametersVe
 -- | Increment the update sequence number for Protocol Level Tokens (PLT).
 -- Unlike the other chain updates this is a separate function, since there is no queue associated with PLTs.
 incrementPLTUpdateSequenceNumber ::
-    forall m cpv auv.
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv, SupportsCreatePLT auv ~ 'True) =>
-    BufferedRef (Updates' cpv auv) ->
-    m (BufferedRef (Updates' cpv auv))
+    forall m pv cpv auv.
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv, SupportsCreatePLT auv ~ 'True) =>
+    BufferedRef (Updates' pv cpv auv) ->
+    m (BufferedRef (Updates' pv cpv auv))
 incrementPLTUpdateSequenceNumber updatesRef = do
     currentUpdates <- refLoad updatesRef
     let currentSequenceNumber = uncond $ pltUpdateSequenceNumber currentUpdates
@@ -1705,13 +1706,14 @@ incrementPLTUpdateSequenceNumber updatesRef = do
 --  any pending updates to the election difficulty from the queue.
 overwriteElectionDifficulty ::
     ( MonadBlobStore m,
+      IsProtocolVersion pv,
       IsChainParametersVersion cpv,
       IsAuthorizationsVersion auv,
       ConsensusParametersVersionFor cpv ~ 'ConsensusParametersVersion0
     ) =>
     ElectionDifficulty ->
-    BufferedRef (Updates' cpv auv) ->
-    m (BufferedRef (Updates' cpv auv))
+    BufferedRef (Updates' pv cpv auv) ->
+    m (BufferedRef (Updates' pv cpv auv))
 overwriteElectionDifficulty newDifficulty uref = do
     u@Updates{pendingUpdates = p@PendingUpdates{..}, ..} <- refLoad uref
     cp <- loadChainParametersRef currentParameters
@@ -1722,9 +1724,9 @@ overwriteElectionDifficulty newDifficulty uref = do
 -- | Clear the protocol update and remove any pending protocol updates from
 --  the queue.
 clearProtocolUpdate ::
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
-    BufferedRef (Updates' cpv auv) ->
-    m (BufferedRef (Updates' cpv auv))
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    BufferedRef (Updates' pv cpv auv) ->
+    m (BufferedRef (Updates' pv cpv auv))
 clearProtocolUpdate uref = do
     u@Updates{pendingUpdates = p@PendingUpdates{..}} <- refLoad uref
     newPendingUpdates <- clearQueue pProtocolQueue <&> \newQ -> p{pProtocolQueue = newQ}
@@ -1732,8 +1734,8 @@ clearProtocolUpdate uref = do
 
 -- | Get the current exchange rates, which are the Euro per NRG, micro CCD per Euro and the energy rate.
 lookupExchangeRates ::
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
-    BufferedRef (Updates' cpv auv) ->
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    BufferedRef (Updates' pv cpv auv) ->
     m ExchangeRates
 lookupExchangeRates uref = do
     Updates{..} <- refLoad uref
@@ -1742,8 +1744,8 @@ lookupExchangeRates uref = do
 
 -- | Look up the current chain parameters.
 lookupCurrentParameters ::
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
-    BufferedRef (Updates' cpv auv) ->
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    BufferedRef (Updates' pv cpv auv) ->
     m (ChainParameters' cpv)
 lookupCurrentParameters uref = do
     Updates{..} <- refLoad uref
@@ -1751,8 +1753,8 @@ lookupCurrentParameters uref = do
 
 -- | Look up the pending changes to the time parameters.
 lookupPendingTimeParameters ::
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
-    BufferedRef (Updates' cpv auv) ->
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    BufferedRef (Updates' pv cpv auv) ->
     m [(TransactionTime, TimeParameters)]
 lookupPendingTimeParameters uref = do
     Updates{..} <- refLoad uref
@@ -1762,9 +1764,9 @@ lookupPendingTimeParameters uref = do
 
 -- | Look up the pending changes to the pool parameters.
 lookupPendingPoolParameters ::
-    forall m cpv auv.
-    (MonadBlobStore m, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
-    BufferedRef (Updates' cpv auv) ->
+    forall m pv cpv auv.
+    (MonadBlobStore m, IsProtocolVersion pv, IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    BufferedRef (Updates' pv cpv auv) ->
     m [(TransactionTime, PoolParameters cpv)]
 lookupPendingPoolParameters uref = do
     Updates{..} <- refLoad uref

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Migration.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Migration.hs
@@ -266,13 +266,18 @@ migrateChainParametersVersionUnchanged ::
     PersistentChainParameters oldpv ->
     t m (PersistentChainParameters pv)
 migrateChainParametersVersionUnchanged StateMigrationParametersTrivial params = return params
-migrateChainParametersVersionUnchanged StateMigrationParametersP1P2 params = return params
-migrateChainParametersVersionUnchanged StateMigrationParametersP2P3 params = return params
-migrateChainParametersVersionUnchanged StateMigrationParametersP4ToP5 params = return params
-migrateChainParametersVersionUnchanged StateMigrationParametersP6ToP7 params = return params
+migrateChainParametersVersionUnchanged StateMigrationParametersP1P2 PersistentChainParameters{..} =
+    return PersistentChainParameters{pcpExternalChainParameters = CFalse, ..}
+migrateChainParametersVersionUnchanged StateMigrationParametersP2P3 PersistentChainParameters{..} =
+    return PersistentChainParameters{pcpExternalChainParameters = CFalse, ..}
+migrateChainParametersVersionUnchanged StateMigrationParametersP4ToP5 PersistentChainParameters{..} =
+    return PersistentChainParameters{pcpExternalChainParameters = CFalse, ..}
+migrateChainParametersVersionUnchanged StateMigrationParametersP6ToP7 PersistentChainParameters{..} =
+    return PersistentChainParameters{pcpExternalChainParameters = CFalse, ..}
 migrateChainParametersVersionUnchanged StateMigrationParametersP8ToP9{} PersistentChainParameters{..} =
     return PersistentChainParameters{pcpExternalChainParameters = CFalse, ..}
-migrateChainParametersVersionUnchanged StateMigrationParametersP9ToP10{} params = return params
+migrateChainParametersVersionUnchanged StateMigrationParametersP9ToP10{} PersistentChainParameters{..} =
+    return PersistentChainParameters{pcpExternalChainParameters = CFalse, ..}
 migrateChainParametersVersionUnchanged (StateMigrationParametersP10ToP11 migration) PersistentChainParameters{..} = do
     newExternalChainParameters <- CTrue <$> ECP.p11NewExternalChainParameters updateMaxLockDuration
     return PersistentChainParameters{pcpExternalChainParameters = newExternalChainParameters, ..}

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Migration.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Migration.hs
@@ -191,6 +191,7 @@ migrateChainParameters m = case chainParametersMigrationFor m of
                   _cpPoolParameters = migratePoolParameters m _cpPoolParameters,
                   _cpFinalizationCommitteeParameters = NoParam,
                   _cpValidatorScoreParameters = NoParam,
+                  _cpMaxLockDuration = NoParam,
                   ..
                 }
           where
@@ -212,6 +213,7 @@ migrateChainParameters m = case chainParametersMigrationFor m of
                   -- with the time parameters.
                   _cpTimeParameters = SomeParam $ unOParam _cpTimeParameters,
                   _cpValidatorScoreParameters = NoParam,
+                  _cpMaxLockDuration = NoParam,
                   ..
                 }
           where
@@ -221,6 +223,7 @@ migrateChainParameters m = case chainParametersMigrationFor m of
         StateMigrationParametersP7ToP8 migrationData ->
             ChainParameters
                 { _cpValidatorScoreParameters = SomeParam updateValidatorScoreParameters,
+                  _cpMaxLockDuration = SomeParam Nothing,
                   _cpTimeParameters = SomeParam $ unOParam _cpTimeParameters,
                   _cpFinalizationCommitteeParameters = SomeParam $ unOParam _cpFinalizationCommitteeParameters,
                   _cpPoolParameters = migratePoolParameters m _cpPoolParameters,

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/Migration.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/Migration.hs
@@ -1,17 +1,24 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Concordium.GlobalState.Persistent.Migration where
 
 import Concordium.Genesis.Data
+import qualified Concordium.Genesis.Data.P11 as P11
 import qualified Concordium.Genesis.Data.P4 as P4
 import qualified Concordium.Genesis.Data.P6 as P6
 import qualified Concordium.Genesis.Data.P8 as P8
 import qualified Concordium.Genesis.Data.P9 as P9
+import Concordium.GlobalState.Persistent.BlobStore (SupportMigration)
+import qualified Concordium.GlobalState.Persistent.BlockState.ExternalChainParameters as ECP
+import Concordium.GlobalState.Persistent.BlockState.Parameters
 import Concordium.Types
 import Concordium.Types.Accounts
+import Concordium.Types.Conditionally
 import Concordium.Types.Parameters
 import Concordium.Types.Updates
 
@@ -100,7 +107,13 @@ migrateAuthorizations (StateMigrationParametersP8ToP9 migration) Authorizations{
   where
     P9.ProtocolUpdateData{..} = P9.migrationProtocolUpdateData migration
 migrateAuthorizations StateMigrationParametersP9ToP10{} auths = auths
-migrateAuthorizations StateMigrationParametersP10ToP11{} auths = auths
+migrateAuthorizations (StateMigrationParametersP10ToP11 migration) Authorizations{..} =
+    Authorizations
+        { asTokenParameters = CTrue updateTokenParametersAccessStructure,
+          ..
+        }
+  where
+    P11.ProtocolUpdateData{..} = P11.migrationProtocolUpdateData migration
 
 -- | Apply a state migration to an 'UpdateKeysCollection' structure.
 --
@@ -170,74 +183,102 @@ migrateGASRewards migration = case chainParametersMigrationFor migration of
 --    the GAS finalization proof reward is removed.
 --
 --  [P7 to P8]: the new validator score parameters are given by the migration parameters.
+--
+--  [P10 to P11]: the new max lock duration is given by the migration parameters
 migrateChainParameters ::
-    forall oldpv pv.
+    forall oldpv pv t m.
+    (SupportMigration m t) =>
     StateMigrationParameters oldpv pv ->
-    ChainParameters oldpv ->
-    ChainParameters pv
-migrateChainParameters m = case chainParametersMigrationFor m of
-    ChainParametersMigrationTrivial -> id
-    ChainParametersMigrationCPV0toCPV1 -> \ChainParameters{..} -> case m of
+    PersistentChainParameters oldpv ->
+    t m (PersistentChainParameters pv)
+migrateChainParameters migration = case chainParametersMigrationFor migration of
+    ChainParametersMigrationTrivial -> migrateChainParametersVersionUnchanged migration
+    ChainParametersMigrationCPV0toCPV1 -> \PersistentChainParameters{..} -> case migration of
         StateMigrationParametersP3ToP4 migrationData ->
-            ChainParameters
-                { _cpCooldownParameters = updateCooldownParameters,
-                  _cpTimeParameters = SomeParam updateTimeParameters,
-                  _cpRewardParameters =
-                    RewardParameters
-                        { _rpMintDistribution = migrateMintDistribution m _rpMintDistribution,
-                          _rpGASRewards = migrateGASRewards m _rpGASRewards,
-                          ..
-                        },
-                  _cpPoolParameters = migratePoolParameters m _cpPoolParameters,
-                  _cpFinalizationCommitteeParameters = NoParam,
-                  _cpValidatorScoreParameters = NoParam,
-                  _cpMaxLockDuration = NoParam,
-                  ..
-                }
+            return $
+                PersistentChainParameters
+                    { pcpCooldownParameters = updateCooldownParameters,
+                      pcpTimeParameters = SomeParam updateTimeParameters,
+                      pcpRewardParameters =
+                        RewardParameters
+                            { _rpMintDistribution = migrateMintDistribution migration _rpMintDistribution,
+                              _rpGASRewards = migrateGASRewards migration _rpGASRewards,
+                              ..
+                            },
+                      pcpPoolParameters = migratePoolParameters migration pcpPoolParameters,
+                      pcpFinalizationCommitteeParameters = NoParam,
+                      pcpValidatorScoreParameters = NoParam,
+                      pcpExternalChainParameters = CFalse,
+                      ..
+                    }
           where
-            RewardParameters{..} = _cpRewardParameters
+            RewardParameters{..} = pcpRewardParameters
             P4.ProtocolUpdateData{..} = P4.migrationProtocolUpdateData migrationData
-    ChainParametersMigrationCPV1toCPV2 -> \ChainParameters{..} -> case m of
+    ChainParametersMigrationCPV1toCPV2 -> \PersistentChainParameters{..} -> case migration of
         StateMigrationParametersP5ToP6 migrationData ->
-            ChainParameters
-                { _cpConsensusParameters = updateConsensusParameters,
-                  _cpRewardParameters =
-                    RewardParameters
-                        { _rpMintDistribution = migrateMintDistribution m _rpMintDistribution,
-                          _rpGASRewards = migrateGASRewards m _rpGASRewards,
-                          ..
-                        },
-                  _cpPoolParameters = migratePoolParameters m _cpPoolParameters,
-                  _cpFinalizationCommitteeParameters = SomeParam updateFinalizationCommitteeParameters,
-                  -- We unwrap and wrap here in order to associate the correct cpv
-                  -- with the time parameters.
-                  _cpTimeParameters = SomeParam $ unOParam _cpTimeParameters,
-                  _cpValidatorScoreParameters = NoParam,
-                  _cpMaxLockDuration = NoParam,
-                  ..
-                }
+            return $
+                PersistentChainParameters
+                    { pcpConsensusParameters = updateConsensusParameters,
+                      pcpRewardParameters =
+                        RewardParameters
+                            { _rpMintDistribution = migrateMintDistribution migration _rpMintDistribution,
+                              _rpGASRewards = migrateGASRewards migration _rpGASRewards,
+                              ..
+                            },
+                      pcpPoolParameters = migratePoolParameters migration pcpPoolParameters,
+                      pcpFinalizationCommitteeParameters = SomeParam updateFinalizationCommitteeParameters,
+                      -- We unwrap and wrap here in order to associate the correct cpv
+                      -- with the time parameters.
+                      pcpTimeParameters = SomeParam $ unOParam pcpTimeParameters,
+                      pcpValidatorScoreParameters = NoParam,
+                      pcpExternalChainParameters = CFalse,
+                      ..
+                    }
           where
             P6.ProtocolUpdateData{..} = P6.migrationProtocolUpdateData migrationData
-            RewardParameters{..} = _cpRewardParameters
-    ChainParametersMigrationCPV2toCPV3 -> \ChainParameters{..} -> case m of
+            RewardParameters{..} = pcpRewardParameters
+    ChainParametersMigrationCPV2toCPV3 -> \PersistentChainParameters{..} -> case migration of
         StateMigrationParametersP7ToP8 migrationData ->
-            ChainParameters
-                { _cpValidatorScoreParameters = SomeParam updateValidatorScoreParameters,
-                  _cpMaxLockDuration = SomeParam Nothing,
-                  _cpTimeParameters = SomeParam $ unOParam _cpTimeParameters,
-                  _cpFinalizationCommitteeParameters = SomeParam $ unOParam _cpFinalizationCommitteeParameters,
-                  _cpPoolParameters = migratePoolParameters m _cpPoolParameters,
-                  _cpRewardParameters =
-                    RewardParameters
-                        { _rpMintDistribution = migrateMintDistribution m _rpMintDistribution,
-                          _rpGASRewards = migrateGASRewards m _rpGASRewards,
-                          ..
-                        },
-                  ..
-                }
+            return $
+                PersistentChainParameters
+                    { pcpValidatorScoreParameters = SomeParam updateValidatorScoreParameters,
+                      pcpTimeParameters = SomeParam $ unOParam pcpTimeParameters,
+                      pcpFinalizationCommitteeParameters = SomeParam $ unOParam pcpFinalizationCommitteeParameters,
+                      pcpPoolParameters = migratePoolParameters migration pcpPoolParameters,
+                      pcpRewardParameters =
+                        RewardParameters
+                            { _rpMintDistribution = migrateMintDistribution migration _rpMintDistribution,
+                              _rpGASRewards = migrateGASRewards migration _rpGASRewards,
+                              ..
+                            },
+                      pcpExternalChainParameters = CFalse,
+                      ..
+                    }
           where
             P8.ProtocolUpdateData{..} = P8.migrationProtocolUpdateData migrationData
-            RewardParameters{..} = _cpRewardParameters
+            RewardParameters{..} = pcpRewardParameters
+
+-- | Migrate persistent chain parameters when the chain parameter version is unchanged.
+migrateChainParametersVersionUnchanged ::
+    forall oldpv pv t m.
+    (SupportMigration m t) =>
+    StateMigrationParameters oldpv pv ->
+    PersistentChainParameters oldpv ->
+    t m (PersistentChainParameters pv)
+migrateChainParametersVersionUnchanged StateMigrationParametersTrivial params = return params
+migrateChainParametersVersionUnchanged StateMigrationParametersP1P2 params = return params
+migrateChainParametersVersionUnchanged StateMigrationParametersP2P3 params = return params
+migrateChainParametersVersionUnchanged StateMigrationParametersP4ToP5 params = return params
+migrateChainParametersVersionUnchanged StateMigrationParametersP6ToP7 params = return params
+migrateChainParametersVersionUnchanged StateMigrationParametersP8ToP9{} PersistentChainParameters{..} =
+    return PersistentChainParameters{pcpExternalChainParameters = CFalse, ..}
+migrateChainParametersVersionUnchanged StateMigrationParametersP9ToP10{} params = return params
+migrateChainParametersVersionUnchanged (StateMigrationParametersP10ToP11 migration) PersistentChainParameters{..} = do
+    newExternalChainParameters <- CTrue <$> ECP.p11NewExternalChainParameters updateMaxLockDuration
+    return PersistentChainParameters{pcpExternalChainParameters = newExternalChainParameters, ..}
+  where
+    P11.ProtocolUpdateData{..} = P11.migrationProtocolUpdateData migration
+migrateChainParametersVersionUnchanged _ _ = error "migrateChainParametersVersionUnchanged called for non-trivial chain parameter version migration"
 
 -- | Migrate time of the effective change from V0 to V1 accounts. Currently this
 --  translates times relative to genesis to times relative to the unix epoch.

--- a/concordium-consensus/src/Concordium/ProtocolUpdate/P10.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/P10.hs
@@ -10,12 +10,13 @@ module Concordium.ProtocolUpdate.P10 (
 
 import Control.Monad.State
 import qualified Data.HashMap.Strict as HM
-import Data.Serialize
+import qualified Data.Serialize as S
 
 import qualified Concordium.Crypto.SHA256 as SHA256
 import Concordium.Types
 import Concordium.Types.Updates
 
+import qualified Concordium.Genesis.Data.P11 as P11
 import Concordium.GlobalState.BlockState
 import qualified Concordium.GlobalState.Persistent.BlockState as PBS
 import Concordium.GlobalState.Types
@@ -28,22 +29,22 @@ import qualified Concordium.ProtocolUpdate.P10.Reboot as Reboot
 -- | Updates that are supported from protocol version P10.
 data Update
     = Reboot
-    | ProtocolP11
+    | ProtocolP11 P11.ProtocolUpdateData
     deriving (Show)
 
 -- | Hash map for resolving updates from their specification hash.
-updates :: HM.HashMap SHA256.Hash (Get Update)
+updates :: HM.HashMap SHA256.Hash (S.Get Update)
 updates =
     HM.fromList
         [ (Reboot.updateHash, return Reboot),
-          (ProtocolP11.updateHash, return ProtocolP11)
+          (ProtocolP11.updateHash, ProtocolP11 <$> S.get)
         ]
 
 -- | Determine if a 'ProtocolUpdate' corresponds to a supported update type.
 checkUpdate :: ProtocolUpdate -> Either String Update
 checkUpdate ProtocolUpdate{..} = case HM.lookup puSpecificationHash updates of
     Nothing -> Left "Specification hash does not correspond to a known protocol update."
-    Just updateGet -> case runGet updateGet puSpecificationAuxiliaryData of
+    Just updateGet -> case S.runGet updateGet puSpecificationAuxiliaryData of
         Left err -> Left $! "Could not deserialize auxiliary data: " ++ err
         Right update -> return update
 
@@ -60,7 +61,7 @@ updateRegenesis ::
     BlockPointer (MPV m) ->
     m (PVInit m)
 updateRegenesis Reboot = Reboot.updateRegenesis
-updateRegenesis ProtocolP11 = ProtocolP11.updateRegenesis
+updateRegenesis (ProtocolP11 protocolUpdateData) = ProtocolP11.updateRegenesis protocolUpdateData
 
 -- | Determine the protocol version the update will update to.
 updateNextProtocolVersion ::

--- a/concordium-consensus/src/Concordium/ProtocolUpdate/P10/ProtocolP11.hs
+++ b/concordium-consensus/src/Concordium/ProtocolUpdate/P10/ProtocolP11.hs
@@ -27,7 +27,7 @@
 --
 --  * 'genesisStateHash' is the state hash of the last finalized block of the previous chain.
 --
---  * 'genesisMigration' is empty as there is no state migration between P10 and P11.
+--  * 'genesisMigration' is derived from the protocol update auxiliary data.
 --
 --  The block state is taken from the last finalized block of the previous chain. It is updated
 --  as part of the state migration, which makes the following changes:
@@ -88,9 +88,10 @@ updateRegenesis ::
       MonadState (TreeState.SkovData (MPV m)) m,
       GSTypes.BlockState m ~ PBS.HashedPersistentBlockState (MPV m)
     ) =>
+    P11.ProtocolUpdateData ->
     BlockPointer 'P10 ->
     m (PVInit m)
-updateRegenesis terminalBlock = do
+updateRegenesis protocolUpdateData terminalBlock = do
     let regenesisTime = blockTimestamp terminalBlock
     gMetadata <- use TreeState.genesisMetadata
     BaseV1.CoreGenesisParametersV1{..} <- gmParameters <$> use TreeState.genesisMetadata
@@ -104,6 +105,9 @@ updateRegenesis terminalBlock = do
         genesisTerminalBlock = getHash terminalBlock
     let regenesisBlockState = bpState terminalBlock
     genesisStateHash <- getStateHash regenesisBlockState
-    let genesisMigration = P11.StateMigrationData
+    let genesisMigration =
+            P11.StateMigrationData
+                { migrationProtocolUpdateData = protocolUpdateData
+                }
     let newGenesis = GenesisData.RGDP11 $ P11.GDP11RegenesisFromP10{genesisRegenesis = BaseV1.RegenesisDataV1{genesisCore = core, ..}, ..}
     return (PVInit newGenesis (GenesisData.StateMigrationParametersP10ToP11 genesisMigration) (bmHeight $ bpInfo terminalBlock))

--- a/concordium-consensus/src/Concordium/Queries.hs
+++ b/concordium-consensus/src/Concordium/Queries.hs
@@ -916,6 +916,7 @@ getBlockPendingUpdates = liftSkovQueryStateBHI query
                             SAuthorizationsVersion0 -> queueMapper PUELevel2KeysV0 _pLevel2KeysUpdateQueue
                             SAuthorizationsVersion1 -> queueMapper PUELevel2KeysV1 _pLevel2KeysUpdateQueue
                             SAuthorizationsVersion2 -> queueMapper PUELevel2KeysV2 _pLevel2KeysUpdateQueue
+                            SAuthorizationsVersion3 -> queueMapper PUELevel2KeysV3 _pLevel2KeysUpdateQueue
                         )
                 `merge` queueMapper PUEProtocol _pProtocolQueue
                 `merge` queueMapperOptional PUEElectionDifficulty _pElectionDifficultyQueue

--- a/concordium-consensus/src/Concordium/Scheduler.hs
+++ b/concordium-consensus/src/Concordium/Scheduler.hs
@@ -2842,6 +2842,9 @@ handleChainUpdate (WithMetadata{wmdData = ui@UpdateInstruction{..}, ..}, maybeVe
                                 RootUpdatePayload (Level2KeysRootUpdateV2 u) -> case sauv of
                                     SAuthorizationsVersion2 -> checkSigAndEnqueue $ UVLevel2Keys u
                                     _ -> return $ TxInvalid NotSupportedAtCurrentProtocolVersion
+                                RootUpdatePayload (Level2KeysRootUpdateV3 u) -> case sauv of
+                                    SAuthorizationsVersion3 -> checkSigAndEnqueue $ UVLevel2Keys u
+                                    _ -> return $ TxInvalid NotSupportedAtCurrentProtocolVersion
                                 Level1UpdatePayload (Level1KeysLevel1Update u) -> checkSigAndEnqueue $ UVLevel1Keys u
                                 Level1UpdatePayload (Level2KeysLevel1Update u) -> case sauv of
                                     SAuthorizationsVersion0 -> checkSigAndEnqueue $ UVLevel2Keys u
@@ -2851,6 +2854,9 @@ handleChainUpdate (WithMetadata{wmdData = ui@UpdateInstruction{..}, ..}, maybeVe
                                     _ -> return $ TxInvalid NotSupportedAtCurrentProtocolVersion
                                 Level1UpdatePayload (Level2KeysLevel1UpdateV2 u) -> case sauv of
                                     SAuthorizationsVersion2 -> checkSigAndEnqueue $ UVLevel2Keys u
+                                    _ -> return $ TxInvalid NotSupportedAtCurrentProtocolVersion
+                                Level1UpdatePayload (Level2KeysLevel1UpdateV3 u) -> case sauv of
+                                    SAuthorizationsVersion3 -> checkSigAndEnqueue $ UVLevel2Keys u
                                     _ -> return $ TxInvalid NotSupportedAtCurrentProtocolVersion
                                 TimeoutParametersUpdatePayload u -> case sIsSupported SPTTimeoutParameters scpv of
                                     STrue -> checkSigAndEnqueue $ UVTimeoutParameters u
@@ -2877,6 +2883,8 @@ handleChainUpdate (WithMetadata{wmdData = ui@UpdateInstruction{..}, ..}, maybeVe
                                             handleCreatePLT uiHeader payload >>= \case
                                                 Left invalidReason -> return $ TxInvalid invalidReason
                                                 Right valid -> buildValidTxSummary' valid
+                                -- TODO: added in subsequent PR
+                                MaxLockDurationUpdatePayload{} -> return $ TxInvalid NotSupportedAtCurrentProtocolVersion
   where
     scpv :: SChainParametersVersion (ChainParametersVersionFor (MPV m))
     scpv = chainParametersVersion

--- a/concordium-consensus/test-runners/app/Main.hs
+++ b/concordium-consensus/test-runners/app/Main.hs
@@ -343,7 +343,8 @@ main = do
                         { _ppBakerStakeThreshold = 300000000000
                         },
                   _cpFinalizationCommitteeParameters = NoParam,
-                  _cpValidatorScoreParameters = NoParam
+                  _cpValidatorScoreParameters = NoParam,
+                  _cpMaxLockDuration = NoParam
                 }
     let (genesisData, bakerIdentities, _) =
             makeGenesisDataV0 @PV

--- a/concordium-consensus/test-runners/catchup/Main.hs
+++ b/concordium-consensus/test-runners/catchup/Main.hs
@@ -372,7 +372,8 @@ main = do
                         { _ppBakerStakeThreshold = 300000000000
                         },
                   _cpFinalizationCommitteeParameters = NoParam,
-                  _cpValidatorScoreParameters = NoParam
+                  _cpValidatorScoreParameters = NoParam,
+                  _cpMaxLockDuration = NoParam
                 }
     let (genesisData, bakerIdentities, _) =
             makeGenesisDataV0 @PV

--- a/concordium-consensus/test-runners/deterministic/Main.hs
+++ b/concordium-consensus/test-runners/deterministic/Main.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -Wno-deprecations #-}
 
@@ -290,7 +291,7 @@ initialState numAccts = do
     return SimState{..}
   where
     chainParams =
-        Dummy.dummyChainParameters
+        (Dummy.dummyChainParameters' @ChainParametersV1)
             { _cpConsensusParameters = ConsensusParametersV0{_cpElectionDifficulty = makeElectionDifficulty 50000},
               _cpExchangeRates = makeExchangeRates 1 1,
               _cpFoundationAccount = maxBakerId + 1

--- a/concordium-consensus/tests/consensus/ConcordiumTests/EndToEnd/CredentialDeploymentTests.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/EndToEnd/CredentialDeploymentTests.hs
@@ -106,7 +106,7 @@ testBB1 =
                         SP8 -> read "9edf091441b19468d82a637c270472b0474592f3089e56415e4982351b095d35"
                         SP9 -> read "ad588c91476f5865dabf2ffe9b6954c924479aa0a2ef4057a5b79dbc110b1219"
                         SP10 -> read "5272b398aa5ade5ef14c6be41d586537f5212d96ea609b414bf2051e0c3780f7"
-                        SP11 -> read "5a286c00ef3f83a6dcb7c2e461fee2ab806217a8a5bf176d2edffc5937433139"
+                        SP11 -> read "522349e4e7a6f09423a98d2c4d3cd1123e84eda30118fd605c4635df44943623"
                     }
         }
   where
@@ -140,7 +140,7 @@ testBB2 =
                         SP8 -> read "7ead7edff60ac23771f15052278304e3e2c9186826439ec7d04e28e55676f41b"
                         SP9 -> read "29d974384b047eaa8cb5b809dd37e9fe617e046ad22b7f9dbe605cdac9cf8e40"
                         SP10 -> read "29d974384b047eaa8cb5b809dd37e9fe617e046ad22b7f9dbe605cdac9cf8e40"
-                        SP11 -> read "dca21bbc3d8ff517a94cc3f4767cd5af3c0ddc18a82f83dfd1107f3d4f30fde7"
+                        SP11 -> read "bc1e7ce7ee57028bca894df32532e6a67de2823cdf4b588ef19494c4d41098ab"
                     }
         }
   where
@@ -174,7 +174,7 @@ testBB3 =
                         SP8 -> read "c8b3fc868c79703945638c709c9e2d03b67c3f70b023aac8ae5b980b41181726"
                         SP9 -> read "0282c255df3cb95180050ae3ee8838c0ab303fa7fe4e5e754ecf5d4c8db5152a"
                         SP10 -> read "0282c255df3cb95180050ae3ee8838c0ab303fa7fe4e5e754ecf5d4c8db5152a"
-                        SP11 -> read "bf2216807a09431a102ad4e8f1eb58bdbebc7b0630b1d8f2460dcc9147f48688"
+                        SP11 -> read "b233a10b1c58cbc266a395dab7f2656bb1f172730af7121d93157fe92de19f22"
                     }
         }
   where
@@ -232,7 +232,7 @@ testBB2' =
                         SP8 -> read "3abd796108d6fdcdf8c4361973d7152973cad3695b58b0c92a4e5021c0f80e33"
                         SP9 -> read "e10fe99a06aec8675f442ef0232ff0af9106ad6f5845335513603bcb4f3ff707"
                         SP10 -> read "0182d9155fb80b22fa43b8f7e1d9da389209bfa27340ec5a823a3f587e4455f9"
-                        SP11 -> read "134415ff5ee3871a00805f9d99ab0d262c15c60b7dd0fc748c39a2041810ce07"
+                        SP11 -> read "7b6eb9799667f9a9740c4d2bab3584006607d3955ce170718a45aef19849166c"
                     }
         }
   where
@@ -266,7 +266,7 @@ testBB3' =
                         SP8 -> read "9e46988a9afd8470e25c33f2133d2c10cbb38050979957f200b4aca072e3c932"
                         SP9 -> read "075e1732e475a84b89f1ba89c06d58df7d7e42936dc16e0cf3d8b02dacf27c52"
                         SP10 -> read "2a9b336c419c9e64dc7db6735a297119649c4b579ac4d32ac58e1ab09302d17c"
-                        SP11 -> read "72cb461a2be08aec4ba5ccba84e09300b09ee1af6912018b25ec54eab2da0e23"
+                        SP11 -> read "a3fce70d95978c024471ae47729e84d3ca7e5fb20e33783b82ccf93826366364"
                     }
         }
   where
@@ -298,7 +298,7 @@ testBB4 =
                         SP8 -> read "5bdf447992d82321a921bca9eeb6211bf3a290029164976885cf6b2fd14d923c"
                         SP9 -> read "ff90510a80285645170b5ff4614af366de2d8898e2bee111cae61e05ad640ada"
                         SP10 -> read "ff90510a80285645170b5ff4614af366de2d8898e2bee111cae61e05ad640ada"
-                        SP11 -> read "9f43139a2d197c7c9c839e1cef473fa5139ade2649ae800fa14c47c1e91c356e"
+                        SP11 -> read "03b436d4fe2dc0592098ada97e6395babf338f878cdd041ca503ca55aab6bb29"
                     }
         }
   where
@@ -330,7 +330,7 @@ testBB5 =
                         SP8 -> read "e704583a45aec569aca9039e977d9a3a7c2db8bdfd650532182600b6a19cbb70"
                         SP9 -> read "6ad235a2db0349340044197b9c23da565f6bf4dd1ad40b89eab5bae7bcab0997"
                         SP10 -> read "6ad235a2db0349340044197b9c23da565f6bf4dd1ad40b89eab5bae7bcab0997"
-                        SP11 -> read "c7582c9cdf70fbb4463dce18277c1e495d2b74e3635ecfc5707e30ae5c3cf213"
+                        SP11 -> read "862ed29041ef682c1ee440836f0f71d4f7ac91e38ee5e8228c78f031db38344e"
                     }
         }
   where

--- a/concordium-consensus/tests/consensus/ConcordiumTests/EndToEnd/TransactionTableIntegrationTest.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/EndToEnd/TransactionTableIntegrationTest.hs
@@ -75,7 +75,7 @@ testBB1 =
                         SP8 -> read "6f02a3e339abab1af9d23bc74369b6e142ad3b09f4d7042d16e076e225e3753f"
                         SP9 -> read "27ad830abd9d1f456f2a1666365ffff1fb216911d8dab2fbae5d3ad701816733"
                         SP10 -> read "5634a54bfdfb954205b78129c93236fba97b3190ad3fa412b4e2ffbaad6e7324"
-                        SP11 -> read "54d0c1eac303ede359f6f5fae1d92ecd7f6d8413fec5c78c78b6c4dddba02d5c"
+                        SP11 -> read "0b21ad3509826ffc26e6bb93c83bc0fecc34e4dd3a1eccf3ff662504c9f02ab4"
                     }
         }
   where
@@ -109,7 +109,7 @@ testBB2 =
                         SP8 -> read "b0c8b7a3872b7bb35a9df1f620e47f2b7dad09889b29772d7bc03d713cff862d"
                         SP9 -> read "3017ca78e30e5bfc25a15849c07b1266c46185340b909e26aee439ddc694af7b"
                         SP10 -> read "3017ca78e30e5bfc25a15849c07b1266c46185340b909e26aee439ddc694af7b"
-                        SP11 -> read "ce6422ea14d286970f346aa59025debb89ceb1be99324b7a9f087de4f65e91cb"
+                        SP11 -> read "6dd9d1bfb51c4bed46ba51740a96e115d631e737c747d8e6d4ba60acc3b9b444"
                     }
         }
   where
@@ -143,7 +143,7 @@ testBB3 =
                         SP8 -> read "8adf29ed11f4784b4b32dbf84887ff9f5dd38ef2f78dbefe579822b48acd9e51"
                         SP9 -> read "8935d7fb4c2906ecf1e10b225e319fb39933ca7b0970b93084e4b7b6b01a8dca"
                         SP10 -> read "8935d7fb4c2906ecf1e10b225e319fb39933ca7b0970b93084e4b7b6b01a8dca"
-                        SP11 -> read "15279dd38b91f69114e25658e537f12fe3c4839bf56bf0bbb4249f8ba2ebab20"
+                        SP11 -> read "5a6476c0ec4939cfc0258755ad5b07df8c445d38423f9df7028d09d3eff21237"
                     }
         }
   where
@@ -176,7 +176,7 @@ testBB4 =
                         SP8 -> read "487c4bdf8af054727f0688bd8a7176f6c2a9c85dffc5d8acc1de23e0c3b6ef49"
                         SP9 -> read "fe5c4a3c4943440c34a72884ccf178af8f7b2043f0179b6bbf554574bb4ba581"
                         SP10 -> read "7ccdea365c8283b97af6b5d00fedc17853e84021dcbf1417c34fefbfe7736091"
-                        SP11 -> read "7871e2eace30dda1d602db9438b9a5b7ef90827e10711e0a282017ad421815f1"
+                        SP11 -> read "c13a17b04b3d999288f7a97ab6e40d2069519b1502ab99f9e076ea9ad0229f68"
                     }
         }
   where

--- a/concordium-consensus/tests/consensus/ConcordiumTests/FinalizationRecover.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/FinalizationRecover.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-deprecations #-}
 
 module ConcordiumTests.FinalizationRecover where
@@ -55,7 +56,7 @@ genesis nBakers =
         []
         1234
         Dummy.dummyKeyCollection
-        Dummy.dummyChainParameters
+        (Dummy.dummyChainParameters' @ChainParametersV0)
 
 makeFinalizationInstance :: BakerIdentity -> FinalizationInstance
 makeFinalizationInstance bid = FinalizationInstance (bakerSignKey bid) (bakerElectionKey bid) (bakerAggregationKey bid)

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/CatchUp.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/CatchUp.hs
@@ -426,7 +426,7 @@ hashesRound4Block sProtocolVersion = case sBlockHashVersionFor sProtocolVersion 
                 spv
                     | TestBlocks.blockResultHashAsP9 spv ->
                         read "93837fbd7183afca6f32723f44f13f68a980b30e832ff93b5ed1c7a5e19ecdaa"
-                SP11 -> read "8fef1fa579c3fa44a592592f5b5c683e05188927cd147b680b8f1c70e39129b6"
+                SP11 -> read "01095208aa0dd2f03133fe9f31fba1db2d55225cded7682ad033bb2ad32046ff"
                 spv -> TestBlocks.dummyBRH spv 0xc04
             }
 

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Consensus.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Consensus.hs
@@ -40,7 +40,7 @@ genesisDataV1 ::
     SProtocolVersion pv ->
     (GenesisData pv, [(BakerIdentity, FullBakerInfo)], Amount)
 genesisDataV1 sProtocolVersion =
-    makeGenesisDataV1 @pv
+    makeGenesisDataV1
         0
         10
         3_600_000
@@ -50,7 +50,7 @@ genesisDataV1 sProtocolVersion =
         [ foundationAcct
         ]
         (withIsAuthorizationsVersionFor sProtocolVersion Dummy.dummyKeyCollection)
-        Dummy.dummyChainParameters
+        (Dummy.dummyChainParameters @pv)
   where
     foundationAcct =
         Dummy.createCustomAccount

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Consensus/Blocks.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Consensus/Blocks.hs
@@ -85,7 +85,7 @@ genesisDataV1 ::
     SProtocolVersion pv ->
     (GenesisData pv, [(BakerIdentity, FullBakerInfo)], Amount)
 genesisDataV1 sProtocolVersion =
-    makeGenesisDataV1 @pv
+    makeGenesisDataV1
         genTime
         (maxBaker + 1)
         genEpochDuration
@@ -95,7 +95,7 @@ genesisDataV1 sProtocolVersion =
         [ foundationAcct
         ]
         (withIsAuthorizationsVersionFor sProtocolVersion Dummy.dummyKeyCollection)
-        Dummy.dummyChainParameters
+        (Dummy.dummyChainParameters @pv)
   where
     foundationAcct =
         Dummy.createCustomAccount
@@ -352,7 +352,7 @@ testBB1 =
                         SP7 -> read "0970b0f7459e5150a56ac283eee6f587fc49cb1c3408146b46ee05457235bec7"
                         SP8 -> read "69f807bdafa7ef495089545cf89837cbcd5d1424fe53770efae4608a8bbf7560"
                         spv | blockResultHashAsP9 spv -> read "747769e675019732bd4de37f2486ed696bea329b9c31b618a1e3a583ed5e4aaf"
-                        SP11 -> read "254a46adc7c472f81f6fdb9227f26cadce54616fa55d9a29b299acbf7d45b286"
+                        SP11 -> read "d3f3adf8ea10ca5dfd9db12b477683d55bc6058c88b0ef30971f3f0ee0540e04"
                         spv -> dummyBRH spv 1
                     }
         }
@@ -385,7 +385,7 @@ testBB2 =
                         SP7 -> read "2e6636b8275663e44452650e4b7968ecb26a32d57998fbbccc0292fdecb1522d"
                         SP8 -> read "8315e1c9ac06bf9b8d0902616dda6781648baef8765be529d583267ea6376a17"
                         spv | blockResultHashAsP9 spv -> read "6434d129fa41e0b469a056369f63e1f6eaafbfed3539c84c2f1542ae8e6cbcb2"
-                        SP11 -> read "86bba28814121db31389fe10beadfa8b17d49d2315f11fb0683f117bb1ed0230"
+                        SP11 -> read "203e38435cea753e0ad8c33d809d5e954aca401b0767d223b6cae4f7ba0ca34b"
                         spv -> dummyBRH spv 2
                     }
         }
@@ -418,7 +418,7 @@ testBB3 =
                         SP7 -> read "5777ce2df452ce52ee6beb43c555051588cdad67ad742e7be438cf9d22e31950"
                         SP8 -> read "aa38f2426aecf0103671767ececf2a5a5cbc6ebf20cb929d90f6cfd086bba258"
                         spv | blockResultHashAsP9 spv -> read "df8dd05c64cab1f1a6ba4c971aa751d1dfb653dfed3605a1334f601f1f808acf"
-                        SP11 -> read "57e6bdcb2a68735c4cbbd904b73347253ed156225d40a0b841c758bb95fd7944"
+                        SP11 -> read "47470bc2344fb86ac594688c34107951d135d727cae581b7b89a6be8853ddecf"
                         spv -> dummyBRH spv 3
                     }
         }
@@ -444,7 +444,7 @@ testBB2' =
                         SP7 -> read "04185ac844f6aea6e32b667debd1e9a337d67a80350d12f1cb813bf212a4bc23"
                         SP8 -> read "0b7a0106ac9293606424bf03e9f0314c3ac8e41a4097f30435eb9b2ee9463aa4"
                         spv | blockResultHashAsP9 spv -> read "bf7634ab27d1c7509d6d230f78e7df94eea7f53c04f3f92619c901b042a1b663"
-                        SP11 -> read "a19e7e286a146c98ecca8ff6248281eaa071faf8c2eca86e8316e62c341de947"
+                        SP11 -> read "52f37eb291badff400348b697b6c2599f86dbf8b863abb43cd683cb173c0a2ce"
                         spv -> dummyBRH spv 0x102
                     }
         }
@@ -471,7 +471,7 @@ testBB3' =
                         SP7 -> read "11e59c1a721359a64b86a0c6bcee8f6cac7c5bc3a6b98517b0b4f8c5a726f9c5"
                         SP8 -> read "0a1d22fd9404974bb43616ad3d0152acb9de40f856b6fb66150b2c496730add5"
                         spv | blockResultHashAsP9 spv -> read "0d6386d76cff950e60543a03485cbbee5e11667e2ad09dc77a48cce5168dab58"
-                        SP11 -> read "9211d233f24c44770e4553c42dcb0d56e222c86a20c7101e422c8559d69f1392"
+                        SP11 -> read "ed59b6d758ac2993af07853b3e806a6eaee89f66c7ab4b53cd3dd12bcac8b243"
                         spv -> dummyBRH spv 0x103
                     }
         }
@@ -505,7 +505,7 @@ testBB4' =
                         SP7 -> read "ad8a288f88806037899d782b7dd3a37ade59e0d5f3e7a90b1db2b722ae9cbe3d"
                         SP8 -> read "1afb0b0bd86301671549f1b1e407d71818d1d9d29c19beed584d17e2ace638d4"
                         spv | blockResultHashAsP9 spv -> read "874ad0c151a7e2ec3252af524de4348203f5ac607580dd99e1c70bce94787b93"
-                        SP11 -> read "9aa754b61722d5f8129c4e3690df6dad3659a570a3f2fdfc4ef2d222a7afc3bd"
+                        SP11 -> read "52ecc3d0e78907d28ac99d971123952dc9bc701a5b42e6368fe08b433474da76"
                         spv -> dummyBRH spv 0x104
                     }
         }
@@ -564,7 +564,7 @@ testBB1E =
                         SP7 -> read "1811353ec3811af6241f3e5dc2e19740acf518f02dccc51f427310b8cfe9ca6c"
                         SP8 -> read "a002fe8adf77ca8cb992fd25dd3c5430db7ee52e383212eeb0827170af323d2e"
                         spv | blockResultHashAsP9 spv -> read "f59f26a1b1da5858ccc51589c7eb9227493434aa0788f3fb8ffb3104ecebe4fb"
-                        SP11 -> read "db39ad8956645cbcbcc053dff0d96cc6b04c639aa21e280f6eb7a6b56a297f20"
+                        SP11 -> read "f46af052480825962e506e703c1714152f16e3297754a09623ee5e47922775f5"
                         spv -> dummyBRH spv 0xe01
                     }
         }
@@ -597,7 +597,7 @@ testBB2E =
                         SP7 -> read "99fc52af1ee2336f0d353a84c4d6c15345882271f648f7b84e69d9c40d5571c2"
                         SP8 -> read "af4910f96957a8fc36844cfd1ca9dfadd47776b2a5b4e5f23011b4f580a01902"
                         spv | blockResultHashAsP9 spv -> read "8e068776dc01e0079a00d9b531897e2a1e732c91ce9db92d64fd2cd183cea83e"
-                        SP11 -> read "0b932aee7d4ad4c6567759ab723d655e0e1423d1f425c1664aafa9d69279f9e2"
+                        SP11 -> read "f738453456587d417cf5e0700ebf4ff23a2f70990f52242fcbf2193ea2b3d94c"
                         spv -> dummyBRH spv 0xe02
                     }
         }
@@ -632,7 +632,7 @@ testBB3EX =
                         SP7 -> read "0236b72bafe1575fdde0b01b35d24ad16613569600b83ed46b7e17c3c3dbaf28"
                         SP8 -> read "854f08741a720a65b136eceae61cdb5fa59dd5f1af8bdcb58e41e850fec5034d"
                         spv | blockResultHashAsP9 spv -> read "abe0485900b7b651c670f2fa506534ec2bc095f6d586a92f5b5b1160ca73c58c"
-                        SP11 -> read "42a2780099bfb291f58847348cc64bb0f92f6ef96cfbbbb4cfa92b9bbdcefdf8"
+                        SP11 -> read "182304eb4fc6f2f3f34f5a3876a680609b0f29c96547822484bdb7c7b0c5f5b0"
                         spv -> dummyBRH spv 0x1e03
                     }
         }
@@ -683,7 +683,7 @@ testBB3E =
                         SP7 -> read "2a12a1b02d8cfb835d6f572ffd3a0156145ec2142b47ef7b9e9495b61ff241b7"
                         SP8 -> read "d3cf0aa2e2c6fc2fd7d0be7f4192cc8d04e3afce1041d194a2c9ae437bc4aad6"
                         spv | blockResultHashAsP9 spv -> read "87df979129f4462d51ca7214068557add1e4ecbb7ef097f2dc76bcc9ea7c90bb"
-                        SP11 -> read "d1f819ecf0f67b3c59da232d8802d67d1ed1a131da1195534d0b515e7a93e183"
+                        SP11 -> read "9429416c73a2ccd34e754f5532d21db9ffda4314179c81f1cb3d91df3863b622"
                         spv -> dummyBRH spv 0xe03
                     }
         }
@@ -727,7 +727,7 @@ testBB4E =
                         SP7 -> read "66cf8d97a956e2306e60337848775d606f575bd48f4d1e4420d4cf579d5bfb0e"
                         SP8 -> read "d11da8da6f4a14fe5221847690e754450e79d65ad7e7ab1606f4f14d333f3a53"
                         spv | blockResultHashAsP9 spv -> read "5f84d37c5c7d22893a285f3229d3b19dc9933e8220dbce84dc3f5bb7d1e325f1"
-                        SP11 -> read "8bdbe771749fd21e8b9b5981eee43ea21254193240f565384e0756790b27ab8b"
+                        SP11 -> read "2012577704a907729ad4e8535a9f19efde503a77b7b2a2a96fdeea38233da769"
                         spv -> dummyBRH spv 0xe04
                     }
         }
@@ -755,7 +755,7 @@ testBB4E' =
                         SP7 -> read "e0d460456228a923c4d0116b6add192b491279b24ce160067652e1afa11bac56"
                         SP8 -> read "51894272a8818fc7ad4290f921bb2ff0488a098ebd0697b479136ec6ae5f5ed7"
                         spv | blockResultHashAsP9 spv -> read "e44e1e7f0eac84030f80fe191c8ca9216da54a8533b9602c249d9b0a89b08ed9"
-                        SP11 -> read "54f835e79543a15b08aad0bd899a95b908582f62fe0b77701da33ec468ecf4b3"
+                        SP11 -> read "1033970523d2450c70afc4383db48fc2ef62048fc112a66aeeeee9ad1ac71fd1"
                         spv -> dummyBRH spv 0x1e04
                     }
         }
@@ -790,7 +790,7 @@ testBB5E' =
                         SP7 -> read "2c8ff8fbc07b5e1486ebad3e241fa0aefdb7637651c6120b0a50a27057f7431a"
                         SP8 -> read "970f5145277abea69844b53189c803ad7d5a8fd19105208ae4c580957224099a"
                         spv | blockResultHashAsP9 spv -> read "d15789473fdb0b472bd1e1c2590f2b069ffe4c58a7079fec0e4f737a46d2c3f5"
-                        SP11 -> read "f907023b395cc115cad152fabe69c43b6674232a8e161bdf73ef3a96794a8d72"
+                        SP11 -> read "3bd0aedea2e591acf56454ba6307f0b6c02497faafa785b81c43e76ae75758fd"
                         spv -> dummyBRH spv 0x1e05
                     }
         }
@@ -838,7 +838,7 @@ testBB2Ex =
                         SP7 -> read "a562963223c07cbcee46e78bba06968d578120b71eaf59d8ce12f3f384b21f47"
                         SP8 -> read "85974099bbc92a64a27df7d057d130dd4eabcc0a8e605f701b449db3e68b3c3b"
                         spv | blockResultHashAsP9 spv -> read "781624811b67e3c24f2e0d4b3596e4b973fe52306ba43448a47748e6f25269a0"
-                        SP11 -> read "7e7777955e70566567f3e8cf8cdee8332d85590eb22822b4c893628a8679bbde"
+                        SP11 -> read "70bc5a75405ee38ad24958a993c61f0b2dc8bcb233f0c3cc7d26b80b843b2df1"
                         spv -> dummyBRH spv 0x0f02
                     }
         }
@@ -888,7 +888,7 @@ testBB3Ex =
                         SP7 -> read "2ea4f556dc29b5a1774635cb670f7b9aa3182eb2cc685b0e4f59daf9541cb539"
                         SP8 -> read "fcb11273e588af86426c36f3d825d6eaf3d6db29339a071253ce764b4be3d45e"
                         spv | blockResultHashAsP9 spv -> read "0cf1a98c6f1c0798cc2441633cabada717c2c9c2344f9f8593934ae5abf1d56f"
-                        SP11 -> read "91dfb964896dd5996cf5d8a48829ca88841a203dba9209cb2c05e030270fac3b"
+                        SP11 -> read "61d2610d673a0996d7b18f023b1648ee145bbc893e7ea070d5903a6798b04947"
                         spv -> dummyBRH spv 0x1e03
                     }
         }
@@ -926,7 +926,7 @@ testBB3EA =
                         SP7 -> read "99fc52af1ee2336f0d353a84c4d6c15345882271f648f7b84e69d9c40d5571c2"
                         SP8 -> read "af4910f96957a8fc36844cfd1ca9dfadd47776b2a5b4e5f23011b4f580a01902"
                         spv | blockResultHashAsP9 spv -> read "8e068776dc01e0079a00d9b531897e2a1e732c91ce9db92d64fd2cd183cea83e"
-                        SP11 -> read "0b932aee7d4ad4c6567759ab723d655e0e1423d1f425c1664aafa9d69279f9e2"
+                        SP11 -> read "f738453456587d417cf5e0700ebf4ff23a2f70990f52242fcbf2193ea2b3d94c"
                         spv -> dummyBRH spv 0x2f03
                     }
         }
@@ -964,7 +964,7 @@ testBB4EA =
                         SP7 -> read "e0d460456228a923c4d0116b6add192b491279b24ce160067652e1afa11bac56"
                         SP8 -> read "e5c82e4ff33f6f068704a4da8a829e3e27659df26512a5b6449d4e27c50b0c5d"
                         spv | blockResultHashAsP9 spv -> read "71df1f4743ed4401ff0ec3d3b8dc3edc66b639f3aa2c564f583a7c622fa46f76"
-                        SP11 -> read "cecab17d3b19b09785116c754e205a0a53410bdf5f4064ce7585b584b51654b9"
+                        SP11 -> read "5d2ac438cfe57cbe4c01007b545a6d2f5e96f4b6b0871f7b928a248e28d7eabd"
                         spv -> dummyBRH spv 0x2f04
                     }
         }
@@ -1017,7 +1017,7 @@ testBB1T =
                         SP8 -> read "928a6ab0ca2a38086812bdbf39d46737345c358479d35c435f97c609ee0e215d"
                         SP9 -> read "ba0d5ccac35703d012901d95669aea8088530b89d0e887f76c0b0ade4dd9c829"
                         SP10 -> read "4a3d62fc566532a0151727c50cd80190e07f44b474f7074623b1e89646be9044"
-                        SP11 -> read "347a54c18d2d9395aadca56be5fa2601dbd2bdc60ecbd350a0d78472eef57965"
+                        SP11 -> read "5a7892300284c29a89b704c5c56beb915686bcebdc483bc24f23866cd5132abf"
                         spv -> dummyBRH spv 0x7001
                     }
         }
@@ -1051,7 +1051,7 @@ testBB2T =
                         SP8 -> read "60905a3baea93cf9564621ff1d8bbbc2469b50f26d101d125a092d104ca4fe16"
                         SP9 -> read "691a94879d0b135e6b55bb8afdc6740f4a29d0a5ab94670bec0fb02b36291bd0"
                         SP10 -> read "3a1fe79e0c5df5a73a55a02c9f410da73e10cfb02094fd053ef180ca3d6d8bac"
-                        SP11 -> read "1d1e9bd0d690cfbdbaadb656c0968729730e2ad81a809f5e38e3c537fef10ce9"
+                        SP11 -> read "35337ca110753d8b16a2d64f721c6df7484f3c19017c573c1da3c5db60f4d179"
                         spv -> dummyBRH spv 0x7002
                     }
         }
@@ -1091,7 +1091,7 @@ testBB3T =
                         SP8 -> read "8f1d79480a04412221a6a90c02ff98b8c59f08510067691c005f2e36b3c32563"
                         SP9 -> read "51fbaf0502c838c7455786ac3c0397c51f3e6116a71cdc4a759b3a4bd243907f"
                         SP10 -> read "eafb304cf3a771810688878fbc3b19d265d3728c455d9ae4941deacdbd7abbc6"
-                        SP11 -> read "74ceb7b50405b7ba469faa456cf03b7c6f2b252fcca5b2eee59e3d352bf6a2aa"
+                        SP11 -> read "c2802bcacc4ce5f031df6a0820c0fdaff9e5c877e53a263db7fd0d6175c5bc95"
                         spv -> dummyBRH spv 0x7003
                     }
         }
@@ -1126,7 +1126,7 @@ testBB4T =
                         SP8 -> read "efbd04f230226d140dcb1bd9a4eb06c0583a2b6edfa16dac2dde895383559998"
                         SP9 -> read "0f73ad403626533632c43f2ca5938f9c3abb658df73a45328a5ca8c6630a973b"
                         SP10 -> read "0f73ad403626533632c43f2ca5938f9c3abb658df73a45328a5ca8c6630a973b"
-                        SP11 -> read "22f37d67c6eb781310e244aae54daca34362fa1f92507ed34f25379df97b6e2c"
+                        SP11 -> read "40d5f62f99ee0e2fcfa0aa07edcc7105dafc4615ede248016db3891d1187e78b"
                         spv -> dummyBRH spv 0x7004
                     }
         }
@@ -1161,7 +1161,7 @@ testBB5T =
                         SP8 -> read "242e8f6bf7e2a6fc9263b95b6e233b43010308d061e1f511b920ff7deea3ac9f"
                         SP9 -> read "f375cd289ab3c51ff09cb910dcc89d942ea26a3c22904b0dd37a933c21805634"
                         SP10 -> read "f375cd289ab3c51ff09cb910dcc89d942ea26a3c22904b0dd37a933c21805634"
-                        SP11 -> read "13df774a7af01705c6f76d9589cb11088c3c23ec931428952e2d440a146ddae2"
+                        SP11 -> read "3380436e3e2b7523dc4abb37a574da0ea90315d03e4a395841926eaefd6e6e24"
                         spv -> dummyBRH spv 0x7005
                     }
         }

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Timeout.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Timeout.hs
@@ -73,7 +73,7 @@ genesisDataV1 sProtocolVersion =
         [ foundationAcct
         ]
         (withIsAuthorizationsVersionFor sProtocolVersion Dummy.dummyKeyCollection)
-        Dummy.dummyChainParameters
+        (Dummy.dummyChainParameters @pv)
   where
     foundationAcct =
         Dummy.createCustomAccount
@@ -667,7 +667,7 @@ testExecuteTimeoutMessages sProtocolVersion =
             [ foundationAcct
             ]
             (withIsAuthorizationsVersionFor sProtocolVersion Dummy.dummyKeyCollection)
-            Dummy.dummyChainParameters
+            (Dummy.dummyChainParameters @pv)
 
 -- | Tests the 'checkTimeoutCertificate' function.
 testCheckTimeoutCertificate ::

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/TransactionProcessingTest.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/TransactionProcessingTest.hs
@@ -262,7 +262,7 @@ makeTestingGenesisData idps =
             withIsAuthorizationsVersionFor
                 (protocolVersion @pv)
                 (dummyKeyCollection @(AuthorizationsVersionFor pv))
-        genesisChainParameters = dummyChainParameters @(ChainParametersVersionFor pv)
+        genesisChainParameters = dummyChainParameters @pv
         genesisLeadershipElectionNonce = Hash.hash "LeadershipElectionNonce"
         genesisAccounts = Vec.fromList $ makeFakeBakers 1
     in  case protocolVersion @pv of
@@ -434,7 +434,7 @@ testTransactionVerification _ = describe "transaction verification" $ do
     -- Create a context suitable for verifying a transaction within a 'Individual' context.
     getCtx = do
         _ctxBs <- bpState <$> gets' _lastFinalized
-        let chainParams = dummyChainParameters @(ChainParametersVersionFor pv)
+        let chainParams = dummyChainParameters @pv
         let _ctxMaxBlockEnergy = chainParams ^. cpConsensusParameters . cpBlockEnergyLimit
         return $! Context{_ctxTransactionOrigin = TVer.Individual, ..}
 

--- a/concordium-consensus/tests/consensus/ConcordiumTests/PassiveFinalization.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/PassiveFinalization.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans -Wno-deprecations #-}
 
@@ -32,7 +33,7 @@ import qualified Concordium.GlobalState.AccountMap.LMDB as LMDBAccountMap
 import Concordium.GlobalState.BakerInfo
 import Concordium.GlobalState.Block
 import qualified Concordium.GlobalState.BlockPointer as BS
-import Concordium.GlobalState.DummyData (dummyChainParameters, dummyKeyCollection)
+import Concordium.GlobalState.DummyData (dummyChainParameters', dummyKeyCollection)
 import Concordium.GlobalState.Finalization
 import Concordium.GlobalState.Parameters
 import Concordium.GlobalState.Persistent.Account
@@ -344,7 +345,7 @@ createInitStates additionalFinMembers = do
                 _ -> error "bis should be a list with four elements"
     let
         bakerAccounts = map (\(_, _, acc, _) -> acc) bis
-        cps = dummyChainParameters & cpConsensusParameters . cpElectionDifficulty .~ makeElectionDifficultyUnchecked 100000
+        cps = dummyChainParameters' @'ChainParametersV0 & cpConsensusParameters . cpElectionDifficulty .~ makeElectionDifficultyUnchecked 100000
         gen =
             GDP1
                 GDP1Initial

--- a/concordium-consensus/tests/consensus/ConcordiumTests/ReceiveTransactionsTest.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/ReceiveTransactionsTest.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -282,7 +283,7 @@ maxBlockEnergy = 3_000_000
 -- | Construct a genesis state with hardcoded values for parameters that should not affect this test.
 --  Modify as you see fit.
 testGenesisData :: UTCTime -> IdentityProviders -> AnonymityRevokers -> CryptographicParameters -> GenesisData PV
-testGenesisData now ips ars cryptoParams = makeTestingGenesisDataP5 (utcTimeToTimestamp now) 1 1 1 dummyFinalizationCommitteeMaxSize cryptoParams ips ars maxBlockEnergy dummyKeyCollection dummyChainParameters
+testGenesisData now ips ars cryptoParams = makeTestingGenesisDataP5 (utcTimeToTimestamp now) 1 1 1 dummyFinalizationCommitteeMaxSize cryptoParams ips ars maxBlockEnergy dummyKeyCollection (dummyChainParameters @PV)
 
 -- | Run the doReceiveTransaction function and obtain the results
 testDoReceiveTransaction :: [BlockItem] -> Slot -> TestSkovQueryMonad [(TransactionHash, UpdateResult)]

--- a/concordium-consensus/tests/consensus/ConcordiumTests/Update.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/Update.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans -Wno-deprecations #-}
 
@@ -107,7 +108,7 @@ createInitStates dir = do
             -- This does not happen due to how `bis` is constructed
             _ -> error "bis should be a list with two elements"
         bakerAccounts = (^. _3) <$> bis
-        cps = Dummy.dummyChainParameters & cpConsensusParameters . cpElectionDifficulty .~ makeElectionDifficultyUnchecked 100000
+        cps = Dummy.dummyChainParameters' @ChainParametersV0 & cpConsensusParameters . cpElectionDifficulty .~ makeElectionDifficultyUnchecked 100000
         gen =
             GDP1
                 GDP1Initial

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/AccountReleaseScheduleTest.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/AccountReleaseScheduleTest.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-deprecations #-}
 
 module GlobalStateTests.AccountReleaseScheduleTest (tests) where
@@ -85,7 +86,7 @@ createGS = do
             dummyIdentityProviders
             dummyArs
             dummyKeyCollection
-            dummyChainParameters
+            (dummyChainParameters @PV)
     -- save the block state so accounts are written to the lmdb database.
     void $ saveBlockState initState
     addr0 <- BS.accountCanonicalAddress acc0

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/BlockStateHelpers.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/BlockStateHelpers.hs
@@ -298,7 +298,7 @@ checkActiveBakers bs = do
             DummyData.dummyIdentityProviders
             DummyData.dummyArs
             (withIsAuthorizationsVersionFor spv DummyData.dummyKeyCollection)
-            DummyData.dummyChainParameters
+            (DummyData.dummyChainParameters @pv)
 
 dumpState :: (SupportsPersistentState pv m) => HashedPersistentBlockState pv -> m ()
 dumpState hpbs = do

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/ConfigureDelegator.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/ConfigureDelegator.hs
@@ -242,7 +242,7 @@ runAddDelegatorTest spv dtc@DelegatorTestConfig{..} da@DelegatorAdd{..} = runTes
   where
     flexibleCooldown = sSupportsFlexibleCooldown (sAccountVersionFor spv)
     chainParams =
-        DummyData.dummyChainParameters @(ChainParametersVersionFor pv)
+        DummyData.dummyChainParameters @pv
             & cpPoolParameters . ppCapitalBound .~ dtcCapitalBound
             & cpPoolParameters . ppLeverageBound .~ dtcLeverageBound
     mkInitialState accounts =
@@ -435,7 +435,7 @@ runUpdateDelegatorTest spv dtc@DelegatorTestConfig{..} du@DelegatorUpdate{..} = 
   where
     flexibleCooldown = sSupportsFlexibleCooldown (sAccountVersionFor spv)
     chainParams =
-        DummyData.dummyChainParameters @(ChainParametersVersionFor pv)
+        DummyData.dummyChainParameters @pv
             & cpPoolParameters . ppCapitalBound .~ dtcCapitalBound
             & cpPoolParameters . ppLeverageBound .~ dtcLeverageBound
     (oldCapital, oldRestake, oldTarget, oldPendingChange) =

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/ConfigureValidator.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/ConfigureValidator.hs
@@ -113,7 +113,7 @@ testAddValidatorAllCases spv = describe "bsoAddValidator" $ do
     supportSuspension = supportsValidatorSuspension $ accountVersionFor $ demoteProtocolVersion (protocolVersion @pv)
     minEquity = 1_000_000_000
     chainParams =
-        DummyData.dummyChainParameters @(ChainParametersVersionFor pv)
+        DummyData.dummyChainParameters @pv
             & cpPoolParameters . ppMinimumEquityCapital .~ minEquity
             & cpPoolParameters . ppCommissionBounds
                 .~ CommissionRanges
@@ -565,7 +565,7 @@ runUpdateValidatorTest spv commissionRanges ValidatorUpdateConfig{vucValidatorUp
     hasValidatorSuspension = sSupportsValidatorSuspension (accountVersion @(AccountVersionFor pv))
     minEquity = 1_000_000_000
     chainParams =
-        DummyData.dummyChainParameters @(ChainParametersVersionFor pv)
+        DummyData.dummyChainParameters @pv
             & cpPoolParameters . ppMinimumEquityCapital .~ minEquity
             & cpPoolParameters . ppCommissionBounds
                 .~ commissionRanges

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/CooldownProcessing.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/CooldownProcessing.hs
@@ -40,7 +40,7 @@ propProcessPrePreCooldowns cds = runTestBlockState @P7 $ do
             DummyData.dummyIdentityProviders
             DummyData.dummyArs
             DummyData.dummyKeyCollection
-            DummyData.dummyChainParameters
+            (DummyData.dummyChainParameters @P7)
     bs' <- bsoProcessPrePreCooldowns (hpbsPointers initialBS)
     newCooldowns <- checkCooldowns bs'
     liftIO $ assertEqual "Cooldowns" (processPrePreCooldown <$> cds) newCooldowns
@@ -57,7 +57,7 @@ propProcessCooldowns cds expire new = runTestBlockState @P7 $ do
             DummyData.dummyIdentityProviders
             DummyData.dummyArs
             DummyData.dummyKeyCollection
-            DummyData.dummyChainParameters
+            (DummyData.dummyChainParameters @P7)
     bs' <- bsoProcessCooldowns (hpbsPointers initialBS) expire new
     newCooldowns <- checkCooldowns bs'
     liftIO $ assertEqual "Cooldowns" (processPreCooldown new . processCooldowns expire <$> cds) newCooldowns

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/PersistentChainParameters.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/PersistentChainParameters.hs
@@ -64,10 +64,10 @@ instance (MonadBlobStore m, IsChainParametersVersion cpv) => BlobStorable m (Old
 
 -- | Store bytes in the historical layout and load them as the new persistent type.
 loadOldLayoutAsPersistent ::
-    forall cpv auv.
-    (IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
-    ChainParameters' cpv ->
-    MemBlobStoreT IO (PCP.PersistentChainParameters' cpv auv)
+    forall pv.
+    (IsProtocolVersion pv) =>
+    ChainParameters pv ->
+    MemBlobStoreT IO (PCP.PersistentChainParameters pv)
 loadOldLayoutAsPersistent chainParameters = do
     oldRef <- storeRef (OldPersistentChainParametersLayout chainParameters)
     loadRef (BlobRef (theBlobRef oldRef))
@@ -75,24 +75,24 @@ loadOldLayoutAsPersistent chainParameters = do
 -- | Assert that old-layout bytes load as persistent chain parameters and convert
 -- back to the public view without changing ordinary fields.
 assertOldLayoutLoadsAsPersistent ::
-    forall cpv auv.
-    (IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
-    ChainParameters' cpv ->
+    forall pv.
+    (IsProtocolVersion pv) =>
+    ChainParameters pv ->
     Assertion
 assertOldLayoutLoadsAsPersistent chainParameters = runWithNewMemBlobStore $ do
-    persistent <- loadOldLayoutAsPersistent @cpv @auv chainParameters
+    persistent <- loadOldLayoutAsPersistent @pv chainParameters
     let publicView = PCP.persistentChainParametersToChainParameters persistent
     liftIO $ assertEqual "old persistent layout should load as the new persistent type" chainParameters publicView
 
 -- | Assert that hashing pre-P11 persistent chain parameters is unchanged from
 -- hashing the historical persistent byte layout.
 assertOldLayoutHashCompatible ::
-    forall cpv auv.
-    (IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
-    ChainParameters' cpv ->
+    forall pv.
+    (IsProtocolVersion pv) =>
+    ChainParameters pv ->
     Assertion
 assertOldLayoutHashCompatible chainParameters = runWithNewMemBlobStore $ do
-    persistent <- loadOldLayoutAsPersistent @cpv @auv chainParameters
+    persistent <- loadOldLayoutAsPersistent @pv chainParameters
     persistentHash <- getHashM persistent
     let oldHash = H.hash (S.runPut (putOldPersistentChainParametersLayout chainParameters))
     liftIO $ assertEqual "persistent chain-parameter hash should match the historical layout hash" oldHash persistentHash
@@ -114,7 +114,7 @@ assertP10P11MigrationExposesMaxLockDuration :: Assertion
 assertP10P11MigrationExposesMaxLockDuration = runWithNewMemBlobStore $ do
     let duration = Duration 12345
         migration = StateMigrationParametersP10ToP11 (P11.StateMigrationData (p11ProtocolUpdateData duration))
-    persistent0 <- PCP.makePersistentChainParameters @(MemBlobStoreT IO) @'ChainParametersV3 @'AuthorizationsVersion2 p10ChainParameters
+    persistent0 <- PCP.makePersistentChainParameters @(MemBlobStoreT IO) @'P10 p10ChainParameters
     migratedMaybe <- runMaybeT $ Migration.migrateChainParameters migration persistent0
     migrated <- case migratedMaybe of
         Nothing -> liftIO $ assertFailure "P10-to-P11 chain-parameter migration unexpectedly failed"
@@ -159,7 +159,7 @@ assertP11InitialPersistentStateRequiresMaxLockDuration = do
 assertP11RoundtripExposesMaxLockDuration :: Assertion
 assertP11RoundtripExposesMaxLockDuration = runWithNewMemBlobStore $ do
     let duration = Duration 42
-    persistent0 <- PCP.makePersistentChainParameters @(MemBlobStoreT IO) @'ChainParametersV3 @'AuthorizationsVersion3 (p11ChainParameters duration)
+    persistent0 <- PCP.makePersistentChainParameters @(MemBlobStoreT IO) @'P11 (p11ChainParameters duration)
     (hash0 :: H.Hash) <- getHashM persistent0
     persistent1 <- loadRef =<< storeRef persistent0
     (hash1 :: H.Hash) <- getHashM persistent1
@@ -171,8 +171,8 @@ assertP11RoundtripExposesMaxLockDuration = runWithNewMemBlobStore $ do
 
 assertP11HashIncludesExternalChainParameters :: Assertion
 assertP11HashIncludesExternalChainParameters = runWithNewMemBlobStore $ do
-    persistent1 <- PCP.makePersistentChainParameters @(MemBlobStoreT IO) @'ChainParametersV3 @'AuthorizationsVersion3 (p11ChainParameters (Duration 1))
-    persistent2 <- PCP.makePersistentChainParameters @(MemBlobStoreT IO) @'ChainParametersV3 @'AuthorizationsVersion3 (p11ChainParameters (Duration 2))
+    persistent1 <- PCP.makePersistentChainParameters @(MemBlobStoreT IO) @'P11 (p11ChainParameters (Duration 1))
+    persistent2 <- PCP.makePersistentChainParameters @(MemBlobStoreT IO) @'P11 (p11ChainParameters (Duration 2))
     (hash1 :: H.Hash) <- getHashM persistent1
     (hash2 :: H.Hash) <- getHashM persistent2
     liftIO $ assertBool "P11 persistent chain-parameter hash should include external maxLockDuration" (hash1 /= hash2)
@@ -180,7 +180,7 @@ assertP11HashIncludesExternalChainParameters = runWithNewMemBlobStore $ do
 assertP11ConstructionRequiresMaxLockDuration :: Assertion
 assertP11ConstructionRequiresMaxLockDuration = do
     result <- try $ runWithNewMemBlobStore $ do
-        persistent <- PCP.makePersistentChainParameters @(MemBlobStoreT IO) @'ChainParametersV3 @'AuthorizationsVersion3 p10ChainParameters
+        persistent <- PCP.makePersistentChainParameters @(MemBlobStoreT IO) @'P11 p10ChainParameters
         liftIO $ evaluate persistent
     case result of
         Left (_ :: ErrorCall) -> return ()
@@ -189,18 +189,18 @@ assertP11ConstructionRequiresMaxLockDuration = do
 tests :: Spec
 tests = describe "GlobalStateTests.PersistentChainParameters" $ do
     it "loads old CPV0 persistent bytes as node-owned persistent chain parameters" $
-        assertOldLayoutLoadsAsPersistent @'ChainParametersV0 @'AuthorizationsVersion0 dummyChainParameters'
+        assertOldLayoutLoadsAsPersistent @'P1 dummyChainParameters'
     it "loads old CPV1 persistent bytes as node-owned persistent chain parameters" $
-        assertOldLayoutLoadsAsPersistent @'ChainParametersV1 @'AuthorizationsVersion1 dummyChainParameters'
+        assertOldLayoutLoadsAsPersistent @'P4 dummyChainParameters'
     it "loads old CPV2 persistent bytes as node-owned persistent chain parameters" $
-        assertOldLayoutLoadsAsPersistent @'ChainParametersV2 @'AuthorizationsVersion1 dummyChainParameters'
+        assertOldLayoutLoadsAsPersistent @'P6 dummyChainParameters'
     it "loads old pre-P11 CPV3 persistent bytes as node-owned persistent chain parameters" $
-        assertOldLayoutLoadsAsPersistent @'ChainParametersV3 @'AuthorizationsVersion2 p10ChainParameters
+        assertOldLayoutLoadsAsPersistent @'P10 p10ChainParameters
     it "keeps old pre-P11 persistent chain-parameter hashes unchanged" $ do
-        assertOldLayoutHashCompatible @'ChainParametersV0 @'AuthorizationsVersion0 dummyChainParameters'
-        assertOldLayoutHashCompatible @'ChainParametersV1 @'AuthorizationsVersion1 dummyChainParameters'
-        assertOldLayoutHashCompatible @'ChainParametersV2 @'AuthorizationsVersion1 dummyChainParameters'
-        assertOldLayoutHashCompatible @'ChainParametersV3 @'AuthorizationsVersion2 p10ChainParameters
+        assertOldLayoutHashCompatible @'P1 dummyChainParameters'
+        assertOldLayoutHashCompatible @'P4 dummyChainParameters'
+        assertOldLayoutHashCompatible @'P6 dummyChainParameters'
+        assertOldLayoutHashCompatible @'P10 p10ChainParameters
     it "migrates P10 chain parameters to P11 with protocol-update maxLockDuration" $
         assertP10P11MigrationExposesMaxLockDuration
     it "initializes P11 persistent state with genesis maxLockDuration" $

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/PersistentChainParameters.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/PersistentChainParameters.hs
@@ -7,18 +7,29 @@ module GlobalStateTests.PersistentChainParameters (tests) where
 
 import Control.Exception (ErrorCall, evaluate, try)
 import Control.Monad.IO.Class
+import Control.Monad.Trans.Maybe
 import qualified Data.Serialize as S
+import qualified Data.Set as Set
 import Lens.Micro.Platform
 import Test.HUnit
 import Test.Hspec
 
 import qualified Concordium.Crypto.SHA256 as H
+import Concordium.Genesis.Data
+import qualified Concordium.Genesis.Data.P11 as P11
 import Concordium.GlobalState.DummyData
 import Concordium.GlobalState.Persistent.BlobStore
+import qualified Concordium.GlobalState.Persistent.BlockState as PBS
 import qualified Concordium.GlobalState.Persistent.BlockState.Parameters as PCP
+import qualified Concordium.GlobalState.Persistent.BlockState.Updates as PU
+import qualified Concordium.GlobalState.Persistent.Migration as Migration
 import Concordium.Types
 import Concordium.Types.HashableTo
 import Concordium.Types.Parameters
+import qualified Concordium.Types.UpdateQueues as UQ
+import Concordium.Types.Updates (AccessStructure (..))
+
+import GlobalStateTests.BlockStateHelpers (dummySeedState, runTestBlockState)
 
 -- | Run an action in the 'MemBlobStoreT' monad transformer from an empty store.
 runWithNewMemBlobStore :: MemBlobStoreT IO a -> IO a
@@ -92,6 +103,59 @@ p10ChainParameters = dummyChainParameters' & cpMaxLockDuration .~ SomeParam Noth
 p11ChainParameters :: Duration -> ChainParameters' 'ChainParametersV3
 p11ChainParameters duration = dummyChainParameters' & cpMaxLockDuration .~ SomeParam (Just duration)
 
+p11ProtocolUpdateData :: Duration -> P11.ProtocolUpdateData
+p11ProtocolUpdateData duration =
+    P11.ProtocolUpdateData
+        { P11.updateTokenParametersAccessStructure = AccessStructure (Set.singleton 0) 1,
+          P11.updateMaxLockDuration = duration
+        }
+
+assertP10P11MigrationExposesMaxLockDuration :: Assertion
+assertP10P11MigrationExposesMaxLockDuration = runWithNewMemBlobStore $ do
+    let duration = Duration 12345
+        migration = StateMigrationParametersP10ToP11 (P11.StateMigrationData (p11ProtocolUpdateData duration))
+    persistent0 <- PCP.makePersistentChainParameters @(MemBlobStoreT IO) @'ChainParametersV3 @'AuthorizationsVersion2 p10ChainParameters
+    migratedMaybe <- runMaybeT $ Migration.migrateChainParameters migration persistent0
+    migrated <- case migratedMaybe of
+        Nothing -> liftIO $ assertFailure "P10-to-P11 chain-parameter migration unexpectedly failed"
+        Just migrated -> return migrated
+    publicView <- PCP.persistentChainParametersToChainParametersM migrated
+    liftIO $ assertEqual "P10-to-P11 migration should expose protocol-update maxLockDuration" (SomeParam (Just duration)) (publicView ^. cpMaxLockDuration)
+
+assertP11InitialPersistentStateExposesMaxLockDuration :: Assertion
+assertP11InitialPersistentStateExposesMaxLockDuration = runTestBlockState @'P11 $ do
+    let duration = Duration 67890
+    hpbs <-
+        PBS.initialPersistentState @'P11
+            (dummySeedState SP11)
+            dummyCryptographicParameters
+            []
+            dummyIdentityProviders
+            dummyArs
+            (dummyKeyCollection @'AuthorizationsVersion3)
+            (p11ChainParameters duration)
+    bsp <- PBS.loadPBS (PBS.hpbsPointers hpbs)
+    updates <- refLoad (PBS.bspUpdates bsp)
+    basicUpdates <- PU.makeBasicUpdates updates
+    liftIO $ assertEqual "P11 initial state should expose genesis maxLockDuration" (SomeParam (Just duration)) (UQ._currentParameters basicUpdates ^. cpMaxLockDuration)
+
+assertP11InitialPersistentStateRequiresMaxLockDuration :: Assertion
+assertP11InitialPersistentStateRequiresMaxLockDuration = do
+    result <- try $ runTestBlockState @'P11 $ do
+        hpbs <-
+            PBS.initialPersistentState @'P11
+                (dummySeedState SP11)
+                dummyCryptographicParameters
+                []
+                dummyIdentityProviders
+                dummyArs
+                (dummyKeyCollection @'AuthorizationsVersion3)
+                p10ChainParameters
+        liftIO $ evaluate hpbs
+    case result of
+        Left (_ :: ErrorCall) -> return ()
+        Right _ -> assertFailure "P11 initial persistent state should require maxLockDuration"
+
 assertP11RoundtripExposesMaxLockDuration :: Assertion
 assertP11RoundtripExposesMaxLockDuration = runWithNewMemBlobStore $ do
     let duration = Duration 42
@@ -137,6 +201,12 @@ tests = describe "GlobalStateTests.PersistentChainParameters" $ do
         assertOldLayoutHashCompatible @'ChainParametersV1 @'AuthorizationsVersion1 dummyChainParameters'
         assertOldLayoutHashCompatible @'ChainParametersV2 @'AuthorizationsVersion1 dummyChainParameters'
         assertOldLayoutHashCompatible @'ChainParametersV3 @'AuthorizationsVersion2 p10ChainParameters
+    it "migrates P10 chain parameters to P11 with protocol-update maxLockDuration" $
+        assertP10P11MigrationExposesMaxLockDuration
+    it "initializes P11 persistent state with genesis maxLockDuration" $
+        assertP11InitialPersistentStateExposesMaxLockDuration
+    it "rejects P11 initial persistent state without maxLockDuration" $
+        assertP11InitialPersistentStateRequiresMaxLockDuration
     it "stores, loads, caches, hashes, and exposes P11 external maxLockDuration" $
         assertP11RoundtripExposesMaxLockDuration
     it "includes P11 external maxLockDuration in the persistent chain-parameter hash" $

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/PersistentChainParameters.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/PersistentChainParameters.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/PersistentChainParameters.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/PersistentChainParameters.hs
@@ -1,0 +1,145 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module GlobalStateTests.PersistentChainParameters (tests) where
+
+import Control.Exception (ErrorCall, evaluate, try)
+import Control.Monad.IO.Class
+import qualified Data.Serialize as S
+import Lens.Micro.Platform
+import Test.HUnit
+import Test.Hspec
+
+import qualified Concordium.Crypto.SHA256 as H
+import Concordium.GlobalState.DummyData
+import Concordium.GlobalState.Persistent.BlobStore
+import qualified Concordium.GlobalState.Persistent.BlockState.Parameters as PCP
+import Concordium.Types
+import Concordium.Types.HashableTo
+import Concordium.Types.Parameters
+
+-- | Run an action in the 'MemBlobStoreT' monad transformer from an empty store.
+runWithNewMemBlobStore :: MemBlobStoreT IO a -> IO a
+runWithNewMemBlobStore a = do
+    mbs <- newMemBlobStore
+    runMemBlobStoreT a mbs
+
+-- | The historical chain-parameter layout used for persistent storage before
+-- node-owned persistent chain parameters were split from the public view.
+--
+-- This deliberately omits '_cpMaxLockDuration'.
+newtype OldPersistentChainParametersLayout cpv = OldPersistentChainParametersLayout (ChainParameters' cpv)
+
+-- | Serialize the historical persistent chain-parameter layout.
+putOldPersistentChainParametersLayout :: forall cpv. (IsChainParametersVersion cpv) => S.Putter (ChainParameters' cpv)
+putOldPersistentChainParametersLayout ChainParameters{..} = do
+    withIsConsensusParametersVersionFor (chainParametersVersion @cpv) $ S.put _cpConsensusParameters
+    S.put _cpExchangeRates
+    putCooldownParameters _cpCooldownParameters
+    S.put _cpTimeParameters
+    S.put _cpAccountCreationLimit
+    S.put _cpRewardParameters
+    S.put _cpFoundationAccount
+    putPoolParameters _cpPoolParameters
+    S.put _cpFinalizationCommitteeParameters
+    S.put _cpValidatorScoreParameters
+
+instance (MonadBlobStore m, IsChainParametersVersion cpv) => BlobStorable m (OldPersistentChainParametersLayout cpv) where
+    storeUpdate (OldPersistentChainParametersLayout chainParameters) =
+        return (putOldPersistentChainParametersLayout chainParameters, OldPersistentChainParametersLayout chainParameters)
+    load = error "OldPersistentChainParametersLayout is only used for writing compatibility test blobs"
+
+-- | Store bytes in the historical layout and load them as the new persistent type.
+loadOldLayoutAsPersistent ::
+    forall cpv auv.
+    (IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    ChainParameters' cpv ->
+    MemBlobStoreT IO (PCP.PersistentChainParameters' cpv auv)
+loadOldLayoutAsPersistent chainParameters = do
+    oldRef <- storeRef (OldPersistentChainParametersLayout chainParameters)
+    loadRef (BlobRef (theBlobRef oldRef))
+
+-- | Assert that old-layout bytes load as persistent chain parameters and convert
+-- back to the public view without changing ordinary fields.
+assertOldLayoutLoadsAsPersistent ::
+    forall cpv auv.
+    (IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    ChainParameters' cpv ->
+    Assertion
+assertOldLayoutLoadsAsPersistent chainParameters = runWithNewMemBlobStore $ do
+    persistent <- loadOldLayoutAsPersistent @cpv @auv chainParameters
+    let publicView = PCP.persistentChainParametersToChainParameters persistent
+    liftIO $ assertEqual "old persistent layout should load as the new persistent type" chainParameters publicView
+
+-- | Assert that hashing pre-P11 persistent chain parameters is unchanged from
+-- hashing the historical persistent byte layout.
+assertOldLayoutHashCompatible ::
+    forall cpv auv.
+    (IsChainParametersVersion cpv, IsAuthorizationsVersion auv) =>
+    ChainParameters' cpv ->
+    Assertion
+assertOldLayoutHashCompatible chainParameters = runWithNewMemBlobStore $ do
+    persistent <- loadOldLayoutAsPersistent @cpv @auv chainParameters
+    persistentHash <- getHashM persistent
+    let oldHash = H.hash (S.runPut (putOldPersistentChainParametersLayout chainParameters))
+    liftIO $ assertEqual "persistent chain-parameter hash should match the historical layout hash" oldHash persistentHash
+
+p10ChainParameters :: ChainParameters' 'ChainParametersV3
+p10ChainParameters = dummyChainParameters' & cpMaxLockDuration .~ SomeParam Nothing
+
+p11ChainParameters :: Duration -> ChainParameters' 'ChainParametersV3
+p11ChainParameters duration = dummyChainParameters' & cpMaxLockDuration .~ SomeParam (Just duration)
+
+assertP11RoundtripExposesMaxLockDuration :: Assertion
+assertP11RoundtripExposesMaxLockDuration = runWithNewMemBlobStore $ do
+    let duration = Duration 42
+    persistent0 <- PCP.makePersistentChainParameters @(MemBlobStoreT IO) @'ChainParametersV3 @'AuthorizationsVersion3 (p11ChainParameters duration)
+    (hash0 :: H.Hash) <- getHashM persistent0
+    persistent1 <- loadRef =<< storeRef persistent0
+    (hash1 :: H.Hash) <- getHashM persistent1
+    persistent2 <- cache persistent1
+    publicView <- PCP.persistentChainParametersToChainParametersM persistent2
+    liftIO $ do
+        assertEqual "P11 maxLockDuration should survive store/load/cache" (SomeParam (Just duration)) (publicView ^. cpMaxLockDuration)
+        assertEqual "P11 persistent chain-parameter hash should survive store/load" hash0 hash1
+
+assertP11HashIncludesExternalChainParameters :: Assertion
+assertP11HashIncludesExternalChainParameters = runWithNewMemBlobStore $ do
+    persistent1 <- PCP.makePersistentChainParameters @(MemBlobStoreT IO) @'ChainParametersV3 @'AuthorizationsVersion3 (p11ChainParameters (Duration 1))
+    persistent2 <- PCP.makePersistentChainParameters @(MemBlobStoreT IO) @'ChainParametersV3 @'AuthorizationsVersion3 (p11ChainParameters (Duration 2))
+    (hash1 :: H.Hash) <- getHashM persistent1
+    (hash2 :: H.Hash) <- getHashM persistent2
+    liftIO $ assertBool "P11 persistent chain-parameter hash should include external maxLockDuration" (hash1 /= hash2)
+
+assertP11ConstructionRequiresMaxLockDuration :: Assertion
+assertP11ConstructionRequiresMaxLockDuration = do
+    result <- try $ runWithNewMemBlobStore $ do
+        persistent <- PCP.makePersistentChainParameters @(MemBlobStoreT IO) @'ChainParametersV3 @'AuthorizationsVersion3 p10ChainParameters
+        liftIO $ evaluate persistent
+    case result of
+        Left (_ :: ErrorCall) -> return ()
+        Right _ -> assertFailure "P11 persistent chain-parameter construction should require maxLockDuration"
+
+tests :: Spec
+tests = describe "GlobalStateTests.PersistentChainParameters" $ do
+    it "loads old CPV0 persistent bytes as node-owned persistent chain parameters" $
+        assertOldLayoutLoadsAsPersistent @'ChainParametersV0 @'AuthorizationsVersion0 dummyChainParameters'
+    it "loads old CPV1 persistent bytes as node-owned persistent chain parameters" $
+        assertOldLayoutLoadsAsPersistent @'ChainParametersV1 @'AuthorizationsVersion1 dummyChainParameters'
+    it "loads old CPV2 persistent bytes as node-owned persistent chain parameters" $
+        assertOldLayoutLoadsAsPersistent @'ChainParametersV2 @'AuthorizationsVersion1 dummyChainParameters'
+    it "loads old pre-P11 CPV3 persistent bytes as node-owned persistent chain parameters" $
+        assertOldLayoutLoadsAsPersistent @'ChainParametersV3 @'AuthorizationsVersion2 p10ChainParameters
+    it "keeps old pre-P11 persistent chain-parameter hashes unchanged" $ do
+        assertOldLayoutHashCompatible @'ChainParametersV0 @'AuthorizationsVersion0 dummyChainParameters'
+        assertOldLayoutHashCompatible @'ChainParametersV1 @'AuthorizationsVersion1 dummyChainParameters'
+        assertOldLayoutHashCompatible @'ChainParametersV2 @'AuthorizationsVersion1 dummyChainParameters'
+        assertOldLayoutHashCompatible @'ChainParametersV3 @'AuthorizationsVersion2 p10ChainParameters
+    it "stores, loads, caches, hashes, and exposes P11 external maxLockDuration" $
+        assertP11RoundtripExposesMaxLockDuration
+    it "includes P11 external maxLockDuration in the persistent chain-parameter hash" $
+        assertP11HashIncludesExternalChainParameters
+    it "rejects P11 persistent construction without maxLockDuration" $
+        assertP11ConstructionRequiresMaxLockDuration

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/PersistentTreeState.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/PersistentTreeState.hs
@@ -78,7 +78,7 @@ createGlobalState dbDir = do
     accountMap <- LMDBAccountMap.openDatabase (dbDir </> "accountmap")
     let
         n = 3
-        genesis = makeTestingGenesisDataP5 now n 1 1 dummyFinalizationCommitteeMaxSize dummyCryptographicParameters emptyIdentityProviders emptyAnonymityRevokers maxBound dummyKeyCollection dummyChainParameters
+        genesis = makeTestingGenesisDataP5 now n 1 1 dummyFinalizationCommitteeMaxSize dummyCryptographicParameters emptyIdentityProviders emptyAnonymityRevokers maxBound dummyKeyCollection (dummyChainParameters @PV)
         config = GlobalStateConfig defaultRuntimeParameters dbDir (dbDir </> "blockstate" <.> "dat") accountMap
     (x, y) <- runSilentLogger $ initialiseGlobalState genesis config
     return (x, y)

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/UpdateQueues.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/UpdateQueues.hs
@@ -20,19 +20,19 @@ import Concordium.Types
 
 -- This tests that chain parameter updates that are scheduled at the same time are not lost
 -- when calling 'PU.processUpdateQueues'.
-testCase :: forall cpv auv. (IsChainParametersVersion cpv, IsAuthorizationsVersion auv) => SChainParametersVersion cpv -> SAuthorizationsVersion auv -> String -> IO ()
-testCase _ _ pvString = do
+testCase :: forall pv. (IsProtocolVersion pv) => SProtocolVersion pv -> String -> IO ()
+testCase _ pvString = do
     -- Schedule three updates
     let rootKeyUpdate = UVRootKeys dummyHigherLevelKeys
-    let poolParameterUpdate = UVPoolParameters (dummyChainParameters' @cpv ^. cpPoolParameters)
-    let euroEnergyExchange = UVEuroPerEnergy (_erEuroPerEnergy (dummyChainParameters' @cpv ^. cpExchangeRates))
+    let poolParameterUpdate = UVPoolParameters (dummyChainParameters' @(ChainParametersVersionFor pv) ^. cpPoolParameters)
+    let euroEnergyExchange = UVEuroPerEnergy (_erEuroPerEnergy (dummyChainParameters' @(ChainParametersVersionFor pv) ^. cpExchangeRates))
     -- The first two are scheduled at effectiveTime = 123
     -- The last one is schedule for a millisecond earlier.
     let effectiveTime = 123 :: TransactionTime
     effects <- liftIO . runBlobStoreTemp "." $ do
-        (u1 :: BufferedRef (PU.Updates' cpv auv)) <-
+        (u1 :: BufferedRef (PU.Updates pv)) <-
             refMake
-                =<< PU.initialUpdates (dummyKeyCollection @auv) (dummyChainParameters' @cpv)
+                =<< PU.initialUpdates (dummyKeyCollection @(AuthorizationsVersionFor pv)) (dummyChainParameters' @(ChainParametersVersionFor pv))
         enqueuedState <-
             PU.enqueueUpdate effectiveTime poolParameterUpdate
                 =<< PU.enqueueUpdate (effectiveTime - 1) euroEnergyExchange
@@ -52,6 +52,6 @@ tests :: Spec
 tests = do
     describe "Scheduler.UpdateQueues" $ do
         specify "Correct effects are returned" $ do
-            testCase SChainParametersV0 SAuthorizationsVersion0 "CPV0"
-            testCase SChainParametersV1 SAuthorizationsVersion1 "CPV1"
-            testCase SChainParametersV2 SAuthorizationsVersion1 "CPV2"
+            testCase SP1 "CPV0"
+            testCase SP4 "CPV1"
+            testCase SP6 "CPV2"

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/UpdateQueues.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/UpdateQueues.hs
@@ -24,8 +24,8 @@ testCase :: forall cpv auv. (IsChainParametersVersion cpv, IsAuthorizationsVersi
 testCase _ _ pvString = do
     -- Schedule three updates
     let rootKeyUpdate = UVRootKeys dummyHigherLevelKeys
-    let poolParameterUpdate = UVPoolParameters (dummyChainParameters @cpv ^. cpPoolParameters)
-    let euroEnergyExchange = UVEuroPerEnergy (_erEuroPerEnergy (dummyChainParameters @cpv ^. cpExchangeRates))
+    let poolParameterUpdate = UVPoolParameters (dummyChainParameters' @cpv ^. cpPoolParameters)
+    let euroEnergyExchange = UVEuroPerEnergy (_erEuroPerEnergy (dummyChainParameters' @cpv ^. cpExchangeRates))
     -- The first two are scheduled at effectiveTime = 123
     -- The last one is schedule for a millisecond earlier.
     let effectiveTime = 123 :: TransactionTime

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/UpdateQueues.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/UpdateQueues.hs
@@ -32,7 +32,7 @@ testCase _ _ pvString = do
     effects <- liftIO . runBlobStoreTemp "." $ do
         (u1 :: BufferedRef (PU.Updates' cpv auv)) <-
             refMake
-                =<< PU.initialUpdates dummyKeyCollection dummyChainParameters
+                =<< PU.initialUpdates (dummyKeyCollection @auv) (dummyChainParameters' @cpv)
         enqueuedState <-
             PU.enqueueUpdate effectiveTime poolParameterUpdate
                 =<< PU.enqueueUpdate (effectiveTime - 1) euroEnergyExchange

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/Updates.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/Updates.hs
@@ -39,6 +39,7 @@ import Concordium.Crypto.DummyData
 import qualified Concordium.Crypto.SHA256 as Hash
 import qualified Concordium.Crypto.VRF as VRF
 import Concordium.GlobalState.BakerInfo
+import qualified Concordium.GlobalState.Persistent.BlockState.Parameters as PCP
 import qualified Concordium.GlobalState.Persistent.BlockState.Updates as PU
 import Concordium.ID.DummyData
 import Concordium.ID.Parameters
@@ -94,7 +95,7 @@ createGS = do
 --------------------------------------------------------------------------------
 
 limit :: Amount
-limit = dummyChainParameters @'ChainParametersV0 ^. cpPoolParameters . ppBakerStakeThreshold
+limit = dummyChainParameters' @'ChainParametersV0 ^. cpPoolParameters . ppBakerStakeThreshold
 limitDelta :: AmountDelta
 limitDelta = fromIntegral limit
 
@@ -183,9 +184,10 @@ increaseLimit newLimit (bs2, ai) = do
     -- load the updates field
     updates <- refLoad (PBS.bspUpdates bsp)
     -- load the current parameters
-    currentParams <- unStoreSerialized <$> refLoad (PU.currentParameters updates)
+    currentPersistentParams <- refLoad (PU.currentParameters updates)
+    let currentParams = PCP.persistentChainParametersToChainParameters currentPersistentParams
     -- store the new parameters
-    newParams <- refMake $ StoreSerialized (currentParams & cpPoolParameters . ppMinimumEquityCapital .~ newLimit)
+    newParams <- refMake $ PCP.updateChainParameters (currentParams & cpPoolParameters . ppMinimumEquityCapital .~ newLimit) currentPersistentParams
     -- store the new updates
     newUpdates <- refMake (updates{PU.currentParameters = newParams})
     -- store the new block in the IORef

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/Updates.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/Updates.hs
@@ -86,7 +86,7 @@ createGS = do
             dummyIdentityProviders
             dummyArs
             dummyKeyCollection
-            dummyChainParameters
+            (dummyChainParameters @PV)
 
 --------------------------------------------------------------------------------
 --                                                                            --

--- a/concordium-consensus/tests/globalstate/Spec.hs
+++ b/concordium-consensus/tests/globalstate/Spec.hs
@@ -22,6 +22,7 @@ import qualified GlobalStateTests.FinalizationSerializationSpec (tests)
 import qualified GlobalStateTests.Instances (tests)
 import qualified GlobalStateTests.LFMBTree (tests)
 import qualified GlobalStateTests.LMDBAccountMap (tests)
+import qualified GlobalStateTests.PersistentChainParameters (tests)
 import qualified GlobalStateTests.PersistentTreeState (tests)
 import qualified GlobalStateTests.ProtocolLevelTokens (tests)
 import qualified GlobalStateTests.RustPLTBlockState (tests)
@@ -49,6 +50,7 @@ main = atLevel $ \lvl -> hspec $ do
     GlobalStateTests.Accounts.tests lvl
     GlobalStateTests.Trie.tests
     GlobalStateTests.PersistentTreeState.tests
+    GlobalStateTests.PersistentChainParameters.tests
     GlobalStateTests.FinalizationSerializationSpec.tests
     GlobalStateTests.Instances.tests lvl
     GlobalStateTests.AccountReleaseScheduleTest.tests

--- a/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/Helpers.hs
@@ -173,7 +173,7 @@ createTestBlockStateWithAccountsAndKeys accounts keys = do
             DummyData.dummyIdentityProviders
             DummyData.dummyArs
             keys
-            DummyData.dummyChainParameters
+            (DummyData.dummyChainParameters @pv)
     -- save block state and accounts.
     void $ BS.saveBlockState bs
     void $ BS.saveGlobalMaps bs

--- a/concordium-consensus/tests/scheduler/SchedulerTests/KonsensusV1/EpochTransition.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/KonsensusV1/EpochTransition.hs
@@ -480,7 +480,7 @@ testEpochTransitionPaydayOnly accountConfigs = runTestBlockState @P7 $ do
     startEpoch = 10
     startTriggerTime = 1000
     cooldownDuration =
-        DummyData.dummyChainParameters @ChainParametersV2
+        DummyData.dummyChainParameters' @ChainParametersV2
             ^. cpCooldownParameters . cpUnifiedCooldown
 
 -- | Test an snapshot epoch transition.
@@ -541,7 +541,7 @@ testEpochTransitionSnapshotOnly accountConfigs = runTestBlockState @P7 $ do
     hour = Duration 3_600_000
     startEpoch = 10
     startTriggerTime = 1000
-    chainParams = DummyData.dummyChainParameters @ChainParametersV2
+    chainParams = DummyData.dummyChainParameters' @ChainParametersV2
 
 -- | Test two successive epoch transitions where the first is a snapshot and the second is a payday.
 testEpochTransitionSnapshotPayday :: [AccountConfig 'AccountV3] -> Assertion
@@ -626,7 +626,7 @@ testEpochTransitionSnapshotPayday accountConfigs = runTestBlockState @P7 $ do
     hour = Duration 3_600_000
     startEpoch = 10
     startTriggerTime = 1000
-    chainParams = DummyData.dummyChainParameters @ChainParametersV2
+    chainParams = DummyData.dummyChainParameters' @ChainParametersV2
     cooldownDuration = chainParams ^. cpCooldownParameters . cpUnifiedCooldown
 
 -- | Test epoch transitions for two successive transitions where the payday length is one epoch.
@@ -735,7 +735,7 @@ testEpochTransitionSnapshotPaydayCombo accountConfigs = runTestBlockState @P7 $ 
     hour = Duration 3_600_000
     startEpoch = 10
     startTriggerTime = 1000
-    chainParams = DummyData.dummyChainParameters @ChainParametersV2
+    chainParams = DummyData.dummyChainParameters' @ChainParametersV2
     cooldownDuration = chainParams ^. cpCooldownParameters . cpUnifiedCooldown
 
 -- | Test that missed rounds are carried over when rotating current capital distribution.

--- a/concordium-consensus/tests/scheduler/SchedulerTests/KonsensusV1/EpochTransition.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/KonsensusV1/EpochTransition.hs
@@ -337,7 +337,7 @@ makeInitialState ::
 makeInitialState accs seedState rpLen = withIsAuthorizationsVersionFor (protocolVersion @pv) $ do
     initialAccounts <- mapM makeDummyAccount accs
     let chainParams :: ChainParameters pv
-        chainParams = DummyData.dummyChainParameters & cpTimeParameters . tpRewardPeriodLength .~ rpLen
+        chainParams = DummyData.dummyChainParameters @pv & cpTimeParameters . tpRewardPeriodLength .~ rpLen
     initialBS <-
         initialPersistentState
             seedState

--- a/concordium-consensus/tests/scheduler/SchedulerTests/Payday.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/Payday.hs
@@ -108,7 +108,7 @@ testDoMintingP4 = do
             DummyData.dummyIdentityProviders
             DummyData.dummyArs
             DummyData.dummyKeyCollection
-            DummyData.dummyChainParameters
+            (DummyData.dummyChainParameters @'P4)
     -- Run a test of doMintingP4. It is provided a list of updates (paired with effective slot time),
     -- a list of expected special transaction outcomes to have been produced, the expected balance
     -- on the foundation account and the expected bank status.
@@ -123,7 +123,7 @@ testDoMintingP4 = do
             initialState <- thawBlockState =<< initialBlockState
             newState <-
                 doMintingP4
-                    dummyChainParameters
+                    (dummyChainParameters @'P4)
                     targetEpoch
                     mintRate
                     foundationAccount
@@ -305,7 +305,7 @@ genesis nBakers =
         []
         1_234
         (withIsAuthorizationsVersionFor (protocolVersion @pv) dummyKeyCollection)
-        dummyChainParameters
+        (dummyChainParameters @pv)
 
 type MyPersistentTreeState pv = SkovPersistentData pv
 type MyPersistentMonad pv =

--- a/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Queries.hs
+++ b/concordium-consensus/tests/scheduler/SchedulerTests/SmartContracts/V1/Queries.hs
@@ -78,7 +78,7 @@ keyPair1 :: SigScheme.KeyPair
 keyPair1 = Helpers.keyPairFromSeed 1
 
 blockEnergyRate :: Types.EnergyRate
-blockEnergyRate = dummyChainParameters @'Types.ChainParametersV1 ^. Types.energyRate
+blockEnergyRate = dummyChainParameters' @'Types.ChainParametersV1 ^. Types.energyRate
 
 accountBalanceSourceFile :: FilePath
 accountBalanceSourceFile = "../concordium-base/smart-contracts/testdata/contracts/v1/queries-account-balance.wasm"
@@ -749,8 +749,8 @@ exchangeRatesTestCase spv pvString =
         Wasm.putExchangeRateLE currentEuroPerEnergy
         Wasm.putExchangeRateLE currentAmountPerEnergy
 
-    currentEuroPerEnergy = dummyChainParameters @'Types.ChainParametersV1 ^. Types.euroPerEnergy
-    currentAmountPerEnergy = dummyChainParameters @'Types.ChainParametersV1 ^. Types.microGTUPerEuro
+    currentEuroPerEnergy = dummyChainParameters' @'Types.ChainParametersV1 ^. Types.euroPerEnergy
+    currentAmountPerEnergy = dummyChainParameters' @'Types.ChainParametersV1 ^. Types.microGTUPerEuro
 
 allSourceFile :: FilePath
 allSourceFile = "../concordium-base/smart-contracts/testdata/contracts/v1/queries-all.wasm"

--- a/plt/plt-block-state/src/ffi.rs
+++ b/plt/plt-block-state/src/ffi.rs
@@ -5,5 +5,6 @@
 pub mod blob_store_callbacks;
 pub mod block_state;
 pub mod block_state_callbacks;
+pub mod external_chain_parameters;
 pub mod memory;
 pub mod status;

--- a/plt/plt-block-state/src/ffi/external_chain_parameters.rs
+++ b/plt/plt-block-state/src/ffi/external_chain_parameters.rs
@@ -38,6 +38,32 @@ extern "C" fn ffi_empty_external_chain_parameters(
     }
 }
 
+/// Allocate new P11 external chain parameters with an initial maximum lock duration.
+///
+/// # Safety
+///
+/// - `params_out` must be non-null and valid for writing.
+#[unsafe(no_mangle)]
+extern "C" fn ffi_p11_new_external_chain_parameters(
+    max_lock_duration: u64,
+    params_out: *mut *mut PersistentChainParameters,
+) -> status::FfiStatusCode {
+    let panic_message = status::catch_unwind(move || {
+        assert!(!params_out.is_null(), "params_out is a null pointer.");
+        unsafe {
+            *params_out = Box::into_raw(Box::new(
+                PersistentChainParameters::p11_new_external_chain_parameters(max_lock_duration),
+            ));
+        }
+    });
+    if let Some(message) = panic_message {
+        eprintln!("{}", message);
+        status::FfiStatusCode::Panic
+    } else {
+        status::FfiStatusCode::Success
+    }
+}
+
 /// Deallocate external chain parameters.
 ///
 /// # Safety

--- a/plt/plt-block-state/src/ffi/external_chain_parameters.rs
+++ b/plt/plt-block-state/src/ffi/external_chain_parameters.rs
@@ -1,0 +1,206 @@
+//! This module provides a C ABI for external chain parameters.
+//!
+//! It is only available if the `ffi` feature is enabled.
+
+use super::status;
+use crate::ffi::blob_store_callbacks::{LoadCallback, StoreCallback};
+use crate::persistent::blob_store;
+use crate::persistent::blob_store::BlobStoreLocation;
+use crate::persistent::cacheable::Cacheable;
+use crate::persistent::chain_parameters::PersistentChainParameters;
+use crate::persistent::hash::Hashable;
+use plt_scheduler_types::types::protocol_version::ProtocolVersion;
+
+/// Allocate new empty external chain parameters.
+///
+/// # Safety
+///
+/// - `params_out` must be non-null and valid for writing.
+#[unsafe(no_mangle)]
+extern "C" fn ffi_empty_external_chain_parameters(
+    protocol_version: u64,
+    params_out: *mut *mut PersistentChainParameters,
+) -> status::FfiStatusCode {
+    let panic_message = status::catch_unwind(move || {
+        assert!(!params_out.is_null(), "params_out is a null pointer.");
+        let protocol_version =
+            ProtocolVersion::try_from(protocol_version).expect("Unknown protocol version");
+        unsafe {
+            *params_out =
+                Box::into_raw(Box::new(PersistentChainParameters::empty(protocol_version)));
+        }
+    });
+    if let Some(message) = panic_message {
+        eprintln!("{}", message);
+        status::FfiStatusCode::Panic
+    } else {
+        status::FfiStatusCode::Success
+    }
+}
+
+/// Deallocate external chain parameters.
+///
+/// # Safety
+///
+/// - `params` must be a unique, non-null pointer to a well-formed [`PersistentChainParameters`].
+#[unsafe(no_mangle)]
+extern "C" fn ffi_free_external_chain_parameters(params: *mut PersistentChainParameters) {
+    let panic_message = status::catch_unwind(move || {
+        assert!(!params.is_null(), "params is a null pointer.");
+        let params = unsafe { Box::from_raw(params) };
+        drop(params);
+    });
+    if let Some(message) = panic_message {
+        eprintln!("{}", message);
+    }
+}
+
+/// Load external chain parameters from the blob store.
+///
+/// # Safety
+///
+/// - `load_callback` must be a valid blob-store load callback.
+/// - `params_out` must be non-null and valid for writing.
+#[unsafe(no_mangle)]
+extern "C" fn ffi_load_external_chain_parameters(
+    load_callback: LoadCallback,
+    blob_ref: BlobStoreLocation,
+    protocol_version: u64,
+    params_out: *mut *mut PersistentChainParameters,
+) -> status::FfiStatusCode {
+    let panic_message = status::catch_unwind(move || {
+        assert!(!params_out.is_null(), "params_out is a null pointer.");
+        let protocol_version =
+            ProtocolVersion::try_from(protocol_version).expect("Unknown protocol version");
+        let params =
+            PersistentChainParameters::load_from_store(&load_callback, blob_ref, protocol_version)
+                .expect("Failed loading external chain parameters");
+        unsafe {
+            *params_out = Box::into_raw(Box::new(params));
+        }
+    });
+    if let Some(message) = panic_message {
+        eprintln!("{}", message);
+        status::FfiStatusCode::Panic
+    } else {
+        status::FfiStatusCode::Success
+    }
+}
+
+/// Store external chain parameters in the blob store.
+///
+/// # Safety
+///
+/// - `store_callback` must be a valid blob-store store callback.
+/// - `blob_ref_out` must be non-null and valid for writing.
+/// - `params` must be non-null and point to well-formed [`PersistentChainParameters`].
+#[unsafe(no_mangle)]
+extern "C" fn ffi_store_external_chain_parameters(
+    mut store_callback: StoreCallback,
+    blob_ref_out: *mut BlobStoreLocation,
+    params: *const PersistentChainParameters,
+) -> status::FfiStatusCode {
+    let panic_message = status::catch_unwind(move || {
+        assert!(!blob_ref_out.is_null(), "blob_ref_out is a null pointer.");
+        assert!(!params.is_null(), "params is a null pointer.");
+        let params = unsafe { &*params };
+        let reference = blob_store::store_to_store(&mut store_callback, params);
+        unsafe {
+            *blob_ref_out = reference;
+        }
+    });
+    if let Some(message) = panic_message {
+        eprintln!("{}", message);
+        status::FfiStatusCode::Panic
+    } else {
+        status::FfiStatusCode::Success
+    }
+}
+
+/// Cache external chain parameters into memory.
+///
+/// # Safety
+///
+/// - `load_callback` must be a valid blob-store load callback.
+/// - `params` must be non-null and point to well-formed [`PersistentChainParameters`].
+#[unsafe(no_mangle)]
+extern "C" fn ffi_cache_external_chain_parameters(
+    load_callback: LoadCallback,
+    params: *const PersistentChainParameters,
+) -> status::FfiStatusCode {
+    let panic_message = status::catch_unwind(move || {
+        assert!(!params.is_null(), "params is a null pointer.");
+        let params = unsafe { &*params };
+        params
+            .cache_reference_values(&load_callback)
+            .expect("Failed caching external chain parameters");
+    });
+    if let Some(message) = panic_message {
+        eprintln!("{}", message);
+        status::FfiStatusCode::Panic
+    } else {
+        status::FfiStatusCode::Success
+    }
+}
+
+/// Compute the hash of external chain parameters.
+///
+/// # Safety
+///
+/// - `load_callback` must be a valid blob-store load callback.
+/// - `params` must be non-null and point to well-formed [`PersistentChainParameters`].
+/// - `hash_out` must be non-null and valid for writes of 32 bytes.
+#[unsafe(no_mangle)]
+extern "C" fn ffi_hash_external_chain_parameters(
+    load_callback: LoadCallback,
+    params: *const PersistentChainParameters,
+    hash_out: *mut u8,
+) -> status::FfiStatusCode {
+    let panic_message = status::catch_unwind(move || {
+        assert!(!params.is_null(), "params is a null pointer.");
+        assert!(!hash_out.is_null(), "hash_out is a null pointer.");
+        let params = unsafe { &*params };
+        let hash = params
+            .hash(&load_callback)
+            .expect("Failed hashing external chain parameters");
+        unsafe {
+            std::ptr::copy_nonoverlapping(hash.as_ptr(), hash_out, hash.len());
+        }
+    });
+    if let Some(message) = panic_message {
+        eprintln!("{}", message);
+        status::FfiStatusCode::Panic
+    } else {
+        status::FfiStatusCode::Success
+    }
+}
+
+/// Read `max_lock_duration` from external chain parameters.
+///
+/// # Safety
+///
+/// - `params` must be non-null and point to well-formed [`PersistentChainParameters`].
+/// - `duration_out` must be non-null and valid for writing.
+#[unsafe(no_mangle)]
+extern "C" fn ffi_get_external_chain_parameters_max_lock_duration(
+    params: *const PersistentChainParameters,
+    duration_out: *mut u64,
+) -> status::FfiStatusCode {
+    let panic_message = status::catch_unwind(move || {
+        assert!(!params.is_null(), "params is a null pointer.");
+        assert!(!duration_out.is_null(), "duration_out is a null pointer.");
+        let params = unsafe { &*params };
+        let duration = match params {
+            PersistentChainParameters::P11(params) => params.max_lock_duration,
+        };
+        unsafe {
+            *duration_out = duration;
+        }
+    });
+    if let Some(message) = panic_message {
+        eprintln!("{}", message);
+        status::FfiStatusCode::Panic
+    } else {
+        status::FfiStatusCode::Success
+    }
+}

--- a/plt/plt-block-state/src/ffi/external_chain_parameters.rs
+++ b/plt/plt-block-state/src/ffi/external_chain_parameters.rs
@@ -11,34 +11,7 @@ use crate::persistent::chain_parameters::PersistentChainParameters;
 use crate::persistent::hash::Hashable;
 use plt_scheduler_types::types::protocol_version::ProtocolVersion;
 
-/// Allocate new empty external chain parameters.
-///
-/// # Safety
-///
-/// - `params_out` must be non-null and valid for writing.
-#[unsafe(no_mangle)]
-extern "C" fn ffi_empty_external_chain_parameters(
-    protocol_version: u64,
-    params_out: *mut *mut PersistentChainParameters,
-) -> status::FfiStatusCode {
-    let panic_message = status::catch_unwind(move || {
-        assert!(!params_out.is_null(), "params_out is a null pointer.");
-        let protocol_version =
-            ProtocolVersion::try_from(protocol_version).expect("Unknown protocol version");
-        unsafe {
-            *params_out =
-                Box::into_raw(Box::new(PersistentChainParameters::empty(protocol_version)));
-        }
-    });
-    if let Some(message) = panic_message {
-        eprintln!("{}", message);
-        status::FfiStatusCode::Panic
-    } else {
-        status::FfiStatusCode::Success
-    }
-}
-
-/// Allocate new P11 external chain parameters with an initial maximum lock duration.
+/// Allocate new external chain parameters with an initial maximum lock duration.
 ///
 /// # Safety
 ///

--- a/plt/plt-block-state/src/persistent.rs
+++ b/plt/plt-block-state/src/persistent.rs
@@ -8,6 +8,7 @@ pub mod blob_reference;
 pub mod blob_store;
 pub mod block_state;
 pub mod cacheable;
+pub mod chain_parameters;
 pub mod hash;
 pub mod lfmb_tree;
 pub mod protocol_level_locks;

--- a/plt/plt-block-state/src/persistent/chain_parameters.rs
+++ b/plt/plt-block-state/src/persistent/chain_parameters.rs
@@ -1,0 +1,89 @@
+use crate::failure::{BlockStateFailure, BlockStateResult};
+use crate::persistent::blob_store::{
+    BlobStoreLoad, BlobStoreLocation, BlobStoreStore, Loadable, Storable,
+};
+use crate::persistent::cacheable::Cacheable;
+use crate::persistent::chain_parameters::p11::PersistentChainParametersP11;
+use crate::persistent::hash::Hashable;
+use concordium_base::common::Buffer;
+use concordium_base::hashes::Hash;
+use plt_scheduler_types::types::protocol_version::ProtocolVersion;
+use std::any;
+use std::io::Read;
+
+pub mod p11;
+
+/// Persistent node-owned chain parameters managed by Rust.
+#[derive(Debug, Clone)]
+pub enum PersistentChainParameters {
+    /// P11 external chain parameters.
+    P11(PersistentChainParametersP11),
+}
+
+impl PersistentChainParameters {
+    /// Construct empty persistent chain parameters for the given protocol version.
+    pub fn empty(protocol_version: ProtocolVersion) -> Self {
+        match protocol_version {
+            ProtocolVersion::P11 => Self::P11(Default::default()),
+            ProtocolVersion::P9 | ProtocolVersion::P10 => {
+                panic!("No Rust-managed external chain parameters before P11")
+            }
+        }
+    }
+
+    /// Load persistent chain parameters from the blob store.
+    pub fn load_from_store(
+        loader: &impl BlobStoreLoad,
+        location: BlobStoreLocation,
+        protocol_version: ProtocolVersion,
+    ) -> BlockStateResult<Self> {
+        let bytes = loader.load_raw(location);
+        let mut bytes_slice = bytes.as_slice();
+        let value = Self::load_from_buffer(&mut bytes_slice, loader, protocol_version)?;
+        if !bytes_slice.is_empty() {
+            return Err(BlockStateFailure::BlobStoreDecode(format!(
+                "Bytes remaining after loading value of type {} from blob store",
+                any::type_name::<PersistentChainParameters>()
+            )));
+        };
+        Ok(value)
+    }
+
+    /// Load persistent chain parameters from bytes for the given protocol version.
+    fn load_from_buffer(
+        buffer: impl Read,
+        loader: &impl BlobStoreLoad,
+        protocol_version: ProtocolVersion,
+    ) -> BlockStateResult<Self> {
+        Ok(match protocol_version {
+            ProtocolVersion::P11 => Self::P11(Loadable::load_from_buffer(buffer, loader)?),
+            ProtocolVersion::P9 | ProtocolVersion::P10 => {
+                panic!("No Rust-managed external chain parameters before P11")
+            }
+        })
+    }
+}
+
+impl Storable for PersistentChainParameters {
+    fn store_to_buffer(&self, buffer: impl Buffer, storer: &mut impl BlobStoreStore) {
+        match self {
+            PersistentChainParameters::P11(params) => params.store_to_buffer(buffer, storer),
+        }
+    }
+}
+
+impl Cacheable for PersistentChainParameters {
+    fn cache_reference_values(&self, loader: &impl BlobStoreLoad) -> BlockStateResult<()> {
+        match self {
+            PersistentChainParameters::P11(params) => params.cache_reference_values(loader),
+        }
+    }
+}
+
+impl Hashable for PersistentChainParameters {
+    fn hash(&self, loader: &impl BlobStoreLoad) -> BlockStateResult<Hash> {
+        match self {
+            PersistentChainParameters::P11(params) => params.hash(loader),
+        }
+    }
+}

--- a/plt/plt-block-state/src/persistent/chain_parameters.rs
+++ b/plt/plt-block-state/src/persistent/chain_parameters.rs
@@ -31,6 +31,11 @@ impl PersistentChainParameters {
         }
     }
 
+    /// Construct P11 persistent chain parameters with an initial maximum lock duration.
+    pub fn p11_new_external_chain_parameters(max_lock_duration: u64) -> Self {
+        Self::P11(PersistentChainParametersP11 { max_lock_duration })
+    }
+
     /// Load persistent chain parameters from the blob store.
     pub fn load_from_store(
         loader: &impl BlobStoreLoad,

--- a/plt/plt-block-state/src/persistent/chain_parameters.rs
+++ b/plt/plt-block-state/src/persistent/chain_parameters.rs
@@ -21,16 +21,6 @@ pub enum PersistentChainParameters {
 }
 
 impl PersistentChainParameters {
-    /// Construct empty persistent chain parameters for the given protocol version.
-    pub fn empty(protocol_version: ProtocolVersion) -> Self {
-        match protocol_version {
-            ProtocolVersion::P11 => Self::P11(Default::default()),
-            ProtocolVersion::P9 | ProtocolVersion::P10 => {
-                panic!("No Rust-managed external chain parameters before P11")
-            }
-        }
-    }
-
     /// Construct P11 persistent chain parameters with an initial maximum lock duration.
     pub fn p11_new_external_chain_parameters(max_lock_duration: u64) -> Self {
         Self::P11(PersistentChainParametersP11 { max_lock_duration })
@@ -60,12 +50,12 @@ impl PersistentChainParameters {
         loader: &impl BlobStoreLoad,
         protocol_version: ProtocolVersion,
     ) -> BlockStateResult<Self> {
-        Ok(match protocol_version {
-            ProtocolVersion::P11 => Self::P11(Loadable::load_from_buffer(buffer, loader)?),
+        match protocol_version {
+            ProtocolVersion::P11 => Ok(Self::P11(Loadable::load_from_buffer(buffer, loader)?)),
             ProtocolVersion::P9 | ProtocolVersion::P10 => {
                 panic!("No Rust-managed external chain parameters before P11")
             }
-        })
+        }
     }
 }
 
@@ -89,6 +79,27 @@ impl Hashable for PersistentChainParameters {
     fn hash(&self, loader: &impl BlobStoreLoad) -> BlockStateResult<Hash> {
         match self {
             PersistentChainParameters::P11(params) => params.hash(loader),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::persistent::blob_store;
+    use crate::persistent::blob_store::test_stub::BlobStoreStub;
+
+    #[test]
+    fn store_load_roundtrip() {
+        let mut store = BlobStoreStub::default();
+        let params = PersistentChainParameters::p11_new_external_chain_parameters(42);
+        let location = blob_store::store_to_store(&mut store, &params);
+        let loaded =
+            PersistentChainParameters::load_from_store(&store, location, ProtocolVersion::P11)
+                .expect("external chain parameters should load");
+
+        match loaded {
+            PersistentChainParameters::P11(params) => assert_eq!(params.max_lock_duration, 42),
         }
     }
 }

--- a/plt/plt-block-state/src/persistent/chain_parameters/p11.rs
+++ b/plt/plt-block-state/src/persistent/chain_parameters/p11.rs
@@ -1,0 +1,82 @@
+use crate::failure::{BlockStateFailure, BlockStateResult};
+use crate::persistent::blob_store::{BlobStoreLoad, BlobStoreStore, Loadable, Storable};
+use crate::persistent::cacheable::Cacheable;
+use crate::persistent::hash;
+use crate::persistent::hash::Hashable;
+use concordium_base::common::{Buffer, Get, Put};
+use concordium_base::hashes::Hash;
+use std::io::Read;
+
+/// Node-owned persistent external chain parameters for P11.
+///
+/// This mirrors the parts of the public chain-parameter view whose authoritative
+/// state is managed outside the ordinary Haskell chain-parameter record.
+#[derive(Debug, Clone, Default, Eq, PartialEq)]
+pub struct PersistentChainParametersP11 {
+    /// Maximum relative duration for protocol-level token locks, in milliseconds.
+    pub max_lock_duration: u64,
+}
+
+impl Loadable for PersistentChainParametersP11 {
+    fn load_from_buffer(
+        mut buffer: impl Read,
+        _loader: &impl BlobStoreLoad,
+    ) -> Result<Self, BlockStateFailure> {
+        let max_lock_duration = buffer.get().map_err(|err| {
+            BlockStateFailure::BlobStoreDecode(format!(
+                "Error parsing P11 chain-parameters max_lock_duration: {err}"
+            ))
+        })?;
+        Ok(Self { max_lock_duration })
+    }
+}
+
+impl Storable for PersistentChainParametersP11 {
+    fn store_to_buffer(&self, mut buffer: impl Buffer, _storer: &mut impl BlobStoreStore) {
+        buffer.put(self.max_lock_duration);
+    }
+}
+
+impl Cacheable for PersistentChainParametersP11 {
+    fn cache_reference_values(&self, _loader: &impl BlobStoreLoad) -> BlockStateResult<()> {
+        Ok(())
+    }
+}
+
+impl Hashable for PersistentChainParametersP11 {
+    fn hash(&self, _loader: &impl BlobStoreLoad) -> BlockStateResult<Hash> {
+        Ok(hash::hash_of_serialization(self.max_lock_duration))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::persistent::blob_store;
+    use crate::persistent::blob_store::test_stub::BlobStoreStub;
+
+    #[test]
+    fn store_load_roundtrip() {
+        let mut store = BlobStoreStub::default();
+        let params = PersistentChainParametersP11 {
+            max_lock_duration: 42,
+        };
+        let location = blob_store::store_to_store(&mut store, &params);
+        let loaded: PersistentChainParametersP11 = blob_store::load_from_store(&store, location)
+            .expect("P11 chain parameters should load");
+        assert_eq!(params, loaded);
+    }
+
+    #[test]
+    fn hash_changes_with_max_lock_duration() {
+        let store = BlobStoreStub::default();
+        let zero = PersistentChainParametersP11::default();
+        let non_zero = PersistentChainParametersP11 {
+            max_lock_duration: 42,
+        };
+        assert_ne!(
+            zero.hash(&store).expect("zero hash"),
+            non_zero.hash(&store).expect("non-zero hash")
+        );
+    }
+}


### PR DESCRIPTION
Ref COR-2335
Depends on https://github.com/Concordium/concordium-base/pull/945

## Purpose

Adds structure for rust managed chain parameters + max lock duration chain parameter. Additionally, the authorizations structure to be used for the update.

`CHANGELOG.md` updated as part of subsequent PR: https://github.com/Concordium/concordium-node/pull/1672

## Changes

Adds a separate type for persistent state storage of chain parameters. This is due to changing the chain parameters from being a flat serialization to additionally have a pointer to token parameters managed by rust.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.