### PR TITLE
Fix p10 to p11 plt migration

### DIFF
--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/ProtocolLevelTokens.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/ProtocolLevelTokens.hs
@@ -519,7 +519,7 @@ migrateProtocolLevelTokensForPV migration oldPLTsV0@(ProtocolLevelTokensV0 oldPL
                         id
                         oldBlobRefMaybe
             -- 2. Load it into Rust block state (supports P10)
-            (oldState :: ForeignPLTBlockStatePtr (MPV m)) <- lift $ loadDirect (coerce oldBlobRef)
+            (oldState :: ForeignPLTBlockStatePtr (MPV m)) <- lift $ RustBS.loadFromBlobRef (coerce oldBlobRef)
             -- 3. Migrate Rust block state from P10 to P11
             ProtocolLevelTokensV1 <$> RustBS.migrate oldState
 migrateProtocolLevelTokensForPV migration (ProtocolLevelTokensV1 oldState) =

--- a/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/ProtocolLevelTokens/RustPLTBlockState.hs
+++ b/concordium-consensus/src/Concordium/GlobalState/Persistent/BlockState/ProtocolLevelTokens/RustPLTBlockState.hs
@@ -12,6 +12,7 @@ module Concordium.GlobalState.Persistent.BlockState.ProtocolLevelTokens.RustPLTB
     ForeignPLTBlockStatePtr,
     wrapFFIPtr,
     empty,
+    loadFromBlobRef,
     withPLTBlockState,
     migrate,
     ProtocolLevelTokensHash (..),
@@ -88,25 +89,31 @@ foreign import ccall "ffi_empty_plt_block_state"
         -- | Status code
         IO FFI.Word8
 
+-- | Load a PLT block state directly from an existing blob-store location.
+loadFromBlobRef ::
+    forall m pv.
+    (BlobStore.MonadBlobStore m, Types.IsProtocolVersion pv) =>
+    BlobStore.BlobRef RustPLTBlockState ->
+    m (ForeignPLTBlockStatePtr pv)
+loadFromBlobRef blobRef = do
+    loadCallback <- fst <$> BlobStore.getCallbacks
+    liftIO $! do
+        FFI.alloca $ \blockStateDestPtr -> do
+            status <-
+                ffiLoadPLTBlockState
+                    loadCallback
+                    blobRef
+                    (sProtocolVersionToWord64 $ Types.protocolVersion @pv)
+                    blockStateDestPtr
+            Monad.unless (status == 0) $ error "Unexpected panic when loading a block state"
+            blockState <- FFI.peek blockStateDestPtr
+            wrapFFIPtr blockState
+
 instance
     (BlobStore.MonadBlobStore m, Types.IsProtocolVersion pv) =>
     BlobStore.BlobStorable m (ForeignPLTBlockStatePtr pv)
     where
-    load = do
-        blobRef <- S.get
-        pure $! do
-            loadCallback <- fst <$> BlobStore.getCallbacks
-            liftIO $! do
-                FFI.alloca $ \blockStateDestPtr -> do
-                    status <-
-                        ffiLoadPLTBlockState
-                            loadCallback
-                            blobRef
-                            (sProtocolVersionToWord64 $ Types.protocolVersion @pv)
-                            blockStateDestPtr
-                    Monad.unless (status == 0) $ error "Unexpected panic when loading a block state"
-                    blockState <- FFI.peek blockStateDestPtr
-                    wrapFFIPtr blockState
+    load = S.get >>= pure . loadFromBlobRef
     storeUpdate pltBlockState = do
         storeCallback <- snd <$> BlobStore.getCallbacks
         blobRef <- liftIO $ FFI.alloca $ \blobRefDestPtr -> do

--- a/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/RustPLTScheduler/Queries.hs
+++ b/concordium-consensus/src/Concordium/Scheduler/ProtocolLevelTokens/RustPLTScheduler/Queries.hs
@@ -11,6 +11,7 @@ module Concordium.Scheduler.ProtocolLevelTokens.RustPLTScheduler.Queries (
     SerializedLockId,
     queryPLTList,
     queryTokenInfo,
+    queryTokenInfoInBlobStoreMonad,
     queryTokenAccountInfos,
     queryTokenAuthorizations,
     queryLockList,
@@ -164,75 +165,79 @@ queryTokenInfo ::
 queryTokenInfo bs tokenId = do
     queryCallbacks <- unliftBlockStateQueryCallbacks bs
     pltState <- BS.getRustPLTBlockState bs
-    BS.liftBlobStore $ queryTokenInfoInBlobStoreMonad pltState queryCallbacks
-  where
-    -- Get token info for the given token in the given block state. The function is a wrapper around an FFI call
-    -- to the Rust PLT Scheduler library.
-    queryTokenInfoInBlobStoreMonad ::
-        (BlobStore.MonadBlobStore m') =>
-        -- Block state to query.
-        PLTBlockState.ForeignPLTBlockStatePtr (Types.MPV m) ->
-        -- Callback need for queries.
-        BlockStateQueryCallbacks ->
-        -- The token info.
-        m' (Maybe QueriesTypes.TokenInfo)
-    queryTokenInfoInBlobStoreMonad
-        pltBlockState
-        queryCallbacks =
-            do
-                loadCallbackPtr <- fst <$> BlobStore.getCallbacks
-                liftIO $ FFI.alloca $ \returnDataPtrOutPtr -> FFI.alloca $ \returnDataLenOutPtr ->
-                    do
-                        readTokenAccountBalanceCallbackPtr <- wrapReadTokenAccountBalance $ readTokenAccountBalance queryCallbacks
-                        getAccountIndexByAddressCallbackPtr <- wrapGetAccountIndexByAddress $ getAccountIndexByAddress queryCallbacks
-                        getAccountAddressByIndexCallbackPtr <- wrapGetAccountAddressByIndex $ getAccountAddressByIndex queryCallbacks
-                        getTokenAccountStatesCallbackPtr <- wrapGetTokenAccountStates $ getTokenAccountStates queryCallbacks
-                        -- Invoke the ffi call
-                        statusCode <- PLTBlockState.withPLTBlockState pltBlockState $ \pltBlockStatePtr ->
-                            BSS.useAsCStringLen (Types.tokenId tokenId) $ \(tokenIdPtr, tokenIdLen) ->
-                                ffiQueryTokenInfo
-                                    loadCallbackPtr
-                                    readTokenAccountBalanceCallbackPtr
-                                    getAccountIndexByAddressCallbackPtr
-                                    getAccountAddressByIndexCallbackPtr
-                                    getTokenAccountStatesCallbackPtr
-                                    pltBlockStatePtr
-                                    (FFI.castPtr tokenIdPtr)
-                                    (fromIntegral tokenIdLen)
-                                    returnDataPtrOutPtr
-                                    returnDataLenOutPtr
-                        -- Free the function pointers we have just created
-                        -- (loadCallbackPtr is created in another context,
-                        -- so we should not free it)
-                        FFI.freeHaskellFunPtr readTokenAccountBalanceCallbackPtr
-                        FFI.freeHaskellFunPtr getAccountIndexByAddressCallbackPtr
-                        FFI.freeHaskellFunPtr getAccountAddressByIndexCallbackPtr
-                        FFI.freeHaskellFunPtr getTokenAccountStatesCallbackPtr
-                        -- Process the returned status and values returned via out pointers
-                        returnDataLen <- FFI.peek returnDataLenOutPtr
-                        returnDataPtr <- FFI.peek returnDataPtrOutPtr
-                        returnData <-
-                            BS.unsafePackCStringFinalizer
-                                returnDataPtr
-                                (fromIntegral returnDataLen)
-                                (Memory.rs_free_array_len_2 returnDataPtr (fromIntegral returnDataLen))
-                        case Status.parseStatusCode statusCode of
-                            Just Status.FSCSuccess -> do
-                                let getTokenInfo = S.isolate (BS.length returnData) S.get
-                                let tokenInfo =
-                                        either
-                                            (\message -> error $ "Token info from Rust PLT Scheduler could not be deserialized: " ++ message)
-                                            id
-                                            $ S.runGet getTokenInfo returnData
-                                return $ Just tokenInfo
-                            Just Status.FSCFailed -> do
-                                return Nothing
-                            Just Status.FSCPanic -> do
-                                let message = case Text.decodeUtf8' returnData of
-                                        Right decoded -> decoded
-                                        Left _ -> "<panic message was invalid UTF-8>"
-                                error ("Call to 'ffiQueryTokenInfo' resulted in panic with message: " ++ show message)
-                            Nothing -> error ("Unexpected status code from calling 'ffiQueryTokenInfo': " ++ show statusCode)
+    BS.liftBlobStore $ queryTokenInfoInBlobStoreMonad pltState queryCallbacks tokenId
+
+-- | Get token info directly from a Rust-managed PLT state.
+-- This helper is exported so persistence-boundary tests can query PLT state without
+-- constructing a complete block state.
+queryTokenInfoInBlobStoreMonad ::
+    (BlobStore.MonadBlobStore m) =>
+    -- | PLT state to query.
+    PLTBlockState.ForeignPLTBlockStatePtr pv ->
+    -- | Callbacks for querying Haskell-managed account state.
+    BlockStateQueryCallbacks ->
+    -- | Token to find token info for.
+    Types.TokenId ->
+    -- | The token info, or 'Nothing' when the token does not exist.
+    m (Maybe QueriesTypes.TokenInfo)
+queryTokenInfoInBlobStoreMonad
+    pltBlockState
+    queryCallbacks
+    tokenId =
+        do
+            loadCallbackPtr <- fst <$> BlobStore.getCallbacks
+            liftIO $ FFI.alloca $ \returnDataPtrOutPtr -> FFI.alloca $ \returnDataLenOutPtr ->
+                do
+                    readTokenAccountBalanceCallbackPtr <- wrapReadTokenAccountBalance $ readTokenAccountBalance queryCallbacks
+                    getAccountIndexByAddressCallbackPtr <- wrapGetAccountIndexByAddress $ getAccountIndexByAddress queryCallbacks
+                    getAccountAddressByIndexCallbackPtr <- wrapGetAccountAddressByIndex $ getAccountAddressByIndex queryCallbacks
+                    getTokenAccountStatesCallbackPtr <- wrapGetTokenAccountStates $ getTokenAccountStates queryCallbacks
+                    -- Invoke the ffi call
+                    statusCode <- PLTBlockState.withPLTBlockState pltBlockState $ \pltBlockStatePtr ->
+                        BSS.useAsCStringLen (Types.tokenId tokenId) $ \(tokenIdPtr, tokenIdLen) ->
+                            ffiQueryTokenInfo
+                                loadCallbackPtr
+                                readTokenAccountBalanceCallbackPtr
+                                getAccountIndexByAddressCallbackPtr
+                                getAccountAddressByIndexCallbackPtr
+                                getTokenAccountStatesCallbackPtr
+                                pltBlockStatePtr
+                                (FFI.castPtr tokenIdPtr)
+                                (fromIntegral tokenIdLen)
+                                returnDataPtrOutPtr
+                                returnDataLenOutPtr
+                    -- Free the function pointers we have just created
+                    -- (loadCallbackPtr is created in another context,
+                    -- so we should not free it)
+                    FFI.freeHaskellFunPtr readTokenAccountBalanceCallbackPtr
+                    FFI.freeHaskellFunPtr getAccountIndexByAddressCallbackPtr
+                    FFI.freeHaskellFunPtr getAccountAddressByIndexCallbackPtr
+                    FFI.freeHaskellFunPtr getTokenAccountStatesCallbackPtr
+                    -- Process the returned status and values returned via out pointers
+                    returnDataLen <- FFI.peek returnDataLenOutPtr
+                    returnDataPtr <- FFI.peek returnDataPtrOutPtr
+                    returnData <-
+                        BS.unsafePackCStringFinalizer
+                            returnDataPtr
+                            (fromIntegral returnDataLen)
+                            (Memory.rs_free_array_len_2 returnDataPtr (fromIntegral returnDataLen))
+                    case Status.parseStatusCode statusCode of
+                        Just Status.FSCSuccess -> do
+                            let getTokenInfo = S.isolate (BS.length returnData) S.get
+                            let tokenInfo =
+                                    either
+                                        (\message -> error $ "Token info from Rust PLT Scheduler could not be deserialized: " ++ message)
+                                        id
+                                        $ S.runGet getTokenInfo returnData
+                            return $ Just tokenInfo
+                        Just Status.FSCFailed -> do
+                            return Nothing
+                        Just Status.FSCPanic -> do
+                            let message = case Text.decodeUtf8' returnData of
+                                    Right decoded -> decoded
+                                    Left _ -> "<panic message was invalid UTF-8>"
+                            error ("Call to 'ffiQueryTokenInfo' resulted in panic with message: " ++ show message)
+                        Nothing -> error ("Unexpected status code from calling 'ffiQueryTokenInfo': " ++ show statusCode)
 
 -- | C-binding for calling the Rust function `plt_scheduler::queries::query_token_info`.
 --

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/ProtocolLevelTokens.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/ProtocolLevelTokens.hs
@@ -1,11 +1,15 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module GlobalStateTests.ProtocolLevelTokens where
 
 import Control.Monad.Trans.Class
+import Control.Monad.Trans.Maybe
 import Test.HUnit
 import Test.Hspec
 import Test.QuickCheck as QuickCheck
@@ -14,18 +18,25 @@ import qualified Concordium.Crypto.SHA256 as SHA256
 import Concordium.Types
 import Concordium.Types.Conditionally
 import Concordium.Types.HashableTo
+import Concordium.Types.ProtocolLevelTokens.CBOR
 import Concordium.Types.Tokens
 
 import Concordium.Crypto.SHA256
+import Concordium.Genesis.Data
 import Concordium.GlobalState.Persistent.BlobStore
 import Concordium.GlobalState.Persistent.BlockState.ProtocolLevelTokens
-import Concordium.GlobalState.Persistent.BlockState.ProtocolLevelTokens.RustPLTBlockState
+import Concordium.GlobalState.Persistent.BlockState.ProtocolLevelTokens.RustPLTBlockState (ProtocolLevelTokensHash)
 import Control.Monad.IO.Class
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base16.Lazy as B16
 import Data.Either
 import qualified Data.FixedByteString as FBS
 import Data.Maybe
+import Data.Serialize (encode)
+
+import qualified Concordium.Scheduler.ProtocolLevelTokens.RustPLTScheduler.BlockStateCallbacks as Callbacks
+import qualified Concordium.Scheduler.ProtocolLevelTokens.RustPLTScheduler.Queries as Queries
+import qualified Concordium.Types.Queries.Tokens as TokenQueries
 
 -- | Generate a 'TokenRawAmount' value.
 genTokenRawAmount :: Gen TokenRawAmount
@@ -61,6 +72,39 @@ configDEF =
 
 emptyPLTPV :: (MonadBlobStore m) => m (ProtocolLevelTokensForPV 'P9)
 emptyPLTPV = emptyProtocolLevelTokensForPV
+
+-- These test-only protocol-version wrappers exercise the production migration
+-- seam without constructing a complete persistent block state.
+newtype P10BlobStore a = P10BlobStore {runP10BlobStore :: MemBlobStoreT IO a}
+    deriving (Functor, Applicative, Monad, MonadIO)
+
+instance MonadBlobStore P10BlobStore where
+    storeRaw = P10BlobStore . storeRaw
+    loadRaw = P10BlobStore . loadRaw
+    flushStore = P10BlobStore flushStore
+    getCallbacks = P10BlobStore getCallbacks
+    withBlobPtr blobPtr = P10BlobStore . withBlobPtr blobPtr
+    loadBlobPtr = P10BlobStore . loadBlobPtr
+
+instance MonadProtocolVersion P10BlobStore where
+    type MPV P10BlobStore = 'P10
+
+newtype P11Migration m a = P11Migration {runP11Migration :: MaybeT m a}
+    deriving (Functor, Applicative, Monad, MonadIO)
+
+instance MonadTrans P11Migration where
+    lift = P11Migration . lift
+
+instance (MonadBlobStore m) => MonadBlobStore (P11Migration m) where
+    storeRaw = lift . storeRaw
+    loadRaw = lift . loadRaw
+    flushStore = lift flushStore
+    getCallbacks = lift getCallbacks
+    withBlobPtr blobPtr = lift . withBlobPtr blobPtr
+    loadBlobPtr = lift . loadBlobPtr
+
+instance MonadProtocolVersion (P11Migration P10BlobStore) where
+    type MPV (P11Migration P10BlobStore) = 'P11
 
 testCreateToken :: Assertion
 testCreateToken = runWithNewMemBlobStore $ do
@@ -254,6 +298,56 @@ fixtureTestLoadEmpty = runWithNewMemBlobStore $ do
         )
 
 -- | Load PLTs state with some simple PLTs from storage fixture, to make sure we stay compatible.
+testP10P11PLTMigration :: Assertion
+testP10P11PLTMigration = runWithNewMemBlobStore . runP10BlobStore $ do
+    (tokenIndex, tokens1 :: ProtocolLevelTokensForPV 'P10) <- createToken configABC =<< emptyProtocolLevelTokensForPV
+    tokens2 <- setTokenCirculatingSupply tokenIndex 123 tokens1
+    tokenState <- getMutableTokenState tokenIndex tokens2
+    _ <- updateTokenState "\NUL\NULname" (Just "migration-value") tokenState
+    _ <- updateTokenState "\NUL\NULmetadata" (Just (tokenMetadataUrlToBytes $ createTokenMetadataUrl "https://migration.token")) tokenState
+    _ <- updateTokenState "\NUL\NULgovernanceAccount" (Just (encode (AccountIndex 0))) tokenState
+    tokens3 <- setTokenState tokenIndex tokenState tokens2
+    persistedTokens <- case tokens3 of
+        ProtocolLevelTokensV0 tokensRef -> ProtocolLevelTokensV0 . fst <$> refFlush tokensRef
+    migrated <-
+        runMaybeT . runP11Migration $
+            migrateProtocolLevelTokensForPV
+                (StateMigrationParametersP10ToP11 (error "PLT migration does not inspect P11 migration data"))
+                persistedTokens
+    migratedTokens <- case migrated of
+        Nothing -> liftIO $ assertFailure "P10-to-P11 PLT migration unexpectedly failed"
+        Just tokens -> return tokens
+    -- The migrated P11 state must remain persistable through the production FFI.
+    p11Reference <- storeRef migratedTokens
+    (reloaded :: ProtocolLevelTokensForPV 'P11) <- loadRef p11Reference
+    tokenInfo <- queryMigratedTokenInfo reloaded tokenABC
+    liftIO $ assertEqual "token identity" tokenABC (TokenQueries.tiTokenId tokenInfo)
+    let tokenState' = TokenQueries.tiTokenState tokenInfo
+    liftIO $ assertEqual "token configuration" (_pltModule configABC) (TokenQueries.tsTokenModuleRef tokenState')
+    liftIO $ assertEqual "token decimals" (_pltDecimals configABC) (TokenQueries.tsDecimals tokenState')
+    liftIO $ assertEqual "circulating supply" 123 (TokenQueries.taValue (TokenQueries.tsTotalSupply tokenState'))
+    liftIO $ assertBool "token state" ("migration-value" `BS.isInfixOf` TokenQueries.tsModuleState tokenState')
+
+-- | Query the migrated P11 state without constructing an unrelated complete block state.
+-- The fixture has no token holders, so its account callbacks return empty values.
+queryMigratedTokenInfo ::
+    (MonadBlobStore m) =>
+    ProtocolLevelTokensForPV 'P11 ->
+    TokenId ->
+    m TokenQueries.TokenInfo
+queryMigratedTokenInfo tokens queriedTokenId = do
+    tokenInfo <-
+        Queries.queryTokenInfoInBlobStoreMonad
+            (getRustPLTBlockState tokens)
+            Callbacks.BlockStateQueryCallbacks
+                { Callbacks.readTokenAccountBalance = \_ _ -> return 0,
+                  Callbacks.getAccountIndexByAddress = \_ -> return Nothing,
+                  Callbacks.getAccountAddressByIndex = \_ -> return $ Just (AccountAddress (FBS.pack (replicate 32 0))),
+                  Callbacks.getTokenAccountStates = \_ -> return []
+                }
+            queriedTokenId
+    maybe (liftIO $ assertFailure "migrated token not found") return tokenInfo
+
 fixtureTestLoadSimple :: Assertion
 fixtureTestLoadSimple = runWithNewMemBlobStore $ do
     mbs1 <- liftIO $ newMemBlobStoreWithBytes $ fromRight undefined $ B16.decode "000000000000002806746f6b656e310505050505050505050505050505050505050505050505050505050505050505020000000000000025edbda48b85971b3a874334ca94f07e55e6a6e63eabca968d1257a3223e1b84e14002010100000000000000002503b0eab929105fd6df1ec793cbaf1b554a7a385520a9f7c902adf0219ace6dab4002000000000000000000003648b07111a93452374c7bcf66ee01959af6b4a52cb7cd299341e9ea77b378b0230300000201000000000000005d020000000000000030000000000000000901000000000000008a0000000000000011000000000000000000000000000000c86400000000000000090000000000000000d9000000000000002806746f6b656e3205050505050505050505050505050505050505050505050505050505050505050400000000000000010000000000000000110000000000000103000000000000013300000000000000000900000000000000013c0000000000000021000000000000000201000000000000000000000000000000f20000000000000155"
@@ -302,4 +396,5 @@ tests = describe "GlobalStateTests.ProtocolLevelTokens" $ do
     it "snapshotHashEmpty" snapshotTestHashEmpty
     it "snapshotHashSimple" snapshotTestHashSimple
     it "fixtureLoadEmpty" fixtureTestLoadEmpty
+    it "migrates persisted P10 PLTs to P11" testP10P11PLTMigration
     it "fixtureLoadSimple" fixtureTestLoadSimple

--- a/concordium-consensus/tests/globalstate/GlobalStateTests/ProtocolLevelTokens.hs
+++ b/concordium-consensus/tests/globalstate/GlobalStateTests/ProtocolLevelTokens.hs
@@ -29,6 +29,7 @@ import Concordium.GlobalState.Persistent.BlockState.ProtocolLevelTokens.RustPLTB
 import Control.Monad.IO.Class
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base16.Lazy as B16
+import qualified Data.ByteString.Lazy as LBS
 import Data.Either
 import qualified Data.FixedByteString as FBS
 import Data.Maybe
@@ -326,7 +327,18 @@ testP10P11PLTMigration = runWithNewMemBlobStore . runP10BlobStore $ do
     liftIO $ assertEqual "token configuration" (_pltModule configABC) (TokenQueries.tsTokenModuleRef tokenState')
     liftIO $ assertEqual "token decimals" (_pltDecimals configABC) (TokenQueries.tsDecimals tokenState')
     liftIO $ assertEqual "circulating supply" 123 (TokenQueries.taValue (TokenQueries.tsTotalSupply tokenState'))
-    liftIO $ assertBool "token state" ("migration-value" `BS.isInfixOf` TokenQueries.tsModuleState tokenState')
+    moduleState <- case tokenModuleStateFromBytes $ LBS.fromStrict $ TokenQueries.tsModuleState tokenState' of
+        Left err -> liftIO $ assertFailure $ "could not decode migrated token module state: " ++ err
+        Right state -> return state
+    liftIO $ assertEqual "token name" (Just "migration-value") (tmsName moduleState)
+    liftIO $ assertEqual "token metadata" (Just $ createTokenMetadataUrl "https://migration.token") (tmsMetadata moduleState)
+    liftIO $ assertEqual "token governance account" (Just $ accountTokenHolder $ AccountAddress (FBS.pack $ replicate 32 0)) (tmsGovernanceAccount moduleState)
+    liftIO $ assertEqual "token paused state" (Just False) (tmsPaused moduleState)
+    liftIO $ assertEqual "token allow-list state" (Just False) (tmsAllowList moduleState)
+    liftIO $ assertEqual "token deny-list state" (Just False) (tmsDenyList moduleState)
+    liftIO $ assertEqual "token mintable state" (Just False) (tmsMintable moduleState)
+    liftIO $ assertEqual "token burnable state" (Just False) (tmsBurnable moduleState)
+    liftIO $ assertEqual "additional token state" mempty (tmsAdditional moduleState)
 
 -- | Query the migrated P11 state without constructing an unrelated complete block state.
 -- The fixture has no token holders, so its account callbacks return empty values.


### PR DESCRIPTION
## Purpose

Fix an error in the PLT state migration caused by a double dereference of the haskell managed PLT blob store reference

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
