### PR TITLE
Refactor persistent locks state to trie

### DIFF
--- a/concordium-consensus/tests/consensus/ConcordiumTests/EndToEnd/CredentialDeploymentTests.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/EndToEnd/CredentialDeploymentTests.hs
@@ -106,7 +106,7 @@ testBB1 =
                         SP8 -> read "9edf091441b19468d82a637c270472b0474592f3089e56415e4982351b095d35"
                         SP9 -> read "ad588c91476f5865dabf2ffe9b6954c924479aa0a2ef4057a5b79dbc110b1219"
                         SP10 -> read "5272b398aa5ade5ef14c6be41d586537f5212d96ea609b414bf2051e0c3780f7"
-                        SP11 -> read "ece98c14e32372a737ad945cc67826dc0aa86849dc9fc5485059a406349ed1ec"
+                        SP11 -> read "76c238903833cd8fb3232a3574da9d79e37a7a6c3356ccf5b755e0824a040f87"
                     }
         }
   where
@@ -140,7 +140,7 @@ testBB2 =
                         SP8 -> read "7ead7edff60ac23771f15052278304e3e2c9186826439ec7d04e28e55676f41b"
                         SP9 -> read "29d974384b047eaa8cb5b809dd37e9fe617e046ad22b7f9dbe605cdac9cf8e40"
                         SP10 -> read "29d974384b047eaa8cb5b809dd37e9fe617e046ad22b7f9dbe605cdac9cf8e40"
-                        SP11 -> read "2bb51af7c0be873360ce949b0412acf83ced13924aabdaabf9e5f0d4126adbdb"
+                        SP11 -> read "183985cb9393471fa9e597453b087a9d721f5a39abcca6015aab059742083150"
                     }
         }
   where
@@ -174,7 +174,7 @@ testBB3 =
                         SP8 -> read "c8b3fc868c79703945638c709c9e2d03b67c3f70b023aac8ae5b980b41181726"
                         SP9 -> read "0282c255df3cb95180050ae3ee8838c0ab303fa7fe4e5e754ecf5d4c8db5152a"
                         SP10 -> read "0282c255df3cb95180050ae3ee8838c0ab303fa7fe4e5e754ecf5d4c8db5152a"
-                        SP11 -> read "add91d5bf428e6b290770dc10a5f98027baa81cbf2291bb9d4bdce389d7eb922"
+                        SP11 -> read "056b7e86edb6b2e0cfef54f92bb103afe64c456337b492a774bc568b0c861701"
                     }
         }
   where
@@ -232,7 +232,7 @@ testBB2' =
                         SP8 -> read "3abd796108d6fdcdf8c4361973d7152973cad3695b58b0c92a4e5021c0f80e33"
                         SP9 -> read "e10fe99a06aec8675f442ef0232ff0af9106ad6f5845335513603bcb4f3ff707"
                         SP10 -> read "0182d9155fb80b22fa43b8f7e1d9da389209bfa27340ec5a823a3f587e4455f9"
-                        SP11 -> read "60b9953eeeb4e275fc4f452c546286e7e1b1b974128ce8207b38652588bbd9b1"
+                        SP11 -> read "841145c8d4ba130c090fa6e6deb09ed91d0d2f1b6ee1b3ac7fba4c545202b8ca"
                     }
         }
   where
@@ -266,7 +266,7 @@ testBB3' =
                         SP8 -> read "9e46988a9afd8470e25c33f2133d2c10cbb38050979957f200b4aca072e3c932"
                         SP9 -> read "075e1732e475a84b89f1ba89c06d58df7d7e42936dc16e0cf3d8b02dacf27c52"
                         SP10 -> read "2a9b336c419c9e64dc7db6735a297119649c4b579ac4d32ac58e1ab09302d17c"
-                        SP11 -> read "cf30c95b37bcccf25d55197bad6ba3f5a0085d676a04ef818e1cb16aa24be214"
+                        SP11 -> read "a881b3e6ffce15cdee8033cc4fd429d656edd722c11f0fcc6376852e49f62881"
                     }
         }
   where
@@ -298,7 +298,7 @@ testBB4 =
                         SP8 -> read "5bdf447992d82321a921bca9eeb6211bf3a290029164976885cf6b2fd14d923c"
                         SP9 -> read "ff90510a80285645170b5ff4614af366de2d8898e2bee111cae61e05ad640ada"
                         SP10 -> read "ff90510a80285645170b5ff4614af366de2d8898e2bee111cae61e05ad640ada"
-                        SP11 -> read "1d6c66feef3c319291a67d1bdbf997b018747c369b8213828fd69bfebe6fb984"
+                        SP11 -> read "3887b38651359fc5621bcc835a5789b5038e42447d37b6342d9d9ea0b46408e0"
                     }
         }
   where
@@ -330,7 +330,7 @@ testBB5 =
                         SP8 -> read "e704583a45aec569aca9039e977d9a3a7c2db8bdfd650532182600b6a19cbb70"
                         SP9 -> read "6ad235a2db0349340044197b9c23da565f6bf4dd1ad40b89eab5bae7bcab0997"
                         SP10 -> read "6ad235a2db0349340044197b9c23da565f6bf4dd1ad40b89eab5bae7bcab0997"
-                        SP11 -> read "809f53395251d5ab5093c379c3b2ad5c827b4e4fc4cf65188683b4a6a898c68a"
+                        SP11 -> read "cbfb83291d21306b8e704b2ca26f1f10f9430f7b170af7d689e126fe695ca854"
                     }
         }
   where

--- a/concordium-consensus/tests/consensus/ConcordiumTests/EndToEnd/TransactionTableIntegrationTest.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/EndToEnd/TransactionTableIntegrationTest.hs
@@ -75,7 +75,7 @@ testBB1 =
                         SP8 -> read "6f02a3e339abab1af9d23bc74369b6e142ad3b09f4d7042d16e076e225e3753f"
                         SP9 -> read "27ad830abd9d1f456f2a1666365ffff1fb216911d8dab2fbae5d3ad701816733"
                         SP10 -> read "5634a54bfdfb954205b78129c93236fba97b3190ad3fa412b4e2ffbaad6e7324"
-                        SP11 -> read "b17a4151a48f2887083ccc76d5bc7568f539628ca1bf12031fb13bfa90e07f3c"
+                        SP11 -> read "69831c9d1782ccb97b22edc027a62c8378e06db736003fc8d75f16b2a5637cea"
                     }
         }
   where
@@ -109,7 +109,7 @@ testBB2 =
                         SP8 -> read "b0c8b7a3872b7bb35a9df1f620e47f2b7dad09889b29772d7bc03d713cff862d"
                         SP9 -> read "3017ca78e30e5bfc25a15849c07b1266c46185340b909e26aee439ddc694af7b"
                         SP10 -> read "3017ca78e30e5bfc25a15849c07b1266c46185340b909e26aee439ddc694af7b"
-                        SP11 -> read "13964fd0b90be7dccd11fb38557e5ec2db096c3cf7a894c15d5119eac6ed4acb"
+                        SP11 -> read "9d11ab1631f4058fee22ab139a52bf9206e129153b0d273499823b9037210945"
                     }
         }
   where
@@ -143,7 +143,7 @@ testBB3 =
                         SP8 -> read "8adf29ed11f4784b4b32dbf84887ff9f5dd38ef2f78dbefe579822b48acd9e51"
                         SP9 -> read "8935d7fb4c2906ecf1e10b225e319fb39933ca7b0970b93084e4b7b6b01a8dca"
                         SP10 -> read "8935d7fb4c2906ecf1e10b225e319fb39933ca7b0970b93084e4b7b6b01a8dca"
-                        SP11 -> read "152c02676295c287c1aa51bd264d54e70b49df37adf5fc0ed3df738e822a890d"
+                        SP11 -> read "2fc8fd2d1de9491a05959915a9145907f19951ec98ec1dbafeb41ba502bdc23f"
                     }
         }
   where
@@ -176,7 +176,7 @@ testBB4 =
                         SP8 -> read "487c4bdf8af054727f0688bd8a7176f6c2a9c85dffc5d8acc1de23e0c3b6ef49"
                         SP9 -> read "fe5c4a3c4943440c34a72884ccf178af8f7b2043f0179b6bbf554574bb4ba581"
                         SP10 -> read "7ccdea365c8283b97af6b5d00fedc17853e84021dcbf1417c34fefbfe7736091"
-                        SP11 -> read "31cd7c3a4a9fbfc4d7c32d8210506d7e7cbd1afbc925cb81d81b774a25da2d65"
+                        SP11 -> read "cbe602388154114882f0bd6fee631eb0807787cee39a0e03c6441c1fd7111555"
                     }
         }
   where

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/CatchUp.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/CatchUp.hs
@@ -426,7 +426,7 @@ hashesRound4Block sProtocolVersion = case sBlockHashVersionFor sProtocolVersion 
                 spv
                     | TestBlocks.blockResultHashAsP9 spv ->
                         read "93837fbd7183afca6f32723f44f13f68a980b30e832ff93b5ed1c7a5e19ecdaa"
-                SP11 -> read "768ae2f059966bc0eef30974e51c172b33d61f9088366b7c853f84d08a5fc091"
+                SP11 -> read "2395c92cf06b9fc6f0657983fca1babd291fb51d78802436e0c64aa4d810fcbb"
                 spv -> TestBlocks.dummyBRH spv 0xc04
             }
 

--- a/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Consensus/Blocks.hs
+++ b/concordium-consensus/tests/consensus/ConcordiumTests/KonsensusV1/Consensus/Blocks.hs
@@ -352,7 +352,7 @@ testBB1 =
                         SP7 -> read "0970b0f7459e5150a56ac283eee6f587fc49cb1c3408146b46ee05457235bec7"
                         SP8 -> read "69f807bdafa7ef495089545cf89837cbcd5d1424fe53770efae4608a8bbf7560"
                         spv | blockResultHashAsP9 spv -> read "747769e675019732bd4de37f2486ed696bea329b9c31b618a1e3a583ed5e4aaf"
-                        SP11 -> read "ddc5b542193789c746a37220da7a1b4d5de4834298de11ea826ad9786c3deaf0"
+                        SP11 -> read "d93e9e2fdb7be5bb70664f25d716cb414cd81c017fb89fc6659ed4133b33f62a"
                         spv -> dummyBRH spv 1
                     }
         }
@@ -385,7 +385,7 @@ testBB2 =
                         SP7 -> read "2e6636b8275663e44452650e4b7968ecb26a32d57998fbbccc0292fdecb1522d"
                         SP8 -> read "8315e1c9ac06bf9b8d0902616dda6781648baef8765be529d583267ea6376a17"
                         spv | blockResultHashAsP9 spv -> read "6434d129fa41e0b469a056369f63e1f6eaafbfed3539c84c2f1542ae8e6cbcb2"
-                        SP11 -> read "9351794e72cbc75c244d9f5b95b6771d8abf53f08f1d6b07c32fde2cc584bebe"
+                        SP11 -> read "953c4b7d8cbcb7de93f112cfb0a5a0e83f67718af2358d9c6561e550ee833c2f"
                         spv -> dummyBRH spv 2
                     }
         }
@@ -418,7 +418,7 @@ testBB3 =
                         SP7 -> read "5777ce2df452ce52ee6beb43c555051588cdad67ad742e7be438cf9d22e31950"
                         SP8 -> read "aa38f2426aecf0103671767ececf2a5a5cbc6ebf20cb929d90f6cfd086bba258"
                         spv | blockResultHashAsP9 spv -> read "df8dd05c64cab1f1a6ba4c971aa751d1dfb653dfed3605a1334f601f1f808acf"
-                        SP11 -> read "c05c990491621b293c8195899234964ce7f1401331478dfb8199bce6117cde14"
+                        SP11 -> read "bad1b1c52a5ddbc545c9d364f40098f0ba933fd210403f0ccf9c9670e210df52"
                         spv -> dummyBRH spv 3
                     }
         }
@@ -444,7 +444,7 @@ testBB2' =
                         SP7 -> read "04185ac844f6aea6e32b667debd1e9a337d67a80350d12f1cb813bf212a4bc23"
                         SP8 -> read "0b7a0106ac9293606424bf03e9f0314c3ac8e41a4097f30435eb9b2ee9463aa4"
                         spv | blockResultHashAsP9 spv -> read "bf7634ab27d1c7509d6d230f78e7df94eea7f53c04f3f92619c901b042a1b663"
-                        SP11 -> read "40c1cbc93cdb41e0cf4b7ac67ab588cb01fd5be6b564b205cc34f4c0f0e8b6d5"
+                        SP11 -> read "a197e2fd9f1d26622ebd2f7641dccaaecd345caf2e9d424d220699d96e885b8d"
                         spv -> dummyBRH spv 0x102
                     }
         }
@@ -471,7 +471,7 @@ testBB3' =
                         SP7 -> read "11e59c1a721359a64b86a0c6bcee8f6cac7c5bc3a6b98517b0b4f8c5a726f9c5"
                         SP8 -> read "0a1d22fd9404974bb43616ad3d0152acb9de40f856b6fb66150b2c496730add5"
                         spv | blockResultHashAsP9 spv -> read "0d6386d76cff950e60543a03485cbbee5e11667e2ad09dc77a48cce5168dab58"
-                        SP11 -> read "ea0ad5396417e2f087b67da69da65546246694bf3ed8720400943c57663bc195"
+                        SP11 -> read "dbb5bd600a41e3c0e7d7bae017ee3424b0610bcf3fb1649034be2b53b80b45ba"
                         spv -> dummyBRH spv 0x103
                     }
         }
@@ -505,7 +505,7 @@ testBB4' =
                         SP7 -> read "ad8a288f88806037899d782b7dd3a37ade59e0d5f3e7a90b1db2b722ae9cbe3d"
                         SP8 -> read "1afb0b0bd86301671549f1b1e407d71818d1d9d29c19beed584d17e2ace638d4"
                         spv | blockResultHashAsP9 spv -> read "874ad0c151a7e2ec3252af524de4348203f5ac607580dd99e1c70bce94787b93"
-                        SP11 -> read "abad669bc34a4303f82adbe10dbf8dfa9bf689af57412f3dd6b1657085934a01"
+                        SP11 -> read "55501bfc62a6fa910789cedd7aa8d2731cffe01e72c3ae7d982fdea779680b63"
                         spv -> dummyBRH spv 0x104
                     }
         }
@@ -564,7 +564,7 @@ testBB1E =
                         SP7 -> read "1811353ec3811af6241f3e5dc2e19740acf518f02dccc51f427310b8cfe9ca6c"
                         SP8 -> read "a002fe8adf77ca8cb992fd25dd3c5430db7ee52e383212eeb0827170af323d2e"
                         spv | blockResultHashAsP9 spv -> read "f59f26a1b1da5858ccc51589c7eb9227493434aa0788f3fb8ffb3104ecebe4fb"
-                        SP11 -> read "f24fb5200d24d7a59276602ddc465d06342e552eab3942e7b8760e8670412698"
+                        SP11 -> read "386fd6cd89ae839988f95d33775afa4a66621b9f801a7256241a3c90b0ebc68b"
                         spv -> dummyBRH spv 0xe01
                     }
         }
@@ -597,7 +597,7 @@ testBB2E =
                         SP7 -> read "99fc52af1ee2336f0d353a84c4d6c15345882271f648f7b84e69d9c40d5571c2"
                         SP8 -> read "af4910f96957a8fc36844cfd1ca9dfadd47776b2a5b4e5f23011b4f580a01902"
                         spv | blockResultHashAsP9 spv -> read "8e068776dc01e0079a00d9b531897e2a1e732c91ce9db92d64fd2cd183cea83e"
-                        SP11 -> read "3709ae5e239db9df50edf3690119f6f3381d2c40e986074368b4b3b52a994203"
+                        SP11 -> read "f875cd747a4cb7e08408158fed283678f500c8cb4408901e0455f7c5d0725260"
                         spv -> dummyBRH spv 0xe02
                     }
         }
@@ -632,7 +632,7 @@ testBB3EX =
                         SP7 -> read "0236b72bafe1575fdde0b01b35d24ad16613569600b83ed46b7e17c3c3dbaf28"
                         SP8 -> read "854f08741a720a65b136eceae61cdb5fa59dd5f1af8bdcb58e41e850fec5034d"
                         spv | blockResultHashAsP9 spv -> read "abe0485900b7b651c670f2fa506534ec2bc095f6d586a92f5b5b1160ca73c58c"
-                        SP11 -> read "19c23ccfb4a0d3ef538f1ffadb1968dda0a56bd47f1503612960feeaf505b6d7"
+                        SP11 -> read "f763ade49374a3fde81937148f3ceaff4889b117fa36c4452649176a3db9f41a"
                         spv -> dummyBRH spv 0x1e03
                     }
         }
@@ -683,7 +683,7 @@ testBB3E =
                         SP7 -> read "2a12a1b02d8cfb835d6f572ffd3a0156145ec2142b47ef7b9e9495b61ff241b7"
                         SP8 -> read "d3cf0aa2e2c6fc2fd7d0be7f4192cc8d04e3afce1041d194a2c9ae437bc4aad6"
                         spv | blockResultHashAsP9 spv -> read "87df979129f4462d51ca7214068557add1e4ecbb7ef097f2dc76bcc9ea7c90bb"
-                        SP11 -> read "1b2e3dc1b52845d3ecaaf92cea7e75b91a237ac7e512e8e1be89039f0918a3a6"
+                        SP11 -> read "0a98882528ba6dfd66e23092dca65984d87fab7292e7cea92c31729d3d7a2afc"
                         spv -> dummyBRH spv 0xe03
                     }
         }
@@ -727,7 +727,7 @@ testBB4E =
                         SP7 -> read "66cf8d97a956e2306e60337848775d606f575bd48f4d1e4420d4cf579d5bfb0e"
                         SP8 -> read "d11da8da6f4a14fe5221847690e754450e79d65ad7e7ab1606f4f14d333f3a53"
                         spv | blockResultHashAsP9 spv -> read "5f84d37c5c7d22893a285f3229d3b19dc9933e8220dbce84dc3f5bb7d1e325f1"
-                        SP11 -> read "9cf6abe73d9c5f246da58e3d9be426089a5183334fd91f3b2e4d51804cd0b7c8"
+                        SP11 -> read "a6716edf410f5aa013398363a05ac8dd2f7969be0ba83590a56ad772ba595f95"
                         spv -> dummyBRH spv 0xe04
                     }
         }
@@ -755,7 +755,7 @@ testBB4E' =
                         SP7 -> read "e0d460456228a923c4d0116b6add192b491279b24ce160067652e1afa11bac56"
                         SP8 -> read "51894272a8818fc7ad4290f921bb2ff0488a098ebd0697b479136ec6ae5f5ed7"
                         spv | blockResultHashAsP9 spv -> read "e44e1e7f0eac84030f80fe191c8ca9216da54a8533b9602c249d9b0a89b08ed9"
-                        SP11 -> read "e4dbf5cb062808b8f28149717751bf2f87d949ea2e921de40fae2f8b950a888c"
+                        SP11 -> read "84e1ac5c38593ae51113431a18d7bedf73f86de71e1f39ceffee03b43fa7809c"
                         spv -> dummyBRH spv 0x1e04
                     }
         }
@@ -790,7 +790,7 @@ testBB5E' =
                         SP7 -> read "2c8ff8fbc07b5e1486ebad3e241fa0aefdb7637651c6120b0a50a27057f7431a"
                         SP8 -> read "970f5145277abea69844b53189c803ad7d5a8fd19105208ae4c580957224099a"
                         spv | blockResultHashAsP9 spv -> read "d15789473fdb0b472bd1e1c2590f2b069ffe4c58a7079fec0e4f737a46d2c3f5"
-                        SP11 -> read "ace223d0f67529552b942e77339410a5609ed5c8dfb63a1c57b64fd0c786b82d"
+                        SP11 -> read "6120a38b10a53ae9eb9e232271742b4f8eec37be3efd0a65a0f5e51a90c12f2b"
                         spv -> dummyBRH spv 0x1e05
                     }
         }
@@ -838,7 +838,7 @@ testBB2Ex =
                         SP7 -> read "a562963223c07cbcee46e78bba06968d578120b71eaf59d8ce12f3f384b21f47"
                         SP8 -> read "85974099bbc92a64a27df7d057d130dd4eabcc0a8e605f701b449db3e68b3c3b"
                         spv | blockResultHashAsP9 spv -> read "781624811b67e3c24f2e0d4b3596e4b973fe52306ba43448a47748e6f25269a0"
