### PR TITLE
Pin macos runner image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -400,7 +400,7 @@ jobs:
           path: ${{ env.ARTIFACT_NAME }}
 
   node-macos:
-    runs-on: macos-latest-large
+    runs-on: macos-15-large # TODO: COR-2633: update to macos-latest-large
     environment: release # This step needs to use the release context to access credentials for code signing.
     needs: [validate-preconditions]
     if: contains(fromJSON('["rc", "alpha", "node-macos"]'), needs.validate-preconditions.outputs.release_type)


### PR DESCRIPTION
## Purpose

See https://linear.app/concordium/issue/COR-2633/macos-node-package-fails-to-start-due-to-duplicate-lc-rpath-entries for context
