### PR TITLE
Make RawTokenAmount value private and make all arithmetic go through …

### DIFF
--- a/plt/plt-block-state/src/entity/block_state/migration/p10_to_p11.rs
+++ b/plt/plt-block-state/src/entity/block_state/migration/p10_to_p11.rs
@@ -63,7 +63,7 @@ mod test {
             .unwrap();
         token1
             .token_p9_base
-            .set_token_circulating_supply(RawTokenAmount(100));
+            .set_token_circulating_supply(RawTokenAmount::from(100));
         token1
             .token_p9_base
             .set_deny_list_enabled(&context)
@@ -119,7 +119,7 @@ mod test {
         );
         assert_eq!(
             token1.token_p9_base.token_circulating_supply(),
-            RawTokenAmount(100)
+            RawTokenAmount::from(100)
         );
         assert!(token1.token_p9_base.has_deny_list(&migrated_context));
         assert!(token1.token_p9_base.is_burnable(&migrated_context));
@@ -150,7 +150,7 @@ mod test {
         );
         assert_eq!(
             token2.token_p9_base.token_circulating_supply(),
-            RawTokenAmount(0)
+            RawTokenAmount::from(0)
         );
         assert!(token2.token_p9_base.has_allow_list(&migrated_context));
         assert!(token2.token_p9_base.is_mintable(&migrated_context));

--- a/plt/plt-block-state/src/entity/block_state/migration/p9_to_p10.rs
+++ b/plt/plt-block-state/src/entity/block_state/migration/p9_to_p10.rs
@@ -46,7 +46,7 @@ mod test {
         let mut token1 = block_state.token_by_index(&context, token_index1).unwrap();
         token1
             .token_p9_base
-            .set_token_circulating_supply(RawTokenAmount(100));
+            .set_token_circulating_supply(RawTokenAmount::from(100));
         token1
             .token_p9_base
             .set_deny_list_enabled(&context)
@@ -75,7 +75,7 @@ mod test {
             .unwrap();
         assert_eq!(
             token1.token_p9_base.token_circulating_supply(),
-            RawTokenAmount(100)
+            RawTokenAmount::from(100)
         );
         assert_eq!(
             token1
@@ -98,7 +98,7 @@ mod test {
             .unwrap();
         assert_eq!(
             token2.token_p9_base.token_circulating_supply(),
-            RawTokenAmount(0)
+            RawTokenAmount::from(0)
         );
         assert_eq!(
             token2

--- a/plt/plt-block-state/src/entity/protocol_level_tokens/p11.rs
+++ b/plt/plt-block-state/src/entity/protocol_level_tokens/p11.rs
@@ -100,7 +100,7 @@ impl TokenP11 {
             &context.store,
             &state_keys::account_quanta_state_key(account_index, lock_id),
         ) else {
-            return Ok(RawTokenAmount(0));
+            return Ok(RawTokenAmount::from(0));
         };
         common::from_bytes_complete(value).map_err(|err| {
             BlockStateFailure::BlobStoreDecode(format!(
@@ -118,7 +118,7 @@ impl TokenP11 {
         lock_id: &LockId,
         amount: RawTokenAmount,
     ) -> BlockStateResult<()> {
-        if amount == RawTokenAmount(0) {
+        if amount == RawTokenAmount::from(0) {
             self.token_p9_base.mutable_key_value_state.delete_value(
                 &context.store,
                 &state_keys::account_quanta_state_key(account_index, lock_id),

--- a/plt/plt-block-state/src/entity/protocol_level_tokens/p9.rs
+++ b/plt/plt-block-state/src/entity/protocol_level_tokens/p9.rs
@@ -43,7 +43,7 @@ pub(crate) fn create_token<C: EntityContextTypes>(
     let persistent_token = PersistentTokenP9 {
         configuration: HashedCacheableRef::new(StoreSerialized(configuration)),
         key_value_state: HashedCacheableRef::new(smart_contract_trie::PersistentState::empty()),
-        circulating_supply: StoreSerialized(RawTokenAmount(0)),
+        circulating_supply: StoreSerialized(RawTokenAmount::from(0)),
     };
 
     let token_index;

--- a/plt/plt-block-state/src/external.rs
+++ b/plt/plt-block-state/src/external.rs
@@ -309,10 +309,10 @@ pub mod test_stub {
                 .balance;
             match amount_delta {
                 RawTokenAmountDelta::Add(add) => {
-                    balance.0 = balance.0.checked_add(add.0).ok_or(OverflowError)?;
+                    *balance = balance.checked_add(add).ok_or(OverflowError)?;
                 }
                 RawTokenAmountDelta::Subtract(subtract) => {
-                    balance.0 = balance.0.checked_sub(subtract.0).ok_or(OverflowError)?;
+                    *balance = balance.checked_sub(subtract).ok_or(OverflowError)?;
                 }
             }
             Ok(())

--- a/plt/plt-block-state/src/ffi/block_state_callbacks.rs
+++ b/plt/plt-block-state/src/ffi/block_state_callbacks.rs
@@ -45,7 +45,7 @@ impl ExternalBlockStateQuery for ExternalBlockStateQueryCallbacks {
     ) -> RawTokenAmount {
         let value = (self.read_token_account_balance_ptr)(account.index, token.0);
 
-        RawTokenAmount(value)
+        RawTokenAmount::from(value)
     }
 
     fn account_canonical_address_by_account_index(
@@ -131,8 +131,8 @@ impl ExternalBlockStateOperations for ExternalBlockStateOperationCallbacks {
             account.index,
             token.0,
             match amount_delta {
-                RawTokenAmountDelta::Add(amount) => amount.0,
-                RawTokenAmountDelta::Subtract(amount) => amount.0,
+                RawTokenAmountDelta::Add(amount) => amount.value(),
+                RawTokenAmountDelta::Subtract(amount) => amount.value(),
             },
             match amount_delta {
                 RawTokenAmountDelta::Add(_) => 1,

--- a/plt/plt-block-state/src/persistent/block_state/p11.rs
+++ b/plt/plt-block-state/src/persistent/block_state/p11.rs
@@ -238,7 +238,7 @@ mod test {
         let mut token1 = block_state.token_by_index(&context, token_index1).unwrap();
         token1
             .token_p9_base
-            .set_token_circulating_supply(RawTokenAmount(100));
+            .set_token_circulating_supply(RawTokenAmount::from(100));
         token1
             .token_p9_base
             .mutable_key_value_state

--- a/plt/plt-block-state/src/persistent/block_state/p9.rs
+++ b/plt/plt-block-state/src/persistent/block_state/p9.rs
@@ -94,7 +94,7 @@ mod test {
         let mut token1 = block_state.token_by_index(&context, token_index1).unwrap();
         token1
             .token_p9_base
-            .set_token_circulating_supply(RawTokenAmount(100));
+            .set_token_circulating_supply(RawTokenAmount::from(100));
         token1
             .token_p9_base
             .mutable_key_value_state
@@ -125,7 +125,7 @@ mod test {
             .unwrap();
         assert_eq!(
             token1.token_p9_base.token_circulating_supply(),
-            RawTokenAmount(100)
+            RawTokenAmount::from(100)
         );
         assert_eq!(
             token1.token_p9_base.token_configuration(&context).unwrap(),
@@ -147,7 +147,7 @@ mod test {
             .unwrap();
         assert_eq!(
             token2.token_p9_base.token_circulating_supply(),
-            RawTokenAmount(0)
+            RawTokenAmount::from(0)
         );
         assert_eq!(
             token2.token_p9_base.token_configuration(&context).unwrap(),
@@ -189,7 +189,7 @@ mod test {
         let mut token1 = block_state.token_by_index(&context, token_index1).unwrap();
         token1
             .token_p9_base
-            .set_token_circulating_supply(RawTokenAmount(100));
+            .set_token_circulating_supply(RawTokenAmount::from(100));
         token1
             .token_p9_base
             .mutable_key_value_state
@@ -255,7 +255,7 @@ mod test {
             .unwrap();
         assert_eq!(
             token1.token_p9_base.token_circulating_supply(),
-            RawTokenAmount(100)
+            RawTokenAmount::from(100)
         );
         let configuration1 = TokenConfiguration {
             token_id: "token1".parse().unwrap(),
@@ -282,7 +282,7 @@ mod test {
             .unwrap();
         assert_eq!(
             token2.token_p9_base.token_circulating_supply(),
-            RawTokenAmount(0)
+            RawTokenAmount::from(0)
         );
         let configuration2 = TokenConfiguration {
             token_id: "token2".parse().unwrap(),

--- a/plt/plt-block-state/src/persistent/protocol_level_tokens/p9.rs
+++ b/plt/plt-block-state/src/persistent/protocol_level_tokens/p9.rs
@@ -240,7 +240,7 @@ mod test {
     #[test]
     fn test_token_account_state_serial() {
         let state = TokenAccountState {
-            balance: RawTokenAmount(10),
+            balance: RawTokenAmount::from(10),
         };
 
         let bytes = common::to_bytes(&state);

--- a/plt/plt-block-state/tests/block_state_p11.rs
+++ b/plt/plt-block-state/tests/block_state_p11.rs
@@ -154,7 +154,7 @@ fn test_token_properties() {
         token
             .get_locked_balance_for_account(&context, account_index1, &lock_id)
             .unwrap(),
-        RawTokenAmount(0)
+        RawTokenAmount::from(0)
     );
     assert_eq!(
         token
@@ -172,7 +172,12 @@ fn test_token_properties() {
         )
         .unwrap();
     token
-        .set_locked_balance_for_account(&context, account_index1, &lock_id, RawTokenAmount(100))
+        .set_locked_balance_for_account(
+            &context,
+            account_index1,
+            &lock_id,
+            RawTokenAmount::from(100),
+        )
         .unwrap();
 
     // Update token
@@ -195,13 +200,13 @@ fn test_token_properties() {
         token
             .get_locked_balance_for_account(&context, account_index1, &lock_id)
             .unwrap(),
-        RawTokenAmount(100)
+        RawTokenAmount::from(100)
     );
     assert_eq!(
         token
             .get_locked_balances_for_account(&context, account_index1)
             .unwrap(),
-        vec![(lock_id.clone(), RawTokenAmount(100))]
+        vec![(lock_id.clone(), RawTokenAmount::from(100))]
     );
 
     // Update values
@@ -209,7 +214,7 @@ fn test_token_properties() {
         .revoke_account_roles(&context, account_index1, &[TokenAdminRole::Mint])
         .unwrap();
     token
-        .set_locked_balance_for_account(&context, account_index1, &lock_id, RawTokenAmount(0))
+        .set_locked_balance_for_account(&context, account_index1, &lock_id, RawTokenAmount::from(0))
         .unwrap();
 
     // Update token
@@ -231,7 +236,7 @@ fn test_token_properties() {
         token
             .get_locked_balance_for_account(&context, account_index1, &lock_id)
             .unwrap(),
-        RawTokenAmount(0)
+        RawTokenAmount::from(0)
     );
     assert_eq!(
         token

--- a/plt/plt-block-state/tests/block_state_p9.rs
+++ b/plt/plt-block-state/tests/block_state_p9.rs
@@ -129,12 +129,12 @@ fn test_circulating_supply() {
 
     // Assert initially 0
     let circulating_supply = token.token_p9_base.token_circulating_supply();
-    assert_eq!(circulating_supply, RawTokenAmount(0));
+    assert_eq!(circulating_supply, RawTokenAmount::from(0));
 
     // Set supply
     token
         .token_p9_base
-        .set_token_circulating_supply(RawTokenAmount(10));
+        .set_token_circulating_supply(RawTokenAmount::from(10));
 
     // Update token
     block_state.update_token(&context, token).unwrap();
@@ -143,7 +143,7 @@ fn test_circulating_supply() {
     let token = block_state.token_by_index(&context, token_index).unwrap();
     assert_eq!(
         token.token_p9_base.token_circulating_supply(),
-        RawTokenAmount(10)
+        RawTokenAmount::from(10)
     );
 }
 
@@ -185,7 +185,7 @@ fn test_token_properties() {
     // Set values
     token
         .token_p9_base
-        .set_token_circulating_supply(RawTokenAmount(10));
+        .set_token_circulating_supply(RawTokenAmount::from(10));
     token.token_p9_base.set_deny_list_enabled(&context).unwrap();
     token
         .token_p9_base

--- a/plt/plt-scheduler-types/src/types/events.rs
+++ b/plt/plt-scheduler-types/src/types/events.rs
@@ -235,7 +235,7 @@ mod test {
             from: TokenHolder::Account(AccountAddress([1; 32])),
             to: TokenHolder::Account(AccountAddress([2; 32])),
             amount: TokenAmount {
-                amount: RawTokenAmount(1000),
+                amount: RawTokenAmount::from(1000),
                 decimals: 4,
             },
             memo: None,
@@ -255,7 +255,7 @@ mod test {
             from: TokenHolder::Account(AccountAddress([1; 32])),
             to: TokenHolder::Account(AccountAddress([2; 32])),
             amount: TokenAmount {
-                amount: RawTokenAmount(1000),
+                amount: RawTokenAmount::from(1000),
                 decimals: 4,
             },
             memo: Some(Memo::try_from(vec![1, 2, 3]).unwrap()),
@@ -275,7 +275,7 @@ mod test {
             from: TokenHolder::Account(AccountAddress([1; 32])),
             to: TokenHolder::Account(AccountAddress([2; 32])),
             amount: TokenAmount {
-                amount: RawTokenAmount(1000),
+                amount: RawTokenAmount::from(1000),
                 decimals: 4,
             },
             memo: None,
@@ -298,7 +298,7 @@ mod test {
             from: TokenHolder::Account(AccountAddress([1; 32])),
             to: TokenHolder::Account(AccountAddress([2; 32])),
             amount: TokenAmount {
-                amount: RawTokenAmount(1000),
+                amount: RawTokenAmount::from(1000),
                 decimals: 4,
             },
             memo: None,
@@ -321,7 +321,7 @@ mod test {
             from: TokenHolder::Account(AccountAddress([13; 32])),
             to: TokenHolder::Account(AccountAddress([64; 32])),
             amount: TokenAmount {
-                amount: RawTokenAmount(u64::MAX),
+                amount: RawTokenAmount::from(u64::MAX),
                 decimals: 255,
             },
             memo: Some(Memo::try_from((0x00..=0xff).collect::<Vec<u8>>()).unwrap()),
@@ -358,7 +358,7 @@ mod test {
             token_id: "tokenid1".parse().unwrap(),
             target: TokenHolder::Account(AccountAddress([1; 32])),
             amount: TokenAmount {
-                amount: RawTokenAmount(1000),
+                amount: RawTokenAmount::from(1000),
                 decimals: 4,
             },
         });
@@ -376,7 +376,7 @@ mod test {
             token_id: "tokenid1".parse().unwrap(),
             target: TokenHolder::Account(AccountAddress([1; 32])),
             amount: TokenAmount {
-                amount: RawTokenAmount(1000),
+                amount: RawTokenAmount::from(1000),
                 decimals: 4,
             },
         });

--- a/plt/plt-scheduler-types/src/types/queries.rs
+++ b/plt/plt-scheduler-types/src/types/queries.rs
@@ -82,7 +82,7 @@ mod test {
 
     fn token_amount_fixture(decimals: u8) -> TokenAmount {
         TokenAmount {
-            amount: RawTokenAmount(100),
+            amount: RawTokenAmount::from(100),
             decimals,
         }
     }

--- a/plt/plt-scheduler-types/src/types/tokens.rs
+++ b/plt/plt-scheduler-types/src/types/tokens.rs
@@ -10,7 +10,7 @@ use concordium_base::contracts_common::AccountAddress;
 ///
 /// Corresponding Haskell type: `Concordium.Types.Tokens.TokenRawAmount`
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd, Default)]
-pub struct RawTokenAmount(pub u64);
+pub struct RawTokenAmount(u64);
 
 impl RawTokenAmount {
     /// Maximum representable raw token amount.
@@ -24,6 +24,23 @@ impl RawTokenAmount {
     /// Checked subtraction of raw token amounts. Returns `None` if the result would overflow.
     pub fn checked_sub(self, other: RawTokenAmount) -> Option<RawTokenAmount> {
         self.0.checked_sub(other.0).map(RawTokenAmount)
+    }
+
+    /// The [`RawTokenAmount`] value.
+    pub fn value(self) -> u64 {
+        self.0
+    }
+}
+
+impl From<u64> for RawTokenAmount {
+    fn from(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+impl From<RawTokenAmount> for u64 {
+    fn from(value: RawTokenAmount) -> Self {
+        value.0
     }
 }
 
@@ -117,7 +134,7 @@ pub struct TokenAmount {
 impl TokenAmount {
     pub fn from_raw(amount: u64, decimals: u8) -> Self {
         Self {
-            amount: RawTokenAmount(amount),
+            amount: RawTokenAmount::from(amount),
             decimals,
         }
     }
@@ -145,98 +162,98 @@ mod test {
     /// with the property test [`prop_test_raw_token_amount_serial`].
     #[test]
     fn test_raw_token_amount_serial() {
-        let token_amount = RawTokenAmount(0);
+        let token_amount = RawTokenAmount::from(0);
         let bytes = common::to_bytes(&token_amount);
         assert_eq!(hex::encode(&bytes), "00");
         let token_amount_deserialized: RawTokenAmount =
             common::from_bytes_complete(bytes.as_slice()).unwrap();
         assert_eq!(token_amount_deserialized, token_amount);
 
-        let token_amount = RawTokenAmount(1);
+        let token_amount = RawTokenAmount::from(1);
         let bytes = common::to_bytes(&token_amount);
         assert_eq!(hex::encode(&bytes), "01");
         let token_amount_deserialized: RawTokenAmount =
             common::from_bytes_complete(bytes.as_slice()).unwrap();
         assert_eq!(token_amount_deserialized, token_amount);
 
-        let token_amount = RawTokenAmount(2);
+        let token_amount = RawTokenAmount::from(2);
         let bytes = common::to_bytes(&token_amount);
         assert_eq!(hex::encode(&bytes), "02");
         let token_amount_deserialized: RawTokenAmount =
             common::from_bytes_complete(bytes.as_slice()).unwrap();
         assert_eq!(token_amount_deserialized, token_amount);
 
-        let token_amount = RawTokenAmount(127);
+        let token_amount = RawTokenAmount::from(127);
         let bytes = common::to_bytes(&token_amount);
         assert_eq!(hex::encode(&bytes), "7f");
         let token_amount_deserialized: RawTokenAmount =
             common::from_bytes_complete(bytes.as_slice()).unwrap();
         assert_eq!(token_amount_deserialized, token_amount);
 
-        let token_amount = RawTokenAmount(128);
+        let token_amount = RawTokenAmount::from(128);
         let bytes = common::to_bytes(&token_amount);
         assert_eq!(hex::encode(&bytes), "8100");
         let token_amount_deserialized: RawTokenAmount =
             common::from_bytes_complete(bytes.as_slice()).unwrap();
         assert_eq!(token_amount_deserialized, token_amount);
 
-        let token_amount = RawTokenAmount(129);
+        let token_amount = RawTokenAmount::from(129);
         let bytes = common::to_bytes(&token_amount);
         assert_eq!(hex::encode(&bytes), "8101");
         let token_amount_deserialized: RawTokenAmount =
             common::from_bytes_complete(bytes.as_slice()).unwrap();
         assert_eq!(token_amount_deserialized, token_amount);
 
-        let token_amount = RawTokenAmount(128 * 128 - 1);
+        let token_amount = RawTokenAmount::from(128 * 128 - 1);
         let bytes = common::to_bytes(&token_amount);
         assert_eq!(hex::encode(&bytes), "ff7f");
         let token_amount_deserialized: RawTokenAmount =
             common::from_bytes_complete(bytes.as_slice()).unwrap();
         assert_eq!(token_amount_deserialized, token_amount);
 
-        let token_amount = RawTokenAmount(128 * 128);
+        let token_amount = RawTokenAmount::from(128 * 128);
         let bytes = common::to_bytes(&token_amount);
         assert_eq!(hex::encode(&bytes), "818000");
         let token_amount_deserialized: RawTokenAmount =
             common::from_bytes_complete(bytes.as_slice()).unwrap();
         assert_eq!(token_amount_deserialized, token_amount);
 
-        let token_amount = RawTokenAmount(128 * 128 + 1);
+        let token_amount = RawTokenAmount::from(128 * 128 + 1);
         let bytes = common::to_bytes(&token_amount);
         assert_eq!(hex::encode(&bytes), "818001");
         let token_amount_deserialized: RawTokenAmount =
             common::from_bytes_complete(bytes.as_slice()).unwrap();
         assert_eq!(token_amount_deserialized, token_amount);
 
-        let token_amount = RawTokenAmount(128 * 128 * 128 - 1);
+        let token_amount = RawTokenAmount::from(128 * 128 * 128 - 1);
         let bytes = common::to_bytes(&token_amount);
         assert_eq!(hex::encode(&bytes), "ffff7f");
         let token_amount_deserialized: RawTokenAmount =
             common::from_bytes_complete(bytes.as_slice()).unwrap();
         assert_eq!(token_amount_deserialized, token_amount);
 
-        let token_amount = RawTokenAmount(128 * 128 * 128);
+        let token_amount = RawTokenAmount::from(128 * 128 * 128);
         let bytes = common::to_bytes(&token_amount);
         assert_eq!(hex::encode(&bytes), "81808000");
         let token_amount_deserialized: RawTokenAmount =
             common::from_bytes_complete(bytes.as_slice()).unwrap();
         assert_eq!(token_amount_deserialized, token_amount);
 
-        let token_amount = RawTokenAmount(128 * 128 * 128 + 1);
+        let token_amount = RawTokenAmount::from(128 * 128 * 128 + 1);
         let bytes = common::to_bytes(&token_amount);
         assert_eq!(hex::encode(&bytes), "81808001");
         let token_amount_deserialized: RawTokenAmount =
             common::from_bytes_complete(bytes.as_slice()).unwrap();
         assert_eq!(token_amount_deserialized, token_amount);
 
-        let token_amount = RawTokenAmount(u64::MAX - 1);
+        let token_amount = RawTokenAmount::from(u64::MAX - 1);
         let bytes = common::to_bytes(&token_amount);
         assert_eq!(hex::encode(&bytes), "81ffffffffffffffff7e");
         let token_amount_deserialized: RawTokenAmount =
             common::from_bytes_complete(bytes.as_slice()).unwrap();
         assert_eq!(token_amount_deserialized, token_amount);
 
-        let token_amount = RawTokenAmount(u64::MAX);
+        let token_amount = RawTokenAmount::from(u64::MAX);
         let bytes = common::to_bytes(&token_amount);
         assert_eq!(hex::encode(&bytes), "81ffffffffffffffff7f");
         let token_amount_deserialized: RawTokenAmount =
@@ -293,7 +310,7 @@ mod test {
         /// are tested in the test [`test_raw_token_amount_serial`].
         #[test]
         fn prop_test_raw_token_amount_serial(value: u64) {
-            let token_amount = RawTokenAmount(value);
+            let token_amount = RawTokenAmount::from(value);
             let bytes = common::to_bytes(&token_amount);
             let token_amount_deserialized_result: ParseResult<RawTokenAmount> =
                 common::from_bytes_complete(bytes.as_slice());
@@ -306,7 +323,7 @@ mod test {
     #[test]
     fn test_token_amount_serial() {
         let token_amount = TokenAmount {
-            amount: RawTokenAmount(1000),
+            amount: RawTokenAmount::from(1000),
             decimals: 4,
         };
 

--- a/plt/plt-scheduler/src/protocol_level_locks/p11.rs
+++ b/plt/plt-scheduler/src/protocol_level_locks/p11.rs
@@ -82,7 +82,7 @@ pub fn query_lock_info<C: EntityContextTypes>(
             account_index,
             &configuration.lock_id,
         )?;
-        let amount = TokenAmount::from_raw(raw_balance.0, token_configuration.decimals);
+        let amount = TokenAmount::from_raw(raw_balance.into(), token_configuration.decimals);
         funds_by_account
             .entry(account_index)
             .or_default()
@@ -323,7 +323,7 @@ fn execute_lock_send<C: EntityContextTypes>(
     let token_index = token.token_p9_base.token_index();
     block_state.update_token(context, token)?;
 
-    if remaining_locked == RawTokenAmount(0) {
+    if remaining_locked == RawTokenAmount::from(0) {
         remove_lock_balance_ref(
             context,
             block_state,
@@ -401,7 +401,7 @@ fn execute_lock_return<C: EntityContextTypes>(
     let token_index = token.token_p9_base.token_index();
     block_state.update_token(context, token)?;
 
-    if remaining_locked == RawTokenAmount(0) {
+    if remaining_locked == RawTokenAmount::from(0) {
         remove_lock_balance_ref(
             context,
             block_state,

--- a/plt/plt-scheduler/src/protocol_level_tokens/balance_operations.rs
+++ b/plt/plt-scheduler/src/protocol_level_tokens/balance_operations.rs
@@ -61,7 +61,7 @@ pub fn available_balance<C: EntityContextTypes>(
         return Ok(total);
     };
 
-    let mut total_locked = RawTokenAmount(0);
+    let mut total_locked = RawTokenAmount::from(0);
     for (_, locked_balance) in token
         .get_locked_balances_for_account(context, account.account_index())?
         .into_iter()
@@ -98,16 +98,15 @@ pub fn mint<C: EntityContextTypes>(
     let token_configuration = token.token_configuration(context)?;
 
     // Update total supply
-    let new_circulating_supply = token
-        .token_circulating_supply()
-        .0
-        .checked_add(amount.0)
-        .map(RawTokenAmount)
-        .ok_or(MintWouldOverflowError {
-            requested_amount: amount,
-            current_supply: token.token_circulating_supply(),
-            max_representable_amount: RawTokenAmount::MAX,
-        })?;
+    let new_circulating_supply =
+        token
+            .token_circulating_supply()
+            .checked_add(amount)
+            .ok_or(MintWouldOverflowError {
+                requested_amount: amount,
+                current_supply: token.token_circulating_supply(),
+                max_representable_amount: RawTokenAmount::MAX,
+            })?;
 
     token.set_token_circulating_supply(new_circulating_supply);
 
@@ -184,9 +183,7 @@ pub fn burn<C: EntityContextTypes>(
     let new_circulating_supply = token
         .token_p9_base()
         .token_circulating_supply()
-        .0
-        .checked_sub(amount.0)
-        .map(RawTokenAmount)
+        .checked_sub(amount)
         .ok_or_else(||
         // We should never overflow total supply at burn, since the total circulating supply of the token
         // is always more than any account balance.
@@ -342,7 +339,7 @@ pub fn lock_amount<C: EntityContextTypes>(
         to_lock: Some(lock_id.clone()),
     })));
 
-    Ok(old_locked == RawTokenAmount(0) && new_locked > RawTokenAmount(0))
+    Ok(old_locked == RawTokenAmount::from(0) && new_locked > RawTokenAmount::from(0))
 }
 
 /// Move `amount` of tokens from a lock's control on `source` to `recipient`'s available balance.
@@ -478,11 +475,16 @@ pub fn unlock_balance<C: EntityContextTypes>(
     memo: &Option<Memo>,
 ) -> BlockStateResult<()> {
     let old_balance = token.get_locked_balance_for_account(context, account_index, lock_id)?;
-    if old_balance == RawTokenAmount(0) {
+    if old_balance == RawTokenAmount::from(0) {
         // No locked balance, nothing to do.
         return Ok(());
     }
-    token.set_locked_balance_for_account(context, account_index, lock_id, RawTokenAmount(0))?;
+    token.set_locked_balance_for_account(
+        context,
+        account_index,
+        lock_id,
+        RawTokenAmount::from(0),
+    )?;
 
     let token_configuration = token.token_p9_base.token_configuration(context)?;
     let account_address = context

--- a/plt/plt-scheduler/src/protocol_level_tokens/token_amount.rs
+++ b/plt/plt-scheduler/src/protocol_level_tokens/token_amount.rs
@@ -31,7 +31,7 @@ pub fn to_raw_token_amount(
             found: amount.decimals(),
         })
     } else {
-        Ok(RawTokenAmount(amount.value()))
+        Ok(RawTokenAmount::from(amount.value()))
     }
 }
 
@@ -39,5 +39,5 @@ pub fn to_token_amount(
     token_configuration: &TokenConfiguration,
     amount: RawTokenAmount,
 ) -> TokenAmount {
-    TokenAmount::from_raw(amount.0, token_configuration.decimals)
+    TokenAmount::from_raw(amount.into(), token_configuration.decimals)
 }

--- a/plt/plt-scheduler/src/protocol_level_tokens/token_module/queries.rs
+++ b/plt/plt-scheduler/src/protocol_level_tokens/token_module/queries.rs
@@ -67,7 +67,7 @@ pub fn query_token_module_account_state<C: EntityContextTypes>(
 
     let token_configuration = token_base.token_configuration(context)?;
 
-    let mut total_locked = RawTokenAmount(0);
+    let mut total_locked = RawTokenAmount::from(0);
     let mut locks = Vec::new();
 
     if let TokenPXRef::TokenP11(token_p11) = token {
@@ -75,35 +75,31 @@ pub fn query_token_module_account_state<C: EntityContextTypes>(
             .get_locked_balances_for_account(context, account)?
             .into_iter()
         {
-            if locked_balance == RawTokenAmount(0) {
+            if locked_balance == RawTokenAmount::from(0) {
                 continue;
             }
-            total_locked.0 = total_locked
-                .0
-                .checked_add(locked_balance.0)
-                .ok_or_else(|| {
-                    BlockStateFailure::Invariant("Total locked token balance overflow".to_string())
-                })?;
+            total_locked = total_locked.checked_add(locked_balance).ok_or_else(|| {
+                BlockStateFailure::Invariant("Total locked token balance overflow".to_string())
+            })?;
             locks.push(AccountLockAmount {
                 lock,
-                amount: TokenAmount::from_raw(locked_balance.0, token_configuration.decimals),
+                amount: TokenAmount::from_raw(locked_balance.into(), token_configuration.decimals),
             });
         }
     }
 
-    let available = if total_locked == RawTokenAmount(0) {
+    let available = if total_locked == RawTokenAmount::from(0) {
         None
     } else {
         let available = total_token_balance
-            .0
-            .checked_sub(total_locked.0)
+            .checked_sub(total_locked)
             .ok_or_else(|| {
                 BlockStateFailure::Invariant(
                     "Total locked token balance exceeds account token balance".to_string(),
                 )
             })?;
         Some(TokenAmount::from_raw(
-            available,
+            available.into(),
             token_configuration.decimals,
         ))
     };

--- a/plt/plt-scheduler/tests/lock_cancel.rs
+++ b/plt/plt-scheduler/tests/lock_cancel.rs
@@ -47,7 +47,7 @@ fn test_cancel_by_canceller() {
         plt_x.clone(),
         parameters,
         2,
-        Some(RawTokenAmount(10000)),
+        Some(RawTokenAmount::from(10000)),
     );
 
     let lock_id = LockId {
@@ -106,7 +106,7 @@ fn test_cancel_unauthorized() {
         plt_x.clone(),
         parameters,
         2,
-        Some(RawTokenAmount(10000)),
+        Some(RawTokenAmount::from(10000)),
     );
 
     let lock_id = LockId {
@@ -164,7 +164,7 @@ fn test_cancel_after_expiry() {
         plt_x.clone(),
         parameters,
         2,
-        Some(RawTokenAmount(10000)),
+        Some(RawTokenAmount::from(10000)),
     );
 
     let lock_id = LockId {
@@ -223,7 +223,7 @@ fn test_cancel_with_balances() {
         plt_x.clone(),
         parameters,
         2,
-        Some(RawTokenAmount(10000)),
+        Some(RawTokenAmount::from(10000)),
     );
     let plt_x_gov_acct_address = context
         .account_by_index(plt_x_gov_acct.account_index())
@@ -236,7 +236,7 @@ fn test_cancel_with_balances() {
         plt_y.clone(),
         TokenInitTestParams::default(),
         6,
-        Some(RawTokenAmount(10000000)),
+        Some(RawTokenAmount::from(10000000)),
     );
     let plt_y_gov_acct_address = context
         .account_by_index(plt_y_gov_acct.account_index())
@@ -278,7 +278,7 @@ fn test_cancel_with_balances() {
         &lock_id,
         plt_x_gov_acct.account_index(),
         &plt_x.clone(),
-        RawTokenAmount(500),
+        RawTokenAmount::from(500),
     );
     utils::lock_balance(
         &mut context,
@@ -286,7 +286,7 @@ fn test_cancel_with_balances() {
         &lock_id,
         plt_y_gov_acct.account_index(),
         &plt_y.clone(),
-        RawTokenAmount(1000),
+        RawTokenAmount::from(1000),
     );
 
     let transaction_context = plt_scheduler::TransactionContext {
@@ -391,7 +391,7 @@ fn test_cancel_ignores_token_pause_and_deny_list() {
             .burnable()
             .deny_list(),
         2,
-        Some(RawTokenAmount(10000)),
+        Some(RawTokenAmount::from(10000)),
     );
 
     let owner_addr = context
@@ -402,7 +402,7 @@ fn test_cancel_ignores_token_pause_and_deny_list() {
         &mut block_state,
         owner.account_index(),
         &token_id,
-        RawTokenAmount(500),
+        RawTokenAmount::from(500),
     );
 
     let lock_id = LockId {

--- a/plt/plt-scheduler/tests/lock_fund.rs
+++ b/plt/plt-scheduler/tests/lock_fund.rs
@@ -97,7 +97,7 @@ fn test_lock_fund_updates_account_and_lock_state() {
         &mut block_state,
         sender.account_index(),
         &token_id,
-        RawTokenAmount(1000),
+        RawTokenAmount::from(1000),
     );
 
     let lock_id = LockId::new(sender.account_index(), 7u64, 0);
@@ -143,7 +143,7 @@ fn test_lock_fund_updates_account_and_lock_state() {
         assert_eq!(event_token_id, &token_id);
         assert_eq!(from, &TokenHolder::Account(sender_addr));
         assert_eq!(to, &TokenHolder::Account(sender_addr));
-        assert_eq!(amount.amount, RawTokenAmount(250));
+        assert_eq!(amount.amount, RawTokenAmount::from(250));
         assert_eq!(amount.decimals, 4);
         assert_eq!(from_lock, &None);
         assert_eq!(to_lock, &Some(lock_id.clone()));
@@ -153,7 +153,7 @@ fn test_lock_fund_updates_account_and_lock_state() {
         token_account_info!(&context, &block_state, sender.account_index(), &token_id);
     assert_eq!(
         sender_info.account_state.balance.amount,
-        RawTokenAmount(1000)
+        RawTokenAmount::from(1000)
     );
     let sender_state = token_module_account_state!(&sender_info);
     assert_eq!(sender_state.available.unwrap().value(), 750);
@@ -194,7 +194,7 @@ fn test_lock_fund_rejects_when_amount_exceeds_available_balance() {
         &mut block_state,
         sender.account_index(),
         &token_id,
-        RawTokenAmount(1000),
+        RawTokenAmount::from(1000),
     );
 
     let lock_id = LockId::new(sender.account_index(), 7u64, 0);
@@ -215,7 +215,7 @@ fn test_lock_fund_rejects_when_amount_exceeds_available_balance() {
         &lock_id,
         sender.account_index(),
         &token_id,
-        RawTokenAmount(250),
+        RawTokenAmount::from(250),
     );
 
     let outcome = execute_meta_update!(
@@ -260,7 +260,7 @@ fn test_lock_fund_rejects_unauthorized_sender() {
         &mut block_state,
         owner.account_index(),
         &token_id,
-        RawTokenAmount(1000),
+        RawTokenAmount::from(1000),
     );
 
     let lock_id = LockId::new(owner.account_index(), 7u64, 0);
@@ -317,7 +317,7 @@ fn test_lock_fund_rejects_after_expiry() {
         &mut block_state,
         owner.account_index(),
         &token_id,
-        RawTokenAmount(1000),
+        RawTokenAmount::from(1000),
     );
 
     let lock_id = LockId::new(owner.account_index(), 7u64, 0);

--- a/plt/plt-scheduler/tests/lock_return.rs
+++ b/plt/plt-scheduler/tests/lock_return.rs
@@ -98,7 +98,7 @@ fn test_lock_return_deletes_empty_lock_when_keep_alive_is_false() {
         &mut block_state,
         sender.account_index(),
         &token_id,
-        RawTokenAmount(1000),
+        RawTokenAmount::from(1000),
     );
 
     let lock_id = LockId::new(sender.account_index(), 7u64, 0);
@@ -160,7 +160,7 @@ fn test_lock_return_deletes_empty_lock_when_keep_alive_is_false() {
         assert_eq!(event_token_id, &token_id);
         assert_eq!(from, &TokenHolder::Account(sender_addr));
         assert_eq!(to, &TokenHolder::Account(sender_addr));
-        assert_eq!(amount.amount, RawTokenAmount(250));
+        assert_eq!(amount.amount, RawTokenAmount::from(250));
         assert_eq!(amount.decimals, 4);
         assert_eq!(from_lock, &Some(lock_id.clone()));
         assert_eq!(to_lock, &None);
@@ -173,7 +173,7 @@ fn test_lock_return_deletes_empty_lock_when_keep_alive_is_false() {
         token_account_info!(&context, &block_state, sender.account_index(), &token_id);
     assert_eq!(
         sender_info.account_state.balance.amount,
-        RawTokenAmount(1000)
+        RawTokenAmount::from(1000)
     );
     let sender_state = token_module_account_state!(&sender_info);
     assert!(sender_state.available.is_none());
@@ -205,7 +205,7 @@ fn test_lock_return_keeps_empty_lock_when_keep_alive_is_true() {
         &mut block_state,
         sender.account_index(),
         &token_id,
-        RawTokenAmount(1000),
+        RawTokenAmount::from(1000),
     );
 
     let lock_id = LockId::new(sender.account_index(), 7u64, 0);
@@ -287,7 +287,7 @@ fn test_lock_return_rejects_unauthorized_sender() {
         &mut block_state,
         owner.account_index(),
         &token_id,
-        RawTokenAmount(1000),
+        RawTokenAmount::from(1000),
     );
 
     let lock_id = LockId::new(owner.account_index(), 7u64, 0);
@@ -357,7 +357,7 @@ fn test_lock_return_rejects_after_expiry() {
         &mut block_state,
         owner.account_index(),
         &token_id,
-        RawTokenAmount(1000),
+        RawTokenAmount::from(1000),
     );
 
     let lock_id = LockId::new(owner.account_index(), 7u64, 0);

--- a/plt/plt-scheduler/tests/lock_send.rs
+++ b/plt/plt-scheduler/tests/lock_send.rs
@@ -99,7 +99,7 @@ fn test_lock_send_moves_locked_funds_to_recipient() {
         &mut block_state,
         sender.account_index(),
         &token_id,
-        RawTokenAmount(1000),
+        RawTokenAmount::from(1000),
     );
 
     let lock_id = LockId::new(sender.account_index(), 7u64, 0);
@@ -161,7 +161,7 @@ fn test_lock_send_moves_locked_funds_to_recipient() {
         assert_eq!(event_token_id, &token_id);
         assert_eq!(from, &TokenHolder::Account(sender_addr));
         assert_eq!(to, &TokenHolder::Account(recipient_addr));
-        assert_eq!(amount.amount, RawTokenAmount(100));
+        assert_eq!(amount.amount, RawTokenAmount::from(100));
         assert_eq!(amount.decimals, 4);
         assert_eq!(from_lock, &Some(lock_id.clone()));
         assert_eq!(to_lock, &None);
@@ -171,7 +171,7 @@ fn test_lock_send_moves_locked_funds_to_recipient() {
         token_account_info!(&context, &block_state, sender.account_index(), &token_id);
     assert_eq!(
         sender_info.account_state.balance.amount,
-        RawTokenAmount(900)
+        RawTokenAmount::from(900)
     );
     let sender_state = token_module_account_state!(&sender_info);
     assert_eq!(sender_state.available.unwrap().value(), 750);
@@ -182,7 +182,7 @@ fn test_lock_send_moves_locked_funds_to_recipient() {
         token_account_info!(&context, &block_state, recipient.account_index(), &token_id);
     assert_eq!(
         recipient_info.account_state.balance.amount,
-        RawTokenAmount(100)
+        RawTokenAmount::from(100)
     );
     let recipient_state = token_module_account_state!(&recipient_info);
     assert!(recipient_state.available.is_none());
@@ -218,7 +218,7 @@ fn test_lock_send_allows_any_recipient() {
         &mut block_state,
         owner.account_index(),
         &token_id,
-        RawTokenAmount(1000),
+        RawTokenAmount::from(1000),
     );
 
     let owner_addr = context
@@ -303,7 +303,7 @@ fn test_lock_send_rejects_non_recipient() {
         &mut block_state,
         owner.account_index(),
         &token_id,
-        RawTokenAmount(1000),
+        RawTokenAmount::from(1000),
     );
 
     let lock_id = LockId::new(owner.account_index(), 7u64, 0);
@@ -406,7 +406,7 @@ fn test_lock_send_sender_not_in_allow_list() {
         &mut block_state,
         sender.account_index(),
         &token_id,
-        RawTokenAmount(1000),
+        RawTokenAmount::from(1000),
     );
 
     let lock_id = LockId::new(sender.account_index(), 7u64, 0);
@@ -519,7 +519,7 @@ fn test_lock_send_recipient_not_in_allow_list() {
         &mut block_state,
         sender.account_index(),
         &token_id,
-        RawTokenAmount(1000),
+        RawTokenAmount::from(1000),
     );
 
     let lock_id = LockId::new(sender.account_index(), 7u64, 0);
@@ -606,7 +606,7 @@ fn test_lock_send_sender_in_deny_list() {
         &mut block_state,
         sender.account_index(),
         &token_id,
-        RawTokenAmount(1000),
+        RawTokenAmount::from(1000),
     );
 
     let sender_addr = context
@@ -705,7 +705,7 @@ fn test_lock_send_recipient_in_deny_list() {
         &mut block_state,
         sender.account_index(),
         &token_id,
-        RawTokenAmount(1000),
+        RawTokenAmount::from(1000),
     );
 
     let recipient_addr = context
@@ -804,7 +804,7 @@ fn test_lock_send_rejects_when_token_paused() {
         &mut block_state,
         sender.account_index(),
         &token_id,
-        RawTokenAmount(1000),
+        RawTokenAmount::from(1000),
     );
 
     let lock_id = LockId::new(sender.account_index(), 7u64, 0);
@@ -898,7 +898,7 @@ fn test_lock_send_rejects_unauthorized_sender() {
         &mut block_state,
         owner.account_index(),
         &token_id,
-        RawTokenAmount(1000),
+        RawTokenAmount::from(1000),
     );
 
     let lock_id = LockId::new(owner.account_index(), 7u64, 0);
@@ -972,7 +972,7 @@ fn test_lock_send_rejects_after_expiry() {
         &mut block_state,
         owner.account_index(),
         &token_id,
-        RawTokenAmount(1000),
+        RawTokenAmount::from(1000),
     );
 
     let lock_id = LockId::new(owner.account_index(), 7u64, 0);

--- a/plt/plt-scheduler/tests/migration_p10_to_p11.rs
+++ b/plt/plt-scheduler/tests/migration_p10_to_p11.rs
@@ -53,7 +53,7 @@ fn test_migrate_p10_to_p11() {
     assert_eq!(
         token_info.state.total_supply,
         QueryTokenAmount {
-            amount: RawTokenAmount(0),
+            amount: RawTokenAmount::from(0),
             decimals: DECIMALS,
         }
     );

--- a/plt/plt-scheduler/tests/migration_p9_to_p10.rs
+++ b/plt/plt-scheduler/tests/migration_p9_to_p10.rs
@@ -49,7 +49,7 @@ fn test_migrate_p9_to_p10() {
     assert_eq!(
         token_info.state.total_supply,
         QueryTokenAmount {
-            amount: RawTokenAmount(0),
+            amount: RawTokenAmount::from(0),
             decimals: DECIMALS,
         }
     );

--- a/plt/plt-scheduler/tests/plt_block_state_stub.rs
+++ b/plt/plt-scheduler/tests/plt_block_state_stub.rs
@@ -70,7 +70,7 @@ fn test_account_balance() {
         &mut block_state,
         account0.account_index(),
         &token_id,
-        RawTokenAmount(245),
+        RawTokenAmount::from(245),
     );
 
     let token = block_state
@@ -80,11 +80,11 @@ fn test_account_balance() {
 
     assert_eq!(
         account0.account_token_balance(&context, token.token_p9_base.token_index()),
-        RawTokenAmount(245)
+        RawTokenAmount::from(245)
     );
     assert_eq!(
         account1.account_token_balance(&context, token.token_p9_base.token_index()),
-        RawTokenAmount(0)
+        RawTokenAmount::from(0)
     );
 }
 

--- a/plt/plt-scheduler/tests/plt_create.rs
+++ b/plt/plt-scheduler/tests/plt_create.rs
@@ -95,11 +95,11 @@ fn test_plt_create() {
     // Assert circulating supply and governance account balance
     assert_eq!(
         token.token_p9_base.token_circulating_supply(),
-        RawTokenAmount(0)
+        RawTokenAmount::from(0)
     );
     assert_eq!(
         gov_account.account_token_balance(&context, token.token_p9_base.token_index()),
-        RawTokenAmount(0)
+        RawTokenAmount::from(0)
     );
 
     // Assert create token event
@@ -159,11 +159,11 @@ fn test_plt_create_with_minting() {
         .expect("created token");
     assert_eq!(
         token.token_p9_base.token_circulating_supply(),
-        RawTokenAmount(5000)
+        RawTokenAmount::from(5000)
     );
     assert_eq!(
         gov_account.account_token_balance(&context, token.token_p9_base.token_index()),
-        RawTokenAmount(5000)
+        RawTokenAmount::from(5000)
     );
 
     // Assert create token and mint event
@@ -173,7 +173,7 @@ fn test_plt_create_with_minting() {
     });
     assert_matches!(&events[1], BlockItemEvent::TokenMint(mint) => {
         assert_eq!(mint.token_id, token_id);
-        assert_eq!(mint.amount.amount, RawTokenAmount(5000));
+        assert_eq!(mint.amount.amount, RawTokenAmount::from(5000));
         assert_eq!(mint.amount.decimals, 4);
         assert_eq!(mint.target, TokenHolder::Account(context.external.account_canonical_address(gov_account.account_index())));
     });

--- a/plt/plt-scheduler/tests/plt_lock_queries.rs
+++ b/plt/plt-scheduler/tests/plt_lock_queries.rs
@@ -47,14 +47,14 @@ fn test_query_lock_info_cbor_round_trip_with_funded_balances() {
         token_id.clone(),
         TokenInitTestParams::default().mintable(),
         2,
-        Some(RawTokenAmount(0)),
+        Some(RawTokenAmount::from(0)),
     );
     utils::increment_account_balance_p11(
         &mut context,
         &mut block_state,
         funding_account.account_index(),
         &token_id,
-        RawTokenAmount(123_400),
+        RawTokenAmount::from(123_400),
     );
 
     let lock_id = LockId {
@@ -79,7 +79,7 @@ fn test_query_lock_info_cbor_round_trip_with_funded_balances() {
         &lock_id,
         funding_account.account_index(),
         &token_id,
-        RawTokenAmount(100),
+        RawTokenAmount::from(100),
     );
 
     let bytes = block_state
@@ -128,7 +128,7 @@ fn test_query_lock_info_any_recipient() {
         token_id.clone(),
         TokenInitTestParams::default().mintable(),
         2,
-        Some(RawTokenAmount(0)),
+        Some(RawTokenAmount::from(0)),
     );
 
     let lock_id = LockId {

--- a/plt/plt-scheduler/tests/plt_queries.rs
+++ b/plt/plt-scheduler/tests/plt_queries.rs
@@ -73,7 +73,10 @@ fn test_query_token_info() {
     // Assert that the token id returned is in the canonical casing
     assert_eq!(token_info.token_id, token_id);
     assert_eq!(token_info.state.decimals, 4);
-    assert_eq!(token_info.state.total_supply.amount, RawTokenAmount(0));
+    assert_eq!(
+        token_info.state.total_supply.amount,
+        RawTokenAmount::from(0)
+    );
     assert_eq!(token_info.state.total_supply.decimals, 4);
     assert_eq!(token_info.state.token_module_ref, TOKEN_MODULE_REF);
     let token_module_state: TokenModuleState =
@@ -123,14 +126,14 @@ fn test_query_token_account_info() {
         &mut block_state,
         account.account_index(),
         &token_id1,
-        RawTokenAmount(1000),
+        RawTokenAmount::from(1000),
     );
     utils::increment_account_balance_p11(
         &mut context,
         &mut block_state,
         account.account_index(),
         &token_id2,
-        RawTokenAmount(2000),
+        RawTokenAmount::from(2000),
     );
 
     // Lookup account token infos
@@ -141,13 +144,13 @@ fn test_query_token_account_info() {
     assert_eq!(token_account_infos[0].token_id, token_id1);
     assert_eq!(
         token_account_infos[0].account_state.balance.amount,
-        RawTokenAmount(1000)
+        RawTokenAmount::from(1000)
     );
     assert_eq!(token_account_infos[0].account_state.balance.decimals, 4);
     assert_eq!(token_account_infos[1].token_id, token_id2);
     assert_eq!(
         token_account_infos[1].account_state.balance.amount,
-        RawTokenAmount(2000)
+        RawTokenAmount::from(2000)
     );
     assert_eq!(token_account_infos[1].account_state.balance.decimals, 4);
 }
@@ -174,7 +177,7 @@ fn test_query_token_account_info_available_with_locked_balance() {
         &mut block_state,
         account.account_index(),
         &token_id,
-        RawTokenAmount(1000),
+        RawTokenAmount::from(1000),
     );
 
     let lock_id = LockId {
@@ -199,7 +202,7 @@ fn test_query_token_account_info_available_with_locked_balance() {
         &lock_id,
         account.account_index(),
         &token_id,
-        RawTokenAmount(250),
+        RawTokenAmount::from(250),
     );
 
     let token_account_infos = block_state
@@ -246,7 +249,7 @@ fn test_query_token_account_info_available_with_multiple_locks() {
         &mut block_state,
         account.account_index(),
         &token_id,
-        RawTokenAmount(1000),
+        RawTokenAmount::from(1000),
     );
 
     let lock_id1 = LockId {
@@ -287,7 +290,7 @@ fn test_query_token_account_info_available_with_multiple_locks() {
         &lock_id1,
         account.account_index(),
         &token_id,
-        RawTokenAmount(250),
+        RawTokenAmount::from(250),
     );
     utils::lock_balance(
         &mut context,
@@ -295,7 +298,7 @@ fn test_query_token_account_info_available_with_multiple_locks() {
         &lock_id2,
         account.account_index(),
         &token_id,
-        RawTokenAmount(300),
+        RawTokenAmount::from(300),
     );
 
     let token_account_infos = block_state
@@ -343,7 +346,7 @@ fn test_query_token_account_info_available_zero_when_fully_locked() {
         &mut block_state,
         account.account_index(),
         &token_id,
-        RawTokenAmount(1000),
+        RawTokenAmount::from(1000),
     );
 
     let lock_id = LockId {
@@ -368,7 +371,7 @@ fn test_query_token_account_info_available_zero_when_fully_locked() {
         &lock_id,
         account.account_index(),
         &token_id,
-        RawTokenAmount(1000),
+        RawTokenAmount::from(1000),
     );
 
     let token_account_infos = block_state
@@ -442,7 +445,7 @@ fn test_query_token_account_info_allow_list_no_balance() {
     assert_eq!(token_account_infos[0].token_id, token_id);
     assert_eq!(
         token_account_infos[0].account_state.balance.amount,
-        RawTokenAmount(0)
+        RawTokenAmount::from(0)
     );
     assert_eq!(token_account_infos[0].account_state.balance.decimals, 4);
     let module_state: TokenModuleAccountState = cbor::cbor_decode(

--- a/plt/plt-scheduler/tests/plt_token_burn.rs
+++ b/plt/plt-scheduler/tests/plt_token_burn.rs
@@ -35,7 +35,7 @@ fn test_burn() {
         token_id.clone(),
         TokenInitTestParams::default().burnable(),
         2,
-        Some(RawTokenAmount(5000)),
+        Some(RawTokenAmount::from(5000)),
     );
 
     // First burn
@@ -61,7 +61,7 @@ fn test_burn() {
 
     assert_eq!(
         gov_account.account_token_balance(&context, token_index),
-        RawTokenAmount(4000)
+        RawTokenAmount::from(4000)
     );
 
     // Second burn
@@ -87,7 +87,7 @@ fn test_burn() {
 
     assert_eq!(
         gov_account.account_token_balance(&context, token_index),
-        RawTokenAmount(2000)
+        RawTokenAmount::from(2000)
     );
 }
 
@@ -159,7 +159,7 @@ fn test_burn_insufficient_balance() {
         token_id.clone(),
         TokenInitTestParams::default().burnable(),
         2,
-        Some(RawTokenAmount(1000)),
+        Some(RawTokenAmount::from(1000)),
     );
 
     let operations = vec![TokenOperation::Burn(TokenSupplyUpdateDetails {
@@ -205,7 +205,7 @@ fn test_burn_insufficient_available_balance() {
         token_id.clone(),
         TokenInitTestParams::default().burnable(),
         2,
-        Some(RawTokenAmount(1000)),
+        Some(RawTokenAmount::from(1000)),
     );
     let recipient = context.external.create_account();
 
@@ -231,7 +231,7 @@ fn test_burn_insufficient_available_balance() {
         &lock_id,
         gov_account.account_index(),
         &token_id,
-        RawTokenAmount(250),
+        RawTokenAmount::from(250),
     );
 
     let operations = vec![TokenOperation::Burn(TokenSupplyUpdateDetails {
@@ -322,7 +322,7 @@ fn test_burn_paused() {
         token_id.clone(),
         TokenInitTestParams::default().burnable().mintable(),
         2,
-        Some(RawTokenAmount(5000)),
+        Some(RawTokenAmount::from(5000)),
     );
 
     utils::pause_token(
@@ -422,7 +422,7 @@ fn test_burn_event() {
         token_id.clone(),
         TokenInitTestParams::default().burnable(),
         2,
-        Some(RawTokenAmount(5000)),
+        Some(RawTokenAmount::from(5000)),
     );
 
     let operations = vec![TokenOperation::Burn(TokenSupplyUpdateDetails {
@@ -448,7 +448,7 @@ fn test_burn_event() {
     assert_eq!(events.len(), 1);
     assert_matches!(&events[0], BlockItemEvent::TokenBurn(burn) => {
         assert_eq!(burn.token_id, token_id);
-        assert_eq!(burn.amount.amount, RawTokenAmount(1000));
+        assert_eq!(burn.amount.amount, RawTokenAmount::from(1000));
         assert_eq!(burn.amount.decimals, 2);
         assert_eq!(burn.target, TokenHolder::Account(context.external.account_canonical_address(gov_account.account_index())));
     });
@@ -547,7 +547,7 @@ fn test_new_account_with_role_succeeds_burn() {
         &mut block_state,
         gov_account.account_index(),
         &token_id,
-        RawTokenAmount(10000),
+        RawTokenAmount::from(10000),
     );
     let account2 = context.external.create_account();
     utils::increment_account_balance_p11(
@@ -555,7 +555,7 @@ fn test_new_account_with_role_succeeds_burn() {
         &mut block_state,
         account2.account_index(),
         &token_id,
-        RawTokenAmount(5000),
+        RawTokenAmount::from(5000),
     );
 
     // Assign burn role to account2.
@@ -608,10 +608,10 @@ fn test_new_account_with_role_succeeds_burn() {
 
     assert_eq!(
         gov_account.account_token_balance(&context, token_index),
-        RawTokenAmount(10000)
+        RawTokenAmount::from(10000)
     );
     assert_eq!(
         account2.account_token_balance(&context, token_index),
-        RawTokenAmount(4800)
+        RawTokenAmount::from(4800)
     );
 }

--- a/plt/plt-scheduler/tests/plt_token_general_transactions.rs
+++ b/plt/plt-scheduler/tests/plt_token_general_transactions.rs
@@ -146,14 +146,14 @@ fn test_multiple_operations() {
         &mut block_state,
         sender.account_index(),
         &token_id,
-        RawTokenAmount(5000),
+        RawTokenAmount::from(5000),
     );
     utils::increment_account_balance_p11(
         &mut context,
         &mut block_state,
         receiver.account_index(),
         &token_id,
-        RawTokenAmount(2000),
+        RawTokenAmount::from(2000),
     );
 
     let operations = vec![
@@ -195,11 +195,11 @@ fn test_multiple_operations() {
     assert_matches!(result.outcome, TransactionOutcome::Success(_));
     assert_eq!(
         sender.account_token_balance(&context, token_index),
-        RawTokenAmount(2000)
+        RawTokenAmount::from(2000)
     );
     assert_eq!(
         receiver.account_token_balance(&context, token_index),
-        RawTokenAmount(5000)
+        RawTokenAmount::from(5000)
     );
 }
 
@@ -225,7 +225,7 @@ fn test_single_failing_operation() {
         &mut block_state,
         sender.account_index(),
         &token_id,
-        RawTokenAmount(5000),
+        RawTokenAmount::from(5000),
     );
 
     let operations = vec![
@@ -290,7 +290,7 @@ fn test_energy_charge() {
         &mut block_state,
         sender.account_index(),
         &token_id,
-        RawTokenAmount(5000),
+        RawTokenAmount::from(5000),
     );
 
     let operations = vec![TokenOperation::Transfer(TokenTransfer {
@@ -349,7 +349,7 @@ fn test_out_of_energy_error() {
         &mut block_state,
         sender.account_index(),
         &token_id,
-        RawTokenAmount(5000),
+        RawTokenAmount::from(5000),
     );
 
     let operations = vec![TokenOperation::Transfer(TokenTransfer {

--- a/plt/plt-scheduler/tests/plt_token_initialize.rs
+++ b/plt/plt-scheduler/tests/plt_token_initialize.rs
@@ -196,7 +196,7 @@ fn test_initialize_token_default_values() {
         .expect("created token");
     assert_eq!(
         gov_account.account_token_balance(&context, token.token_p9_base.token_index()),
-        RawTokenAmount(0)
+        RawTokenAmount::from(0)
     );
 }
 
@@ -255,7 +255,7 @@ fn test_initialize_token_no_minting() {
         .expect("created token");
     assert_eq!(
         gov_account.account_token_balance(&context, token.token_p9_base.token_index()),
-        RawTokenAmount(0)
+        RawTokenAmount::from(0)
     );
 }
 
@@ -314,11 +314,11 @@ fn test_initialize_token_with_minting() {
         .expect("created token");
     assert_eq!(
         gov_account.account_token_balance(&context, token.token_p9_base.token_index()),
-        RawTokenAmount(500000)
+        RawTokenAmount::from(500000)
     );
     assert_eq!(
         token.token_p9_base.token_circulating_supply(),
-        RawTokenAmount(500000)
+        RawTokenAmount::from(500000)
     );
 }
 

--- a/plt/plt-scheduler/tests/plt_token_mint.rs
+++ b/plt/plt-scheduler/tests/plt_token_mint.rs
@@ -60,7 +60,7 @@ fn test_mint_p10() {
 
     assert_eq!(
         gov_account.account_token_balance(&context, token_index),
-        RawTokenAmount(1000)
+        RawTokenAmount::from(1000)
     );
 
     // Second mint
@@ -83,7 +83,7 @@ fn test_mint_p10() {
 
     assert_eq!(
         gov_account.account_token_balance(&context, token_index),
-        RawTokenAmount(5000)
+        RawTokenAmount::from(5000)
     );
 }
 
@@ -143,11 +143,11 @@ fn test_unauthorized_mint_p10() {
     // Assert balances remain unchanged.
     assert_eq!(
         gov_account.account_token_balance(&context, token_index),
-        RawTokenAmount(0)
+        RawTokenAmount::from(0)
     );
     assert_eq!(
         non_governance_account.account_token_balance(&context, token_index),
-        RawTokenAmount(0)
+        RawTokenAmount::from(0)
     );
 }
 
@@ -190,7 +190,7 @@ fn test_mint() {
 
     assert_eq!(
         gov_account.account_token_balance(&context, token_index),
-        RawTokenAmount(1000)
+        RawTokenAmount::from(1000)
     );
 
     // Second mint
@@ -213,7 +213,7 @@ fn test_mint() {
 
     assert_eq!(
         gov_account.account_token_balance(&context, token_index),
-        RawTokenAmount(5000)
+        RawTokenAmount::from(5000)
     );
 }
 
@@ -273,11 +273,11 @@ fn test_unauthorized_mint() {
     // Assert balances remain unchanged.
     assert_eq!(
         gov_account.account_token_balance(&context, token_index),
-        RawTokenAmount(0)
+        RawTokenAmount::from(0)
     );
     assert_eq!(
         non_governance_account.account_token_balance(&context, token_index),
-        RawTokenAmount(0)
+        RawTokenAmount::from(0)
     );
 }
 
@@ -350,11 +350,17 @@ fn test_mint_overflow() {
         token_id.clone(),
         TokenInitTestParams::default().mintable(),
         2,
-        Some(RawTokenAmount(1000)),
+        Some(RawTokenAmount::from(1000)),
     );
 
     let operations = vec![TokenOperation::Mint(TokenSupplyUpdateDetails {
-        amount: TokenAmount::from_raw(RawTokenAmount::MAX.0 - 500, 2),
+        amount: TokenAmount::from_raw(
+            RawTokenAmount::MAX
+                .checked_sub(RawTokenAmount::from(500))
+                .unwrap()
+                .into(),
+            2,
+        ),
     })];
     let payload = TokenOperationsPayload {
         token_id: token_id.clone(),
@@ -381,9 +387,9 @@ fn test_mint_overflow() {
             max_representable_amount,
             ..
         }) => {
-            assert_eq!(requested_amount, TokenAmount::from_raw(RawTokenAmount::MAX.0 - 500, 2));
+            assert_eq!(requested_amount, TokenAmount::from_raw(RawTokenAmount::MAX.checked_sub(RawTokenAmount::from(500)).unwrap().into(), 2));
             assert_eq!(current_supply, TokenAmount::from_raw(1000, 2));
-            assert_eq!(max_representable_amount, TokenAmount::from_raw(RawTokenAmount::MAX.0, 2));
+            assert_eq!(max_representable_amount, TokenAmount::from_raw(RawTokenAmount::MAX.into(), 2));
     });
 
     // Supply unchanged
@@ -393,7 +399,7 @@ fn test_mint_overflow() {
         .unwrap();
     assert_eq!(
         token.token_p9_base.token_circulating_supply(),
-        RawTokenAmount(1000)
+        RawTokenAmount::from(1000)
     );
 }
 
@@ -515,7 +521,13 @@ fn test_not_mintable() {
     );
 
     let operations = vec![TokenOperation::Mint(TokenSupplyUpdateDetails {
-        amount: TokenAmount::from_raw(RawTokenAmount::MAX.0 - 500, 2),
+        amount: TokenAmount::from_raw(
+            RawTokenAmount::MAX
+                .checked_sub(RawTokenAmount::from(500))
+                .unwrap()
+                .into(),
+            2,
+        ),
     })];
     let payload = TokenOperationsPayload {
         token_id: token_id.clone(),
@@ -584,7 +596,7 @@ fn test_mint_event() {
     assert_eq!(events.len(), 1);
     assert_matches!(&events[0], BlockItemEvent::TokenMint(mint) => {
         assert_eq!(mint.token_id, token_id);
-        assert_eq!(mint.amount.amount, RawTokenAmount(1000));
+        assert_eq!(mint.amount.amount, RawTokenAmount::from(1000));
         assert_eq!(mint.amount.decimals, 2);
         assert_eq!(mint.target, TokenHolder::Account(gov_account_addr));
     });
@@ -730,10 +742,10 @@ fn test_new_account_with_role_succeeds_mint() {
 
     assert_eq!(
         gov_account.account_token_balance(&context, token_index),
-        RawTokenAmount(0)
+        RawTokenAmount::from(0)
     );
     assert_eq!(
         account2.account_token_balance(&context, token_index),
-        RawTokenAmount(200)
+        RawTokenAmount::from(200)
     );
 }

--- a/plt/plt-scheduler/tests/plt_token_pause.rs
+++ b/plt/plt-scheduler/tests/plt_token_pause.rs
@@ -394,7 +394,7 @@ fn test_pause_multiple_ops() {
     // No tokens minted
     assert_eq!(
         token.token_p9_base.token_circulating_supply(),
-        RawTokenAmount(0)
+        RawTokenAmount::from(0)
     );
     // Token is NOT paused (local state was discarded on rejection)
     assert!(!{
@@ -475,7 +475,7 @@ fn test_unpause_multiple_ops() {
         .unwrap();
     assert_eq!(
         token.token_p9_base.token_circulating_supply(),
-        RawTokenAmount(1000)
+        RawTokenAmount::from(1000)
     );
 }
 

--- a/plt/plt-scheduler/tests/plt_token_transfer.rs
+++ b/plt/plt-scheduler/tests/plt_token_transfer.rs
@@ -44,14 +44,14 @@ fn test_transfer() {
         &mut block_state,
         sender.account_index(),
         &token_id,
-        RawTokenAmount(5000),
+        RawTokenAmount::from(5000),
     );
     utils::increment_account_balance_p11(
         &mut context,
         &mut block_state,
         receiver.account_index(),
         &token_id,
-        RawTokenAmount(2000),
+        RawTokenAmount::from(2000),
     );
 
     let receiver_addr = context
@@ -82,11 +82,11 @@ fn test_transfer() {
     assert_matches!(result.outcome, TransactionOutcome::Success(_));
     assert_eq!(
         sender.account_token_balance(&context, token_index),
-        RawTokenAmount(4000)
+        RawTokenAmount::from(4000)
     );
     assert_eq!(
         receiver.account_token_balance(&context, token_index),
-        RawTokenAmount(3000)
+        RawTokenAmount::from(3000)
     );
 }
 
@@ -111,7 +111,7 @@ fn test_transfer_with_memo() {
         &mut block_state,
         sender.account_index(),
         &token_id,
-        RawTokenAmount(5000),
+        RawTokenAmount::from(5000),
     );
 
     let memo = CborMemo::Cbor(Memo::try_from(cbor::cbor_encode("testvalue")).unwrap());
@@ -143,11 +143,11 @@ fn test_transfer_with_memo() {
     assert_matches!(result.outcome, TransactionOutcome::Success(_));
     assert_eq!(
         sender.account_token_balance(&context, token_index),
-        RawTokenAmount(4000)
+        RawTokenAmount::from(4000)
     );
     assert_eq!(
         receiver.account_token_balance(&context, token_index),
-        RawTokenAmount(1000)
+        RawTokenAmount::from(1000)
     );
 }
 
@@ -171,7 +171,7 @@ fn test_transfer_self() {
         &mut block_state,
         sender.account_index(),
         &token_id,
-        RawTokenAmount(5000),
+        RawTokenAmount::from(5000),
     );
 
     let sender_addr = context
@@ -199,7 +199,7 @@ fn test_transfer_self() {
     assert_matches!(result.outcome, TransactionOutcome::Success(_));
     assert_eq!(
         sender.account_token_balance(&context, token_index),
-        RawTokenAmount(5000)
+        RawTokenAmount::from(5000)
     );
 }
 
@@ -224,7 +224,7 @@ fn test_transfer_insufficient_balance() {
         &mut block_state,
         sender.account_index(),
         &token_id,
-        RawTokenAmount(5000),
+        RawTokenAmount::from(5000),
     );
 
     let receiver_addr = context
@@ -282,7 +282,7 @@ fn test_transfer_insufficient_available_balance() {
         &mut block_state,
         sender.account_index(),
         &token_id,
-        RawTokenAmount(1000),
+        RawTokenAmount::from(1000),
     );
 
     let lock_id = LockId::new(sender.account_index(), 7u64, 0);
@@ -307,7 +307,7 @@ fn test_transfer_insufficient_available_balance() {
         &lock_id,
         sender.account_index(),
         &token_id,
-        RawTokenAmount(250),
+        RawTokenAmount::from(250),
     );
 
     let receiver_addr = context
@@ -365,7 +365,7 @@ fn test_transfer_decimals_mismatch() {
         &mut block_state,
         sender.account_index(),
         &token_id,
-        RawTokenAmount(5000),
+        RawTokenAmount::from(5000),
     );
 
     let receiver_addr = context
@@ -421,7 +421,7 @@ fn test_transfer_to_non_existing_receiver() {
         &mut block_state,
         sender.account_index(),
         &token_id,
-        RawTokenAmount(5000),
+        RawTokenAmount::from(5000),
     );
 
     let sender_addr = context
@@ -466,7 +466,7 @@ fn test_transfer_allow_list_success() {
         token_id.clone(),
         TokenInitTestParams::default().allow_list(),
         2,
-        Some(RawTokenAmount(5000)),
+        Some(RawTokenAmount::from(5000)),
     );
     let receiver = context.external.create_account();
 
@@ -518,11 +518,11 @@ fn test_transfer_allow_list_success() {
     assert_matches!(result.outcome, TransactionOutcome::Success(_));
     assert_eq!(
         gov_account.account_token_balance(&context, token_index),
-        RawTokenAmount(4000)
+        RawTokenAmount::from(4000)
     );
     assert_eq!(
         receiver.account_token_balance(&context, token_index),
-        RawTokenAmount(1000)
+        RawTokenAmount::from(1000)
     );
 }
 
@@ -548,14 +548,14 @@ fn test_transfer_deny_list_success() {
         &mut block_state,
         sender.account_index(),
         &token_id,
-        RawTokenAmount(5000),
+        RawTokenAmount::from(5000),
     );
     utils::increment_account_balance_p11(
         &mut context,
         &mut block_state,
         receiver.account_index(),
         &token_id,
-        RawTokenAmount(2000),
+        RawTokenAmount::from(2000),
     );
 
     let denied_addr = context
@@ -599,11 +599,11 @@ fn test_transfer_deny_list_success() {
     assert_matches!(result.outcome, TransactionOutcome::Success(_));
     assert_eq!(
         sender.account_token_balance(&context, token_index),
-        RawTokenAmount(4000)
+        RawTokenAmount::from(4000)
     );
     assert_eq!(
         receiver.account_token_balance(&context, token_index),
-        RawTokenAmount(3000)
+        RawTokenAmount::from(3000)
     );
 }
 
@@ -619,7 +619,7 @@ fn test_transfer_sender_not_in_allow_list() {
         token_id.clone(),
         TokenInitTestParams::default().allow_list(),
         2,
-        Some(RawTokenAmount(5000)),
+        Some(RawTokenAmount::from(5000)),
     );
     let sender = context.external.create_account();
     let receiver = context.external.create_account();
@@ -684,7 +684,7 @@ fn test_transfer_recipient_not_in_allow_list() {
         token_id.clone(),
         TokenInitTestParams::default().allow_list(),
         2,
-        Some(RawTokenAmount(5000)),
+        Some(RawTokenAmount::from(5000)),
     );
     let receiver = context.external.create_account();
 
@@ -738,11 +738,11 @@ fn test_transfer_recipient_not_in_allow_list() {
     );
     assert_eq!(
         gov_account.account_token_balance(&context, token_index),
-        RawTokenAmount(5000)
+        RawTokenAmount::from(5000)
     );
     assert_eq!(
         receiver.account_token_balance(&context, token_index),
-        RawTokenAmount(0)
+        RawTokenAmount::from(0)
     );
 }
 
@@ -767,14 +767,14 @@ fn test_transfer_sender_in_deny_list() {
         &mut block_state,
         sender.account_index(),
         &token_id,
-        RawTokenAmount(5000),
+        RawTokenAmount::from(5000),
     );
     utils::increment_account_balance_p11(
         &mut context,
         &mut block_state,
         receiver.account_index(),
         &token_id,
-        RawTokenAmount(2000),
+        RawTokenAmount::from(2000),
     );
 
     let sender_addr = context
@@ -825,11 +825,11 @@ fn test_transfer_sender_in_deny_list() {
     );
     assert_eq!(
         sender.account_token_balance(&context, token_index),
-        RawTokenAmount(5000)
+        RawTokenAmount::from(5000)
     );
     assert_eq!(
         receiver.account_token_balance(&context, token_index),
-        RawTokenAmount(2000)
+        RawTokenAmount::from(2000)
     );
 }
 
@@ -854,14 +854,14 @@ fn test_transfer_recipient_in_deny_list() {
         &mut block_state,
         sender.account_index(),
         &token_id,
-        RawTokenAmount(5000),
+        RawTokenAmount::from(5000),
     );
     utils::increment_account_balance_p11(
         &mut context,
         &mut block_state,
         receiver.account_index(),
         &token_id,
-        RawTokenAmount(2000),
+        RawTokenAmount::from(2000),
     );
 
     let receiver_addr = context
@@ -912,11 +912,11 @@ fn test_transfer_recipient_in_deny_list() {
     );
     assert_eq!(
         sender.account_token_balance(&context, token_index),
-        RawTokenAmount(5000)
+        RawTokenAmount::from(5000)
     );
     assert_eq!(
         receiver.account_token_balance(&context, token_index),
-        RawTokenAmount(2000)
+        RawTokenAmount::from(2000)
     );
 }
 
@@ -940,7 +940,7 @@ fn test_transfer_paused() {
         &mut block_state,
         gov_account.account_index(),
         &token_id,
-        RawTokenAmount(5000),
+        RawTokenAmount::from(5000),
     );
 
     let gov_account_addr = context

--- a/plt/plt-scheduler/tests/plt_transactions.rs
+++ b/plt/plt-scheduler/tests/plt_transactions.rs
@@ -38,7 +38,7 @@ fn test_plt_transfer() {
         token_id.clone(),
         TokenInitTestParams::default(),
         4,
-        Some(RawTokenAmount(5000)),
+        Some(RawTokenAmount::from(5000)),
     );
     let account2 = context.external.create_account();
     let account3 = context.external.create_account();
@@ -79,24 +79,24 @@ fn test_plt_transfer() {
     // Assert circulating supply unchanged
     assert_eq!(
         token.token_p9_base.token_circulating_supply(),
-        RawTokenAmount(5000)
+        RawTokenAmount::from(5000)
     );
 
     // Assert balance of sender and receiver
     assert_eq!(
         gov_account.account_token_balance(&context, token_index),
-        RawTokenAmount(2000)
+        RawTokenAmount::from(2000)
     );
     assert_eq!(
         account2.account_token_balance(&context, token_index),
-        RawTokenAmount(3000)
+        RawTokenAmount::from(3000)
     );
 
     // Assert transfer event
     assert_eq!(events.len(), 1);
     assert_matches!(&events[0], BlockItemEvent::TokenTransfer(transfer) => {
         assert_eq!(transfer.token_id, token_id);
-        assert_eq!(transfer.amount.amount, RawTokenAmount(3000));
+        assert_eq!(transfer.amount.amount, RawTokenAmount::from(3000));
         assert_eq!(transfer.amount.decimals, 4);
         assert_eq!(transfer.from, TokenHolder::Account(gov_addr));
         assert_eq!(transfer.to, TokenHolder::Account(account2_addr));
@@ -137,24 +137,24 @@ fn test_plt_transfer() {
     // Assert circulating supply unchanged
     assert_eq!(
         token.token_p9_base.token_circulating_supply(),
-        RawTokenAmount(5000)
+        RawTokenAmount::from(5000)
     );
 
     // Assert balance of sender and receiver
     assert_eq!(
         account2.account_token_balance(&context, token_index),
-        RawTokenAmount(2000)
+        RawTokenAmount::from(2000)
     );
     assert_eq!(
         account3.account_token_balance(&context, token_index),
-        RawTokenAmount(1000)
+        RawTokenAmount::from(1000)
     );
 
     // Assert transfer event
     assert_eq!(events.len(), 1);
     assert_matches!(&events[0], BlockItemEvent::TokenTransfer(transfer) => {
         assert_eq!(transfer.token_id, token_id);
-        assert_eq!(transfer.amount.amount, RawTokenAmount(1000));
+        assert_eq!(transfer.amount.amount, RawTokenAmount::from(1000));
         assert_eq!(transfer.amount.decimals, 4);
         assert_eq!(transfer.from, TokenHolder::Account(account2_addr));
         assert_eq!(transfer.to, TokenHolder::Account(account3_addr));
@@ -174,7 +174,7 @@ fn test_plt_transfer_using_aliases() {
         token_id.clone(),
         TokenInitTestParams::default(),
         4,
-        Some(RawTokenAmount(5000)),
+        Some(RawTokenAmount::from(5000)),
     );
     let account2 = context.external.create_account();
 
@@ -214,18 +214,18 @@ fn test_plt_transfer_using_aliases() {
     // Assert balance of sender and receiver
     assert_eq!(
         gov_account.account_token_balance(&context, token_index),
-        RawTokenAmount(2000)
+        RawTokenAmount::from(2000)
     );
     assert_eq!(
         account2.account_token_balance(&context, token_index),
-        RawTokenAmount(3000)
+        RawTokenAmount::from(3000)
     );
 
     // Assert transfer event
     assert_eq!(events.len(), 1);
     assert_matches!(&events[0], BlockItemEvent::TokenTransfer(transfer) => {
         assert_eq!(transfer.token_id, token_id);
-        assert_eq!(transfer.amount.amount, RawTokenAmount(3000));
+        assert_eq!(transfer.amount.amount, RawTokenAmount::from(3000));
         assert_eq!(transfer.amount.decimals, 4);
         assert_eq!(transfer.from, TokenHolder::Account(gov_account_address_alias));
         assert_eq!(transfer.to, TokenHolder::Account(account2_alias_address));
@@ -245,7 +245,7 @@ fn test_plt_transfer_reject() {
         token_id.clone(),
         TokenInitTestParams::default(),
         4,
-        Some(RawTokenAmount(5000)),
+        Some(RawTokenAmount::from(5000)),
     );
     let account2 = context.external.create_account();
 
@@ -283,15 +283,15 @@ fn test_plt_transfer_reject() {
     // Assert circulating supply and account balances unchanged
     assert_eq!(
         token.token_p9_base.token_circulating_supply(),
-        RawTokenAmount(5000)
+        RawTokenAmount::from(5000)
     );
     assert_eq!(
         gov_account.account_token_balance(&context, token_index),
-        RawTokenAmount(5000)
+        RawTokenAmount::from(5000)
     );
     assert_eq!(
         account2.account_token_balance(&context, token_index),
-        RawTokenAmount(0)
+        RawTokenAmount::from(0)
     );
 
     let reject_reason = utils::assert_token_module_reject_reason(&token_id, reject_reason);
@@ -316,7 +316,7 @@ fn test_plt_transfer_allow_list_flow() {
         token_id.clone(),
         TokenInitTestParams::default().allow_list(),
         4,
-        Some(RawTokenAmount(5000)),
+        Some(RawTokenAmount::from(5000)),
     );
     let receiver = context.external.create_account();
 
@@ -380,15 +380,15 @@ fn test_plt_transfer_allow_list_flow() {
 
     assert_eq!(
         token.token_p9_base.token_circulating_supply(),
-        RawTokenAmount(5000)
+        RawTokenAmount::from(5000)
     );
     assert_eq!(
         gov_account.account_token_balance(&context, token_index),
-        RawTokenAmount(5000)
+        RawTokenAmount::from(5000)
     );
     assert_eq!(
         receiver.account_token_balance(&context, token_index),
-        RawTokenAmount(0)
+        RawTokenAmount::from(0)
     );
 
     let reject_reason = utils::assert_token_module_reject_reason(&token_id, reject_reason);
@@ -457,21 +457,21 @@ fn test_plt_transfer_allow_list_flow() {
 
     assert_eq!(
         token.token_p9_base.token_circulating_supply(),
-        RawTokenAmount(5000)
+        RawTokenAmount::from(5000)
     );
     assert_eq!(
         gov_account.account_token_balance(&context, token_index),
-        RawTokenAmount(4000)
+        RawTokenAmount::from(4000)
     );
     assert_eq!(
         receiver.account_token_balance(&context, token_index),
-        RawTokenAmount(1000)
+        RawTokenAmount::from(1000)
     );
 
     assert_eq!(events.len(), 1);
     assert_matches!(&events[0], BlockItemEvent::TokenTransfer(transfer) => {
         assert_eq!(transfer.token_id, token_id);
-        assert_eq!(transfer.amount.amount, RawTokenAmount(1000));
+        assert_eq!(transfer.amount.amount, RawTokenAmount::from(1000));
         assert_eq!(transfer.amount.decimals, 4);
         assert_eq!(transfer.from, TokenHolder::Account(gov_addr));
         assert_eq!(transfer.to, TokenHolder::Account(receiver_addr));
@@ -572,20 +572,20 @@ fn test_plt_mint() {
     // Assert circulating supply increased
     assert_eq!(
         token.token_p9_base.token_circulating_supply(),
-        RawTokenAmount(1000)
+        RawTokenAmount::from(1000)
     );
 
     // Assert account balance increased
     assert_eq!(
         gov_account.account_token_balance(&context, token_index),
-        RawTokenAmount(1000)
+        RawTokenAmount::from(1000)
     );
 
     // Assert mint event
     assert_eq!(events.len(), 1);
     assert_matches!(&events[0], BlockItemEvent::TokenMint(mint) => {
         assert_eq!(mint.token_id, token_id);
-        assert_eq!(mint.amount.amount, RawTokenAmount(1000));
+        assert_eq!(mint.amount.amount, RawTokenAmount::from(1000));
         assert_eq!(mint.amount.decimals, 4);
         assert_eq!(mint.target, TokenHolder::Account(gov_addr));
     });
@@ -638,20 +638,20 @@ fn test_plt_mint_using_alias() {
     // Assert circulating supply increased
     assert_eq!(
         token.token_p9_base.token_circulating_supply(),
-        RawTokenAmount(1000)
+        RawTokenAmount::from(1000)
     );
 
     // Assert account balance increased
     assert_eq!(
         gov_account.account_token_balance(&context, token_index),
-        RawTokenAmount(1000)
+        RawTokenAmount::from(1000)
     );
 
     // Assert mint event
     assert_eq!(events.len(), 1);
     assert_matches!(&events[0], BlockItemEvent::TokenMint(mint) => {
         assert_eq!(mint.token_id, token_id);
-        assert_eq!(mint.amount.amount, RawTokenAmount(1000));
+        assert_eq!(mint.amount.amount, RawTokenAmount::from(1000));
         assert_eq!(mint.amount.decimals, 4);
         assert_eq!(mint.target, TokenHolder::Account(gov_account_address_alias));
     });
@@ -669,7 +669,7 @@ fn test_plt_mint_reject() {
         token_id.clone(),
         TokenInitTestParams::default().mintable(),
         4,
-        Some(RawTokenAmount(5000)),
+        Some(RawTokenAmount::from(5000)),
     );
 
     let gov_addr = context
@@ -701,11 +701,11 @@ fn test_plt_mint_reject() {
     // Assert circulating supply and account balance unchanged
     assert_eq!(
         token.token_p9_base.token_circulating_supply(),
-        RawTokenAmount(5000)
+        RawTokenAmount::from(5000)
     );
     assert_eq!(
         gov_account.account_token_balance(&context, token_index),
-        RawTokenAmount(5000)
+        RawTokenAmount::from(5000)
     );
 
     let reject_reason = utils::assert_token_module_reject_reason(&token_id, reject_reason);
@@ -757,11 +757,11 @@ fn test_plt_mint_unauthorized() {
     // Assert circulating supply and account balance unchanged
     assert_eq!(
         token.token_p9_base.token_circulating_supply(),
-        RawTokenAmount(0)
+        RawTokenAmount::from(0)
     );
     assert_eq!(
         non_governance_account.account_token_balance(&context, token_index),
-        RawTokenAmount(0)
+        RawTokenAmount::from(0)
     );
 
     let reject_reason = utils::assert_token_module_reject_reason(&token_id, reject_reason);
@@ -794,7 +794,7 @@ fn test_plt_burn() {
         token_id.clone(),
         TokenInitTestParams::default().burnable(),
         4,
-        Some(RawTokenAmount(5000)),
+        Some(RawTokenAmount::from(5000)),
     );
 
     let gov_addr = context
@@ -826,20 +826,20 @@ fn test_plt_burn() {
     // Assert circulating supply decreased
     assert_eq!(
         token.token_p9_base.token_circulating_supply(),
-        RawTokenAmount(4000)
+        RawTokenAmount::from(4000)
     );
 
     // Assert account balance decreased
     assert_eq!(
         gov_account.account_token_balance(&context, token_index),
-        RawTokenAmount(4000)
+        RawTokenAmount::from(4000)
     );
 
     // Assert burn event
     assert_eq!(events.len(), 1);
     assert_matches!(&events[0], BlockItemEvent::TokenBurn(burn) => {
         assert_eq!(burn.token_id, token_id);
-        assert_eq!(burn.amount.amount, RawTokenAmount(1000));
+        assert_eq!(burn.amount.amount, RawTokenAmount::from(1000));
         assert_eq!(burn.amount.decimals, 4);
         assert_eq!(burn.target, TokenHolder::Account(gov_addr));
     });
@@ -857,7 +857,7 @@ fn test_plt_burn_using_alias() {
         token_id.clone(),
         TokenInitTestParams::default().burnable(),
         4,
-        Some(RawTokenAmount(5000)),
+        Some(RawTokenAmount::from(5000)),
     );
 
     let gov_account_address_alias = context
@@ -892,20 +892,20 @@ fn test_plt_burn_using_alias() {
     // Assert circulating supply decreased
     assert_eq!(
         token.token_p9_base.token_circulating_supply(),
-        RawTokenAmount(4000)
+        RawTokenAmount::from(4000)
     );
 
     // Assert account balance decreased
     assert_eq!(
         gov_account.account_token_balance(&context, token_index),
-        RawTokenAmount(4000)
+        RawTokenAmount::from(4000)
     );
 
     // Assert burn event
     assert_eq!(events.len(), 1);
     assert_matches!(&events[0], BlockItemEvent::TokenBurn(burn) => {
         assert_eq!(burn.token_id, token_id);
-        assert_eq!(burn.amount.amount, RawTokenAmount(1000));
+        assert_eq!(burn.amount.amount, RawTokenAmount::from(1000));
         assert_eq!(burn.amount.decimals, 4);
         assert_eq!(burn.target, TokenHolder::Account(gov_account_address_alias));
     });
@@ -923,7 +923,7 @@ fn test_plt_burn_reject() {
         token_id.clone(),
         TokenInitTestParams::default().burnable(),
         4,
-        Some(RawTokenAmount(5000)),
+        Some(RawTokenAmount::from(5000)),
     );
 
     let gov_addr = context
@@ -955,11 +955,11 @@ fn test_plt_burn_reject() {
     // Assert circulating supply and account balance unchanged
     assert_eq!(
         token.token_p9_base.token_circulating_supply(),
-        RawTokenAmount(5000)
+        RawTokenAmount::from(5000)
     );
     assert_eq!(
         gov_account.account_token_balance(&context, token_index),
-        RawTokenAmount(5000)
+        RawTokenAmount::from(5000)
     );
 
     let reject_reason = utils::assert_token_module_reject_reason(&token_id, reject_reason);
@@ -1026,28 +1026,28 @@ fn test_plt_multiple_operations() {
     // Assert circulating supply and account balances
     assert_eq!(
         token.token_p9_base.token_circulating_supply(),
-        RawTokenAmount(3000)
+        RawTokenAmount::from(3000)
     );
     assert_eq!(
         gov_account.account_token_balance(&context, token_index),
-        RawTokenAmount(2000)
+        RawTokenAmount::from(2000)
     );
     assert_eq!(
         account2.account_token_balance(&context, token_index),
-        RawTokenAmount(1000)
+        RawTokenAmount::from(1000)
     );
 
     // Assert two events in right order
     assert_eq!(events.len(), 2);
     assert_matches!(&events[0], BlockItemEvent::TokenMint(mint) => {
         assert_eq!(mint.token_id, token_id);
-        assert_eq!(mint.amount.amount, RawTokenAmount(3000));
+        assert_eq!(mint.amount.amount, RawTokenAmount::from(3000));
         assert_eq!(mint.amount.decimals, 4);
         assert_eq!(mint.target, TokenHolder::Account(gov_addr));
     });
     assert_matches!(&events[1], BlockItemEvent::TokenTransfer(transfer) => {
         assert_eq!(transfer.token_id, token_id);
-        assert_eq!(transfer.amount.amount, RawTokenAmount(1000));
+        assert_eq!(transfer.amount.amount, RawTokenAmount::from(1000));
         assert_eq!(transfer.amount.decimals, 4);
         assert_eq!(transfer.from, TokenHolder::Account(gov_addr));
         assert_eq!(transfer.to, TokenHolder::Account(account2_addr));
@@ -1245,7 +1245,7 @@ fn test_energy_charge() {
         &mut block_state,
         gov_account.account_index(),
         &token_id,
-        RawTokenAmount(5000),
+        RawTokenAmount::from(5000),
     );
 
     let gov_addr = context
@@ -1299,7 +1299,7 @@ fn test_energy_charge_at_reject() {
         &mut block_state,
         gov_account.account_index(),
         &token_id,
-        RawTokenAmount(5000),
+        RawTokenAmount::from(5000),
     );
 
     let gov_addr = context
@@ -1357,7 +1357,7 @@ fn test_out_of_energy_error() {
         &mut block_state,
         gov_account.account_index(),
         &token_id,
-        RawTokenAmount(5000),
+        RawTokenAmount::from(5000),
     );
 
     let gov_addr = context

--- a/plt/plt-scheduler/tests/utils/token.rs
+++ b/plt/plt-scheduler/tests/utils/token.rs
@@ -89,7 +89,7 @@ pub fn create_and_init_token_p9(
         governance_account: Some(gov_holder_account.clone()),
         allow_list: params.allow_list,
         deny_list: params.deny_list,
-        initial_supply: initial_supply.map(|raw| TokenAmount::from_raw(raw.0, decimals)),
+        initial_supply: initial_supply.map(|raw| TokenAmount::from_raw(raw.into(), decimals)),
         mintable: params.mintable,
         burnable: params.burnable,
     };
@@ -137,7 +137,7 @@ pub fn create_and_init_token_p11(
         governance_account: Some(gov_holder_account.clone()),
         allow_list: params.allow_list,
         deny_list: params.deny_list,
-        initial_supply: initial_supply.map(|raw| TokenAmount::from_raw(raw.0, decimals)),
+        initial_supply: initial_supply.map(|raw| TokenAmount::from_raw(raw.into(), decimals)),
         mintable: params.mintable,
         burnable: params.burnable,
     };
@@ -179,10 +179,10 @@ pub fn increment_account_balance_p11(
     let token_configuration = token.token_p9_base.token_configuration(context).unwrap();
     let operations = vec![
         TokenOperation::Mint(TokenSupplyUpdateDetails {
-            amount: TokenAmount::from_raw(balance.0, token_configuration.decimals),
+            amount: TokenAmount::from_raw(balance.into(), token_configuration.decimals),
         }),
         TokenOperation::Transfer(TokenTransfer {
-            amount: TokenAmount::from_raw(balance.0, token_configuration.decimals),
+            amount: TokenAmount::from_raw(balance.into(), token_configuration.decimals),
             recipient: CborHolderAccount::from(
                 context.external.account_canonical_address(account_index),
             ),


### PR DESCRIPTION
## Purpose

Make sure we use checked arithmetics everywhere when doing arithmetic on token amounts.

## Changes

* Made the value in `RawTokenAmount` private
* In `balance_operations` arithmetic was changed to use `RawTokenAmount::checked_xxx` instead of doing checked arithmetic directly on the contained value.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