-                        SP11 -> read "6ac249ded954708e952488db0d63da831e11f0017590f9651110ed5aafa6e673"
+                        SP11 -> read "d138618a4d2805db080686a28fcba972af562906c4cf5c0bb9f1875ee7e6cca3"
                         spv -> dummyBRH spv 0x0f02
                     }
         }
@@ -888,7 +888,7 @@ testBB3Ex =
                         SP7 -> read "2ea4f556dc29b5a1774635cb670f7b9aa3182eb2cc685b0e4f59daf9541cb539"
                         SP8 -> read "fcb11273e588af86426c36f3d825d6eaf3d6db29339a071253ce764b4be3d45e"
                         spv | blockResultHashAsP9 spv -> read "0cf1a98c6f1c0798cc2441633cabada717c2c9c2344f9f8593934ae5abf1d56f"
-                        SP11 -> read "34a1b4dbae466b3d0e378301c4a8634daf4263f286c88f56eae8150740614930"
+                        SP11 -> read "3a60ecc3f5ffa938958c8e5c717d9a8a742c3cdc9985c85d76a13ccc6e7e26ac"
                         spv -> dummyBRH spv 0x1e03
                     }
         }
@@ -926,7 +926,7 @@ testBB3EA =
                         SP7 -> read "99fc52af1ee2336f0d353a84c4d6c15345882271f648f7b84e69d9c40d5571c2"
                         SP8 -> read "af4910f96957a8fc36844cfd1ca9dfadd47776b2a5b4e5f23011b4f580a01902"
                         spv | blockResultHashAsP9 spv -> read "8e068776dc01e0079a00d9b531897e2a1e732c91ce9db92d64fd2cd183cea83e"
-                        SP11 -> read "3709ae5e239db9df50edf3690119f6f3381d2c40e986074368b4b3b52a994203"
+                        SP11 -> read "f875cd747a4cb7e08408158fed283678f500c8cb4408901e0455f7c5d0725260"
                         spv -> dummyBRH spv 0x2f03
                     }
         }
@@ -964,7 +964,7 @@ testBB4EA =
                         SP7 -> read "e0d460456228a923c4d0116b6add192b491279b24ce160067652e1afa11bac56"
                         SP8 -> read "e5c82e4ff33f6f068704a4da8a829e3e27659df26512a5b6449d4e27c50b0c5d"
                         spv | blockResultHashAsP9 spv -> read "71df1f4743ed4401ff0ec3d3b8dc3edc66b639f3aa2c564f583a7c622fa46f76"
-                        SP11 -> read "12ebd8153f03a666c170f50c820680c434552acd42b7a1d333a51bfe34119132"
+                        SP11 -> read "cdf21930456f4964e7a446ac32d84d8a9285ef60dadbaeeea8f62e78124e5226"
                         spv -> dummyBRH spv 0x2f04
                     }
         }
@@ -1017,7 +1017,7 @@ testBB1T =
                         SP8 -> read "928a6ab0ca2a38086812bdbf39d46737345c358479d35c435f97c609ee0e215d"
                         SP9 -> read "ba0d5ccac35703d012901d95669aea8088530b89d0e887f76c0b0ade4dd9c829"
                         SP10 -> read "4a3d62fc566532a0151727c50cd80190e07f44b474f7074623b1e89646be9044"
-                        SP11 -> read "f19f857e16e53dcdffd85fcc84900e832bdde3054431df17fdb8131dde6dd1c1"
+                        SP11 -> read "d3e61c1d5d89d1d0388142b4acae9422148ff27aa7bf89fd6f0c34fc7e7f89fe"
                         spv -> dummyBRH spv 0x7001
                     }
         }
@@ -1051,7 +1051,7 @@ testBB2T =
                         SP8 -> read "60905a3baea93cf9564621ff1d8bbbc2469b50f26d101d125a092d104ca4fe16"
                         SP9 -> read "691a94879d0b135e6b55bb8afdc6740f4a29d0a5ab94670bec0fb02b36291bd0"
                         SP10 -> read "3a1fe79e0c5df5a73a55a02c9f410da73e10cfb02094fd053ef180ca3d6d8bac"
-                        SP11 -> read "27f7a5f1dcc9f1efef2cda7744724852b460bc23645f8378fc2bcd4eb72ac4e1"
+                        SP11 -> read "9d914f5edf9bf6b24df7836d91fa63976c1327b3c0dd6351e9658a80036d03e0"
                         spv -> dummyBRH spv 0x7002
                     }
         }
@@ -1091,7 +1091,7 @@ testBB3T =
                         SP8 -> read "8f1d79480a04412221a6a90c02ff98b8c59f08510067691c005f2e36b3c32563"
                         SP9 -> read "51fbaf0502c838c7455786ac3c0397c51f3e6116a71cdc4a759b3a4bd243907f"
                         SP10 -> read "eafb304cf3a771810688878fbc3b19d265d3728c455d9ae4941deacdbd7abbc6"
-                        SP11 -> read "7195ed6bf75d9b12603d857a4dc31b61ca25934fe3879d29ff8e94ad970c863b"
+                        SP11 -> read "fbaafdf1bd2e53975b4bb00cca0e4b2ecc5051fa090b5ad52aaf5e553ba9864d"
                         spv -> dummyBRH spv 0x7003
                     }
         }
@@ -1126,7 +1126,7 @@ testBB4T =
                         SP8 -> read "efbd04f230226d140dcb1bd9a4eb06c0583a2b6edfa16dac2dde895383559998"
                         SP9 -> read "0f73ad403626533632c43f2ca5938f9c3abb658df73a45328a5ca8c6630a973b"
                         SP10 -> read "0f73ad403626533632c43f2ca5938f9c3abb658df73a45328a5ca8c6630a973b"
-                        SP11 -> read "27735405c5fe492c798448768963a7dd19b1fffb679610af7dc17c97abaa6e44"
+                        SP11 -> read "83ae66c721198348f461ac78005d4ec2f5a8ac619debaa7a23806c27fc2f9f85"
                         spv -> dummyBRH spv 0x7004
                     }
         }
@@ -1161,7 +1161,7 @@ testBB5T =
                         SP8 -> read "242e8f6bf7e2a6fc9263b95b6e233b43010308d061e1f511b920ff7deea3ac9f"
                         SP9 -> read "f375cd289ab3c51ff09cb910dcc89d942ea26a3c22904b0dd37a933c21805634"
                         SP10 -> read "f375cd289ab3c51ff09cb910dcc89d942ea26a3c22904b0dd37a933c21805634"
-                        SP11 -> read "4fdee647224fee55a572130c9a230ba274e5aefd37f1803dde49b897a6a41290"
+                        SP11 -> read "9fd3b32598769f10679c95f64568143c5ea6ca3cde527d4f5c32a1fc6012afc9"
                         spv -> dummyBRH spv 0x7005
                     }
         }

--- a/plt/plt-block-state/src/entity/block_state/p11.rs
+++ b/plt/plt-block-state/src/entity/block_state/p11.rs
@@ -1,5 +1,5 @@
 use crate::entity::block_state::{LockNotFoundByIdError, TokenNotFoundByIdError};
