### PR TITLE
Limit CBOR nesting

### DIFF
--- a/plt/plt-block-state/src/utils.rs
+++ b/plt/plt-block-state/src/utils.rs
@@ -65,8 +65,6 @@ impl<T> Deref for Cow<'_, T> {
 /// Decode given CBOR using decode options set to suit the token module. The decode options
 /// will generally be strict.
 pub fn cbor_decode<T: CborDeserialize>(cbor: impl AsRef<[u8]>) -> CborSerializationResult<T> {
-    let decode_options = SerializationOptions {
-        unknown_map_keys: UnknownMapKeys::Fail,
-    };
+    let decode_options = SerializationOptions::default().unknown_map_keys(UnknownMapKeys::Fail);
     cbor::cbor_decode_with_options(cbor, decode_options)
 }


### PR DESCRIPTION
Depends on https://github.com/Concordium/concordium-base/pull/960

## Purpose

Impose a nesting limit for decoded cbor structures.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.