### PR TITLE
Use PacketDestination as argument and remove call indirections

### DIFF
--- a/concordium-node/src/connection/tests.rs
+++ b/concordium-node/src/connection/tests.rs
@@ -3,8 +3,8 @@ use itertools::Itertools;
 use crate::{
     common::PeerType,
     consensus_ffi::helpers::PacketType,
-    network::NetworkId,
-    p2p::connectivity::send_broadcast_message,
+    network::{NetworkId, PacketDestination},
+    p2p::connectivity::send_message_over_network,
     test_utils::{
         await_handshakes, connect, dummy_regenesis_blocks, make_node_and_sync, next_available_port,
         stop_node_delete_dirs,
@@ -55,12 +55,12 @@ fn basic_connectivity() {
     }
 
     // send a test broadcast from each node
-    for node in &nodes {
-        send_broadcast_message(
-            &node.0,
-            vec![],
+    for (node, _) in &nodes {
+        send_message_over_network(
+            node,
+            PacketDestination::Broadcast(Vec::new()),
             NetworkId::from(NID),
-            Arc::from(&[PacketType::Block as u8][..]), // an empty Block packet
+            Arc::from(&[PacketType::Block as u8][..]),
         );
     }
 

--- a/concordium-node/src/consensus_ffi/messaging.rs
+++ b/concordium-node/src/consensus_ffi/messaging.rs
@@ -14,6 +14,7 @@ pub struct ConsensusMessage {
     pub variant: PacketType,
     pub payload: Arc<[u8]>,
     pub dont_relay_to: Vec<RemotePeerId>,
+    /// Filter out peers with the provided status, `None` meaning no filter.
     pub omit_status: Option<PeerStatus>,
 }
 

--- a/concordium-node/src/p2p/connectivity.rs
+++ b/concordium-node/src/p2p/connectivity.rs
@@ -722,42 +722,13 @@ fn is_valid_broadcast_target(
         && conn.remote_end_networks.contains(&network_id)
 }
 
-/// Send a direct packet with `msg` contents to the specified peer.
 #[inline]
-pub fn send_direct_message(
+pub fn send_message_over_network(
     node: &P2PNode,
-    target_id: RemotePeerId,
-    network_id: NetworkId,
-    msg: Arc<[u8]>,
-) -> usize {
-    send_message_over_network(node, Some(target_id), vec![], network_id, msg)
-}
-
-/// Send a broadcast packet with `msg` contents to the specified peer.
-#[inline]
-pub fn send_broadcast_message(
-    node: &P2PNode,
-    dont_relay_to: Vec<RemotePeerId>,
-    network_id: NetworkId,
-    msg: Arc<[u8]>,
-) -> usize {
-    send_message_over_network(node, None, dont_relay_to, network_id, msg)
-}
-
-#[inline]
-fn send_message_over_network(
-    node: &P2PNode,
-    target_id: Option<RemotePeerId>,
-    dont_relay_to: Vec<RemotePeerId>,
+    destination: PacketDestination,
     network_id: NetworkId,
     message: Arc<[u8]>,
 ) -> usize {
-    let destination = if let Some(target_id) = target_id {
-        PacketDestination::Direct(target_id)
-    } else {
-        PacketDestination::Broadcast(dont_relay_to)
-    };
-
     let message = message.to_vec();
 
     // Create packet.

--- a/concordium-node/src/plugins/consensus.rs
+++ b/concordium-node/src/plugins/consensus.rs
@@ -20,10 +20,8 @@ use crate::{
         },
         messaging::{ConsensusMessage, DistributionMode, MessageType},
     },
-    p2p::{
-        connectivity::{send_broadcast_message, send_direct_message},
-        P2PNode,
-    },
+    network::PacketDestination,
+    p2p::{connectivity::send_message_over_network, P2PNode},
     read_or_die, write_or_die,
 };
 use concordium_base::common::Deserial;
@@ -282,18 +280,18 @@ pub fn handle_consensus_outbound_msg(
         {
             send_consensus_msg_to_net(
                 node,
-                Vec::new(),
-                Some(peer),
-                (message.payload.clone(), message.variant),
+                PacketDestination::Direct(peer),
+                message.payload.clone(),
+                message.variant,
             );
         }
     } else {
-        send_consensus_msg_to_net(
-            node,
-            message.dont_relay_to(),
-            message.target_peer(),
-            (message.payload, message.variant),
-        );
+        let destination = if let Some(target_id) = message.target_peer() {
+            PacketDestination::Direct(target_id)
+        } else {
+            PacketDestination::Broadcast(message.dont_relay_to)
+        };
+        send_consensus_msg_to_net(node, destination, message.payload, message.variant);
     }
     Ok(())
 }
@@ -339,9 +337,9 @@ pub fn handle_consensus_inbound_msg(
     {
         send_consensus_msg_to_net(
             node,
-            request.dont_relay_to(),
-            None,
-            (request.payload, request.variant),
+            PacketDestination::Broadcast(request.dont_relay_to),
+            request.payload,
+            request.variant,
         );
     }
     // Execute any finalizer returned from the consensus layer.
@@ -430,28 +428,23 @@ fn send_msg_to_consensus(
 
 fn send_consensus_msg_to_net(
     node: &P2PNode,
-    dont_relay_to: Vec<RemotePeerId>,
-    target_id: Option<RemotePeerId>,
-    (payload, msg_desc): (Arc<[u8]>, PacketType),
+    destination: PacketDestination,
+    payload: Arc<[u8]>,
+    msg_desc: PacketType,
 ) {
-    let sent = if let Some(target_id) = target_id {
-        send_direct_message(node, target_id, node.config.default_network, payload)
-    } else {
-        send_broadcast_message(
-            node,
-            dont_relay_to.into_iter().collect(),
-            node.config.default_network,
-            payload,
+    let log_message = if let PacketDestination::Direct(id) = destination {
+        format!(
+            "Sent a direct message to peer {} containing a {}",
+            id, msg_desc
         )
+    } else {
+        format!("Sent a broadcast containing a {}", msg_desc)
     };
 
+    let sent = send_message_over_network(node, destination, node.config.default_network, payload);
+
     if sent > 0 {
-        let target_desc = if let Some(id) = target_id {
-            format!("direct message to peer {}", id)
-        } else {
-            "broadcast".to_string()
-        };
-        debug!("Sent a {} containing a {}", target_desc, msg_desc);
+        debug!("{}", log_message);
     }
 }
 
@@ -488,12 +481,15 @@ fn try_catch_up(node: &P2PNode, consensus: &ConsensusContainer, peers: &mut Peer
     if let Some(id) = peers.next_pending() {
         debug!("Attempting to catch up with peer {}", id);
         peers.catch_up_stamp = get_current_stamp();
-        let sent = send_direct_message(
-            node,
-            id,
-            node.config.default_network,
-            consensus.get_catch_up_status(),
-        );
+        let sent = {
+            let msg = consensus.get_catch_up_status();
+            send_message_over_network(
+                node,
+                PacketDestination::Direct(id),
+                node.config.default_network,
+                msg,
+            )
+        };
         if sent > 0 {
             info!(
                 "Sent a direct message to peer {} containing a {}",
@@ -635,9 +631,9 @@ fn update_peer_states(
                 {
                     send_consensus_msg_to_net(
                         node,
-                        Vec::new(),
-                        Some(non_pending_peer),
-                        (request.payload.clone(), request.variant),
+                        PacketDestination::Direct(non_pending_peer),
+                        request.payload.clone(),
+                        request.variant,
                     );
                 }
             }


### PR DESCRIPTION
## Purpose
- Simplify the network messaging layer by passing `PacketDestination` directly instead of routing through direct/broadcast wrapper helpers.
- Reduce call indirection around consensus and connectivity message sending.

No semantic changes

## Changes
- Replace separate direct/broadcast send helpers with `send_message_over_network`.
- Pass `PacketDestination` explicitly from consensus and connection call sites.
- Simplify consensus send logic and logging around message destinations.
- Update connection tests to use the new messaging API.