-use crate::entity::protocol_level_locks::p11::LockP11;
+use crate::entity::protocol_level_locks::p11::{LockP11, LocksP11};
 use crate::entity::protocol_level_tokens::p11::TokenP11;
 use crate::entity::{
     EntityContext, EntityContextTypes, protocol_level_locks, protocol_level_tokens,
@@ -26,8 +26,8 @@ impl BlockStateP11 {
     pub fn locks<C: EntityContextTypes>(
         &self,
         context: &EntityContext<C>,
-    ) -> BlockStateResult<protocol_level_locks::p11::LocksP11> {
-        Ok(protocol_level_locks::p11::LocksP11::from_persistent(
+    ) -> BlockStateResult<LocksP11> {
+        Ok(LocksP11::from_persistent(
             self.persistent.locks.value(&context.store)?.into_owned(),
         ))
     }
@@ -36,7 +36,7 @@ impl BlockStateP11 {
     pub fn commit_locks<C: EntityContextTypes>(
         &mut self,
         context: &EntityContext<C>,
-        locks: protocol_level_locks::p11::LocksP11,
+        locks: LocksP11,
     ) {
         if let Some(locks) = locks.commit(context) {
             self.persistent.locks = HashedCacheableRef::new(locks);

--- a/plt/plt-block-state/src/entity/block_state/p11.rs
+++ b/plt/plt-block-state/src/entity/block_state/p11.rs
@@ -8,7 +8,6 @@ use crate::external::ExternalBlockStateOperations;
 use crate::failure::BlockStateResult;
 use crate::persistent::blob_reference::hashed_cacheable_reference::HashedCacheableRef;
 use crate::persistent::block_state::p11::PersistentBlockStateP11;
-use crate::persistent::protocol_level_locks::p11::LockConfiguration;
 use crate::persistent::protocol_level_tokens::p9::{TokenConfiguration, TokenIndex};
 use concordium_base::protocol_level_locks::LockId;
 use concordium_base::protocol_level_tokens::TokenId;
@@ -21,6 +20,28 @@ pub struct BlockStateP11 {
 }
 
 impl BlockStateP11 {
+    /// Create transaction-local locks from the current persistent state.
+    ///
+    /// Returns a block-state failure if the persistent lock state cannot be loaded.
+    pub fn locks<C: EntityContextTypes>(
+        &self,
+        context: &EntityContext<C>,
+    ) -> BlockStateResult<protocol_level_locks::p11::LocksP11> {
+        Ok(protocol_level_locks::p11::LocksP11::from_persistent(
+            self.persistent.locks.value(&context.store)?.into_owned(),
+        ))
+    }
+
+    /// Replace persistent locks after a successful transaction if they were modified.
+    pub fn commit_locks<C: EntityContextTypes>(
+        &mut self,
+        context: &EntityContext<C>,
+        locks: protocol_level_locks::p11::LocksP11,
+    ) {
+        if let Some(locks) = locks.commit(context) {
+            self.persistent.locks = HashedCacheableRef::new(locks);
+        }
+    }
     /// Get the [`TokenId`]s of all protocol-level tokens.
     pub fn plt_list<C: EntityContextTypes>(
         &self,
@@ -127,58 +148,16 @@ impl BlockStateP11 {
         context.external.increment_plt_update_sequence_number()
     }
 
-    /// Create a new PLT lock with the given configuration. The initial state will be empty.
-    /// Returns [`BlockStateFailure::Invariant`] if a lock with the given id already exists.
-    ///
-    /// # Arguments
-    ///
-    /// - `lock_id` The ID of the PLT lock.
-    /// - `configuration` The configuration for the PLT lock.
-    pub fn create_lock<C: EntityContextTypes>(
-        &mut self,
-        context: &EntityContext<C>,
-        configuration: LockConfiguration,
-    ) -> BlockStateResult<()> {
-        let mut new_locks = self.persistent.locks.value(&context.store)?.into_owned();
-        protocol_level_locks::p11::create_lock(context, &mut new_locks, configuration)?;
-
-        self.persistent.locks = HashedCacheableRef::new(new_locks);
-
-        Ok(())
-    }
-
-    /// Delete the lock with the given [`LockId`] if it exists. Returns `true` if it existed, or
-    /// `false` if it did not exist.
-    ///
-    /// # Arguments
-    /// - `lock_id` The ID of the PLT lock to delete.
-    pub fn delete_lock<C: EntityContextTypes>(
-        &mut self,
-        context: &EntityContext<C>,
-        lock_id: &LockId,
-    ) -> BlockStateResult<bool> {
-        let mut new_locks = self.persistent.locks.value(&context.store)?.into_owned();
-        let existing = protocol_level_locks::p11::delete_lock(context, &mut new_locks, lock_id)?;
-        if existing {
-            // We only need to update the locks if a lock was actually deleted,
-            // otherwise we would be unnecessarily updating the block state.
-            self.persistent.locks = HashedCacheableRef::new(new_locks);
-        }
-        Ok(existing)
-    }
-
     /// Get the [`LockId`]s of all protocol-level locks registered on the chain at the
     /// end of the block.
     pub fn lock_list<C: EntityContextTypes>(
         &self,
         context: &EntityContext<C>,
     ) -> BlockStateResult<Vec<LockId>> {
-        Ok(protocol_level_locks::p11::lock_list(
+        protocol_level_locks::p11::lock_list(
             context,
-            &*self.persistent.locks.value(&context.store)?,
+            &self.persistent.locks.value(&context.store)?.locks,
         )
-        .cloned()
-        .collect())
     }
 
     /// Get the lock associated with a [`LockId`] (if it exists).
@@ -191,26 +170,11 @@ impl BlockStateP11 {
         context: &EntityContext<C>,
         lock_id: &LockId,
     ) -> BlockStateResult<Result<LockP11, LockNotFoundByIdError>> {
-        let lock_option = protocol_level_locks::p11::lock_by_id(
+        protocol_level_locks::p11::lock_by_id(
             context,
-            &*self.persistent.locks.value(&context.store)?,
+            &self.persistent.locks.value(&context.store)?.locks,
             lock_id.clone(),
-        )?;
-
-        Ok(lock_option.ok_or_else(|| LockNotFoundByIdError(lock_id.clone())))
-    }
-
-    /// Update the lock in the block state. Any modifications
-    /// to [`LockP11`] are only applied when the lock is updated.
-    pub fn update_lock<C: EntityContextTypes>(
-        &mut self,
-        context: &EntityContext<C>,
-        lock: LockP11,
-    ) -> BlockStateResult<()> {
-        let mut new_locks = self.persistent.locks.value(&context.store)?.into_owned();
-        protocol_level_locks::p11::update_lock(context, &mut new_locks, lock)?;
-        self.persistent.locks = HashedCacheableRef::new(new_locks);
-
-        Ok(())
+        )
+        .map(|lock| lock.ok_or_else(|| LockNotFoundByIdError(lock_id.clone())))
     }
 }

--- a/plt/plt-block-state/src/entity/block_state/p11.rs
+++ b/plt/plt-block-state/src/entity/block_state/p11.rs
@@ -1,5 +1,5 @@
 use crate::entity::block_state::{LockNotFoundByIdError, TokenNotFoundByIdError};
-use crate::entity::protocol_level_locks::p11::{LockP11, LocksP11};
+use crate::entity::protocol_level_locks::p11::LockP11;
 use crate::entity::protocol_level_tokens::p11::TokenP11;
 use crate::entity::{
     EntityContext, EntityContextTypes, protocol_level_locks, protocol_level_tokens,
@@ -8,6 +8,7 @@ use crate::external::ExternalBlockStateOperations;
 use crate::failure::BlockStateResult;
 use crate::persistent::blob_reference::hashed_cacheable_reference::HashedCacheableRef;
 use crate::persistent::block_state::p11::PersistentBlockStateP11;
+use crate::persistent::protocol_level_locks::p11::LockConfiguration;
 use crate::persistent::protocol_level_tokens::p9::{TokenConfiguration, TokenIndex};
 use concordium_base::protocol_level_locks::LockId;
 use concordium_base::protocol_level_tokens::TokenId;
@@ -20,28 +21,6 @@ pub struct BlockStateP11 {
 }
 
 impl BlockStateP11 {
-    /// Create transaction-local locks from the current persistent state.
-    ///
-    /// Returns a block-state failure if the persistent lock state cannot be loaded.
-    pub fn locks<C: EntityContextTypes>(
-        &self,
-        context: &EntityContext<C>,
-    ) -> BlockStateResult<LocksP11> {
-        Ok(LocksP11::from_persistent(
-            self.persistent.locks.value(&context.store)?.into_owned(),
-        ))
-    }
-
-    /// Replace persistent locks after a successful transaction if they were modified.
-    pub fn commit_locks<C: EntityContextTypes>(
-        &mut self,
-        context: &EntityContext<C>,
-        locks: LocksP11,
-    ) {
-        if let Some(locks) = locks.commit(context) {
-            self.persistent.locks = HashedCacheableRef::new(locks);
-        }
-    }
     /// Get the [`TokenId`]s of all protocol-level tokens.
     pub fn plt_list<C: EntityContextTypes>(
         &self,
@@ -148,6 +127,43 @@ impl BlockStateP11 {
         context.external.increment_plt_update_sequence_number()
     }
 
+    /// Create a new PLT lock with the given ID and configuration. The initial state will be empty.
+    /// Returns [`BlockStateFailure::Invariant`] if a lock with the given id already exists.
+    ///
+    /// # Arguments
+    ///
+    /// - `lock_id` The ID of the PLT lock.
+    /// - `configuration` The configuration for the PLT lock.
+    pub fn create_lock<C: EntityContextTypes>(
+        &mut self,
+        context: &EntityContext<C>,
+        lock_id: &LockId,
+        configuration: LockConfiguration,
+    ) -> BlockStateResult<()> {
+        let mut new_locks = self.persistent.locks.value(&context.store)?.into_owned();
+        protocol_level_locks::p11::create_lock(context, &mut new_locks, lock_id, configuration)?;
+        self.persistent.locks = HashedCacheableRef::new(new_locks);
+        Ok(())
+    }
+
+    /// Delete the lock with the given [`LockId`] if it exists. Returns `true` if it existed, or
+    /// `false` if it did not exist.
+    ///
+    /// # Arguments
+    /// - `lock_id` The ID of the PLT lock to delete.
+    pub fn delete_lock<C: EntityContextTypes>(
+        &mut self,
+        context: &EntityContext<C>,
+        lock_id: &LockId,
+    ) -> BlockStateResult<bool> {
+        let mut new_locks = self.persistent.locks.value(&context.store)?.into_owned();
+        let existing = protocol_level_locks::p11::delete_lock(context, &mut new_locks, lock_id)?;
+        if existing {
+            self.persistent.locks = HashedCacheableRef::new(new_locks);
+        }
+        Ok(existing)
+    }
+
     /// Get the [`LockId`]s of all protocol-level locks registered on the chain at the
     /// end of the block.
     pub fn lock_list<C: EntityContextTypes>(
@@ -176,5 +192,18 @@ impl BlockStateP11 {
             lock_id.clone(),
         )
         .map(|lock| lock.ok_or_else(|| LockNotFoundByIdError(lock_id.clone())))
+    }
+
+    /// Update the lock in the block state. Any modifications
+    /// to [`LockP11`] are only applied when the lock is updated.
+    pub fn update_lock<C: EntityContextTypes>(
+        &mut self,
+        context: &EntityContext<C>,
+        lock: LockP11,
+    ) -> BlockStateResult<()> {
+        let mut new_locks = self.persistent.locks.value(&context.store)?.into_owned();
+        protocol_level_locks::p11::update_lock(context, &mut new_locks, lock)?;
+        self.persistent.locks = HashedCacheableRef::new(new_locks);
+        Ok(())
     }
 }

--- a/plt/plt-block-state/src/entity/protocol_level_locks/p11.rs
+++ b/plt/plt-block-state/src/entity/protocol_level_locks/p11.rs
@@ -1,133 +1,219 @@
+use crate::entity::block_state::LockNotFoundByIdError;
 use crate::entity::{EntityContext, EntityContextTypes};
 use crate::failure::{BlockStateFailure, BlockStateResult};
-use crate::persistent::blob_reference::hashed_cacheable_reference::HashedCacheableRef;
 use crate::persistent::blob_store::StoreSerialized;
 use crate::persistent::protocol_level_locks::p11::{
-    LockConfiguration, LockIndex, PersistentLockP11, PersistentLocksP11,
+    LockConfiguration, PersistentLockP11, PersistentLocksP11, lock_id_from_key, lock_id_key,
+    persistent_lock_from_value, persistent_lock_value,
 };
 use crate::persistent::protocol_level_tokens::p9::TokenIndex;
+use crate::persistent::smart_contract_trie::{MutableState, TrieState};
 use crate::utils;
 use concordium_base::base::AccountIndex;
 use concordium_base::protocol_level_locks::LockId;
 
-/// List all non-deleted lock ids in *no particular order*.
-pub(crate) fn lock_list<'a, C: EntityContextTypes>(
-    _context: &EntityContext<C>,
-    persistent_locks: &'a PersistentLocksP11,
-) -> impl Iterator<Item = &'a LockId> {
-    persistent_locks.lock_id_map.keys()
+/// Transaction-local lock state. Changes are committed to its persistent representation only
+/// after the transaction succeeds.
+#[derive(Debug)]
+pub struct LocksP11 {
+    persistent: PersistentLocksP11,
+    mutable: Option<MutableState>,
+}
+
+impl LocksP11 {
+    /// Create transaction-local locks from the persistent lock state.
+    pub fn from_persistent(persistent: PersistentLocksP11) -> Self {
+        Self {
+            persistent,
+            mutable: None,
+        }
+    }
+
+    /// Freeze and return the persistent lock state if it was modified.
+    ///
+    /// Returns `None` when no lock mutation occurred, preserving the existing
+    /// persistent lock reference.
+    pub fn commit<C: EntityContextTypes>(
+        mut self,
+        context: &EntityContext<C>,
+    ) -> Option<PersistentLocksP11> {
+        let mut locks = self.mutable.filter(|locks| locks.is_dirty())?;
+        self.persistent.locks = locks.freeze(&context.store);
+        Some(self.persistent)
+    }
+
+    fn mutable<C: EntityContextTypes>(
+        &mut self,
+        _context: &EntityContext<C>,
+    ) -> BlockStateResult<&mut MutableState> {
+        if self.mutable.is_none() {
+            self.mutable = Some(self.persistent.locks.thaw());
+        }
+        self.mutable.as_mut().ok_or_else(|| {
+            BlockStateFailure::Invariant("mutable locks were not initialized".to_string())
+        })
+    }
+
+    /// Create a lock with `lock_id` and `configuration`.
+    ///
+    /// Returns a block-state failure if the lock cannot be persisted.
+    pub fn create<C: EntityContextTypes>(
+        &mut self,
+        context: &EntityContext<C>,
+        lock_id: &LockId,
+        configuration: LockConfiguration,
+    ) -> BlockStateResult<()> {
+        let locks = self.mutable(context)?;
+        create_lock(context, locks, lock_id, configuration)
+    }
+    /// Delete the lock identified by `lock_id`.
+    ///
+    /// Returns whether the lock existed, or a block-state failure if the trie cannot be updated.
+    pub fn delete<C: EntityContextTypes>(
+        &mut self,
+        context: &EntityContext<C>,
+        lock_id: &LockId,
+    ) -> BlockStateResult<bool> {
+        let locks = self.mutable(context)?;
+        delete_lock(context, locks, lock_id)
+    }
+    /// Update `lock` in the transaction-local state.
+    ///
+    /// Returns a block-state failure if the lock cannot be persisted.
+    pub fn update<C: EntityContextTypes>(
+        &mut self,
+        context: &EntityContext<C>,
+        lock: LockP11,
+    ) -> BlockStateResult<()> {
+        let locks = self.mutable(context)?;
+        update_lock(context, locks, lock)
+    }
+    /// Look up the lock identified by `lock_id`.
+    ///
+    /// Returns [`LockNotFoundByIdError`] when no matching lock exists, or a
+    /// block-state failure if its persistent value cannot be decoded.
+    pub fn by_id<C: EntityContextTypes>(
+        &self,
+        context: &EntityContext<C>,
+        lock_id: &LockId,
+    ) -> BlockStateResult<Result<LockP11, LockNotFoundByIdError>> {
+        let lock = match &self.mutable {
+            Some(locks) => lock_by_id(context, locks, lock_id.clone()),
+            None => lock_by_id(context, &self.persistent.locks, lock_id.clone()),
+        }?;
+        Ok(lock.ok_or_else(|| LockNotFoundByIdError(lock_id.clone())))
+    }
+    /// List all lock identifiers in no particular order.
+    ///
+    /// Returns a block-state failure if a stored lock identifier cannot be decoded.
+    pub fn list<C: EntityContextTypes>(
+        &self,
+        context: &EntityContext<C>,
+    ) -> BlockStateResult<Vec<LockId>> {
+        match &self.mutable {
+            Some(locks) => lock_list(context, locks),
+            None => lock_list(context, &self.persistent.locks),
+        }
+    }
 }
 
 pub(crate) fn create_lock<C: EntityContextTypes>(
     context: &EntityContext<C>,
-    persistent_locks: &mut PersistentLocksP11,
+    locks: &mut MutableState,
+    lock_id: &LockId,
     configuration: LockConfiguration,
 ) -> BlockStateResult<()> {
-    let lock_id = configuration.lock_id.clone();
-    let persistent = PersistentLockP11 {
-        locked_balances: Default::default(),
-        configuration: HashedCacheableRef::new(StoreSerialized(configuration)),
-    };
-    let (lock_index, updated_locks) = persistent_locks
-        .locks
-        .insert_value(&context.store, Some(persistent))?;
-    persistent_locks.locks = updated_locks;
-    let existing = persistent_locks
-        .lock_id_map
-        .insert(lock_id.clone(), lock_index);
-    if existing.is_some() {
+    let key = lock_id_key(lock_id);
+    if locks.lookup_value(&context.store, &key).is_some() {
         return Err(BlockStateFailure::Invariant(format!(
-            "lock with id {:?} already exists",
-            lock_id
+            "lock with id {lock_id:?} already exists"
         )));
     }
-
-    Ok(())
+    let persistent = PersistentLockP11 {
+        locked_balances: Default::default(),
+        configuration: StoreSerialized(configuration),
+    };
+    locks.insert_value(&context.store, &key, persistent_lock_value(&persistent))
 }
 
 pub(crate) fn delete_lock<C: EntityContextTypes>(
     context: &EntityContext<C>,
-    persistent_locks: &mut PersistentLocksP11,
+    locks: &mut MutableState,
     lock_id: &LockId,
 ) -> BlockStateResult<bool> {
-    let Some(lock_index) = persistent_locks.lock_id_map.remove(lock_id) else {
+    let key = lock_id_key(lock_id);
+    if locks.lookup_value(&context.store, &key).is_none() {
         return Ok(false);
-    };
-    persistent_locks.locks = persistent_locks
-        .locks
-        .update_value(&context.store, lock_index, |_| Ok(None))?
-        .ok_or_else(|| {
-            BlockStateFailure::Invariant(format!("Lock not found by index: {:?}", lock_id))
-        })?;
+    }
+    locks.delete_value(&context.store, &key)?;
     Ok(true)
 }
 
 pub(crate) fn update_lock<C: EntityContextTypes>(
     context: &EntityContext<C>,
-    persistent_locks: &mut PersistentLocksP11,
+    locks: &mut MutableState,
     lock: LockP11,
 ) -> BlockStateResult<()> {
-    persistent_locks.locks = persistent_locks
-        .locks
-        .update_value(&context.store, lock.lock_index, |_| {
-            Ok(Some(lock.persistent))
-        })?
-        .ok_or_else(|| {
-            BlockStateFailure::Invariant(format!("Lock not found by index: {:?}", lock.lock_index))
-        })?;
-    Ok(())
+    let key = lock_id_key(&lock.lock_id);
+    if locks.lookup_value(&context.store, &key).is_none() {
+        return Err(BlockStateFailure::Invariant(format!(
+            "Lock not found by ID: {:?}",
+            lock.lock_id
+        )));
+    }
+    locks.insert_value(
+        &context.store,
+        &key,
+        persistent_lock_value(&lock.persistent),
+    )
 }
 
 pub(crate) fn lock_by_id<C: EntityContextTypes>(
     context: &EntityContext<C>,
-    persistent_locks: &PersistentLocksP11,
+    locks: &impl TrieState,
     lock_id: LockId,
 ) -> BlockStateResult<Option<LockP11>> {
-    let Some(&lock_index) = persistent_locks.lock_id_map.get(&lock_id) else {
-        return Ok(None);
-    };
-    let Some(persistent) = persistent_locks
-        .locks
-        .lookup_value(&context.store, lock_index)?
-    else {
-        return Err(BlockStateFailure::Invariant(format!(
-            "No lock entry found for lock index {} ({lock_id})",
-            lock_index.0
-        )));
-    };
-    let Some(persistent) = persistent.to_owned() else {
-        // Lock is deleted.
+    let key = lock_id_key(&lock_id);
+    let Some(value) = locks.lookup_value(&context.store, &key) else {
         return Ok(None);
     };
     Ok(Some(LockP11 {
-        lock_index,
-        persistent,
+        lock_id,
+        persistent: persistent_lock_from_value(&value)?,
     }))
+}
+
+pub(crate) fn lock_list<C: EntityContextTypes>(
+    context: &EntityContext<C>,
+    locks: &impl TrieState,
+) -> BlockStateResult<Vec<LockId>> {
+    locks
+        .keys_with_prefix(&context.store, &[])?
+        .into_iter()
+        .map(|key| lock_id_from_key(&key))
+        .collect()
 }
 
 /// Representation of protocol-level lock on P11 and later protocols with compatible model.
 #[derive(Debug)]
 pub struct LockP11 {
-    pub(crate) lock_index: LockIndex,
+    pub(crate) lock_id: LockId,
     /// Persistent model of the protocol-level lock.
     pub(crate) persistent: PersistentLockP11,
 }
 
 impl LockP11 {
-    /// Get the internal block state index of the lock.
-    pub fn lock_index(&self) -> LockIndex {
-        self.lock_index
+    /// Get the ID of the lock.
+    pub fn lock_id(&self) -> &LockId {
+        &self.lock_id
     }
 
     /// Get the configuration of the protocol-level lock.
     pub fn lock_configuration<C: EntityContextTypes>(
         &self,
-        context: &EntityContext<C>,
+        _context: &EntityContext<C>,
     ) -> BlockStateResult<utils::Cow<'_, LockConfiguration>> {
-        self.persistent
-            .configuration
-            .value(&context.store)
-            .map(|cow| cow.cow_project())
+        Ok(utils::Cow::Borrowed(&self.persistent.configuration.0))
     }
 
     /// Get the set of account/token balances currently tracked under the lock.
@@ -176,5 +262,73 @@ impl LockP11 {
             .locked_balances
             .0
             .remove(&(account_index, token_index))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::entity::entity_test_stub;
+    use crate::persistent::protocol_level_locks::p11::{
+        LockControllerConfig, LockControllerSimpleV0, LockRecipients,
+    };
+    use concordium_base::common::types::TransactionTime;
+
+    fn configuration() -> LockConfiguration {
+        LockConfiguration {
+            recipients: LockRecipients::Any,
+            expiry: TransactionTime::from(0),
+            controller: LockControllerConfig::SimpleV0(
+                LockControllerSimpleV0::new(Vec::new(), Vec::new(), false, None).unwrap(),
+            ),
+            metadata: None,
+        }
+    }
+
+    #[test]
+    fn committing_read_only_locks_preserves_persistent_state() {
+        let context = entity_test_stub::new_no_external_context();
+        let locks = LocksP11::from_persistent(PersistentLocksP11::default());
+
+        assert!(
+            locks
+                .by_id(&context, &LockId::new(1, 1, 0))
+                .unwrap()
+                .is_err()
+        );
+        assert!(locks.commit(&context).is_none());
+    }
+
+    #[test]
+    fn lookup_and_list_do_not_decode_unrelated_lock_values() {
+        let context = entity_test_stub::new_no_external_context();
+        let lock_id = LockId::new(1, 1, 0);
+        let unrelated_lock_id = LockId::new(2, 1, 0);
+        let missing_lock_id = LockId::new(3, 1, 0);
+        let mut locks = PersistentLocksP11::default();
+        let mut trie = locks.locks.thaw();
+        create_lock(&context, &mut trie, &lock_id, configuration()).unwrap();
+        trie.insert_value(&context.store, &lock_id_key(&unrelated_lock_id), vec![0])
+            .unwrap();
+        locks.locks = trie.freeze(&context.store);
+
+        // The invalid unrelated value must not affect the requested lookup.
+        assert_eq!(
+            lock_by_id(&context, &locks.locks, lock_id.clone())
+                .unwrap()
+                .unwrap()
+                .lock_id(),
+            &lock_id
+        );
+        // The invalid unrelated value must not affect a missing lookup.
+        assert!(
+            lock_by_id(&context, &locks.locks, missing_lock_id)
+                .unwrap()
+                .is_none()
+        );
+        // The invalid unrelated value must not affect key-only listing.
+        let mut ids = lock_list(&context, &locks.locks).unwrap();
+        ids.sort();
+        assert_eq!(ids, vec![lock_id, unrelated_lock_id]);
     }
 }

--- a/plt/plt-block-state/src/entity/protocol_level_locks/p11.rs
+++ b/plt/plt-block-state/src/entity/protocol_level_locks/p11.rs
@@ -1,4 +1,3 @@
-use crate::entity::block_state::LockNotFoundByIdError;
 use crate::entity::{EntityContext, EntityContextTypes};
 use crate::failure::{BlockStateFailure, BlockStateResult};
 use crate::persistent::blob_store::StoreSerialized;
@@ -7,123 +6,19 @@ use crate::persistent::protocol_level_locks::p11::{
     persistent_lock_from_value, persistent_lock_value,
 };
 use crate::persistent::protocol_level_tokens::p9::TokenIndex;
-use crate::persistent::smart_contract_trie::{MutableState, TrieState};
+use crate::persistent::smart_contract_trie::PersistentState;
 use crate::utils;
 use concordium_base::base::AccountIndex;
 use concordium_base::protocol_level_locks::LockId;
 
-/// Transaction-local lock state. Changes are committed to its persistent representation only
-/// after the transaction succeeds.
-#[derive(Debug)]
-pub struct LocksP11 {
-    persistent: PersistentLocksP11,
-    mutable: Option<MutableState>,
-}
-
-impl LocksP11 {
-    /// Create transaction-local locks from the persistent lock state.
-    pub fn from_persistent(persistent: PersistentLocksP11) -> Self {
-        Self {
-            persistent,
-            mutable: None,
-        }
-    }
-
-    /// Freeze and return the persistent lock state if it was modified.
-    ///
-    /// Returns `None` when no lock mutation occurred, preserving the existing
-    /// persistent lock reference.
-    pub fn commit<C: EntityContextTypes>(
-        mut self,
-        context: &EntityContext<C>,
-    ) -> Option<PersistentLocksP11> {
-        let mut locks = self.mutable.filter(|locks| locks.is_dirty())?;
-        self.persistent.locks = locks.freeze(&context.store);
-        Some(self.persistent)
-    }
-
-    fn mutable<C: EntityContextTypes>(
-        &mut self,
-        _context: &EntityContext<C>,
-    ) -> BlockStateResult<&mut MutableState> {
-        if self.mutable.is_none() {
-            self.mutable = Some(self.persistent.locks.thaw());
-        }
-        self.mutable.as_mut().ok_or_else(|| {
-            BlockStateFailure::Invariant("mutable locks were not initialized".to_string())
-        })
-    }
-
-    /// Create a lock with `lock_id` and `configuration`.
-    ///
-    /// Returns a block-state failure if the lock cannot be persisted.
-    pub fn create<C: EntityContextTypes>(
-        &mut self,
-        context: &EntityContext<C>,
-        lock_id: &LockId,
-        configuration: LockConfiguration,
-    ) -> BlockStateResult<()> {
-        let locks = self.mutable(context)?;
-        create_lock(context, locks, lock_id, configuration)
-    }
-    /// Delete the lock identified by `lock_id`.
-    ///
-    /// Returns whether the lock existed, or a block-state failure if the trie cannot be updated.
-    pub fn delete<C: EntityContextTypes>(
-        &mut self,
-        context: &EntityContext<C>,
-        lock_id: &LockId,
-    ) -> BlockStateResult<bool> {
-        let locks = self.mutable(context)?;
-        delete_lock(context, locks, lock_id)
-    }
-    /// Update `lock` in the transaction-local state.
-    ///
-    /// Returns a block-state failure if the lock cannot be persisted.
-    pub fn update<C: EntityContextTypes>(
-        &mut self,
-        context: &EntityContext<C>,
-        lock: LockP11,
-    ) -> BlockStateResult<()> {
-        let locks = self.mutable(context)?;
-        update_lock(context, locks, lock)
-    }
-    /// Look up the lock identified by `lock_id`.
-    ///
-    /// Returns [`LockNotFoundByIdError`] when no matching lock exists, or a
-    /// block-state failure if its persistent value cannot be decoded.
-    pub fn by_id<C: EntityContextTypes>(
-        &self,
-        context: &EntityContext<C>,
-        lock_id: &LockId,
-    ) -> BlockStateResult<Result<LockP11, LockNotFoundByIdError>> {
-        let lock = match &self.mutable {
-            Some(locks) => lock_by_id(context, locks, lock_id.clone()),
-            None => lock_by_id(context, &self.persistent.locks, lock_id.clone()),
-        }?;
-        Ok(lock.ok_or_else(|| LockNotFoundByIdError(lock_id.clone())))
-    }
-    /// List all lock identifiers in no particular order.
-    ///
-    /// Returns a block-state failure if a stored lock identifier cannot be decoded.
-    pub fn list<C: EntityContextTypes>(
-        &self,
-        context: &EntityContext<C>,
-    ) -> BlockStateResult<Vec<LockId>> {
-        match &self.mutable {
-            Some(locks) => lock_list(context, locks),
-            None => lock_list(context, &self.persistent.locks),
-        }
-    }
-}
-
 pub(crate) fn create_lock<C: EntityContextTypes>(
     context: &EntityContext<C>,
-    locks: &mut MutableState,
+    persistent_locks: &mut PersistentLocksP11,
     lock_id: &LockId,
     configuration: LockConfiguration,
 ) -> BlockStateResult<()> {
     let key = lock_id_key(lock_id);
+    let mut locks = persistent_locks.locks.thaw();
     if locks.lookup_value(&context.store, &key).is_some() {
         return Err(BlockStateFailure::Invariant(format!(
             "lock with id {lock_id:?} already exists"
@@ -133,28 +28,33 @@ pub(crate) fn create_lock<C: EntityContextTypes>(
         locked_balances: Default::default(),
         configuration: StoreSerialized(configuration),
     };
-    locks.insert_value(&context.store, &key, persistent_lock_value(&persistent))
+    locks.insert_value(&context.store, &key, persistent_lock_value(&persistent))?;
+    persistent_locks.locks = locks.freeze(&context.store);
+    Ok(())
 }
 
 pub(crate) fn delete_lock<C: EntityContextTypes>(
     context: &EntityContext<C>,
-    locks: &mut MutableState,
+    persistent_locks: &mut PersistentLocksP11,
     lock_id: &LockId,
 ) -> BlockStateResult<bool> {
     let key = lock_id_key(lock_id);
+    let mut locks = persistent_locks.locks.thaw();
     if locks.lookup_value(&context.store, &key).is_none() {
         return Ok(false);
     }
     locks.delete_value(&context.store, &key)?;
+    persistent_locks.locks = locks.freeze(&context.store);
     Ok(true)
 }
 
 pub(crate) fn update_lock<C: EntityContextTypes>(
     context: &EntityContext<C>,
-    locks: &mut MutableState,
+    persistent_locks: &mut PersistentLocksP11,
     lock: LockP11,
 ) -> BlockStateResult<()> {
     let key = lock_id_key(&lock.lock_id);
+    let mut locks = persistent_locks.locks.thaw();
     if locks.lookup_value(&context.store, &key).is_none() {
         return Err(BlockStateFailure::Invariant(format!(
             "Lock not found by ID: {:?}",
@@ -165,12 +65,14 @@ pub(crate) fn update_lock<C: EntityContextTypes>(
         &context.store,
         &key,
         persistent_lock_value(&lock.persistent),
-    )
+    )?;
+    persistent_locks.locks = locks.freeze(&context.store);
+    Ok(())
 }
 
 pub(crate) fn lock_by_id<C: EntityContextTypes>(
     context: &EntityContext<C>,
-    locks: &impl TrieState,
+    locks: &PersistentState,
     lock_id: LockId,
 ) -> BlockStateResult<Option<LockP11>> {
     let key = lock_id_key(&lock_id);
@@ -185,11 +87,10 @@ pub(crate) fn lock_by_id<C: EntityContextTypes>(
 
 pub(crate) fn lock_list<C: EntityContextTypes>(
     context: &EntityContext<C>,
-    locks: &impl TrieState,
+    locks: &PersistentState,
 ) -> BlockStateResult<Vec<LockId>> {
     locks
         .keys_with_prefix(&context.store, &[])?
-        .into_iter()
         .map(|key| lock_id_from_key(&key))
         .collect()
 }
@@ -286,28 +187,14 @@ mod test {
     }
 
     #[test]
-    fn committing_read_only_locks_preserves_persistent_state() {
-        let context = entity_test_stub::new_no_external_context();
-        let locks = LocksP11::from_persistent(PersistentLocksP11::default());
-
-        assert!(
-            locks
-                .by_id(&context, &LockId::new(1, 1, 0))
-                .unwrap()
-                .is_err()
-        );
-        assert!(locks.commit(&context).is_none());
-    }
-
-    #[test]
     fn lookup_and_list_do_not_decode_unrelated_lock_values() {
         let context = entity_test_stub::new_no_external_context();
         let lock_id = LockId::new(1, 1, 0);
         let unrelated_lock_id = LockId::new(2, 1, 0);
         let missing_lock_id = LockId::new(3, 1, 0);
         let mut locks = PersistentLocksP11::default();
+        create_lock(&context, &mut locks, &lock_id, configuration()).unwrap();
         let mut trie = locks.locks.thaw();
-        create_lock(&context, &mut trie, &lock_id, configuration()).unwrap();
         trie.insert_value(&context.store, &lock_id_key(&unrelated_lock_id), vec![0])
             .unwrap();
         locks.locks = trie.freeze(&context.store);

--- a/plt/plt-block-state/src/entity/protocol_level_locks/p11.rs
+++ b/plt/plt-block-state/src/entity/protocol_level_locks/p11.rs
@@ -1,6 +1,5 @@
 use crate::entity::{EntityContext, EntityContextTypes};
 use crate::failure::{BlockStateFailure, BlockStateResult};
-use crate::persistent::blob_store::StoreSerialized;
 use crate::persistent::protocol_level_locks::p11::{
     LockConfiguration, PersistentLockP11, PersistentLocksP11, lock_id_from_key, lock_id_key,
     persistent_lock_from_value, persistent_lock_value,
@@ -26,7 +25,7 @@ pub(crate) fn create_lock<C: EntityContextTypes>(
     }
     let persistent = PersistentLockP11 {
         locked_balances: Default::default(),
-        configuration: StoreSerialized(configuration),
+        configuration,
     };
     locks.insert_value(&context.store, &key, persistent_lock_value(&persistent))?;
     persistent_locks.locks = locks.freeze(&context.store);
@@ -114,7 +113,7 @@ impl LockP11 {
         &self,
         _context: &EntityContext<C>,
     ) -> BlockStateResult<utils::Cow<'_, LockConfiguration>> {
-        Ok(utils::Cow::Borrowed(&self.persistent.configuration.0))
+        Ok(utils::Cow::Borrowed(&self.persistent.configuration))
     }
 
     /// Get the set of account/token balances currently tracked under the lock.
@@ -123,7 +122,7 @@ impl LockP11 {
     /// hold a non-zero locked balance. The corresponding amount is tracked in the
     /// token module state.
     pub fn lock_balance_refs(&self) -> Vec<(AccountIndex, TokenIndex)> {
-        self.persistent.locked_balances.0.iter().cloned().collect()
+        self.persistent.locked_balances.iter().cloned().collect()
     }
 
     /// Track that the lock holds a balance for the given account and token.
@@ -138,7 +137,6 @@ impl LockP11 {
     pub fn add_lock_balance_ref(&mut self, account_index: AccountIndex, token_index: TokenIndex) {
         self.persistent
             .locked_balances
-            .0
             .insert((account_index, token_index));
     }
 
@@ -161,7 +159,6 @@ impl LockP11 {
     ) -> bool {
         self.persistent
             .locked_balances
-            .0
             .remove(&(account_index, token_index))
     }
 }

--- a/plt/plt-block-state/src/persistent/block_state/p11.rs
+++ b/plt/plt-block-state/src/persistent/block_state/p11.rs
@@ -87,7 +87,6 @@ mod test {
             creation_order: 0,
         };
         let configuration1 = LockConfiguration {
-            lock_id: lock_id1.clone(),
             recipients: LockRecipients::try_from(vec![
                 AccountIndex::from(1),
                 AccountIndex::from(2),
@@ -112,23 +111,23 @@ mod test {
             metadata: None,
         };
 
-        block_state
-            .create_lock(&context, configuration1.clone())
+        let mut locks = block_state.locks(&context).unwrap();
+        locks
+            .create(&context, &lock_id1, configuration1.clone())
             .unwrap();
-        let mut lock1 = block_state
-            .lock_by_id(&context, &lock_id1)
+        let mut lock1 = locks
+            .by_id(&context, &lock_id1)
             .unwrap()
             .expect("lock should exist");
         lock1.add_lock_balance_ref(AccountIndex::from(0), TokenIndex(0));
         lock1.add_lock_balance_ref(AccountIndex::from(1), TokenIndex(1));
-        block_state.update_lock(&context, lock1).unwrap();
+        locks.update(&context, lock1).unwrap();
         let lock_id2 = LockId {
             account_index: 2,
             sequence_number: 7,
             creation_order: 0,
         };
         let configuration2 = LockConfiguration {
-            lock_id: lock_id2.clone(),
             recipients: LockRecipients::try_from(vec![]).unwrap(),
             expiry: TransactionTime::from(0u64),
             controller: LockControllerConfig::SimpleV0(
@@ -136,8 +135,8 @@ mod test {
             ),
             metadata: None,
         };
-        block_state
-            .create_lock(&context, configuration2.clone())
+        locks
+            .create(&context, &lock_id2, configuration2.clone())
             .unwrap();
 
         // Create a third lock and then delete it
@@ -147,7 +146,6 @@ mod test {
             creation_order: 0,
         };
         let configuration3 = LockConfiguration {
-            lock_id: lock_id3.clone(),
             recipients: LockRecipients::try_from(vec![]).unwrap(),
             expiry: TransactionTime::from(0u64),
             controller: LockControllerConfig::SimpleV0(
@@ -155,9 +153,10 @@ mod test {
             ),
             metadata: None,
         };
-        block_state.create_lock(&context, configuration3).unwrap();
-        let was_deleted = block_state.delete_lock(&context, &lock_id3).unwrap();
+        locks.create(&context, &lock_id3, configuration3).unwrap();
+        let was_deleted = locks.delete(&context, &lock_id3).unwrap();
         assert!(was_deleted, "lock3 should be deleted");
+        block_state.commit_locks(&context, locks);
 
         // Store and load block state
         let blob_ref = blob_store::store_to_store(&mut context.store, block_state.persistent);
@@ -208,14 +207,14 @@ mod test {
         let hash = persistent_block_state.hash(&context.store).expect("hash");
         assert_eq!(
             format!("{}", hash),
-            "db35d91962f8f0315adb99d687d65c796ac67f2956b02e80fb667589f64efcb5"
+            "d84a104f55bddbfba65cfe902175f9337db147b8f93507de58a141225e59434c"
         );
 
         // Assert storage
         blob_store::store_to_store(&mut context.store, &persistent_block_state);
         assert_eq!(
             hex::encode(context.store.0),
-            "0000000000000008000000000000000000000000000000080000000000000000000000000000001000000000000000000000000000000010"
+            "00000000000000080000000000000000000000000000000100000000000000001000000000000000000000000000000010"
         );
     }
 
@@ -265,7 +264,6 @@ mod test {
             creation_order: 0,
         };
         let configuration1 = LockConfiguration {
-            lock_id: lock_id1.clone(),
             recipients: LockRecipients::try_from(vec![
                 AccountIndex::from(1),
                 AccountIndex::from(2),
@@ -289,21 +287,21 @@ mod test {
             ),
             metadata: None,
         };
-        block_state.create_lock(&context, configuration1).unwrap();
-        let mut lock1 = block_state
-            .lock_by_id(&context, &lock_id1)
+        let mut locks = block_state.locks(&context).unwrap();
+        locks.create(&context, &lock_id1, configuration1).unwrap();
+        let mut lock1 = locks
+            .by_id(&context, &lock_id1)
             .unwrap()
             .expect("lock should exist");
         lock1.add_lock_balance_ref(AccountIndex::from(0), TokenIndex(0));
         lock1.add_lock_balance_ref(AccountIndex::from(1), TokenIndex(1));
-        block_state.update_lock(&context, lock1).unwrap();
+        locks.update(&context, lock1).unwrap();
         let lock_id2 = LockId {
             account_index: 2,
             sequence_number: 7,
             creation_order: 0,
         };
         let configuration2 = LockConfiguration {
-            lock_id: lock_id2.clone(),
             recipients: LockRecipients::try_from(vec![]).unwrap(),
             expiry: TransactionTime::from(0u64),
             controller: LockControllerConfig::SimpleV0(
@@ -311,20 +309,21 @@ mod test {
             ),
             metadata: None,
         };
-        block_state.create_lock(&context, configuration2).unwrap();
+        locks.create(&context, &lock_id2, configuration2).unwrap();
+        block_state.commit_locks(&context, locks);
 
         // Assert hash
         let hash = block_state.persistent.hash(&context.store).expect("hash");
         assert_eq!(
             format!("{}", hash),
-            "a58ed4fdc2d127e1cdaf3fdb4cad4dc0819e6c66943f2b85592adbb471e44c01"
+            "087291ee0596eb189674d6fca89fa020c31d147b0b434f3f8ca1e859c56418ae"
         );
 
         // Assert storage
         blob_store::store_to_store(&mut context.store, &block_state.persistent);
         assert_eq!(
             hex::encode(context.store.0),
-            "000000000000002806746f6b656e310505050505050505050505050505050505050505050505050505050505050505020000000000000025edbda48b85971b3a874334ca94f07e55e6a6e63eabca968d1257a3223e1b84e14002010100000000000000002503b0eab929105fd6df1ec793cbaf1b554a7a385520a9f7c902adf0219ace6dab4002000000000000000000003648b07111a93452374c7bcf66ee01959af6b4a52cb7cd299341e9ea77b378b0230300000201000000000000005d020000000000000030000000000000000901000000000000008a0000000000000011000000000000000000000000000000c86400000000000000090000000000000000d9000000000000002806746f6b656e3205050505050505050505050505050505050505050505050505050505050505050400000000000000010000000000000000110000000000000103000000000000013300000000000000000900000000000000013c0000000000000021000000000000000201000000000000000000000000000000f20000000000000155000000000000005d0000000000000001000000000000000100000000000000000100020000000000000001000000000000000200000000000000640000010000000000000001020003000208746f6b656e69643108746f6b656e696432010100000200010000000000000000310100000000000000020000000000000000000000000000000000000000000000010000000000000001000000000000018f00000000000000090000000000000001f4000000000000002b000000000000000200000000000000070000000000000000010000000000000000000000000000000000000000000000000011010000000000000000000000000000023e000000000000000900000000000000027100000000000000210000000000000002010000000000000000000000000000022d000000000000028a00000000000000100000000000000166000000000000029b"
+            "000000000000002806746f6b656e310505050505050505050505050505050505050505050505050505050505050505020000000000000025edbda48b85971b3a874334ca94f07e55e6a6e63eabca968d1257a3223e1b84e14002010100000000000000002503b0eab929105fd6df1ec793cbaf1b554a7a385520a9f7c902adf0219ace6dab4002000000000000000000003648b07111a93452374c7bcf66ee01959af6b4a52cb7cd299341e9ea77b378b0230300000201000000000000005d020000000000000030000000000000000901000000000000008a0000000000000011000000000000000000000000000000c86400000000000000090000000000000000d9000000000000002806746f6b656e3205050505050505050505050505050505050505050505050505050505050505050400000000000000010000000000000000110000000000000103000000000000013300000000000000000900000000000000013c0000000000000021000000000000000201000000000000000000000000000000f20000000000000155000000000000004e2bb048177e32a285acbafc8731e45062038a9d1793e5a8ec4f80c800ad75fc1160000000000000000700000000000000001b00000000000000000100000000000000000000000000000000000000000000000000006d000000000000000200000000000000000000000000000000000000000000000100000000000000010100020000000000000001000000000000000200000000000000640000010000000000000001020003000208746f6b656e69643108746f6b656e6964320101000002000100000000000000005b9b0ba94873aa0311787743d5f066d2e3f1ee25edf6afcf5a01907621a92ca2fe6000000000000000010000000000000000ff5e53bf51600ef190e4b7cd2ff0b7c185d7073f6bdd9b311fd7b05d08e0af731700000000000001e500000000000000003c0ad4825a72ed1a8bd0c55105819eecf2883d9d92a223b1645b868b4a6fda866c0f00000000000000000201000000000000025a02000000000000018f00000000000000090100000000000002bd000000000000001000000000000001660000000000000301"
         );
     }
 }

--- a/plt/plt-block-state/src/persistent/block_state/p11.rs
+++ b/plt/plt-block-state/src/persistent/block_state/p11.rs
@@ -111,17 +111,16 @@ mod test {
             metadata: None,
         };
 
-        let mut locks = block_state.locks(&context).unwrap();
-        locks
-            .create(&context, &lock_id1, configuration1.clone())
+        block_state
+            .create_lock(&context, &lock_id1, configuration1.clone())
             .unwrap();
-        let mut lock1 = locks
-            .by_id(&context, &lock_id1)
+        let mut lock1 = block_state
+            .lock_by_id(&context, &lock_id1)
             .unwrap()
             .expect("lock should exist");
         lock1.add_lock_balance_ref(AccountIndex::from(0), TokenIndex(0));
         lock1.add_lock_balance_ref(AccountIndex::from(1), TokenIndex(1));
-        locks.update(&context, lock1).unwrap();
+        block_state.update_lock(&context, lock1).unwrap();
         let lock_id2 = LockId {
             account_index: 2,
             sequence_number: 7,
@@ -135,8 +134,8 @@ mod test {
             ),
             metadata: None,
         };
-        locks
-            .create(&context, &lock_id2, configuration2.clone())
+        block_state
+            .create_lock(&context, &lock_id2, configuration2.clone())
             .unwrap();
 
         // Create a third lock and then delete it
@@ -153,10 +152,11 @@ mod test {
             ),
             metadata: None,
         };
-        locks.create(&context, &lock_id3, configuration3).unwrap();
-        let was_deleted = locks.delete(&context, &lock_id3).unwrap();
+        block_state
+            .create_lock(&context, &lock_id3, configuration3)
+            .unwrap();
+        let was_deleted = block_state.delete_lock(&context, &lock_id3).unwrap();
         assert!(was_deleted, "lock3 should be deleted");
-        block_state.commit_locks(&context, locks);
 
         // Store and load block state
         let blob_ref = blob_store::store_to_store(&mut context.store, block_state.persistent);
@@ -287,15 +287,16 @@ mod test {
             ),
             metadata: None,
         };
-        let mut locks = block_state.locks(&context).unwrap();
-        locks.create(&context, &lock_id1, configuration1).unwrap();
-        let mut lock1 = locks
-            .by_id(&context, &lock_id1)
+        block_state
+            .create_lock(&context, &lock_id1, configuration1)
+            .unwrap();
+        let mut lock1 = block_state
+            .lock_by_id(&context, &lock_id1)
             .unwrap()
             .expect("lock should exist");
         lock1.add_lock_balance_ref(AccountIndex::from(0), TokenIndex(0));
         lock1.add_lock_balance_ref(AccountIndex::from(1), TokenIndex(1));
-        locks.update(&context, lock1).unwrap();
+        block_state.update_lock(&context, lock1).unwrap();
         let lock_id2 = LockId {
             account_index: 2,
             sequence_number: 7,
@@ -309,8 +310,9 @@ mod test {
             ),
             metadata: None,
         };
-        locks.create(&context, &lock_id2, configuration2).unwrap();
-        block_state.commit_locks(&context, locks);
+        block_state
+            .create_lock(&context, &lock_id2, configuration2)
+            .unwrap();
 
         // Assert hash
         let hash = block_state.persistent.hash(&context.store).expect("hash");

--- a/plt/plt-block-state/src/persistent/protocol_level_locks/p11.rs
+++ b/plt/plt-block-state/src/persistent/protocol_level_locks/p11.rs
@@ -8,7 +8,7 @@ use crate::persistent::protocol_level_tokens::p9::TokenIndex;
 use crate::persistent::smart_contract_trie::PersistentState;
 use concordium_base::base::AccountIndex;
 use concordium_base::common::types::TransactionTime;
-use concordium_base::common::{Buffer, Serialize};
+use concordium_base::common::{Buffer, Serialize, from_bytes_complete, to_bytes};
 use concordium_base::hashes::Hash;
 use concordium_base::protocol_level_locks::{LockControllerSimpleV0Capability, LockId};
 use concordium_base::protocol_level_tokens::{CborMemo, RawCbor, TokenId};
@@ -107,33 +107,28 @@ impl Hashable for PersistentLockP11 {
 
 /// Serialize a lock ID for use as a persistent trie key.
 pub(crate) fn lock_id_key(lock_id: &LockId) -> Vec<u8> {
-    concordium_base::common::to_bytes(lock_id)
+    to_bytes(lock_id)
 }
 
 /// Decode a canonical serialized lock ID from a persistent trie key.
 pub(crate) fn lock_id_from_key(key: &[u8]) -> BlockStateResult<LockId> {
-    let lock_id = concordium_base::common::from_bytes_complete(key).map_err(|err| {
+    from_bytes_complete(key).map_err(|err| {
         BlockStateFailure::BlobStoreDecode(format!("Stored lock ID key cannot be decoded: {err}"))
-    })?;
-    Ok(lock_id)
+    })
 }
 
 /// Serialize a persistent lock for use as a persistent trie value.
 pub(crate) fn persistent_lock_value(lock: &PersistentLockP11) -> Vec<u8> {
-    concordium_base::common::to_bytes(&(
-        lock.locked_balances.0.clone(),
-        lock.configuration.0.clone(),
-    ))
+    to_bytes(&(lock.locked_balances.0.clone(), lock.configuration.0.clone()))
 }
 
 /// Decode a persistent lock from a persistent trie value.
 pub(crate) fn persistent_lock_from_value(value: &[u8]) -> BlockStateResult<PersistentLockP11> {
-    let (locked_balances, configuration) = concordium_base::common::from_bytes_complete(value)
-        .map_err(|err| {
-            BlockStateFailure::BlobStoreDecode(format!(
-                "Stored persistent lock value cannot be decoded: {err}"
-            ))
-        })?;
+    let (locked_balances, configuration) = from_bytes_complete(value).map_err(|err| {
+        BlockStateFailure::BlobStoreDecode(format!(
+            "Stored persistent lock value cannot be decoded: {err}"
+        ))
+    })?;
     Ok(PersistentLockP11 {
         locked_balances: StoreSerialized(locked_balances),
         configuration: StoreSerialized(configuration),

--- a/plt/plt-block-state/src/persistent/protocol_level_locks/p11.rs
+++ b/plt/plt-block-state/src/persistent/protocol_level_locks/p11.rs
@@ -1,12 +1,11 @@
 use crate::failure::{BlockStateFailure, BlockStateResult};
-use crate::persistent::blob_reference::hashed_cacheable_reference::HashedCacheableRef;
 use crate::persistent::blob_store::{
     BlobStoreLoad, BlobStoreStore, Loadable, Storable, StoreSerialized,
 };
 use crate::persistent::cacheable::Cacheable;
 use crate::persistent::hash::{self, Hashable};
-use crate::persistent::lfmb_tree::{LfmbTree, LfmbTreeKey};
 use crate::persistent::protocol_level_tokens::p9::TokenIndex;
+use crate::persistent::smart_contract_trie::PersistentState;
 use concordium_base::base::AccountIndex;
 use concordium_base::common::types::TransactionTime;
 use concordium_base::common::{Buffer, Serialize};
@@ -16,58 +15,29 @@ use concordium_base::protocol_level_tokens::{CborMemo, RawCbor, TokenId};
 use std::collections::BTreeSet;
 use std::io::Read;
 
-/// Index of the protocol-level lock in the block state map of locks.
-///
-/// This type is the internal identifier of the lock in the block state and should never be exposed
-/// in the API, events or used in state hashing.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
-pub struct LockIndex(pub u64);
-
-impl LfmbTreeKey for LockIndex {
-    fn to_u64(self) -> u64 {
-        self.0
-    }
-
-    fn from_u64(key: u64) -> Self {
-        Self(key)
-    }
+/// Block state for protocol level locks on P11 and later protocols that uses the same representation.
+#[derive(Debug, Clone)]
+pub struct PersistentLocksP11 {
+    /// Persistent trie of serialized [`LockId`] keys and [`PersistentLockP11`] values.
+    pub(crate) locks: PersistentState,
 }
 
-/// Block state for protocol level locks on P11 and later protocols that uses the same representation.
-#[derive(Debug, Clone, Default)]
-pub struct PersistentLocksP11 {
-    /// Persistent map of lock index to locks.
-    ///
-    /// Here `None` represents a lock which has been deleted and acts as tombstone, preventing new
-    /// locks from using the same index.
-    pub(crate) locks: LfmbTree<LockIndex, Option<PersistentLockP11>>,
-    /// Index for mapping Lock ID to the internal lock index used above.
-    ///
-    /// Deleted locks are absent from this index.
-    pub(crate) lock_id_map: im::HashMap<LockId, LockIndex>,
+impl Default for PersistentLocksP11 {
+    fn default() -> Self {
+        Self {
+            locks: PersistentState::empty(),
+        }
+    }
 }
 
 impl Loadable for PersistentLocksP11 {
     fn load_from_buffer(
-        mut buffer: impl Read,
+        buffer: impl Read,
         loader: &impl BlobStoreLoad,
     ) -> Result<Self, BlockStateFailure> {
-        let locks: LfmbTree<LockIndex, Option<PersistentLockP11>> =
-            Loadable::load_from_buffer(&mut buffer, loader)?;
-        // To construct the full lock id to lock index map, we need to read the LFMBTree from
-        // the blob store. This is not ideal. If the state is to be cached after loading, we would
-        // rather wait until it is cached in memory before constructing the map.
-        let mut lock_id_map = im::HashMap::new();
-        for item in locks.values(loader) {
-            let (lock_index, lock) = item?;
-            // Skip the deleted locks.
-            let Some(lock) = lock.as_ref() else {
-                continue;
-            };
-            let conf = lock.configuration.value(loader)?;
-            lock_id_map.insert(conf.0.lock_id.clone(), lock_index);
-        }
-        Ok(Self { locks, lock_id_map })
+        Ok(Self {
+            locks: Loadable::load_from_buffer(buffer, loader)?,
+        })
     }
 }
 
@@ -97,7 +67,7 @@ pub struct PersistentLockP11 {
     /// Note the entire collection will be written to disk every time this struct is written to disk.
     pub locked_balances: StoreSerialized<BTreeSet<(AccountIndex, TokenIndex)>>,
     /// The configuration parameters for the lock.
-    pub configuration: HashedCacheableRef<StoreSerialized<LockConfiguration>>,
+    pub configuration: StoreSerialized<LockConfiguration>,
 }
 
 impl Loadable for PersistentLockP11 {
@@ -122,8 +92,8 @@ impl Storable for PersistentLockP11 {
 }
 
 impl Cacheable for PersistentLockP11 {
-    fn cache_reference_values(&self, loader: &impl BlobStoreLoad) -> BlockStateResult<()> {
-        self.configuration.cache_reference_values(loader)
+    fn cache_reference_values(&self, _loader: &impl BlobStoreLoad) -> BlockStateResult<()> {
+        Ok(())
     }
 }
 
@@ -133,6 +103,41 @@ impl Hashable for PersistentLockP11 {
         let configuration = self.configuration.hash(loader)?;
         Ok(hash::hash_of_hashes(locked_balances, configuration))
     }
+}
+
+/// Serialize a lock ID for use as a persistent trie key.
+pub(crate) fn lock_id_key(lock_id: &LockId) -> Vec<u8> {
+    concordium_base::common::to_bytes(lock_id)
+}
+
+/// Decode a canonical serialized lock ID from a persistent trie key.
+pub(crate) fn lock_id_from_key(key: &[u8]) -> BlockStateResult<LockId> {
+    let lock_id = concordium_base::common::from_bytes_complete(key).map_err(|err| {
+        BlockStateFailure::BlobStoreDecode(format!("Stored lock ID key cannot be decoded: {err}"))
+    })?;
+    Ok(lock_id)
+}
+
+/// Serialize a persistent lock for use as a persistent trie value.
+pub(crate) fn persistent_lock_value(lock: &PersistentLockP11) -> Vec<u8> {
+    concordium_base::common::to_bytes(&(
+        lock.locked_balances.0.clone(),
+        lock.configuration.0.clone(),
+    ))
+}
+
+/// Decode a persistent lock from a persistent trie value.
+pub(crate) fn persistent_lock_from_value(value: &[u8]) -> BlockStateResult<PersistentLockP11> {
+    let (locked_balances, configuration) = concordium_base::common::from_bytes_complete(value)
+        .map_err(|err| {
+            BlockStateFailure::BlobStoreDecode(format!(
+                "Stored persistent lock value cannot be decoded: {err}"
+            ))
+        })?;
+    Ok(PersistentLockP11 {
+        locked_balances: StoreSerialized(locked_balances),
+        configuration: StoreSerialized(configuration),
+    })
 }
 
 /// Error returned when a persistent container exceeds its serialized capacity.
@@ -227,8 +232,6 @@ impl TryFrom<Vec<AccountIndex>> for LockRecipients {
 /// Lock configuration at the block state level.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub struct LockConfiguration {
-    /// Identifier of the lock.
-    pub lock_id: LockId,
     /// Accounts that can receive funds from this lock.
     pub recipients: LockRecipients,
     /// Expiry time of the lock (seconds since epoch).
@@ -362,6 +365,9 @@ impl LockControllerSimpleV0Grant {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::persistent::blob_store;
+    use crate::persistent::blob_store::test_stub::BlobStoreStub;
+    use crate::persistent::hash::Hashable;
     use concordium_base::common;
     use concordium_base::transactions::Memo;
 
@@ -371,11 +377,6 @@ mod test {
         use concordium_base::protocol_level_locks::LockControllerSimpleV0Capability;
 
         let lock_config = LockConfiguration {
-            lock_id: LockId {
-                account_index: 50,
-                sequence_number: 2,
-                creation_order: 0,
-            },
             recipients: LockRecipients::try_from(vec![
                 AccountIndex::from(1u64),
                 AccountIndex::from(2u64),
@@ -397,7 +398,7 @@ mod test {
         let bytes = common::to_bytes(&lock_config);
         assert_eq!(
             hex::encode(&bytes),
-            "0000000000000032000000000000000200000000000000000100020000000000000001000000000000000200000000000003e800000100000000000000010100000106746f6b656e31010000"
+            "0100020000000000000001000000000000000200000000000003e800000100000000000000010100000106746f6b656e31010000"
         );
 
         let deserialized: LockConfiguration =
@@ -410,11 +411,6 @@ mod test {
         use concordium_base::common::types::TransactionTime;
 
         let lock_config = LockConfiguration {
-            lock_id: LockId {
-                account_index: 50,
-                sequence_number: 2,
-                creation_order: 0,
-            },
             recipients: LockRecipients::try_from(vec![]).unwrap(),
             expiry: TransactionTime::from(500u64),
             controller: LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
@@ -429,7 +425,7 @@ mod test {
         let bytes = common::to_bytes(&lock_config);
         assert_eq!(
             hex::encode(&bytes),
-            "00000000000000320000000000000002000000000000000001000000000000000001f40000000000000000"
+            "01000000000000000001f40000000000000000"
         );
 
         let deserialized: LockConfiguration =
@@ -442,11 +438,6 @@ mod test {
         use concordium_base::common::types::TransactionTime;
 
         let lock_config = LockConfiguration {
-            lock_id: LockId {
-                account_index: 50,
-                sequence_number: 2,
-                creation_order: 0,
-            },
             recipients: LockRecipients::Any,
             expiry: TransactionTime::from(500u64),
             controller: LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
@@ -463,12 +454,89 @@ mod test {
         let bytes = common::to_bytes(&lock_config);
         assert_eq!(
             hex::encode(&bytes),
-            "0000000000000032000000000000000200000000000000000000000000000001f400000000000000010000000ba1646e616d656474657374"
+            "0000000000000001f400000000000000010000000ba1646e616d656474657374"
         );
 
         let deserialized: LockConfiguration =
             common::from_bytes_complete(bytes.as_slice()).unwrap();
         assert_eq!(deserialized, lock_config);
+    }
+
+    #[test]
+    fn lock_state_store_load_round_trip_preserves_entries_and_hash() {
+        let mut store = BlobStoreStub::default();
+        let lock_id = LockId::new(50, 2, 0);
+        let lock = PersistentLockP11 {
+            locked_balances: StoreSerialized(BTreeSet::from([(
+                AccountIndex::from(1),
+                TokenIndex(2),
+            )])),
+            configuration: StoreSerialized(LockConfiguration {
+                recipients: LockRecipients::Any,
+                expiry: TransactionTime::from(1000),
+                controller: LockControllerConfig::SimpleV0(
+                    LockControllerSimpleV0::new(Vec::new(), Vec::new(), false, None).unwrap(),
+                ),
+                metadata: None,
+            }),
+        };
+        let mut locks = PersistentLocksP11::default();
+        let mut mutable_locks = locks.locks.thaw();
+        mutable_locks
+            .insert_value(&store, &lock_id_key(&lock_id), persistent_lock_value(&lock))
+            .unwrap();
+        locks.locks = mutable_locks.freeze(&store);
+        let hash = locks.hash(&store).unwrap();
+        assert_eq!(locks.hash(&store).unwrap(), hash);
+
+        let location = blob_store::store_to_store(&mut store, &locks);
+        let loaded: PersistentLocksP11 = blob_store::load_from_store(&store, location).unwrap();
+        assert_eq!(loaded.hash(&store).unwrap(), hash);
+        let loaded_lock = persistent_lock_from_value(
+            &loaded
+                .locks
+                .lookup_value(&store, &lock_id_key(&lock_id))
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(loaded_lock.locked_balances, lock.locked_balances);
+        assert_eq!(loaded_lock.configuration, lock.configuration);
+    }
+
+    #[test]
+    fn lock_trie_key_and_value_round_trip() {
+        let lock_id = LockId::new(50, 2, 0);
+        let lock = PersistentLockP11 {
+            locked_balances: StoreSerialized(BTreeSet::from([(
+                AccountIndex::from(1),
+                TokenIndex(2),
+            )])),
+            configuration: StoreSerialized(LockConfiguration {
+                recipients: LockRecipients::Any,
+                expiry: TransactionTime::from(1000),
+                controller: LockControllerConfig::SimpleV0(
+                    LockControllerSimpleV0::new(Vec::new(), Vec::new(), false, None).unwrap(),
+                ),
+                metadata: None,
+            }),
+        };
+
+        assert_eq!(lock_id_from_key(&lock_id_key(&lock_id)).unwrap(), lock_id);
+        let decoded = persistent_lock_from_value(&persistent_lock_value(&lock)).unwrap();
+        assert_eq!(decoded.locked_balances, lock.locked_balances);
+        assert_eq!(decoded.configuration, lock.configuration);
+    }
+
+    #[test]
+    fn malformed_lock_trie_key_and_value_are_decode_failures() {
+        assert!(matches!(
+            lock_id_from_key(&[0]),
+            Err(BlockStateFailure::BlobStoreDecode(_))
+        ));
+        assert!(matches!(
+            persistent_lock_from_value(&[0]),
+            Err(BlockStateFailure::BlobStoreDecode(_))
+        ));
     }
 
     #[test]
@@ -489,11 +557,6 @@ mod test {
         use concordium_base::common::types::TransactionTime;
 
         let lock_config = LockConfiguration {
-            lock_id: LockId {
-                account_index: 50,
-                sequence_number: 2,
-                creation_order: 0,
-            },
             recipients: LockRecipients::Any,
             expiry: TransactionTime::from(500u64),
             controller: LockControllerConfig::SimpleV0(LockControllerSimpleV0 {
@@ -518,10 +581,7 @@ mod test {
         );
 
         let bytes = common::to_bytes(&lock_config);
-        assert_eq!(
-            hex::encode(&bytes),
-            "0000000000000032000000000000000200000000000000000000000000000001f40000000000000000"
-        );
+        assert_eq!(hex::encode(&bytes), "0000000000000001f40000000000000000");
 
         let deserialized: LockConfiguration =
             common::from_bytes_complete(bytes.as_slice()).unwrap();

--- a/plt/plt-block-state/src/persistent/protocol_level_locks/p11.rs
+++ b/plt/plt-block-state/src/persistent/protocol_level_locks/p11.rs
@@ -1,9 +1,7 @@
 use crate::failure::{BlockStateFailure, BlockStateResult};
-use crate::persistent::blob_store::{
-    BlobStoreLoad, BlobStoreStore, Loadable, Storable, StoreSerialized,
-};
+use crate::persistent::blob_store::{BlobStoreLoad, BlobStoreStore, Loadable, Storable};
 use crate::persistent::cacheable::Cacheable;
-use crate::persistent::hash::{self, Hashable};
+use crate::persistent::hash::Hashable;
 use crate::persistent::protocol_level_tokens::p9::TokenIndex;
 use crate::persistent::smart_contract_trie::PersistentState;
 use concordium_base::base::AccountIndex;
@@ -65,44 +63,9 @@ pub struct PersistentLockP11 {
     /// Contains references to the tokens with balances locked within this lock.
     ///
     /// Note the entire collection will be written to disk every time this struct is written to disk.
-    pub locked_balances: StoreSerialized<BTreeSet<(AccountIndex, TokenIndex)>>,
+    pub locked_balances: BTreeSet<(AccountIndex, TokenIndex)>,
     /// The configuration parameters for the lock.
-    pub configuration: StoreSerialized<LockConfiguration>,
-}
-
-impl Loadable for PersistentLockP11 {
-    fn load_from_buffer(
-        mut buffer: impl Read,
-        loader: &impl BlobStoreLoad,
-    ) -> Result<Self, BlockStateFailure> {
-        let locked_balances = Loadable::load_from_buffer(&mut buffer, loader)?;
-        let configuration = Loadable::load_from_buffer(&mut buffer, loader)?;
-        Ok(Self {
-            locked_balances,
-            configuration,
-        })
-    }
-}
-
-impl Storable for PersistentLockP11 {
-    fn store_to_buffer(&self, mut buffer: impl Buffer, storer: &mut impl BlobStoreStore) {
-        self.locked_balances.store_to_buffer(&mut buffer, storer);
-        self.configuration.store_to_buffer(&mut buffer, storer);
-    }
-}
-
-impl Cacheable for PersistentLockP11 {
-    fn cache_reference_values(&self, _loader: &impl BlobStoreLoad) -> BlockStateResult<()> {
-        Ok(())
-    }
-}
-
-impl Hashable for PersistentLockP11 {
-    fn hash(&self, loader: &impl BlobStoreLoad) -> BlockStateResult<Hash> {
-        let locked_balances = self.locked_balances.hash(loader)?;
-        let configuration = self.configuration.hash(loader)?;
-        Ok(hash::hash_of_hashes(locked_balances, configuration))
-    }
+    pub configuration: LockConfiguration,
 }
 
 /// Serialize a lock ID for use as a persistent trie key.
@@ -119,7 +82,7 @@ pub(crate) fn lock_id_from_key(key: &[u8]) -> BlockStateResult<LockId> {
 
 /// Serialize a persistent lock for use as a persistent trie value.
 pub(crate) fn persistent_lock_value(lock: &PersistentLockP11) -> Vec<u8> {
-    to_bytes(&(lock.locked_balances.0.clone(), lock.configuration.0.clone()))
+    to_bytes(&(lock.locked_balances.clone(), lock.configuration.clone()))
 }
 
 /// Decode a persistent lock from a persistent trie value.
@@ -130,8 +93,8 @@ pub(crate) fn persistent_lock_from_value(value: &[u8]) -> BlockStateResult<Persi
         ))
     })?;
     Ok(PersistentLockP11 {
-        locked_balances: StoreSerialized(locked_balances),
-        configuration: StoreSerialized(configuration),
+        locked_balances,
+        configuration,
     })
 }
 
@@ -462,18 +425,15 @@ mod test {
         let mut store = BlobStoreStub::default();
         let lock_id = LockId::new(50, 2, 0);
         let lock = PersistentLockP11 {
-            locked_balances: StoreSerialized(BTreeSet::from([(
-                AccountIndex::from(1),
-                TokenIndex(2),
-            )])),
-            configuration: StoreSerialized(LockConfiguration {
+            locked_balances: BTreeSet::from([(AccountIndex::from(1), TokenIndex(2))]),
+            configuration: LockConfiguration {
                 recipients: LockRecipients::Any,
                 expiry: TransactionTime::from(1000),
                 controller: LockControllerConfig::SimpleV0(
                     LockControllerSimpleV0::new(Vec::new(), Vec::new(), false, None).unwrap(),
                 ),
                 metadata: None,
-            }),
+            },
         };
         let mut locks = PersistentLocksP11::default();
         let mut mutable_locks = locks.locks.thaw();
@@ -502,18 +462,15 @@ mod test {
     fn lock_trie_key_and_value_round_trip() {
         let lock_id = LockId::new(50, 2, 0);
         let lock = PersistentLockP11 {
-            locked_balances: StoreSerialized(BTreeSet::from([(
-                AccountIndex::from(1),
-                TokenIndex(2),
-            )])),
-            configuration: StoreSerialized(LockConfiguration {
+            locked_balances: BTreeSet::from([(AccountIndex::from(1), TokenIndex(2))]),
+            configuration: LockConfiguration {
                 recipients: LockRecipients::Any,
                 expiry: TransactionTime::from(1000),
                 controller: LockControllerConfig::SimpleV0(
                     LockControllerSimpleV0::new(Vec::new(), Vec::new(), false, None).unwrap(),
                 ),
                 metadata: None,
-            }),
+            },
         };
 
         assert_eq!(lock_id_from_key(&lock_id_key(&lock_id)).unwrap(), lock_id);

--- a/plt/plt-block-state/src/persistent/smart_contract_trie.rs
+++ b/plt/plt-block-state/src/persistent/smart_contract_trie.rs
@@ -21,6 +21,25 @@ use std::sync::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
 #[derive(Debug)]
 pub struct PersistentState(RwLock<trie::PersistentState>);
 
+impl Clone for PersistentState {
+    fn clone(&self) -> Self {
+        Self(RwLock::new(self.lock_read().clone()))
+    }
+}
+
+/// Common read-only operations supported by frozen and mutable tries.
+pub(crate) trait TrieState {
+    /// Return a copied value for `key`, or `None` when the key is absent.
+    fn lookup_value(&self, loader: &impl BlobStoreLoad, key: &[u8]) -> Option<Vec<u8>>;
+
+    /// Return keys with `prefix` without loading values; iteration can fail.
+    fn keys_with_prefix(
+        &self,
+        loader: &impl BlobStoreLoad,
+        prefix: &[u8],
+    ) -> BlockStateResult<Vec<Vec<u8>>>;
+}
+
 impl PersistentState {
     /// Create empty trie.
     pub fn empty() -> Self {
@@ -36,7 +55,7 @@ impl PersistentState {
     }
 
     /// Iterate entries whose keys start with the given prefix. Returns an iterator over
-    /// key-value pairs.
+    /// key-value pairs. Use [`Self::keys_with_prefix`] when only keys are needed.
     pub fn iter_prefix<'a, L: BlobStoreLoad>(
         &self,
         loader: &'a L,
@@ -50,6 +69,26 @@ impl PersistentState {
         })?;
 
         Ok(PrefixIterator {
+            loader,
+            trie: trie.clone(),
+            trie_iter,
+        })
+    }
+
+    /// Iterate keys that start with the given prefix without loading their values.
+    pub fn keys_with_prefix<'a, L: BlobStoreLoad>(
+        &self,
+        loader: &'a L,
+        prefix: &[u8],
+    ) -> BlockStateResult<impl Iterator<Item = Vec<u8>> + use<'a, L>> {
+        let mut loader_adapter = LoaderAdapter(loader);
+        let mut mutable_state = self.lock_read().thaw();
+        let mut trie = mutable_state.get_inner(&mut loader_adapter).lock();
+        let trie_iter = trie.iter(&mut loader_adapter, prefix).map_err(|err| {
+            BlockStateFailure::Invariant(format!("Error iterating keys in MutableTrie: {err}"))
+        })?;
+
+        Ok(KeyPrefixIterator {
             loader,
             trie: trie.clone(),
             trie_iter,
@@ -100,6 +139,37 @@ impl BlobStoreMovable for PersistentState {
     }
 }
 
+struct KeyPrefixIterator<'a, L> {
+    loader: &'a L,
+    trie: trie::MutableTrie,
+    trie_iter: Option<trie::low_level::Iterator>,
+}
+
+impl<L> Drop for KeyPrefixIterator<'_, L> {
+    fn drop(&mut self) {
+        if let Some(trie_iter) = self.trie_iter.as_ref() {
+            self.trie.delete_iter(trie_iter);
+        }
+    }
+}
+
+impl<L: BlobStoreLoad> Iterator for KeyPrefixIterator<'_, L> {
+    type Item = Vec<u8>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let trie_iter = self.trie_iter.as_mut()?;
+        let mut loader = LoaderAdapter(self.loader);
+        match self
+            .trie
+            .next(&mut loader, trie_iter, &mut trie::EmptyCounter)
+        {
+            Ok(Some(_)) => Some(trie_iter.get_key().to_vec()),
+            Ok(None) => None,
+            Err(counter_err) => match counter_err {},
+        }
+    }
+}
+
 struct PrefixIterator<'a, L> {
     loader: &'a L,
     trie: trie::MutableTrie,
@@ -140,6 +210,20 @@ where
     }
 }
 
+impl TrieState for PersistentState {
+    fn lookup_value(&self, loader: &impl BlobStoreLoad, key: &[u8]) -> Option<Vec<u8>> {
+        self.lookup_value(loader, key)
+    }
+
+    fn keys_with_prefix(
+        &self,
+        loader: &impl BlobStoreLoad,
+        prefix: &[u8],
+    ) -> BlockStateResult<Vec<Vec<u8>>> {
+        Ok(self.keys_with_prefix(loader, prefix)?.collect())
+    }
+}
+
 /// Mutable trie. This is the thawed/mutable dual to [`PersistentState`].
 #[derive(Debug)]
 pub struct MutableState {
@@ -168,7 +252,7 @@ impl MutableState {
     }
 
     /// Iterate entries whose keys start with the given prefix. Returns an iterator over
-    /// key-value pairs.
+    /// key-value pairs. Use [`Self::keys_with_prefix`] when only keys are needed.
     pub fn iter_prefix<'a, L: BlobStoreLoad>(
         &self,
         loader: &'a L,
@@ -182,6 +266,26 @@ impl MutableState {
         })?;
 
         Ok(PrefixIterator {
+            loader,
+            trie,
+            trie_iter,
+        })
+    }
+
+    /// Iterate keys that start with the given prefix without loading their values.
+    pub fn keys_with_prefix<'a, L: BlobStoreLoad>(
+        &self,
+        loader: &'a L,
+        prefix: &[u8],
+    ) -> BlockStateResult<impl Iterator<Item = Vec<u8>> + use<'a, L>> {
+        let mut loader_adapter = LoaderAdapter(loader);
+        let mut mutable_state = self.lock();
+        let mut trie = mutable_state.get_inner(&mut loader_adapter).lock().clone();
+        let trie_iter = trie.iter(&mut loader_adapter, prefix).map_err(|err| {
+            BlockStateFailure::Invariant(format!("Error iterating keys in MutableTrie: {err}"))
+        })?;
+
+        Ok(KeyPrefixIterator {
             loader,
             trie,
             trie_iter,
@@ -235,6 +339,20 @@ impl MutableState {
 
     fn get_mut(&mut self) -> &mut trie::MutableState {
         self.inner.get_mut().expect("MutableState lock poisoned")
+    }
+}
+
+impl TrieState for MutableState {
+    fn lookup_value(&self, loader: &impl BlobStoreLoad, key: &[u8]) -> Option<Vec<u8>> {
+        self.lookup_value(loader, key)
+    }
+
+    fn keys_with_prefix(
+        &self,
+        loader: &impl BlobStoreLoad,
+        prefix: &[u8],
+    ) -> BlockStateResult<Vec<Vec<u8>>> {
+        Ok(self.keys_with_prefix(loader, prefix)?.collect())
     }
 }
 

--- a/plt/plt-block-state/src/persistent/smart_contract_trie.rs
+++ b/plt/plt-block-state/src/persistent/smart_contract_trie.rs
@@ -27,19 +27,6 @@ impl Clone for PersistentState {
     }
 }
 
-/// Common read-only operations supported by frozen and mutable tries.
-pub(crate) trait TrieState {
-    /// Return a copied value for `key`, or `None` when the key is absent.
-    fn lookup_value(&self, loader: &impl BlobStoreLoad, key: &[u8]) -> Option<Vec<u8>>;
-
-    /// Return keys with `prefix` without loading values; iteration can fail.
-    fn keys_with_prefix(
-        &self,
-        loader: &impl BlobStoreLoad,
-        prefix: &[u8],
-    ) -> BlockStateResult<Vec<Vec<u8>>>;
-}
-
 impl PersistentState {
     /// Create empty trie.
     pub fn empty() -> Self {
@@ -210,20 +197,6 @@ where
     }
 }
 
-impl TrieState for PersistentState {
-    fn lookup_value(&self, loader: &impl BlobStoreLoad, key: &[u8]) -> Option<Vec<u8>> {
-        self.lookup_value(loader, key)
-    }
-
-    fn keys_with_prefix(
-        &self,
-        loader: &impl BlobStoreLoad,
-        prefix: &[u8],
-    ) -> BlockStateResult<Vec<Vec<u8>>> {
-        Ok(self.keys_with_prefix(loader, prefix)?.collect())
-    }
-}
-
 /// Mutable trie. This is the thawed/mutable dual to [`PersistentState`].
 #[derive(Debug)]
 pub struct MutableState {
@@ -266,26 +239,6 @@ impl MutableState {
         })?;
 
         Ok(PrefixIterator {
-            loader,
-            trie,
-            trie_iter,
-        })
-    }
-
-    /// Iterate keys that start with the given prefix without loading their values.
-    pub fn keys_with_prefix<'a, L: BlobStoreLoad>(
-        &self,
-        loader: &'a L,
-        prefix: &[u8],
-    ) -> BlockStateResult<impl Iterator<Item = Vec<u8>> + use<'a, L>> {
-        let mut loader_adapter = LoaderAdapter(loader);
-        let mut mutable_state = self.lock();
-        let mut trie = mutable_state.get_inner(&mut loader_adapter).lock().clone();
-        let trie_iter = trie.iter(&mut loader_adapter, prefix).map_err(|err| {
-            BlockStateFailure::Invariant(format!("Error iterating keys in MutableTrie: {err}"))
-        })?;
-
-        Ok(KeyPrefixIterator {
             loader,
             trie,
             trie_iter,
@@ -339,20 +292,6 @@ impl MutableState {
 
     fn get_mut(&mut self) -> &mut trie::MutableState {
         self.inner.get_mut().expect("MutableState lock poisoned")
-    }
-}
-
-impl TrieState for MutableState {
-    fn lookup_value(&self, loader: &impl BlobStoreLoad, key: &[u8]) -> Option<Vec<u8>> {
-        self.lookup_value(loader, key)
-    }
-
-    fn keys_with_prefix(
-        &self,
-        loader: &impl BlobStoreLoad,
-        prefix: &[u8],
-    ) -> BlockStateResult<Vec<Vec<u8>>> {
-        Ok(self.keys_with_prefix(loader, prefix)?.collect())
     }
 }
 

--- a/plt/plt-block-state/tests/block_state_p11.rs
+++ b/plt/plt-block-state/tests/block_state_p11.rs
@@ -260,7 +260,6 @@ fn test_create_lock() {
     };
     let metadata = RawCbor::from(vec![0xa1]); // The node does not care what is in the metadata
     let configuration = LockConfiguration {
-        lock_id: lock_id.clone(),
         recipients: LockRecipients::try_from(vec![AccountIndex::from(1), AccountIndex::from(2)])
             .unwrap(),
         expiry: TransactionTime::from(100u64),
@@ -282,9 +281,11 @@ fn test_create_lock() {
         metadata: Some(metadata),
     };
 
-    block_state
-        .create_lock(&context, configuration.clone())
+    let mut locks = block_state.locks(&context).unwrap();
+    locks
+        .create(&context, &lock_id, configuration.clone())
         .unwrap();
+    block_state.commit_locks(&context, locks);
 
     // Read configuration
     let read_configuration = block_state
@@ -295,6 +296,20 @@ fn test_create_lock() {
         .unwrap()
         .into_owned();
     assert_eq!(read_configuration, configuration);
+
+    let mut locks = block_state.locks(&context).unwrap();
+    let duplicate = locks.create(&context, &lock_id, configuration.clone());
+    assert!(duplicate.is_err(), "creating a duplicate lock ID must fail");
+    assert_eq!(
+        block_state
+            .lock_by_id(&context, &lock_id)
+            .unwrap()
+            .unwrap()
+            .lock_configuration(&context)
+            .unwrap()
+            .into_owned(),
+        configuration
+    );
 }
 
 /// Test getting lock by id.
@@ -310,7 +325,6 @@ fn test_lock_by_id() {
         creation_order: 0,
     };
     let configuration = LockConfiguration {
-        lock_id: lock_id.clone(),
         recipients: LockRecipients::try_from(vec![]).unwrap(),
         expiry: TransactionTime::from(0u64),
         controller: LockControllerConfig::SimpleV0(
@@ -319,17 +333,16 @@ fn test_lock_by_id() {
         metadata: None,
     };
 
-    block_state.create_lock(&context, configuration).unwrap();
+    let mut locks = block_state.locks(&context).unwrap();
+    locks.create(&context, &lock_id, configuration).unwrap();
+    block_state.commit_locks(&context, locks);
 
     // Get lock by id
     let lock = block_state
         .lock_by_id(&context, &lock_id)
         .unwrap()
         .expect("lock should exist");
-    assert_eq!(
-        &lock.lock_configuration(&context).unwrap().lock_id,
-        &lock_id
-    );
+    assert_eq!(lock.lock_id(), &lock_id);
 
     // Get non-existing lock by id
     let non_existing_lock_id = LockId {
@@ -357,7 +370,6 @@ fn test_lock_balance_refs() {
         creation_order: 0,
     };
     let configuration = LockConfiguration {
-        lock_id: lock_id.clone(),
         recipients: LockRecipients::try_from(vec![]).unwrap(),
         expiry: TransactionTime::from(0u64),
         controller: LockControllerConfig::SimpleV0(
@@ -366,9 +378,10 @@ fn test_lock_balance_refs() {
         metadata: None,
     };
 
-    block_state.create_lock(&context, configuration).unwrap();
-    let mut lock = block_state
-        .lock_by_id(&context, &lock_id)
+    let mut locks = block_state.locks(&context).unwrap();
+    locks.create(&context, &lock_id, configuration).unwrap();
+    let mut lock = locks
+        .by_id(&context, &lock_id)
         .unwrap()
         .expect("lock should exist");
 
@@ -380,7 +393,8 @@ fn test_lock_balance_refs() {
     lock.add_lock_balance_ref(AccountIndex::from(1), TokenIndex(1));
 
     // Update lock
-    block_state.update_lock(&context, lock).unwrap();
+    locks.update(&context, lock).unwrap();
+    block_state.commit_locks(&context, locks);
 
     // Read balance refs
     let lock = block_state
@@ -409,7 +423,6 @@ fn test_create_and_delete_lock() {
         creation_order: 0,
     };
     let configuration = LockConfiguration {
-        lock_id: lock_id.clone(),
         recipients: LockRecipients::try_from(vec![]).unwrap(),
         expiry: TransactionTime::from(0u64),
         controller: LockControllerConfig::SimpleV0(
@@ -418,7 +431,9 @@ fn test_create_and_delete_lock() {
         metadata: None,
     };
 
-    block_state.create_lock(&context, configuration).unwrap();
+    let mut locks = block_state.locks(&context).unwrap();
+    locks.create(&context, &lock_id, configuration).unwrap();
+    block_state.commit_locks(&context, locks);
 
     // Verify lock exists
     block_state
@@ -427,7 +442,9 @@ fn test_create_and_delete_lock() {
         .expect("lock should exist after creation");
 
     // Delete lock
-    let was_deleted = block_state.delete_lock(&context, &lock_id).unwrap();
+    let mut locks = block_state.locks(&context).unwrap();
+    let was_deleted = locks.delete(&context, &lock_id).unwrap();
+    block_state.commit_locks(&context, locks);
     assert!(
         was_deleted,
         "delete_lock should return true for an existing lock"
@@ -440,7 +457,8 @@ fn test_create_and_delete_lock() {
         .expect_err("lock should not exist after deletion");
 
     // Deleting again should return false
-    let was_deleted_again = block_state.delete_lock(&context, &lock_id).unwrap();
+    let mut locks = block_state.locks(&context).unwrap();
+    let was_deleted_again = locks.delete(&context, &lock_id).unwrap();
     assert!(
         !was_deleted_again,
         "delete_lock should return false for a non-existing lock"
@@ -464,7 +482,6 @@ fn test_lock_list() {
         creation_order: 0,
     };
     let configuration_a = LockConfiguration {
-        lock_id: lock_id_a.clone(),
         recipients: LockRecipients::try_from(vec![]).unwrap(),
         expiry: TransactionTime::from(0u64),
         controller: LockControllerConfig::SimpleV0(
@@ -479,7 +496,6 @@ fn test_lock_list() {
         creation_order: 0,
     };
     let configuration_b = LockConfiguration {
-        lock_id: lock_id_b.clone(),
         recipients: LockRecipients::try_from(vec![]).unwrap(),
         expiry: TransactionTime::from(0u64),
         controller: LockControllerConfig::SimpleV0(
@@ -487,11 +503,14 @@ fn test_lock_list() {
         ),
         metadata: None,
     };
-    block_state.create_lock(&context, configuration_a).unwrap();
-    block_state.create_lock(&context, configuration_b).unwrap();
+    let mut locks = block_state.locks(&context).unwrap();
+    locks.create(&context, &lock_id_a, configuration_a).unwrap();
+    locks.create(&context, &lock_id_b, configuration_b).unwrap();
+    assert!(locks.delete(&context, &lock_id_a).unwrap());
+    block_state.commit_locks(&context, locks);
 
     // Read lock list and sort for a stable comparison (lock_list order is not guaranteed).
     let mut locks = block_state.lock_list(&context).unwrap();
     locks.sort();
-    assert_eq!(locks, vec![lock_id_a, lock_id_b]);
+    assert_eq!(locks, vec![lock_id_b]);
 }

--- a/plt/plt-block-state/tests/block_state_p11.rs
+++ b/plt/plt-block-state/tests/block_state_p11.rs
@@ -281,11 +281,9 @@ fn test_create_lock() {
         metadata: Some(metadata),
     };
 
-    let mut locks = block_state.locks(&context).unwrap();
-    locks
-        .create(&context, &lock_id, configuration.clone())
+    block_state
+        .create_lock(&context, &lock_id, configuration.clone())
         .unwrap();
-    block_state.commit_locks(&context, locks);
 
     // Read configuration
     let read_configuration = block_state
@@ -297,8 +295,7 @@ fn test_create_lock() {
         .into_owned();
     assert_eq!(read_configuration, configuration);
 
-    let mut locks = block_state.locks(&context).unwrap();
-    let duplicate = locks.create(&context, &lock_id, configuration.clone());
+    let duplicate = block_state.create_lock(&context, &lock_id, configuration.clone());
     assert!(duplicate.is_err(), "creating a duplicate lock ID must fail");
     assert_eq!(
         block_state
@@ -333,9 +330,9 @@ fn test_lock_by_id() {
         metadata: None,
     };
 
-    let mut locks = block_state.locks(&context).unwrap();
-    locks.create(&context, &lock_id, configuration).unwrap();
-    block_state.commit_locks(&context, locks);
+    block_state
+        .create_lock(&context, &lock_id, configuration)
+        .unwrap();
 
     // Get lock by id
     let lock = block_state
@@ -378,10 +375,11 @@ fn test_lock_balance_refs() {
         metadata: None,
     };
 
-    let mut locks = block_state.locks(&context).unwrap();
-    locks.create(&context, &lock_id, configuration).unwrap();
-    let mut lock = locks
-        .by_id(&context, &lock_id)
+    block_state
+        .create_lock(&context, &lock_id, configuration)
+        .unwrap();
+    let mut lock = block_state
+        .lock_by_id(&context, &lock_id)
         .unwrap()
         .expect("lock should exist");
 
@@ -393,8 +391,7 @@ fn test_lock_balance_refs() {
     lock.add_lock_balance_ref(AccountIndex::from(1), TokenIndex(1));
 
     // Update lock
-    locks.update(&context, lock).unwrap();
-    block_state.commit_locks(&context, locks);
+    block_state.update_lock(&context, lock).unwrap();
 
     // Read balance refs
     let lock = block_state
@@ -431,9 +428,9 @@ fn test_create_and_delete_lock() {
         metadata: None,
     };
 
-    let mut locks = block_state.locks(&context).unwrap();
-    locks.create(&context, &lock_id, configuration).unwrap();
-    block_state.commit_locks(&context, locks);
+    block_state
+        .create_lock(&context, &lock_id, configuration)
+        .unwrap();
 
     // Verify lock exists
     block_state
@@ -442,9 +439,7 @@ fn test_create_and_delete_lock() {
         .expect("lock should exist after creation");
 
     // Delete lock
-    let mut locks = block_state.locks(&context).unwrap();
-    let was_deleted = locks.delete(&context, &lock_id).unwrap();
-    block_state.commit_locks(&context, locks);
+    let was_deleted = block_state.delete_lock(&context, &lock_id).unwrap();
     assert!(
         was_deleted,
         "delete_lock should return true for an existing lock"
@@ -457,8 +452,7 @@ fn test_create_and_delete_lock() {
         .expect_err("lock should not exist after deletion");
 
     // Deleting again should return false
-    let mut locks = block_state.locks(&context).unwrap();
-    let was_deleted_again = locks.delete(&context, &lock_id).unwrap();
+    let was_deleted_again = block_state.delete_lock(&context, &lock_id).unwrap();
     assert!(
         !was_deleted_again,
         "delete_lock should return false for a non-existing lock"
@@ -503,11 +497,13 @@ fn test_lock_list() {
         ),
         metadata: None,
     };
-    let mut locks = block_state.locks(&context).unwrap();
-    locks.create(&context, &lock_id_a, configuration_a).unwrap();
-    locks.create(&context, &lock_id_b, configuration_b).unwrap();
-    assert!(locks.delete(&context, &lock_id_a).unwrap());
-    block_state.commit_locks(&context, locks);
+    block_state
+        .create_lock(&context, &lock_id_a, configuration_a)
+        .unwrap();
+    block_state
+        .create_lock(&context, &lock_id_b, configuration_b)
+        .unwrap();
+    assert!(block_state.delete_lock(&context, &lock_id_a).unwrap());
 
     // Read lock list and sort for a stable comparison (lock_list order is not guaranteed).
     let mut locks = block_state.lock_list(&context).unwrap();

--- a/plt/plt-scheduler/src/protocol_level_locks/p11.rs
+++ b/plt/plt-scheduler/src/protocol_level_locks/p11.rs
@@ -23,6 +23,7 @@ use plt_block_state::entity::accounts::Accounts;
 use plt_block_state::entity::block_state::LockNotFoundByIdError;
 use plt_block_state::entity::block_state::TokenNotFoundByIdError;
 use plt_block_state::entity::block_state::p11::BlockStateP11;
+use plt_block_state::entity::protocol_level_locks::p11::LocksP11;
 use plt_block_state::entity::{EntityContext, EntityContextTypes};
 use plt_block_state::external::AccountNotFoundByIndexError;
 use plt_block_state::failure::{BlockStateFailure, BlockStateResult};
@@ -77,12 +78,8 @@ pub fn query_lock_info<C: EntityContextTypes>(
 
         // for each locked balance record for the lock, get the locked token amount recorded in the
         // account state of the token.
-        let raw_balance = token_module::query_locked_balance(
-            context,
-            &token,
-            account_index,
-            &configuration.lock_id,
-        )?;
+        let raw_balance =
+            token_module::query_locked_balance(context, &token, account_index, lock.lock_id())?;
         let amount = TokenAmount::from_raw(raw_balance.into(), token_configuration.decimals);
         funds_by_account
             .entry(account_index)
@@ -113,7 +110,7 @@ pub fn query_lock_info<C: EntityContextTypes>(
         .collect::<Result<_, BlockStateFailure>>()?;
 
     let lock_info = LockInfo {
-        lock: configuration.lock_id.clone(),
+        lock: lock.lock_id().clone(),
         recipients,
         expiry: configuration.expiry,
         controller,
@@ -124,52 +121,70 @@ pub fn query_lock_info<C: EntityContextTypes>(
     Ok(RawCbor::from(cbor::cbor_encode(&lock_info)))
 }
 
+/// Context shared by a lock operation within a meta update.
+pub struct LockOperationContext<'a> {
+    /// Maximum permitted duration for a newly created lock.
+    pub max_lock_duration: Duration,
+    /// Zero-based index of the operation in the meta update.
+    pub operation_index: usize,
+    /// Events emitted by the operation.
+    pub events: &'a mut Vec<BlockItemEvent>,
+}
+
 /// Execute [`LockOperation`].
 pub fn execute_lock_operation<C: EntityContextTypes>(
     context: &mut EntityContext<C>,
     transaction_execution: &mut TransactionExecution,
     block_state: &mut BlockStateP11,
-    max_lock_duration: Duration,
-    operation_index: usize,
+    locks: &mut LocksP11,
+    lock_context: LockOperationContext<'_>,
     lock_operation: LockOperation,
-    events: &mut Vec<BlockItemEvent>,
 ) -> ResultWithBlockStateFailure<(), TransactionRejectReason> {
     match lock_operation {
         LockOperation::Fund(details) => execute_lock_fund(
             context,
             transaction_execution,
             block_state,
-            operation_index,
+            locks,
+            lock_context.operation_index,
             details,
-            events,
+            lock_context.events,
         ),
         LockOperation::Send(details) => execute_lock_send(
             context,
             transaction_execution,
             block_state,
-            operation_index,
+            locks,
+            lock_context.operation_index,
             details,
-            events,
+            lock_context.events,
         ),
         LockOperation::Return(details) => execute_lock_return(
             context,
             transaction_execution,
             block_state,
-            operation_index,
+            locks,
+            lock_context.operation_index,
             details,
-            events,
+            lock_context.events,
         ),
         LockOperation::Create(details) => execute_lock_create(
             context,
             transaction_execution,
             block_state,
-            max_lock_duration,
+            locks,
+            lock_context.max_lock_duration,
             details,
-            events,
+            lock_context.events,
         ),
-        LockOperation::Cancel(details) => {
-            execute_lock_cancel(context, transaction_execution, block_state, details, events)
-        }
+        LockOperation::Cancel(details) => execute_lock_cancel(
+            context,
+            transaction_execution,
+            block_state,
+            locks,
+            details,
+            lock_context.events,
+        ),
     }
 }
 
@@ -177,13 +192,14 @@ fn execute_lock_fund<C: EntityContextTypes>(
     context: &mut EntityContext<C>,
     transaction_execution: &TransactionExecution,
     block_state: &mut BlockStateP11,
+    locks: &mut LocksP11,
     operation_index: usize,
     details: MetaLockFundDetails,
     events: &mut Vec<BlockItemEvent>,
 ) -> ResultWithBlockStateFailure<(), TransactionRejectReason> {
     // TODO: (COR-2306) charge.
-    let mut lock = block_state
-        .lock_by_id(context, &details.lock)?
+    let mut lock = locks
+        .by_id(context, &details.lock)?
         .map_err(|err| TransactionRejectReason::NonExistentLockId(err.0))?;
 
     let lock_configuration = lock.lock_configuration(context)?;
@@ -191,9 +207,7 @@ fn execute_lock_fund<C: EntityContextTypes>(
         .expiry
         .is_expired(transaction_execution.timestamp())
     {
-        return Err(
-            TransactionRejectReason::LockExpired(lock_configuration.lock_id.clone()).into(),
-        );
+        return Err(TransactionRejectReason::LockExpired(lock.lock_id().clone()).into());
     }
 
     lock_controller::validate_operation(
@@ -219,7 +233,7 @@ fn execute_lock_fund<C: EntityContextTypes>(
         &mut token,
         transaction_execution.sender_account(),
         transaction_execution.sender_account_address(),
-        &lock_configuration.lock_id,
+        lock.lock_id(),
         raw_amount,
         memo,
     )
@@ -235,7 +249,7 @@ fn execute_lock_fund<C: EntityContextTypes>(
             transaction_execution.sender_account().account_index(),
             token_index,
         );
-        block_state.update_lock(context, lock)?;
+        locks.update(context, lock)?;
     }
     Ok(())
 }
@@ -244,13 +258,14 @@ fn execute_lock_send<C: EntityContextTypes>(
     context: &mut EntityContext<C>,
     transaction_execution: &TransactionExecution,
     block_state: &mut BlockStateP11,
+    locks: &mut LocksP11,
     operation_index: usize,
     details: MetaLockSendDetails,
     events: &mut Vec<BlockItemEvent>,
 ) -> ResultWithBlockStateFailure<(), TransactionRejectReason> {
     // TODO: (COR-2306) charge.
-    let lock = block_state
-        .lock_by_id(context, &details.lock)?
+    let lock = locks
+        .by_id(context, &details.lock)?
         .map_err(|err| TransactionRejectReason::NonExistentLockId(err.0))?;
 
     let lock_configuration = lock.lock_configuration(context)?;
@@ -258,9 +273,7 @@ fn execute_lock_send<C: EntityContextTypes>(
         .expiry
         .is_expired(transaction_execution.timestamp())
     {
-        return Err(
-            TransactionRejectReason::LockExpired(lock_configuration.lock_id.clone()).into(),
-        );
+        return Err(TransactionRejectReason::LockExpired(lock.lock_id().clone()).into());
     }
 
     let source_address = details.source.address;
@@ -292,7 +305,7 @@ fn execute_lock_send<C: EntityContextTypes>(
         .is_recipient(&recipient.account_index())
     {
         return Err(TransactionRejectReason::LockRecipientNotPermitted(
-            lock_configuration.lock_id.clone(),
+            lock.lock_id().clone(),
             recipient_address,
         )
         .into());
@@ -319,7 +332,7 @@ fn execute_lock_send<C: EntityContextTypes>(
         source_address,
         &recipient,
         recipient_address,
-        &lock_configuration.lock_id,
+        lock.lock_id(),
         raw_amount,
         memo,
     )
@@ -334,6 +347,7 @@ fn execute_lock_send<C: EntityContextTypes>(
         remove_lock_balance_ref(
             context,
             block_state,
+            locks,
             events,
             lock_configuration_keeps_alive(&lock_configuration),
             lock,
@@ -350,13 +364,14 @@ fn execute_lock_return<C: EntityContextTypes>(
     context: &mut EntityContext<C>,
     transaction_execution: &TransactionExecution,
     block_state: &mut BlockStateP11,
+    locks: &mut LocksP11,
     operation_index: usize,
     details: MetaLockReturnDetails,
     events: &mut Vec<BlockItemEvent>,
 ) -> ResultWithBlockStateFailure<(), TransactionRejectReason> {
     // TODO: (COR-2306) charge.
-    let lock = block_state
-        .lock_by_id(context, &details.lock)?
+    let lock = locks
+        .by_id(context, &details.lock)?
         .map_err(|err| TransactionRejectReason::NonExistentLockId(err.0))?;
 
     let lock_configuration = lock.lock_configuration(context)?;
@@ -364,9 +379,7 @@ fn execute_lock_return<C: EntityContextTypes>(
         .expiry
         .is_expired(transaction_execution.timestamp())
     {
-        return Err(
-            TransactionRejectReason::LockExpired(lock_configuration.lock_id.clone()).into(),
-        );
+        return Err(TransactionRejectReason::LockExpired(lock.lock_id().clone()).into());
     }
 
     let source_address = details.source.address;
@@ -397,7 +410,7 @@ fn execute_lock_return<C: EntityContextTypes>(
         &mut token,
         source.account_index(),
         source_address,
-        &lock_configuration.lock_id,
+        lock.lock_id(),
         raw_amount,
         memo,
     )
@@ -412,6 +425,7 @@ fn execute_lock_return<C: EntityContextTypes>(
         remove_lock_balance_ref(
             context,
             block_state,
+            locks,
             events,
             lock_configuration_keeps_alive(&lock_configuration),
             lock,
@@ -428,6 +442,7 @@ fn execute_lock_create<C: EntityContextTypes>(
     context: &mut EntityContext<C>,
     transaction_execution: &mut TransactionExecution,
     block_state: &mut BlockStateP11,
+    locks: &mut LocksP11,
     max_lock_duration: Duration,
     details: MetaLockCreateDetails,
     events: &mut Vec<BlockItemEvent>,
@@ -479,7 +494,6 @@ fn execute_lock_create<C: EntityContextTypes>(
         }
     };
     let configuration = LockConfiguration {
-        lock_id: lock_id.clone(),
         recipients,
         expiry,
         controller,
@@ -493,7 +507,7 @@ fn execute_lock_create<C: EntityContextTypes>(
     };
     events.push(BlockItemEvent::LockCreated(event));
 
-    block_state.create_lock(context, configuration)?;
+    locks.create(context, &lock_id, configuration)?;
     Ok(())
 }
 
@@ -501,12 +515,13 @@ fn execute_lock_cancel<C: EntityContextTypes>(
     context: &mut EntityContext<C>,
     transaction_execution: &TransactionExecution,
     block_state: &mut BlockStateP11,
+    locks: &mut LocksP11,
     details: MetaLockCancelDetails,
     events: &mut Vec<BlockItemEvent>,
 ) -> ResultWithBlockStateFailure<(), TransactionRejectReason> {
     // TODO: (COR-2306) charge.
-    let lock = block_state
-        .lock_by_id(context, &details.lock)?
+    let lock = locks
+        .by_id(context, &details.lock)?
         .map_err(|err| TransactionRejectReason::NonExistentLockId(err.0))?;
 
     let lock_configuration = lock.lock_configuration(context)?;
@@ -530,14 +545,14 @@ fn execute_lock_cancel<C: EntityContextTypes>(
             events,
             &mut token,
             account_index,
-            &lock_configuration.lock_id,
+            lock.lock_id(),
             &memo,
         )?;
         block_state.update_token(context, token)?;
     }
-    block_state.delete_lock(context, &lock_configuration.lock_id)?;
+    locks.delete(context, lock.lock_id())?;
     let event = events::LockDestroyEvent {
-        lock_id: lock_configuration.lock_id.clone(),
+        lock_id: lock.lock_id().clone(),
     };
     events.push(BlockItemEvent::LockDestroyed(event));
     Ok(())
@@ -546,7 +561,8 @@ fn execute_lock_cancel<C: EntityContextTypes>(
 #[allow(clippy::too_many_arguments)]
 fn remove_lock_balance_ref<C: EntityContextTypes>(
     context: &EntityContext<C>,
-    block_state: &mut BlockStateP11,
+    _block_state: &mut BlockStateP11,
+    locks: &mut LocksP11,
     events: &mut Vec<BlockItemEvent>,
     lock_keeps_alive: bool,
     mut lock: plt_block_state::entity::protocol_level_locks::p11::LockP11,
@@ -560,12 +576,12 @@ fn remove_lock_balance_ref<C: EntityContextTypes>(
         return Ok(());
     }
     if lock.lock_balance_refs().is_empty() && !lock_keeps_alive {
-        block_state.delete_lock(context, &lock_id)?;
+        locks.delete(context, &lock_id)?;
         events.push(BlockItemEvent::LockDestroyed(events::LockDestroyEvent {
             lock_id,
         }));
     } else {
-        block_state.update_lock(context, lock)?;
+        locks.update(context, lock)?;
     }
     Ok(())
 }

--- a/plt/plt-scheduler/src/protocol_level_locks/p11.rs
+++ b/plt/plt-scheduler/src/protocol_level_locks/p11.rs
@@ -127,6 +127,8 @@ pub struct LockOperationContext<'a> {
     pub max_lock_duration: Duration,
     /// Zero-based index of the operation in the meta update.
     pub operation_index: usize,
+    /// the lock operation to execute.
+    pub operation: LockOperation,
     /// Events emitted by the operation.
     pub events: &'a mut Vec<BlockItemEvent>,
 }
@@ -136,16 +138,15 @@ pub fn execute_lock_operation<C: EntityContextTypes>(
     context: &mut EntityContext<C>,
     transaction_execution: &mut TransactionExecution,
     block_state: &mut BlockStateP11,
-    locks: &mut LocksP11,
+    locks_state: &mut LocksP11,
     lock_context: LockOperationContext<'_>,
-    lock_operation: LockOperation,
 ) -> ResultWithBlockStateFailure<(), TransactionRejectReason> {
-    match lock_operation {
+    match lock_context.operation {
         LockOperation::Fund(details) => execute_lock_fund(
             context,
             transaction_execution,
             block_state,
-            locks,
+            locks_state,
             lock_context.operation_index,
             details,
             lock_context.events,
@@ -154,7 +155,7 @@ pub fn execute_lock_operation<C: EntityContextTypes>(
             context,
             transaction_execution,
             block_state,
-            locks,
+            locks_state,
             lock_context.operation_index,
             details,
             lock_context.events,
@@ -163,7 +164,7 @@ pub fn execute_lock_operation<C: EntityContextTypes>(
             context,
             transaction_execution,
             block_state,
-            locks,
+            locks_state,
             lock_context.operation_index,
             details,
             lock_context.events,
@@ -172,7 +173,7 @@ pub fn execute_lock_operation<C: EntityContextTypes>(
             context,
             transaction_execution,
             block_state,
-            locks,
+            locks_state,
             lock_context.max_lock_duration,
             details,
             lock_context.events,
@@ -181,7 +182,7 @@ pub fn execute_lock_operation<C: EntityContextTypes>(
             context,
             transaction_execution,
             block_state,
-            locks,
+            locks_state,
             details,
             lock_context.events,
         ),
@@ -192,13 +193,13 @@ fn execute_lock_fund<C: EntityContextTypes>(
     context: &mut EntityContext<C>,
     transaction_execution: &TransactionExecution,
     block_state: &mut BlockStateP11,
-    locks: &mut LocksP11,
+    locks_state: &mut LocksP11,
     operation_index: usize,
     details: MetaLockFundDetails,
     events: &mut Vec<BlockItemEvent>,
 ) -> ResultWithBlockStateFailure<(), TransactionRejectReason> {
     // TODO: (COR-2306) charge.
-    let mut lock = locks
+    let mut lock = locks_state
         .by_id(context, &details.lock)?
         .map_err(|err| TransactionRejectReason::NonExistentLockId(err.0))?;
 
@@ -249,7 +250,7 @@ fn execute_lock_fund<C: EntityContextTypes>(
             transaction_execution.sender_account().account_index(),
             token_index,
         );
-        locks.update(context, lock)?;
+        locks_state.update(context, lock)?;
     }
     Ok(())
 }
@@ -258,13 +259,13 @@ fn execute_lock_send<C: EntityContextTypes>(
     context: &mut EntityContext<C>,
     transaction_execution: &TransactionExecution,
     block_state: &mut BlockStateP11,
-    locks: &mut LocksP11,
+    locks_state: &mut LocksP11,
     operation_index: usize,
     details: MetaLockSendDetails,
     events: &mut Vec<BlockItemEvent>,
 ) -> ResultWithBlockStateFailure<(), TransactionRejectReason> {
     // TODO: (COR-2306) charge.
-    let lock = locks
+    let lock = locks_state
         .by_id(context, &details.lock)?
         .map_err(|err| TransactionRejectReason::NonExistentLockId(err.0))?;
 
@@ -346,8 +347,7 @@ fn execute_lock_send<C: EntityContextTypes>(
     if remaining_locked == RawTokenAmount::from(0) {
         remove_lock_balance_ref(
             context,
-            block_state,
-            locks,
+            locks_state,
             events,
             lock_configuration_keeps_alive(&lock_configuration),
             lock,
@@ -364,13 +364,13 @@ fn execute_lock_return<C: EntityContextTypes>(
     context: &mut EntityContext<C>,
     transaction_execution: &TransactionExecution,
     block_state: &mut BlockStateP11,
-    locks: &mut LocksP11,
+    locks_state: &mut LocksP11,
     operation_index: usize,
     details: MetaLockReturnDetails,
     events: &mut Vec<BlockItemEvent>,
 ) -> ResultWithBlockStateFailure<(), TransactionRejectReason> {
     // TODO: (COR-2306) charge.
-    let lock = locks
+    let lock = locks_state
         .by_id(context, &details.lock)?
         .map_err(|err| TransactionRejectReason::NonExistentLockId(err.0))?;
 
@@ -424,8 +424,7 @@ fn execute_lock_return<C: EntityContextTypes>(
     if remaining_locked == RawTokenAmount::from(0) {
         remove_lock_balance_ref(
             context,
-            block_state,
-            locks,
+            locks_state,
             events,
             lock_configuration_keeps_alive(&lock_configuration),
             lock,
@@ -442,7 +441,7 @@ fn execute_lock_create<C: EntityContextTypes>(
     context: &mut EntityContext<C>,
     transaction_execution: &mut TransactionExecution,
     block_state: &mut BlockStateP11,
-    locks: &mut LocksP11,
+    locks_state: &mut LocksP11,
     max_lock_duration: Duration,
     details: MetaLockCreateDetails,
     events: &mut Vec<BlockItemEvent>,
@@ -507,7 +506,7 @@ fn execute_lock_create<C: EntityContextTypes>(
     };
     events.push(BlockItemEvent::LockCreated(event));
 
-    locks.create(context, &lock_id, configuration)?;
+    locks_state.create(context, &lock_id, configuration)?;
     Ok(())
 }
 
@@ -515,12 +514,12 @@ fn execute_lock_cancel<C: EntityContextTypes>(
     context: &mut EntityContext<C>,
     transaction_execution: &TransactionExecution,
     block_state: &mut BlockStateP11,
-    locks: &mut LocksP11,
+    locks_state: &mut LocksP11,
     details: MetaLockCancelDetails,
     events: &mut Vec<BlockItemEvent>,
 ) -> ResultWithBlockStateFailure<(), TransactionRejectReason> {
     // TODO: (COR-2306) charge.
-    let lock = locks
+    let lock = locks_state
         .by_id(context, &details.lock)?
         .map_err(|err| TransactionRejectReason::NonExistentLockId(err.0))?;
 
@@ -550,7 +549,7 @@ fn execute_lock_cancel<C: EntityContextTypes>(
         )?;
         block_state.update_token(context, token)?;
     }
-    locks.delete(context, lock.lock_id())?;
+    locks_state.delete(context, lock.lock_id())?;
     let event = events::LockDestroyEvent {
         lock_id: lock.lock_id().clone(),
     };
@@ -561,7 +560,6 @@ fn execute_lock_cancel<C: EntityContextTypes>(
 #[allow(clippy::too_many_arguments)]
 fn remove_lock_balance_ref<C: EntityContextTypes>(
     context: &EntityContext<C>,
-    _block_state: &mut BlockStateP11,
     locks: &mut LocksP11,
     events: &mut Vec<BlockItemEvent>,
     lock_keeps_alive: bool,

--- a/plt/plt-scheduler/src/protocol_level_locks/p11.rs
+++ b/plt/plt-scheduler/src/protocol_level_locks/p11.rs
@@ -23,7 +23,6 @@ use plt_block_state::entity::accounts::Accounts;
 use plt_block_state::entity::block_state::LockNotFoundByIdError;
 use plt_block_state::entity::block_state::TokenNotFoundByIdError;
 use plt_block_state::entity::block_state::p11::BlockStateP11;
-use plt_block_state::entity::protocol_level_locks::p11::LocksP11;
 use plt_block_state::entity::{EntityContext, EntityContextTypes};
 use plt_block_state::external::AccountNotFoundByIndexError;
 use plt_block_state::failure::{BlockStateFailure, BlockStateResult};
@@ -121,71 +120,52 @@ pub fn query_lock_info<C: EntityContextTypes>(
     Ok(RawCbor::from(cbor::cbor_encode(&lock_info)))
 }
 
-/// Context shared by a lock operation within a meta update.
-pub struct LockOperationContext<'a> {
-    /// Maximum permitted duration for a newly created lock.
-    pub max_lock_duration: Duration,
-    /// Zero-based index of the operation in the meta update.
-    pub operation_index: usize,
-    /// the lock operation to execute.
-    pub operation: LockOperation,
-    /// Events emitted by the operation.
-    pub events: &'a mut Vec<BlockItemEvent>,
-}
-
 /// Execute [`LockOperation`].
 pub fn execute_lock_operation<C: EntityContextTypes>(
     context: &mut EntityContext<C>,
     transaction_execution: &mut TransactionExecution,
     block_state: &mut BlockStateP11,
-    locks_state: &mut LocksP11,
-    lock_context: LockOperationContext<'_>,
+    max_lock_duration: Duration,
+    operation_index: usize,
+    lock_operation: LockOperation,
+    events: &mut Vec<BlockItemEvent>,
 ) -> ResultWithBlockStateFailure<(), TransactionRejectReason> {
-    match lock_context.operation {
+    match lock_operation {
         LockOperation::Fund(details) => execute_lock_fund(
             context,
             transaction_execution,
             block_state,
-            locks_state,
-            lock_context.operation_index,
+            operation_index,
             details,
-            lock_context.events,
+            events,
         ),
         LockOperation::Send(details) => execute_lock_send(
             context,
             transaction_execution,
             block_state,
-            locks_state,
-            lock_context.operation_index,
+            operation_index,
             details,
-            lock_context.events,
+            events,
         ),
         LockOperation::Return(details) => execute_lock_return(
             context,
             transaction_execution,
             block_state,
-            locks_state,
-            lock_context.operation_index,
+            operation_index,
             details,
-            lock_context.events,
+            events,
         ),
         LockOperation::Create(details) => execute_lock_create(
             context,
             transaction_execution,
             block_state,
-            locks_state,
-            lock_context.max_lock_duration,
+            max_lock_duration,
             details,
-            lock_context.events,
+            events,
         ),
-        LockOperation::Cancel(details) => execute_lock_cancel(
-            context,
-            transaction_execution,
-            block_state,
-            locks_state,
-            details,
-            lock_context.events,
-        ),
+        LockOperation::Cancel(details) => {
+            execute_lock_cancel(context, transaction_execution, block_state, details, events)
+        }
     }
 }
 
@@ -193,14 +173,13 @@ fn execute_lock_fund<C: EntityContextTypes>(
     context: &mut EntityContext<C>,
     transaction_execution: &TransactionExecution,
     block_state: &mut BlockStateP11,
-    locks_state: &mut LocksP11,
     operation_index: usize,
     details: MetaLockFundDetails,
     events: &mut Vec<BlockItemEvent>,
 ) -> ResultWithBlockStateFailure<(), TransactionRejectReason> {
     // TODO: (COR-2306) charge.
-    let mut lock = locks_state
-        .by_id(context, &details.lock)?
+    let mut lock = block_state
+        .lock_by_id(context, &details.lock)?
         .map_err(|err| TransactionRejectReason::NonExistentLockId(err.0))?;
 
     let lock_configuration = lock.lock_configuration(context)?;
@@ -250,7 +229,7 @@ fn execute_lock_fund<C: EntityContextTypes>(
             transaction_execution.sender_account().account_index(),
             token_index,
         );
-        locks_state.update(context, lock)?;
+        block_state.update_lock(context, lock)?;
     }
     Ok(())
 }
@@ -259,14 +238,13 @@ fn execute_lock_send<C: EntityContextTypes>(
     context: &mut EntityContext<C>,
     transaction_execution: &TransactionExecution,
     block_state: &mut BlockStateP11,
-    locks_state: &mut LocksP11,
     operation_index: usize,
     details: MetaLockSendDetails,
     events: &mut Vec<BlockItemEvent>,
 ) -> ResultWithBlockStateFailure<(), TransactionRejectReason> {
     // TODO: (COR-2306) charge.
-    let lock = locks_state
-        .by_id(context, &details.lock)?
+    let lock = block_state
+        .lock_by_id(context, &details.lock)?
         .map_err(|err| TransactionRejectReason::NonExistentLockId(err.0))?;
 
     let lock_configuration = lock.lock_configuration(context)?;
@@ -347,7 +325,7 @@ fn execute_lock_send<C: EntityContextTypes>(
     if remaining_locked == RawTokenAmount::from(0) {
         remove_lock_balance_ref(
             context,
-            locks_state,
+            block_state,
             events,
             lock_configuration_keeps_alive(&lock_configuration),
             lock,
@@ -364,14 +342,13 @@ fn execute_lock_return<C: EntityContextTypes>(
     context: &mut EntityContext<C>,
     transaction_execution: &TransactionExecution,
     block_state: &mut BlockStateP11,
-    locks_state: &mut LocksP11,
     operation_index: usize,
     details: MetaLockReturnDetails,
     events: &mut Vec<BlockItemEvent>,
 ) -> ResultWithBlockStateFailure<(), TransactionRejectReason> {
     // TODO: (COR-2306) charge.
-    let lock = locks_state
-        .by_id(context, &details.lock)?
+    let lock = block_state
+        .lock_by_id(context, &details.lock)?
         .map_err(|err| TransactionRejectReason::NonExistentLockId(err.0))?;
 
     let lock_configuration = lock.lock_configuration(context)?;
@@ -424,7 +401,7 @@ fn execute_lock_return<C: EntityContextTypes>(
     if remaining_locked == RawTokenAmount::from(0) {
         remove_lock_balance_ref(
             context,
-            locks_state,
+            block_state,
             events,
             lock_configuration_keeps_alive(&lock_configuration),
             lock,
@@ -441,7 +418,6 @@ fn execute_lock_create<C: EntityContextTypes>(
     context: &mut EntityContext<C>,
     transaction_execution: &mut TransactionExecution,
     block_state: &mut BlockStateP11,
-    locks_state: &mut LocksP11,
     max_lock_duration: Duration,
     details: MetaLockCreateDetails,
     events: &mut Vec<BlockItemEvent>,
@@ -506,7 +482,7 @@ fn execute_lock_create<C: EntityContextTypes>(
     };
     events.push(BlockItemEvent::LockCreated(event));
 
-    locks_state.create(context, &lock_id, configuration)?;
+    block_state.create_lock(context, &lock_id, configuration)?;
     Ok(())
 }
 
@@ -514,13 +490,12 @@ fn execute_lock_cancel<C: EntityContextTypes>(
     context: &mut EntityContext<C>,
     transaction_execution: &TransactionExecution,
     block_state: &mut BlockStateP11,
-    locks_state: &mut LocksP11,
     details: MetaLockCancelDetails,
     events: &mut Vec<BlockItemEvent>,
 ) -> ResultWithBlockStateFailure<(), TransactionRejectReason> {
     // TODO: (COR-2306) charge.
-    let lock = locks_state
-        .by_id(context, &details.lock)?
+    let lock = block_state
+        .lock_by_id(context, &details.lock)?
         .map_err(|err| TransactionRejectReason::NonExistentLockId(err.0))?;
 
     let lock_configuration = lock.lock_configuration(context)?;
@@ -549,7 +524,7 @@ fn execute_lock_cancel<C: EntityContextTypes>(
         )?;
         block_state.update_token(context, token)?;
     }
-    locks_state.delete(context, lock.lock_id())?;
+    block_state.delete_lock(context, lock.lock_id())?;
     let event = events::LockDestroyEvent {
         lock_id: lock.lock_id().clone(),
     };
@@ -560,7 +535,7 @@ fn execute_lock_cancel<C: EntityContextTypes>(
 #[allow(clippy::too_many_arguments)]
 fn remove_lock_balance_ref<C: EntityContextTypes>(
     context: &EntityContext<C>,
-    locks: &mut LocksP11,
+    block_state: &mut BlockStateP11,
     events: &mut Vec<BlockItemEvent>,
     lock_keeps_alive: bool,
     mut lock: plt_block_state::entity::protocol_level_locks::p11::LockP11,
@@ -574,12 +549,12 @@ fn remove_lock_balance_ref<C: EntityContextTypes>(
         return Ok(());
     }
     if lock.lock_balance_refs().is_empty() && !lock_keeps_alive {
-        locks.delete(context, &lock_id)?;
+        block_state.delete_lock(context, &lock_id)?;
         events.push(BlockItemEvent::LockDestroyed(events::LockDestroyEvent {
             lock_id,
         }));
     } else {
-        locks.update(context, lock)?;
+        block_state.update_lock(context, lock)?;
     }
     Ok(())
 }

--- a/plt/plt-scheduler/src/scheduler/p11.rs
+++ b/plt/plt-scheduler/src/scheduler/p11.rs
@@ -1,7 +1,9 @@
+use crate::TransactionContext;
 use crate::failure::ResultWithBlockStateFailureExt;
+use crate::protocol_level_locks::p11::{LockOperationContext, execute_lock_operation};
+use crate::protocol_level_tokens::p11::{self, execute_token_update_operation};
 use crate::scheduler::{ChainUpdateExecutionError, TransactionExecutionError};
 use crate::transaction_execution::{OutOfEnergyError, TransactionExecution};
-use crate::{TransactionContext, protocol_level_locks, protocol_level_tokens};
 use concordium_base::protocol_level_tokens::meta_operations::{
     LockOperation, MetaUpdateOperation, MetaUpdateOperations, MetaUpdatePayload,
 };
@@ -51,25 +53,20 @@ pub fn execute_transaction<C: EntityContextTypes>(
 
     let outcome = match payload {
         Payload::TokenUpdate { payload } => {
-            protocol_level_tokens::p11::execute_token_update_transaction(
-                context,
-                &mut execution,
-                block_state,
-                payload,
-            )?
+            p11::execute_token_update_transaction(context, &mut execution, block_state, payload)?
         }
         Payload::MetaUpdate { payload } => {
-            let mut locks = block_state.locks(context)?;
+            let mut locks_state = block_state.locks(context)?;
             let outcome = execute_meta_update_transaction(
                 context,
                 &mut execution,
                 block_state,
-                &mut locks,
+                &mut locks_state,
                 payload,
                 chain_parameters,
             )?;
             if matches!(outcome, TransactionOutcome::Success(_)) {
-                block_state.commit_locks(context, locks);
+                block_state.commit_locks(context, locks_state);
             }
             outcome
         }
@@ -87,7 +84,7 @@ fn execute_meta_update_transaction<C: EntityContextTypes>(
     context: &mut EntityContext<C>,
     transaction_execution: &mut TransactionExecution,
     block_state: &mut BlockStateP11,
-    locks: &mut LocksP11,
+    locks_state: &mut LocksP11,
     payload: MetaUpdatePayload,
     chain_parameters: &PersistentChainParametersP11,
 ) -> BlockStateResult<TransactionOutcome> {
@@ -118,7 +115,7 @@ fn execute_meta_update_transaction<C: EntityContextTypes>(
     for (index, operation) in operations.into_iter().enumerate() {
         match MetaUpdateOperationKind::from(operation) {
             MetaUpdateOperationKind::Token(token_id, token_operation) => {
-                match protocol_level_tokens::p11::execute_token_update_operation(
+                match execute_token_update_operation(
                     context,
                     transaction_execution,
                     block_state,
@@ -136,17 +133,19 @@ fn execute_meta_update_transaction<C: EntityContextTypes>(
                 }
             }
             MetaUpdateOperationKind::Lock(lock_operation) => {
-                match protocol_level_locks::p11::execute_lock_operation(
+                let lock_context = LockOperationContext {
+                    max_lock_duration: chain_parameters.max_lock_duration,
+                    operation_index: index,
+                    operation: lock_operation,
+                    events: &mut events,
+                };
+
+                match execute_lock_operation(
                     context,
                     transaction_execution,
                     block_state,
-                    locks,
-                    protocol_level_locks::p11::LockOperationContext {
-                        max_lock_duration: chain_parameters.max_lock_duration,
-                        operation_index: index,
-                        events: &mut events,
-                    },
-                    lock_operation,
+                    locks_state,
+                    lock_context,
                 )
                 .nest()?
                 {
@@ -184,11 +183,7 @@ pub fn execute_chain_update<C: EntityContextTypes>(
 ) -> Result<ChainUpdateOutcome, ChainUpdateExecutionError> {
     let outcome = match payload {
         UpdatePayload::CreatePlt(create_plt) => {
-            protocol_level_tokens::p11::execute_create_plt_chain_update(
-                context,
-                block_state,
-                create_plt,
-            )?
+            p11::execute_create_plt_chain_update(context, block_state, create_plt)?
         }
         _ => return Err(ChainUpdateExecutionError::UnexpectedPayload),
     };

--- a/plt/plt-scheduler/src/scheduler/p11.rs
+++ b/plt/plt-scheduler/src/scheduler/p11.rs
@@ -11,6 +11,7 @@ use concordium_base::transactions::Payload;
 use concordium_base::updates::UpdatePayload;
 use plt_block_state::entity::accounts::Account;
 use plt_block_state::entity::block_state::p11::BlockStateP11;
+use plt_block_state::entity::protocol_level_locks::p11::LocksP11;
 use plt_block_state::entity::{EntityContext, EntityContextTypes};
 use plt_block_state::failure::BlockStateResult;
 use plt_block_state::persistent::chain_parameters::p11::PersistentChainParametersP11;
@@ -57,13 +58,21 @@ pub fn execute_transaction<C: EntityContextTypes>(
                 payload,
             )?
         }
-        Payload::MetaUpdate { payload } => execute_meta_update_transaction(
-            context,
-            &mut execution,
-            block_state,
-            payload,
-            chain_parameters,
-        )?,
+        Payload::MetaUpdate { payload } => {
+            let mut locks = block_state.locks(context)?;
+            let outcome = execute_meta_update_transaction(
+                context,
+                &mut execution,
+                block_state,
+                &mut locks,
+                payload,
+                chain_parameters,
+            )?;
+            if matches!(outcome, TransactionOutcome::Success(_)) {
+                block_state.commit_locks(context, locks);
+            }
+            outcome
+        }
         _ => return Err(TransactionExecutionError::UnexpectedPayload),
     };
 
@@ -78,6 +87,7 @@ fn execute_meta_update_transaction<C: EntityContextTypes>(
     context: &mut EntityContext<C>,
     transaction_execution: &mut TransactionExecution,
     block_state: &mut BlockStateP11,
+    locks: &mut LocksP11,
     payload: MetaUpdatePayload,
     chain_parameters: &PersistentChainParametersP11,
 ) -> BlockStateResult<TransactionOutcome> {
@@ -130,10 +140,13 @@ fn execute_meta_update_transaction<C: EntityContextTypes>(
                     context,
                     transaction_execution,
                     block_state,
-                    chain_parameters.max_lock_duration,
-                    index,
+                    locks,
+                    protocol_level_locks::p11::LockOperationContext {
+                        max_lock_duration: chain_parameters.max_lock_duration,
+                        operation_index: index,
+                        events: &mut events,
+                    },
                     lock_operation,
-                    &mut events,
                 )
                 .nest()?
                 {
@@ -169,16 +182,17 @@ pub fn execute_chain_update<C: EntityContextTypes>(
     block_state: &mut BlockStateP11,
     payload: UpdatePayload,
 ) -> Result<ChainUpdateOutcome, ChainUpdateExecutionError> {
-    match payload {
+    let outcome = match payload {
         UpdatePayload::CreatePlt(create_plt) => {
-            Ok(protocol_level_tokens::p11::execute_create_plt_chain_update(
+            protocol_level_tokens::p11::execute_create_plt_chain_update(
                 context,
                 block_state,
                 create_plt,
-            )?)
+            )?
         }
-        _ => Err(ChainUpdateExecutionError::UnexpectedPayload),
-    }
+        _ => return Err(ChainUpdateExecutionError::UnexpectedPayload),
+    };
+    Ok(outcome)
 }
 
 /// Execute a chain update modifying P11 external chain parameters.

--- a/plt/plt-scheduler/src/scheduler/p11.rs
+++ b/plt/plt-scheduler/src/scheduler/p11.rs
@@ -1,9 +1,7 @@
-use crate::TransactionContext;
 use crate::failure::ResultWithBlockStateFailureExt;
-use crate::protocol_level_locks::p11::{LockOperationContext, execute_lock_operation};
-use crate::protocol_level_tokens::p11::{self, execute_token_update_operation};
 use crate::scheduler::{ChainUpdateExecutionError, TransactionExecutionError};
 use crate::transaction_execution::{OutOfEnergyError, TransactionExecution};
+use crate::{TransactionContext, protocol_level_locks, protocol_level_tokens};
 use concordium_base::protocol_level_tokens::meta_operations::{
     LockOperation, MetaUpdateOperation, MetaUpdateOperations, MetaUpdatePayload,
 };
@@ -13,7 +11,6 @@ use concordium_base::transactions::Payload;
 use concordium_base::updates::UpdatePayload;
 use plt_block_state::entity::accounts::Account;
 use plt_block_state::entity::block_state::p11::BlockStateP11;
-use plt_block_state::entity::protocol_level_locks::p11::LocksP11;
 use plt_block_state::entity::{EntityContext, EntityContextTypes};
 use plt_block_state::failure::BlockStateResult;
 use plt_block_state::persistent::chain_parameters::p11::PersistentChainParametersP11;
@@ -53,23 +50,20 @@ pub fn execute_transaction<C: EntityContextTypes>(
 
     let outcome = match payload {
         Payload::TokenUpdate { payload } => {
-            p11::execute_token_update_transaction(context, &mut execution, block_state, payload)?
-        }
-        Payload::MetaUpdate { payload } => {
-            let mut locks_state = block_state.locks(context)?;
-            let outcome = execute_meta_update_transaction(
+            protocol_level_tokens::p11::execute_token_update_transaction(
                 context,
                 &mut execution,
                 block_state,
-                &mut locks_state,
                 payload,
-                chain_parameters,
-            )?;
-            if matches!(outcome, TransactionOutcome::Success(_)) {
-                block_state.commit_locks(context, locks_state);
-            }
-            outcome
+            )?
         }
+        Payload::MetaUpdate { payload } => execute_meta_update_transaction(
+            context,
+            &mut execution,
+            block_state,
+            payload,
+            chain_parameters,
+        )?,
         _ => return Err(TransactionExecutionError::UnexpectedPayload),
     };
 
@@ -84,7 +78,6 @@ fn execute_meta_update_transaction<C: EntityContextTypes>(
     context: &mut EntityContext<C>,
     transaction_execution: &mut TransactionExecution,
     block_state: &mut BlockStateP11,
-    locks_state: &mut LocksP11,
     payload: MetaUpdatePayload,
     chain_parameters: &PersistentChainParametersP11,
 ) -> BlockStateResult<TransactionOutcome> {
@@ -115,7 +108,7 @@ fn execute_meta_update_transaction<C: EntityContextTypes>(
     for (index, operation) in operations.into_iter().enumerate() {
         match MetaUpdateOperationKind::from(operation) {
             MetaUpdateOperationKind::Token(token_id, token_operation) => {
-                match execute_token_update_operation(
+                match protocol_level_tokens::p11::execute_token_update_operation(
                     context,
                     transaction_execution,
                     block_state,
@@ -133,19 +126,14 @@ fn execute_meta_update_transaction<C: EntityContextTypes>(
                 }
             }
             MetaUpdateOperationKind::Lock(lock_operation) => {
-                let lock_context = LockOperationContext {
-                    max_lock_duration: chain_parameters.max_lock_duration,
-                    operation_index: index,
-                    operation: lock_operation,
-                    events: &mut events,
-                };
-
-                match execute_lock_operation(
+                match protocol_level_locks::p11::execute_lock_operation(
                     context,
                     transaction_execution,
                     block_state,
-                    locks_state,
-                    lock_context,
+                    chain_parameters.max_lock_duration,
+                    index,
+                    lock_operation,
+                    &mut events,
                 )
                 .nest()?
                 {
@@ -181,13 +169,16 @@ pub fn execute_chain_update<C: EntityContextTypes>(
     block_state: &mut BlockStateP11,
     payload: UpdatePayload,
 ) -> Result<ChainUpdateOutcome, ChainUpdateExecutionError> {
-    let outcome = match payload {
+    match payload {
         UpdatePayload::CreatePlt(create_plt) => {
-            p11::execute_create_plt_chain_update(context, block_state, create_plt)?
+            Ok(protocol_level_tokens::p11::execute_create_plt_chain_update(
+                context,
+                block_state,
+                create_plt,
+            )?)
         }
-        _ => return Err(ChainUpdateExecutionError::UnexpectedPayload),
-    };
-    Ok(outcome)
+        _ => Err(ChainUpdateExecutionError::UnexpectedPayload),
+    }
 }
 
 /// Execute a chain update modifying P11 external chain parameters.

--- a/plt/plt-scheduler/tests/utils/lock.rs
+++ b/plt/plt-scheduler/tests/utils/lock.rs
@@ -120,7 +120,9 @@ pub fn lock_balance(
         .unwrap()
         .expect("lock must exist");
     lock.add_lock_balance_ref(funder_account, token_index);
-    block_state.update_lock(context, lock).unwrap();
+    let mut locks = block_state.locks(context).unwrap();
+    locks.update(context, lock).unwrap();
+    block_state.commit_locks(context, locks);
 
     // Set the locked amount in the token module KV state
     let mut token = block_state

--- a/plt/plt-scheduler/tests/utils/lock.rs
+++ b/plt/plt-scheduler/tests/utils/lock.rs
@@ -120,9 +120,7 @@ pub fn lock_balance(
         .unwrap()
         .expect("lock must exist");
     lock.add_lock_balance_ref(funder_account, token_index);
-    let mut locks = block_state.locks(context).unwrap();
-    locks.update(context, lock).unwrap();
-    block_state.commit_locks(context, locks);
+    block_state.update_lock(context, lock).unwrap();
 
     // Set the locked amount in the token module KV state
     let mut token = block_state


### PR DESCRIPTION
Disclaimer: co-authored by AI, heavily reviewed and revised.

The implementation is superseded by #1704. The PR will be closed when this is merged.

## Purpose

Refactor locks persistence to trie to support efficient historical lookup

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.